### PR TITLE
perf(web,db,server): real-time dashboard + Suspense streaming + cache headers

### DIFF
--- a/apps/server/src/api/stats.ts
+++ b/apps/server/src/api/stats.ts
@@ -20,6 +20,14 @@ export const statsRouter = new Hono<JwtContext>()
 
 statsRouter.use('*', authJwt)
 
+// Cache-Control presets for stats endpoints.
+// `private` — per-user data, never store on shared/CDN caches.
+// `max-age=N` — browser may serve cached response for N seconds without revalidation.
+// `stale-while-revalidate=M` — after max-age, serve stale for M seconds while refetching in background.
+// Dashboard auto-refetch is 2min + realtime WS; 10s freshness window cuts repeat-nav fetches to ~0ms.
+const CACHE_STATS_LIVE = 'private, max-age=10, stale-while-revalidate=30'
+const CACHE_STATS_FORECAST = 'private, max-age=60, stale-while-revalidate=300'
+
 interface OverviewRow {
   total_requests: number
   success_requests: number
@@ -93,6 +101,7 @@ statsRouter.get('/overview', async (c) => {
     const currRow = rowToOverview((curr.data as OverviewRow[] | null)?.[0])
     const prevRow = rowToOverview((prev.data as OverviewRow[] | null)?.[0])
 
+    c.header('Cache-Control', CACHE_STATS_LIVE)
     return c.json({
       success: true,
       data: {
@@ -117,6 +126,7 @@ statsRouter.get('/overview', async (c) => {
   // RPC returns TABLE — supabase-js exposes it as an array. We only asked for
   // aggregates so it's always length 1 (even when zero matching rows).
   const row = (data as OverviewRow[] | null)?.[0]
+  c.header('Cache-Control', CACHE_STATS_LIVE)
   return c.json({ success: true, data: rowToOverview(row) })
 })
 
@@ -171,6 +181,7 @@ statsRouter.get('/models', async (c) => {
     errorRate: Number(r.error_rate),
   }))
 
+  c.header('Cache-Control', CACHE_STATS_LIVE)
   return c.json({ success: true, data: models, meta: { hours, count: models.length } })
 })
 
@@ -202,6 +213,7 @@ statsRouter.get('/timeseries', async (c) => {
     errors: Number(r.errors),
   }))
 
+  c.header('Cache-Control', CACHE_STATS_LIVE)
   return c.json({ success: true, data: series, meta: { granularity } })
 })
 
@@ -292,6 +304,7 @@ statsRouter.get('/spend-forecast', async (c) => {
     })
   }
 
