### PR TITLE
revert(web): remove Suspense streaming to fix hydration errors

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from 'react'
 import { HydrationBoundary } from '@tanstack/react-query'
 import { prefetchAll } from '@/lib/server/dehydrate'
 import { alertsSpec } from '@/lib/server/queries/alerts'
@@ -10,11 +9,10 @@ import { statsOverviewSpec, statsTimeseriesSpec, statsModelsSpec, spendForecastS
 import { anomaliesSpec } from '@/lib/server/queries/anomalies'
 import { DashboardClient } from './dashboard-client'
 
-// Below-the-fold queries — prefetched in parallel but streamed in via Suspense
-// so they don't block the initial HTML. The dashboard renders with skeletons
-// in these slots and React Query swaps in real data when the stream arrives.
-async function DeferredHydration() {
+export default async function DashboardPage() {
   const state = await prefetchAll([
+    statsOverviewSpec(),
+    statsTimeseriesSpec(),
     statsModelsSpec(),
     spendForecastSpec(),
     anomaliesSpec({ observationHours: 24 }),
@@ -22,25 +20,12 @@ async function DeferredHydration() {
     recommendationsSpec({ hours: 24 }),
     securitySummarySpec(24),
     auditLogsSpec({ limit: 6 }),
-  ])
-  return <HydrationBoundary state={state} />
-}
-
-export default async function DashboardPage() {
-  // Above-the-fold critical path — blocks initial HTML (KPI row + traffic chart
-  // + attention-card dismissal state). Kept to 3 fast queries so TTFB stays low.
-  const state = await prefetchAll([
-    statsOverviewSpec(),
-    statsTimeseriesSpec(),
     dismissalsSpec(),
   ])
 
   return (
     <HydrationBoundary state={state}>
       <DashboardClient />
-      <Suspense fallback={null}>
-        <DeferredHydration />
-      </Suspense>
     </HydrationBoundary>
   )
 }

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -11,43 +11,34 @@ import type { ApiEnvelope, Organization } from '@/lib/queries/types'
 import { SettingsClient } from './settings-client'
 import type { QuerySpec } from '@/lib/server/dehydrate'
 
-// Streamed-in queries — populate the cache after critical content has rendered.
-// Used by tabs further down the page (audit log, integrations, team).
-async function DeferredHydration({ orgId }: { orgId: string | undefined }) {
+export default async function SettingsPage() {
+  // Fetch org first to get orgId — needed to build members/invitations query keys.
+  // org is also included in the prefetchAll batch below so it lands in the
+  // dehydrated cache (double server-side fetch is intentional and cheap).
+  const orgRes = await apiGetServer<ApiEnvelope<Organization>>('/api/v1/organizations/me')
+  const orgId = orgRes.data?.id
+
   const specs: QuerySpec[] = [
+    organizationSpec(),
+    subscriptionSpec(),
+    quotaSpec(),
     auditLogsSpec({ limit: 100 }),
     webhooksSpec(),
     channelsSpec(),
   ]
+
   if (orgId) {
     specs.push(membersSpec(orgId))
     specs.push(invitationsSpec(orgId))
   }
+
   const state = await prefetchAll(specs)
-  return <HydrationBoundary state={state} />
-}
-
-export default async function SettingsPage() {
-  // Fetch org first to get orgId — needed to build members/invitations query keys.
-  // org is also included in the critical prefetch so it lands in the dehydrated cache.
-  const orgRes = await apiGetServer<ApiEnvelope<Organization>>('/api/v1/organizations/me')
-  const orgId = orgRes.data?.id
-
-  // Above-the-fold critical path: org info + plan summary on the default tab.
-  const state = await prefetchAll([
-    organizationSpec(),
-    subscriptionSpec(),
-    quotaSpec(),
-  ])
 
   return (
     <HydrationBoundary state={state}>
       {/* Suspense required because SettingsClient uses useSearchParams() */}
       <Suspense>
         <SettingsClient />
-      </Suspense>
-      <Suspense fallback={null}>
-        <DeferredHydration orgId={orgId} />
       </Suspense>
     </HydrationBoundary>
   )


### PR DESCRIPTION
## Summary

- Suspense 스트리밍(`DeferredHydration` 패턴)이 React #425/#422 hydration mismatch를 발생시켜 롤백
- TanStack Query의 deferred 데이터 주입이 Suspense boundary hydration 중에 경쟁 조건을 유발
- 단일 배치 `prefetchAll`로 복귀 (dashboard: 10개, settings: 6-8개 쿼리)
- Cache-Control 헤더(주요 성능 개선)는 유지

## Why revert?

Suspense 스트리밍의 실제 이점이 작았음:
- 모든 쿼리가 동일 DB에 병렬 실행 → 가장 느린 쿼리 시간에 맞춰짐
- 반면 hydration 에러로 React가 Suspense boundary를 클라이언트 재렌더로 포기 → 오히려 성능 악화

## Test plan

- [ ] 대시보드 콘솔에서 React #425/#422 에러 사라짐 확인
- [ ] 대시보드/설정 페이지 데이터 정상 렌더링 확인