### PR TITLE
fix(web): align sidebar anomalies query key with RSC prefetch

### DIFF
--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -259,7 +259,7 @@ export function Sidebar() {
   const router = useRouter()
   const overview = useStatsOverview()
   const isAdmin = useIsAdmin()
-  const anomalies = useAnomalies()
+  const anomalies = useAnomalies({ observationHours: 24 })
   const alerts = useAlerts()
   const recommendations = useRecommendations()
   const { isOpen, close } = useSidebar()


### PR DESCRIPTION
## Summary

- Sidebar의 `useAnomalies()` 호출이 파라미터 없이 호출되어 쿼리 키가 `['anomalies', {}]`였음
- Dashboard RSC prefetch는 `anomaliesSpec({ observationHours: 24 })` → 키 `['anomalies', { observationHours: 24 }]`
- 키 불일치로 페이지 로드마다 캐시 미스 → 불필요한 `GET /api/v1/anomalies` 요청 발생
- Fix: sidebar에서 `{ observationHours: 24 }` 전달하여 prefetch 캐시 재사용

## Changes

| 파일 | 변경 내용 |
|------|-----------|
| `apps/web/components/layout/sidebar.tsx` | useAnomalies() 파라미터 추가 |

## Test plan

- [ ] 대시보드 로드 후 네트워크 탭에서 `/api/v1/anomalies` 중복 요청 없는지 확인