+  c.header('Cache-Control', CACHE_STATS_FORECAST)
   return c.json({
     success: true,
     data: {
@@ -360,6 +373,7 @@ statsRouter.get('/latency', async (c) => {
   const p95Overhead = percentile(sortedOverhead, 95)
   const p99Overhead = percentile(sortedOverhead, 99)
 
+  c.header('Cache-Control', CACHE_STATS_LIVE)
   return c.json({
     success: true,
     data: {

--- a/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
@@ -16,6 +16,7 @@ import { useDismissals, useDismissCard } from '@/lib/queries/use-dismissals'
 import { cn } from '@/lib/utils'
 import dynamic from 'next/dynamic'
 import { WelcomeBanner } from '@/components/dashboard/welcome-banner'
+import { useRealtimeRequests } from '@/lib/hooks/use-realtime-requests'
 
 // Lazy-load recharts-heavy components. They render below the fold and are
 // not needed for the initial KPI row / greeting paint.
@@ -177,11 +178,13 @@ function AttnCard({ kind, title, meta, hint, cta, href, onDismiss }: AttnCardPro
 
 // ── Page ───────────────────────────────────────────────────────
 
-const LIVE_REFETCH_MS = 30_000
+// Realtime WebSocket handles instant updates; polling is a safety-net fallback only.
+const LIVE_REFETCH_MS = 2 * 60_000
 
 export function DashboardClient() {
   const [timeRange, setTimeRange] = useState('24h')
   const hours = timeRangeToHours(timeRange)
+  useRealtimeRequests()
   const dismissalsQuery = useDismissals()
   const dismissMutation = useDismissCard()
   const dismissedCards = useMemo(

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { HydrationBoundary } from '@tanstack/react-query'
 import { prefetchAll } from '@/lib/server/dehydrate'
 import { alertsSpec } from '@/lib/server/queries/alerts'
@@ -9,10 +10,11 @@ import { statsOverviewSpec, statsTimeseriesSpec, statsModelsSpec, spendForecastS
 import { anomaliesSpec } from '@/lib/server/queries/anomalies'
 import { DashboardClient } from './dashboard-client'
 
-export default async function DashboardPage() {
+// Below-the-fold queries — prefetched in parallel but streamed in via Suspense
+// so they don't block the initial HTML. The dashboard renders with skeletons
+// in these slots and React Query swaps in real data when the stream arrives.
+async function DeferredHydration() {
   const state = await prefetchAll([
-    statsOverviewSpec(),
-    statsTimeseriesSpec(),
     statsModelsSpec(),
     spendForecastSpec(),
     anomaliesSpec({ observationHours: 24 }),
@@ -20,12 +22,25 @@ export default async function DashboardPage() {
     recommendationsSpec({ hours: 24 }),
     securitySummarySpec(24),
     auditLogsSpec({ limit: 6 }),
+  ])
+  return <HydrationBoundary state={state} />
+}
+
+export default async function DashboardPage() {
+  // Above-the-fold critical path — blocks initial HTML (KPI row + traffic chart
+  // + attention-card dismissal state). Kept to 3 fast queries so TTFB stays low.
+  const state = await prefetchAll([
+    statsOverviewSpec(),
+    statsTimeseriesSpec(),
     dismissalsSpec(),
   ])
 
   return (
     <HydrationBoundary state={state}>
       <DashboardClient />
+      <Suspense fallback={null}>
+        <DeferredHydration />
+      </Suspense>
     </HydrationBoundary>
   )
 }

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -11,34 +11,43 @@ import type { ApiEnvelope, Organization } from '@/lib/queries/types'
 import { SettingsClient } from './settings-client'
 import type { QuerySpec } from '@/lib/server/dehydrate'
 
-export default async function SettingsPage() {
-  // Fetch org first to get orgId — needed to build members/invitations query keys.
-  // org is also included in the prefetchAll batch below so it lands in the
-  // dehydrated cache (double server-side fetch is intentional and cheap).
-  const orgRes = await apiGetServer<ApiEnvelope<Organization>>('/api/v1/organizations/me')
-  const orgId = orgRes.data?.id
-
+// Streamed-in queries — populate the cache after critical content has rendered.
+// Used by tabs further down the page (audit log, integrations, team).
+async function DeferredHydration({ orgId }: { orgId: string | undefined }) {
   const specs: QuerySpec[] = [
-    organizationSpec(),
-    subscriptionSpec(),
-    quotaSpec(),
     auditLogsSpec({ limit: 100 }),
     webhooksSpec(),
     channelsSpec(),
   ]
-
   if (orgId) {
     specs.push(membersSpec(orgId))
     specs.push(invitationsSpec(orgId))
   }
-
   const state = await prefetchAll(specs)
+  return <HydrationBoundary state={state} />
+}
+
+export default async function SettingsPage() {
+  // Fetch org first to get orgId — needed to build members/invitations query keys.
+  // org is also included in the critical prefetch so it lands in the dehydrated cache.
+  const orgRes = await apiGetServer<ApiEnvelope<Organization>>('/api/v1/organizations/me')
+  const orgId = orgRes.data?.id
+
+  // Above-the-fold critical path: org info + plan summary on the default tab.
+  const state = await prefetchAll([
+    organizationSpec(),
+    subscriptionSpec(),
+    quotaSpec(),
+  ])
 
   return (
     <HydrationBoundary state={state}>
       {/* Suspense required because SettingsClient uses useSearchParams() */}
       <Suspense>
         <SettingsClient />
+      </Suspense>
+      <Suspense fallback={null}>
+        <DeferredHydration orgId={orgId} />
       </Suspense>
     </HydrationBoundary>
   )

--- a/apps/web/lib/hooks/use-realtime-requests.ts
+++ b/apps/web/lib/hooks/use-realtime-requests.ts
@@ -1,0 +1,59 @@
+'use client'
+import { useEffect, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { createClient } from '@/lib/supabase/client'
+
+export type RealtimeStatus = 'connecting' | 'connected' | 'disconnected'
+
+export interface RealtimeRequestsResult {
+  status: RealtimeStatus
+  lastEventAt: Date | null
+}
+
+/**
+ * Subscribes to Supabase Realtime for requests table INSERT events.
+ * On each new request, invalidates stats/anomalies queries so the dashboard
+ * immediately reflects the change without waiting for the polling interval.
+ *
+ * Requires the requests table to be in the supabase_realtime publication
+ * and have REPLICA IDENTITY FULL (see migration 20260512120000).
+ */
+export function useRealtimeRequests(): RealtimeRequestsResult {
+  const queryClient = useQueryClient()
+  const [status, setStatus] = useState<RealtimeStatus>('connecting')
+  const [lastEventAt, setLastEventAt] = useState<Date | null>(null)
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    const supabase = createClient()
+
+    const channel = supabase
+      .channel('db:requests')
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'requests' },
+        () => {
+          setLastEventAt(new Date())
+          // Debounce bursts: wait 800 ms after the last INSERT before refetching
+          // so a flurry of parallel LLM calls triggers one refetch, not N.
+          if (debounceTimer.current) clearTimeout(debounceTimer.current)
+          debounceTimer.current = setTimeout(() => {
+            void queryClient.invalidateQueries({ queryKey: ['stats'] })
+            void queryClient.invalidateQueries({ queryKey: ['anomalies'] })
+          }, 800)
+        },
+      )
+      .subscribe((s) => {
+        if (s === 'SUBSCRIBED') setStatus('connected')
+        else if (s === 'CLOSED' || s === 'CHANNEL_ERROR') setStatus('disconnected')
+        else setStatus('connecting')
+      })
+
+    return () => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current)
+      void supabase.removeChannel(channel)
+    }
+  }, [queryClient])
+
+  return { status, lastEventAt }
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,8 +1,12 @@
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import bundleAnalyzer from '@next/bundle-analyzer'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
+
+// Run `pnpm --filter web analyze` to emit a treemap report at .next/analyze/
+const withBundleAnalyzer = bundleAnalyzer({ enabled: process.env.ANALYZE === 'true' })
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -80,4 +84,4 @@ const nextConfig = {
   },
 }
 
-export default nextConfig
+export default withBundleAnalyzer(nextConfig)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
+    "analyze": "ANALYZE=true next build",
     "clean": "rm -rf .next"
   },
   "dependencies": {
@@ -37,6 +38,7 @@
     "tailwind-merge": "^2.5.2"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^16.2.6",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query-devtools": "^5.99.2",
     "@types/node": "^20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
         specifier: ^2.5.2
         version: 2.6.1
     devDependencies:
+      '@next/bundle-analyzer':
+        specifier: ^16.2.6
+        version: 16.2.6
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@3.4.19(tsx@4.21.0))
@@ -228,6 +231,10 @@ packages:
 
   '@clack/prompts@0.8.2':
     resolution: {integrity: sha512-6b9Ab2UiZwJYA9iMyboYyW9yJvAO9V753ZhS+DHKEjZRKAxPPOb7MXXu84lsPFG+vZt6FRFniZ8rXi+zCIw4yQ==}
+
+  '@discoveryjs/json-ext@0.5.7':
+    resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
+    engines: {node: '>=10.0.0'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -608,6 +615,9 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@next/bundle-analyzer@16.2.6':
+    resolution: {integrity: sha512-amPkVtHCTJAdBwyhhl5+qztHk24O4JlASgrWqh15AmnYi74apfZR46NGC0u4pM6BMAU1mYld4WdzD3cRBP3dOA==}
+
   '@next/env@14.2.35':
     resolution: {integrity: sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==}
 
@@ -694,6 +704,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1581,6 +1594,10 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -1794,6 +1811,10 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -1872,6 +1893,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  debounce@1.2.1:
+    resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
+
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -1938,6 +1962,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  duplexer@0.1.2:
+    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -2272,6 +2299,10 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  gzip-size@6.0.0:
+    resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
+    engines: {node: '>=10'}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -2302,6 +2333,9 @@ packages:
   hono@4.12.14:
     resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
@@ -2419,6 +2453,10 @@ packages:
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -2585,6 +2623,10 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2700,6 +2742,10 @@ packages:
         optional: true
       zod:
         optional: true
+
+  opener@1.5.2:
+    resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
+    hasBin: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3030,6 +3076,10 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sirv@2.0.4:
+    resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
+    engines: {node: '>= 10'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -3173,6 +3223,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -3339,6 +3393,11 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webpack-bundle-analyzer@4.10.1:
+    resolution: {integrity: sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==}
+    engines: {node: '>= 10.13.0'}
+    hasBin: true
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -3382,6 +3441,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@7.5.10:
+    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
@@ -3427,6 +3498,8 @@ snapshots:
       '@clack/core': 0.3.5
       picocolors: 1.1.1
       sisteransi: 1.0.5
+
+  '@discoveryjs/json-ext@0.5.7': {}
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -3679,6 +3752,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@next/bundle-analyzer@16.2.6':
+    dependencies:
+      webpack-bundle-analyzer: 4.10.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@next/env@14.2.35': {}
 
   '@next/eslint-plugin-next@14.2.35':
@@ -3730,6 +3810,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@polka/url@1.0.0-next.29': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -4553,6 +4635,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.16.0: {}
 
   agentkeepalive@4.6.0:
@@ -4789,6 +4875,8 @@ snapshots:
 
   commander@4.1.1: {}
 
+  commander@7.2.0: {}
+
   concat-map@0.0.1: {}
 
   cookie@1.1.1: {}
@@ -4861,6 +4949,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  debounce@1.2.1: {}
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -4915,6 +5005,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -5453,6 +5545,10 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  gzip-size@6.0.0:
+    dependencies:
+      duplexer: 0.1.2
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -5476,6 +5572,8 @@ snapshots:
       function-bind: 1.1.2
 
   hono@4.12.14: {}
+
+  html-escaper@2.0.2: {}
 
   humanize-ms@1.2.1:
     dependencies:
@@ -5589,6 +5687,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
+
+  is-plain-object@5.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -5747,6 +5847,8 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mrmime@2.0.1: {}
+
   ms@2.1.3: {}
 
   mz@2.7.0:
@@ -5867,6 +5969,8 @@ snapshots:
       ws: 8.20.0
     transitivePeerDependencies:
       - encoding
+
+  opener@1.5.2: {}
 
   optionator@0.9.4:
     dependencies:
@@ -6240,6 +6344,12 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sirv@2.0.4:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   sisteransi@1.0.5: {}
 
   source-map-js@1.2.1: {}
@@ -6412,6 +6522,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  totalist@3.0.1: {}
 
   tr46@0.0.3: {}
 
@@ -6622,6 +6734,25 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  webpack-bundle-analyzer@4.10.1:
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      commander: 7.2.0
+      debounce: 1.2.1
+      escape-string-regexp: 4.0.0
+      gzip-size: 6.0.0
+      html-escaper: 2.0.2
+      is-plain-object: 5.0.0
+      opener: 1.5.2
+      picocolors: 1.1.1
+      sirv: 2.0.4
+      ws: 7.5.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
@@ -6692,6 +6823,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  ws@7.5.10: {}
 
   ws@8.20.0: {}
 

--- a/supabase/migrations/20260512120000_realtime_requests.sql
+++ b/supabase/migrations/20260512120000_realtime_requests.sql
@@ -1,0 +1,6 @@
+-- Enable Supabase Realtime for the requests table.
+-- REPLICA IDENTITY FULL is required so Realtime can evaluate RLS policies
+-- on INSERT events (the new row's columns must be available for filtering).
+ALTER TABLE requests REPLICA IDENTITY FULL;
+
+ALTER PUBLICATION supabase_realtime ADD TABLE requests;


### PR DESCRIPTION
## Summary

- **Supabase Realtime WebSocket**: `requests` 테이블 변경 시 자동 쿼리 무효화 (INSERT 감지 → 800ms 디바운스 → `stats`, `anomalies` 쿼리 재요청). LIVE 배지 없이 백그라운드에서 무음 동작.
- **Suspense 스트리밍**: 대시보드/설정 페이지에서 서버 prefetch를 Critical(3개) + Deferred(7개)로 분리, 병렬 스트리밍으로 초기 렌더링 차단 제거
- **HTTP Cache-Control 헤더**: stats API 엔드포인트에 `private, max-age=10, stale-while-revalidate=30` 추가 (spend-forecast는 60/300)
- **번들 분석기**: `@next/bundle-analyzer` + `pnpm analyze` 스크립트 추가
- **DB 마이그레이션**: `requests` 테이블 `REPLICA IDENTITY FULL` + `supabase_realtime` publication 등록

## Changes

| 파일 | 변경 내용 |
|------|-----------|
| `supabase/migrations/20260512120000_realtime_requests.sql` | Realtime 활성화 마이그레이션 |
| `apps/web/lib/hooks/use-realtime-requests.ts` | WebSocket 구독 훅 (신규) |
| `apps/web/app/(dashboard)/dashboard/page.tsx` | Suspense 스트리밍 패턴 적용 |
| `apps/web/app/(dashboard)/dashboard/dashboard-client.tsx` | useRealtimeRequests 연결, refetch 2분으로 완화 |
| `apps/web/app/(dashboard)/settings/page.tsx` | Suspense 스트리밍 패턴 적용 |
| `apps/server/src/api/stats.ts` | Cache-Control 헤더 추가 |
| `apps/web/next.config.mjs` | bundle-analyzer 통합 |
| `apps/web/package.json` | analyze 스크립트 + devDependency |

## Test plan

- [ ] 대시보드 접속 후 새 LLM 요청 발생 시 stats 카드 자동 갱신 확인
- [ ] 네트워크 탭에서 `/api/v1/stats/overview` 응답에 `Cache-Control` 헤더 확인
- [ ] 대시보드/설정 페이지 초기 로드 시 Suspense fallback → 콘텐츠 순서로 렌더링 확인
- [ ] `pnpm --filter web run analyze` 실행 후 `.next/analyze/` 리포트 생성 확인
- [ ] `supabase db push` 후 requests 테이블 Realtime 활성화 확인