### PR TITLE
fix(web): prevent stats refetch on mount — staleTime + stable queryKey

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
@@ -192,15 +192,8 @@ export function DashboardClient() {
     [dismissalsQuery.data],
   )
 
-  // Round `from` to the nearest minute so the query key stays stable between
-  // renders and only changes when the user switches the time range.
-  const queryDateRange = useMemo(() => {
-    const fromMs = Math.floor((Date.now() - hours * 60 * 60 * 1000) / 60_000) * 60_000
-    return { from: new Date(fromMs).toISOString() }
-  }, [hours])
-
-  const overview = useStatsOverview({ ...queryDateRange, compare: true }, { refetchInterval: LIVE_REFETCH_MS })
-  const timeseries = useStatsTimeseries(queryDateRange, { refetchInterval: LIVE_REFETCH_MS })
+  const overview = useStatsOverview({ hours, compare: true }, { refetchInterval: LIVE_REFETCH_MS })
+  const timeseries = useStatsTimeseries({ hours }, { refetchInterval: LIVE_REFETCH_MS })
   const anomalies = useAnomalies({ observationHours: hours })
   const alerts = useAlerts()
   const recommendations = useRecommendations({ hours })

--- a/apps/web/app/(dashboard)/requests/requests-client.tsx
+++ b/apps/web/app/(dashboard)/requests/requests-client.tsx
@@ -73,12 +73,8 @@ function InlineSpark({ values, w = 120, h = 18, stroke = 'var(--border-strong)' 
 
 // ── Stat strip ────────────────────────────────────────────────────────────────
 function StatStrip() {
-  const from24h = useMemo(() => {
-    const ms = Math.floor((Date.now() - 24 * 3600_000) / 60_000) * 60_000
-    return new Date(ms).toISOString()
-  }, [])
-  const overview = useStatsOverview({ from: from24h })
-  const timeseries = useStatsTimeseries({ from: from24h })
+  const overview = useStatsOverview({ hours: 24 })
+  const timeseries = useStatsTimeseries({ hours: 24 })
   const anomalies = useAnomalies()
 
   const o = overview.data

--- a/apps/web/lib/queries/use-stats.ts
+++ b/apps/web/lib/queries/use-stats.ts
@@ -4,24 +4,31 @@ import { useQuery } from '@tanstack/react-query'
 import { apiGet } from '@/lib/api'
 import type { ApiEnvelope, StatsOverview, TimeseriesPoint, SpendForecast } from './types'
 
+// Truncated to the minute — must match server-side fromIso() in lib/server/queries/stats.ts
+// so the queryKey is stable across SSR render and client hydration.
+function fromIso(hours: number): string {
+  const fromMs = Math.floor((Date.now() - hours * 60 * 60 * 1000) / 60_000) * 60_000
+  return new Date(fromMs).toISOString()
+}
+
 export const statsOverviewQueryKey = ['stats', 'overview'] as const
 
 export function useStatsOverview(
-  params?: { projectId?: string; from?: string; to?: string; compare?: boolean },
+  params?: { hours?: number; compare?: boolean },
   options?: { refetchInterval?: number },
 ) {
+  const hours = params?.hours ?? 24
+  const compare = params?.compare ?? false
   return useQuery({
-    queryKey: params ? ([...statsOverviewQueryKey, params] as const) : statsOverviewQueryKey,
+    queryKey: ['stats', 'overview', { hours, compare }] as const,
     queryFn: async () => {
-      const qs = new URLSearchParams()
-      if (params?.projectId) qs.set('projectId', params.projectId)
-      if (params?.from) qs.set('from', params.from)
-      if (params?.to) qs.set('to', params.to)
-      if (params?.compare) qs.set('compare', 'true')
-      const suffix = qs.size > 0 ? `?${qs}` : ''
-      const res = await apiGet<ApiEnvelope<StatsOverview>>(`/api/v1/stats/overview${suffix}`)
+      const from = fromIso(hours)
+      const qs = new URLSearchParams({ from })
+      if (compare) qs.set('compare', 'true')
+      const res = await apiGet<ApiEnvelope<StatsOverview>>(`/api/v1/stats/overview?${qs}`)
       return res.data
     },
+    staleTime: 60_000,
     ...(options?.refetchInterval != null ? { refetchInterval: options.refetchInterval } : {}),
   })
 }
@@ -67,27 +74,25 @@ export function useSpendForecast(projectId?: string) {
   })
 }
 
-export function statsTimeseriesQueryKey(params?: { projectId?: string; from?: string; to?: string }) {
+export function statsTimeseriesQueryKey(params?: { hours?: number }) {
   return params ? (['stats', 'timeseries', params] as const) : (['stats', 'timeseries'] as const)
 }
 
 export function useStatsTimeseries(
-  params?: { projectId?: string; from?: string; to?: string },
+  params?: { hours?: number },
   options?: { refetchInterval?: number },
 ) {
+  const hours = params?.hours ?? 24
   return useQuery({
-    queryKey: statsTimeseriesQueryKey(params),
+    queryKey: statsTimeseriesQueryKey({ hours }),
     queryFn: async () => {
-      const qs = new URLSearchParams()
-      if (params?.projectId) qs.set('projectId', params.projectId)
-      if (params?.from) qs.set('from', params.from)
-      if (params?.to) qs.set('to', params.to)
-      const suffix = qs.size > 0 ? `?${qs}` : ''
+      const from = fromIso(hours)
       const res = await apiGet<ApiEnvelope<TimeseriesPoint[]>>(
-        `/api/v1/stats/timeseries${suffix}`,
+        `/api/v1/stats/timeseries?from=${from}`,
       )
       return res.data ?? []
     },
+    staleTime: 60_000,
     ...(options?.refetchInterval != null ? { refetchInterval: options.refetchInterval } : {}),
   })
 }

--- a/apps/web/lib/server/queries/stats.ts
+++ b/apps/web/lib/server/queries/stats.ts
@@ -12,12 +12,12 @@ function fromIso(hours: number): string {
   return new Date(fromMs).toISOString()
 }
 
-// Must exactly match statsOverviewQueryKey + params shape in use-stats.ts
+// Must exactly match useStatsOverview queryKey in use-stats.ts
 export function statsOverviewSpec(hours = 24): QuerySpec {
-  const from = fromIso(hours)
   return {
-    queryKey: ['stats', 'overview', { from, compare: true }] as const,
+    queryKey: ['stats', 'overview', { hours, compare: true }] as const,
     queryFn: async () => {
+      const from = fromIso(hours)
       const qs = new URLSearchParams({ from, compare: 'true' })
       const res = await apiGetServer<ApiEnvelope<StatsOverview>>(`/api/v1/stats/overview?${qs}`)
       return res.data
@@ -27,15 +27,16 @@ export function statsOverviewSpec(hours = 24): QuerySpec {
 
 // Must exactly match statsTimeseriesQueryKey() in use-stats.ts
 export function statsTimeseriesSpec(hours = 24): QuerySpec {
-  const from = fromIso(hours)
   return {
-    queryKey: ['stats', 'timeseries', { from }] as const,
+    queryKey: ['stats', 'timeseries', { hours }] as const,
     queryFn: async () => {
+      const from = fromIso(hours)
       const res = await apiGetServer<ApiEnvelope<TimeseriesPoint[]>>(
         `/api/v1/stats/timeseries?from=${from}`,
       )
       return res.data ?? []
     },
+    staleTime: 60_000,
   }
 }
 


### PR DESCRIPTION
## Summary

- `useStatsOverview` / `useStatsTimeseries`에 `staleTime` 없음 → 마운트 즉시 재요청 (Vercel cold start 포함 5-6초)
- queryKey에 computed ISO 타임스탬프 포함 → minute 경계에서 서버/클라이언트 key 불일치 → 캐시 미스

## Fix

| 변경 | 내용 |
|------|------|
| `useStatsOverview` | `staleTime: 60_000` 추가 |
| `useStatsTimeseries` | `staleTime: 60_000` 추가 |
| 두 훅의 queryKey | `{ from: ISO }` → `{ hours: number }` (stable) |
| 서버 스펙 queryKey | 동일하게 `{ hours }` 로 통일 |
| `dashboard-client.tsx` | `queryDateRange` useMemo 제거 |
| `requests-client.tsx` | `from24h` useMemo 제거 |

## Test plan

- [ ] 대시보드 첫 진입 시 Network 탭에서 `stats/timeseries` 두 번 요청 안 뜨는지 확인
- [ ] 차트 데이터가 즉시 표시되는지 확인 (SSR 캐시 사용)
- [ ] 1분 이후 재진입 시 정상 refetch 확인