### PR TITLE
feat: Evals · Datasets · Experiments · Annotation 신규 탭 + SDK 0.2.7

### DIFF
--- a/apps/server/src/api/datasets.ts
+++ b/apps/server/src/api/datasets.ts
@@ -1,0 +1,286 @@
+import { Hono } from 'hono'
+import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { supabaseAdmin } from '../lib/db.js'
+
+export const datasetsRouter = new Hono<JwtContext>()
+
+datasetsRouter.use('*', authJwt)
+
+// ── Datasets ────────────────────────────────────────────────────────────────
+
+// POST /api/v1/datasets — create
+datasetsRouter.post('/', async (c) => {
+  const orgId = c.get('orgId')
+  const userId = c.get('userId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  let body: { name?: unknown; description?: unknown }
+  try {
+    body = (await c.req.json()) as typeof body
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400)
+  }
+
+  const name = typeof body.name === 'string' ? body.name.trim() : ''
+  const description = typeof body.description === 'string' ? body.description.trim() : null
+  if (!name) return c.json({ error: 'name is required' }, 400)
+
+  const { data, error } = await supabaseAdmin
+    .from('datasets')
+    .insert({
+      organization_id: orgId,
+      name,
+      description,
+      created_by: userId ?? null,
+    })
+    .select()
+    .single()
+
+  if (error || !data) {
+    if (error?.code === '23505') {
+      return c.json({ error: 'A dataset with this name already exists' }, 409)
+    }
+    return c.json({ error: error?.message ?? 'Failed to create dataset' }, 500)
+  }
+  return c.json({ success: true, data }, 201)
+})
+
+// GET /api/v1/datasets — list (with item counts)
+datasetsRouter.get('/', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const { data: datasets, error } = await supabaseAdmin
+    .from('datasets')
+    .select('*')
+    .eq('organization_id', orgId)
+    .is('archived_at', null)
+    .order('created_at', { ascending: false })
+
+  if (error) return c.json({ error: error.message }, 500)
+
+  const datasetIds = (datasets ?? []).map((d) => d.id)
+  if (datasetIds.length === 0) {
+    return c.json({ success: true, data: [] })
+  }
+
+  // Count items per dataset (single round trip)
+  const { data: counts } = await supabaseAdmin
+    .from('dataset_items')
+    .select('dataset_id')
+    .in('dataset_id', datasetIds)
+
+  const countMap = new Map<string, number>()
+  for (const row of counts ?? []) {
+    countMap.set(row.dataset_id, (countMap.get(row.dataset_id) ?? 0) + 1)
+  }
+
+  const enriched = (datasets ?? []).map((d) => ({
+    ...d,
+    item_count: countMap.get(d.id) ?? 0,
+  }))
+
+  return c.json({ success: true, data: enriched })
+})
+
+// GET /api/v1/datasets/:id — single dataset + items
+datasetsRouter.get('/:id', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const id = c.req.param('id')
+
+  const { data: dataset, error: dsErr } = await supabaseAdmin
+    .from('datasets')
+    .select('*')
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .is('archived_at', null)
+    .maybeSingle()
+
+  if (dsErr || !dataset) return c.json({ error: 'Dataset not found' }, 404)
+
+  const { data: items, error: itemsErr } = await supabaseAdmin
+    .from('dataset_items')
+    .select('*')
+    .eq('dataset_id', id)
+    .order('created_at', { ascending: false })
+
+  if (itemsErr) return c.json({ error: itemsErr.message }, 500)
+
+  return c.json({ success: true, data: { ...dataset, items: items ?? [] } })
+})
+
+// DELETE /api/v1/datasets/:id — soft delete (archive)
+datasetsRouter.delete('/:id', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const id = c.req.param('id')
+  const { error } = await supabaseAdmin
+    .from('datasets')
+    .update({ archived_at: new Date().toISOString() })
+    .eq('id', id)
+    .eq('organization_id', orgId)
+
+  if (error) return c.json({ error: error.message }, 500)
+  return c.json({ success: true })
+})
+
+// ── Dataset items ──────────────────────────────────────────────────────────
+
+// POST /api/v1/datasets/:id/items — add a single item
+datasetsRouter.post('/:id/items', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const datasetId = c.req.param('id')
+
+  // Verify ownership
+  const { data: ds } = await supabaseAdmin
+    .from('datasets')
+    .select('id')
+    .eq('id', datasetId)
+    .eq('organization_id', orgId)
+    .is('archived_at', null)
+    .maybeSingle()
+  if (!ds) return c.json({ error: 'Dataset not found' }, 404)
+
+  let body: { input?: unknown; expectedOutput?: unknown; sourceRequestId?: unknown }
+  try {
+    body = (await c.req.json()) as typeof body
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400)
+  }
+
+  if (!body.input || typeof body.input !== 'object' || Array.isArray(body.input)) {
+    return c.json({ error: 'input must be an object' }, 400)
+  }
+  const input = body.input as Record<string, unknown>
+  // Accept shapes: { variables: {...} } or { messages: [...] }
+  const hasVars = input.variables && typeof input.variables === 'object'
+  const hasMsgs = Array.isArray(input.messages)
+  if (!hasVars && !hasMsgs) {
+    return c.json({ error: 'input must contain "variables" object or "messages" array' }, 400)
+  }
+
+  const expectedOutput = typeof body.expectedOutput === 'string' ? body.expectedOutput : null
+  const sourceRequestId = typeof body.sourceRequestId === 'string' ? body.sourceRequestId : null
+
+  const { data, error } = await supabaseAdmin
+    .from('dataset_items')
+    .insert({
+      organization_id: orgId,
+      dataset_id: datasetId,
+      input: input as Record<string, unknown>,
+      expected_output: expectedOutput,
+      source_request_id: sourceRequestId,
+    })
+    .select()
+    .single()
+
+  if (error || !data) return c.json({ error: error?.message ?? 'Failed to add item' }, 500)
+  return c.json({ success: true, data }, 201)
+})
+
+// POST /api/v1/datasets/:id/items/import-requests — bulk import from production
+datasetsRouter.post('/:id/items/import-requests', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const datasetId = c.req.param('id')
+
+  const { data: ds } = await supabaseAdmin
+    .from('datasets')
+    .select('id')
+    .eq('id', datasetId)
+    .eq('organization_id', orgId)
+    .is('archived_at', null)
+    .maybeSingle()
+  if (!ds) return c.json({ error: 'Dataset not found' }, 404)
+
+  let body: { requestIds?: unknown }
+  try {
+    body = (await c.req.json()) as typeof body
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400)
+  }
+
+  if (!Array.isArray(body.requestIds) || body.requestIds.length === 0) {
+    return c.json({ error: 'requestIds (array) is required' }, 400)
+  }
+  const ids = body.requestIds.filter((x): x is string => typeof x === 'string').slice(0, 200)
+  if (ids.length === 0) return c.json({ error: 'No valid request IDs' }, 400)
+
+  // Fetch source requests
+  const { data: requests, error: reqErr } = await supabaseAdmin
+    .from('requests')
+    .select('id, request_body, response_body')
+    .in('id', ids)
+    .eq('organization_id', orgId)
+
+  if (reqErr) return c.json({ error: reqErr.message }, 500)
+  if (!requests || requests.length === 0) {
+    return c.json({ error: 'No matching requests found' }, 404)
+  }
+
+  // Build dataset_items rows. We try to extract the user message + final response.
+  const rows = requests.map((r) => {
+    const reqBody = r.request_body as Record<string, unknown> | null
+    const messages = Array.isArray(reqBody?.messages) ? reqBody.messages : null
+    const input = messages
+      ? { messages }
+      : { variables: {} }
+
+    const responseBody = r.response_body as Record<string, unknown> | null
+    let expectedOutput: string | null = null
+    if (responseBody) {
+      // OpenAI shape
+      const choices = responseBody.choices as Array<Record<string, unknown>> | undefined
+      if (Array.isArray(choices) && choices[0]) {
+        const msg = choices[0].message as Record<string, unknown> | undefined
+        if (typeof msg?.content === 'string') expectedOutput = msg.content
+      }
+      // Anthropic shape
+      if (!expectedOutput) {
+        const content = responseBody.content as Array<Record<string, unknown>> | undefined
+        if (Array.isArray(content)) {
+          const textBlock = content.find((b) => b.type === 'text')
+          if (textBlock && typeof textBlock.text === 'string') expectedOutput = textBlock.text
+        }
+      }
+    }
+
+    return {
+      organization_id: orgId,
+      dataset_id: datasetId,
+      input,
+      expected_output: expectedOutput,
+      source_request_id: r.id,
+    }
+  })
+
+  const { data, error } = await supabaseAdmin
+    .from('dataset_items')
+    .insert(rows)
+    .select()
+
+  if (error) return c.json({ error: error.message }, 500)
+  return c.json({ success: true, data: { imported: data?.length ?? 0 } }, 201)
+})
+
+// DELETE /api/v1/datasets/:id/items/:itemId
+datasetsRouter.delete('/:id/items/:itemId', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const itemId = c.req.param('itemId')
+  const { error } = await supabaseAdmin
+    .from('dataset_items')
+    .delete()
+    .eq('id', itemId)
+    .eq('organization_id', orgId)
+
+  if (error) return c.json({ error: error.message }, 500)
+  return c.json({ success: true })
+})

--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -131,6 +131,8 @@ evalsRouter.post('/eval-runs', async (c) => {
   let body: {
     evaluatorId?: unknown
     promptVersionId?: unknown
+    source?: unknown
+    datasetId?: unknown
     sampleSize?: unknown
     sampleFrom?: unknown
     sampleTo?: unknown
@@ -143,6 +145,8 @@ evalsRouter.post('/eval-runs', async (c) => {
 
   const evaluatorId = typeof body.evaluatorId === 'string' ? body.evaluatorId.trim() : ''
   const promptVersionId = typeof body.promptVersionId === 'string' ? body.promptVersionId.trim() : ''
+  const source = body.source === 'dataset' ? 'dataset' : 'production'
+  const datasetId = typeof body.datasetId === 'string' ? body.datasetId.trim() : null
   const sampleSize = typeof body.sampleSize === 'number' ? Math.round(body.sampleSize) : 50
   const sampleFrom = typeof body.sampleFrom === 'string' ? body.sampleFrom : null
   const sampleTo = typeof body.sampleTo === 'string' ? body.sampleTo : null
@@ -151,6 +155,9 @@ evalsRouter.post('/eval-runs', async (c) => {
   if (!promptVersionId) return c.json({ error: 'promptVersionId is required' }, 400)
   if (sampleSize < 1 || sampleSize > 1000) {
     return c.json({ error: 'sampleSize must be between 1 and 1000' }, 400)
+  }
+  if (source === 'dataset' && !datasetId) {
+    return c.json({ error: 'datasetId is required when source = dataset' }, 400)
   }
 
   // Verify both belong to org
@@ -171,16 +178,29 @@ evalsRouter.post('/eval-runs', async (c) => {
     .maybeSingle()
   if (!pv) return c.json({ error: 'Prompt version not found' }, 404)
 
+  // Verify dataset belongs to org if requested
+  if (source === 'dataset' && datasetId) {
+    const { data: ds } = await supabaseAdmin
+      .from('datasets')
+      .select('id')
+      .eq('id', datasetId)
+      .eq('organization_id', orgId)
+      .is('archived_at', null)
+      .maybeSingle()
+    if (!ds) return c.json({ error: 'Dataset not found' }, 404)
+  }
+
   const { data: run, error: runErr } = await supabaseAdmin
     .from('eval_runs')
     .insert({
       organization_id: orgId,
       evaluator_id: evaluatorId,
       prompt_version_id: promptVersionId,
-      source: 'production',
+      source,
+      dataset_id: source === 'dataset' ? datasetId : null,
       sample_size: sampleSize,
-      sample_from: sampleFrom,
-      sample_to: sampleTo,
+      sample_from: source === 'production' ? sampleFrom : null,
+      sample_to: source === 'production' ? sampleTo : null,
       status: 'pending',
       created_by: userId ?? null,
     })
@@ -197,6 +217,8 @@ evalsRouter.post('/eval-runs', async (c) => {
     organizationId: orgId,
     evaluatorId,
     promptVersionId,
+    source,
+    datasetId,
     sampleSize,
     sampleFrom,
     sampleTo,

--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -1,0 +1,286 @@
+import { Hono } from 'hono'
+import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { supabaseAdmin } from '../lib/db.js'
+import { runEvalRun, estimateJudgeCostUsd } from '../lib/eval-runner.js'
+import { fireAndForget } from '../lib/wait-until.js'
+
+export const evalsRouter = new Hono<JwtContext>()
+
+evalsRouter.use('*', authJwt)
+
+// ── Evaluators (定義) ────────────────────────────────────────────────────────
+
+// POST /api/v1/evaluators — create a reusable evaluator
+evalsRouter.post('/evaluators', async (c) => {
+  const orgId = c.get('orgId')
+  const userId = c.get('userId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  let body: {
+    promptName?: unknown
+    name?: unknown
+    type?: unknown
+    config?: unknown
+  }
+  try {
+    body = (await c.req.json()) as typeof body
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400)
+  }
+
+  const promptName = typeof body.promptName === 'string' ? body.promptName.trim() : ''
+  const name = typeof body.name === 'string' ? body.name.trim() : ''
+  const type = typeof body.type === 'string' ? body.type.trim() : 'llm_judge'
+
+  if (!promptName) return c.json({ error: 'promptName is required' }, 400)
+  if (!name) return c.json({ error: 'name is required' }, 400)
+  if (type !== 'llm_judge') return c.json({ error: 'Unsupported evaluator type' }, 400)
+
+  if (!body.config || typeof body.config !== 'object' || Array.isArray(body.config)) {
+    return c.json({ error: 'config object is required' }, 400)
+  }
+  const config = body.config as Record<string, unknown>
+
+  const criterion = typeof config.criterion === 'string' ? config.criterion.trim() : ''
+  const judgeProvider = typeof config.judge_provider === 'string' ? config.judge_provider : ''
+  const judgeModel = typeof config.judge_model === 'string' ? config.judge_model.trim() : ''
+  const scaleMin = typeof config.scale_min === 'number' ? config.scale_min : 0
+  const scaleMax = typeof config.scale_max === 'number' ? config.scale_max : 1
+
+  if (!criterion) return c.json({ error: 'config.criterion is required' }, 400)
+  if (judgeProvider !== 'openai' && judgeProvider !== 'anthropic') {
+    return c.json({ error: 'config.judge_provider must be "openai" or "anthropic"' }, 400)
+  }
+  if (!judgeModel) return c.json({ error: 'config.judge_model is required' }, 400)
+  if (!(scaleMax > scaleMin)) {
+    return c.json({ error: 'config.scale_max must be greater than scale_min' }, 400)
+  }
+
+  // Verify prompt exists for this org
+  const { count: promptCount } = await supabaseAdmin
+    .from('prompt_versions')
+    .select('id', { count: 'exact', head: true })
+    .eq('organization_id', orgId)
+    .eq('name', promptName)
+  if (!promptCount) return c.json({ error: 'Prompt not found' }, 404)
+
+  const { data, error } = await supabaseAdmin
+    .from('evaluators')
+    .insert({
+      organization_id: orgId,
+      prompt_name: promptName,
+      name,
+      type,
+      config: { criterion, judge_provider: judgeProvider, judge_model: judgeModel, scale_min: scaleMin, scale_max: scaleMax },
+      created_by: userId ?? null,
+    })
+    .select()
+    .single()
+
+  if (error || !data) {
+    return c.json({ error: error?.message ?? 'Failed to create evaluator' }, 500)
+  }
+  return c.json({ success: true, data }, 201)
+})
+
+// GET /api/v1/evaluators?promptName=...
+evalsRouter.get('/evaluators', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const promptName = c.req.query('promptName')
+
+  let query = supabaseAdmin
+    .from('evaluators')
+    .select('*')
+    .eq('organization_id', orgId)
+    .is('archived_at', null)
+    .order('created_at', { ascending: false })
+
+  if (promptName) query = query.eq('prompt_name', promptName)
+
+  const { data, error } = await query
+  if (error) return c.json({ error: error.message }, 500)
+  return c.json({ success: true, data: data ?? [] })
+})
+
+// DELETE /api/v1/evaluators/:id — soft delete (archive)
+evalsRouter.delete('/evaluators/:id', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const id = c.req.param('id')
+  const { error } = await supabaseAdmin
+    .from('evaluators')
+    .update({ archived_at: new Date().toISOString() })
+    .eq('id', id)
+    .eq('organization_id', orgId)
+
+  if (error) return c.json({ error: error.message }, 500)
+  return c.json({ success: true })
+})
+
+// ── Eval runs (실행) ─────────────────────────────────────────────────────────
+
+// POST /api/v1/eval-runs — kick off a run (returns immediately, run executes in background)
+evalsRouter.post('/eval-runs', async (c) => {
+  const orgId = c.get('orgId')
+  const userId = c.get('userId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  let body: {
+    evaluatorId?: unknown
+    promptVersionId?: unknown
+    sampleSize?: unknown
+    sampleFrom?: unknown
+    sampleTo?: unknown
+  }
+  try {
+    body = (await c.req.json()) as typeof body
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400)
+  }
+
+  const evaluatorId = typeof body.evaluatorId === 'string' ? body.evaluatorId.trim() : ''
+  const promptVersionId = typeof body.promptVersionId === 'string' ? body.promptVersionId.trim() : ''
+  const sampleSize = typeof body.sampleSize === 'number' ? Math.round(body.sampleSize) : 50
+  const sampleFrom = typeof body.sampleFrom === 'string' ? body.sampleFrom : null
+  const sampleTo = typeof body.sampleTo === 'string' ? body.sampleTo : null
+
+  if (!evaluatorId) return c.json({ error: 'evaluatorId is required' }, 400)
+  if (!promptVersionId) return c.json({ error: 'promptVersionId is required' }, 400)
+  if (sampleSize < 1 || sampleSize > 1000) {
+    return c.json({ error: 'sampleSize must be between 1 and 1000' }, 400)
+  }
+
+  // Verify both belong to org
+  const { data: evaluator } = await supabaseAdmin
+    .from('evaluators')
+    .select('id')
+    .eq('id', evaluatorId)
+    .eq('organization_id', orgId)
+    .is('archived_at', null)
+    .maybeSingle()
+  if (!evaluator) return c.json({ error: 'Evaluator not found' }, 404)
+
+  const { data: pv } = await supabaseAdmin
+    .from('prompt_versions')
+    .select('id')
+    .eq('id', promptVersionId)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (!pv) return c.json({ error: 'Prompt version not found' }, 404)
+
+  const { data: run, error: runErr } = await supabaseAdmin
+    .from('eval_runs')
+    .insert({
+      organization_id: orgId,
+      evaluator_id: evaluatorId,
+      prompt_version_id: promptVersionId,
+      source: 'production',
+      sample_size: sampleSize,
+      sample_from: sampleFrom,
+      sample_to: sampleTo,
+      status: 'pending',
+      created_by: userId ?? null,
+    })
+    .select()
+    .single()
+
+  if (runErr || !run) {
+    return c.json({ error: runErr?.message ?? 'Failed to create run' }, 500)
+  }
+
+  // Kick off the worker in background. The HTTP caller polls GET /eval-runs/:id.
+  fireAndForget(c, runEvalRun({
+    evalRunId: run.id,
+    organizationId: orgId,
+    evaluatorId,
+    promptVersionId,
+    sampleSize,
+    sampleFrom,
+    sampleTo,
+  }))
+
+  return c.json({ success: true, data: run }, 202)
+})
+
+// GET /api/v1/eval-runs?evaluatorId=...&promptVersionId=...
+evalsRouter.get('/eval-runs', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const evaluatorId = c.req.query('evaluatorId')
+  const promptVersionId = c.req.query('promptVersionId')
+
+  let query = supabaseAdmin
+    .from('eval_runs')
+    .select('*')
+    .eq('organization_id', orgId)
+    .order('started_at', { ascending: false })
+    .limit(50)
+
+  if (evaluatorId) query = query.eq('evaluator_id', evaluatorId)
+  if (promptVersionId) query = query.eq('prompt_version_id', promptVersionId)
+
+  const { data, error } = await query
+  if (error) return c.json({ error: error.message }, 500)
+  return c.json({ success: true, data: data ?? [] })
+})
+
+// GET /api/v1/eval-runs/:id
+evalsRouter.get('/eval-runs/:id', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const id = c.req.param('id')
+  const { data, error } = await supabaseAdmin
+    .from('eval_runs')
+    .select('*, evaluators(name, config)')
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+
+  if (error || !data) return c.json({ error: 'Eval run not found' }, 404)
+  return c.json({ success: true, data })
+})
+
+// GET /api/v1/eval-runs/:id/results
+evalsRouter.get('/eval-runs/:id/results', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const runId = c.req.param('id')
+
+  // Verify run belongs to org first (extra safety on top of RLS)
+  const { data: run } = await supabaseAdmin
+    .from('eval_runs')
+    .select('id')
+    .eq('id', runId)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (!run) return c.json({ error: 'Eval run not found' }, 404)
+
+  const { data, error } = await supabaseAdmin
+    .from('eval_results')
+    .select('*')
+    .eq('eval_run_id', runId)
+    .order('score', { ascending: true })
+
+  if (error) return c.json({ error: error.message }, 500)
+  return c.json({ success: true, data: data ?? [] })
+})
+
+// POST /api/v1/eval-runs/estimate — cost estimate for a planned run
+evalsRouter.post('/eval-runs/estimate', async (c) => {
+  let body: { sampleSize?: unknown; judgeModel?: unknown }
+  try {
+    body = (await c.req.json()) as typeof body
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400)
+  }
+  const sampleSize = typeof body.sampleSize === 'number' ? Math.round(body.sampleSize) : 50
+  const judgeModel = typeof body.judgeModel === 'string' ? body.judgeModel : 'gpt-4o-mini'
+  const estimateUsd = estimateJudgeCostUsd(sampleSize, judgeModel)
+  return c.json({ success: true, data: { estimateUsd } })
+})

--- a/apps/server/src/api/experiments.ts
+++ b/apps/server/src/api/experiments.ts
@@ -1,0 +1,178 @@
+import { Hono } from 'hono'
+import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { supabaseAdmin } from '../lib/db.js'
+import { runExperiment } from '../lib/experiment-runner.js'
+import { fireAndForget } from '../lib/wait-until.js'
+
+export const experimentsRouter = new Hono<JwtContext>()
+
+experimentsRouter.use('*', authJwt)
+
+// POST /api/v1/experiments — create + kick off
+experimentsRouter.post('/', async (c) => {
+  const orgId = c.get('orgId')
+  const userId = c.get('userId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  let body: {
+    name?: unknown
+    promptName?: unknown
+    versionAId?: unknown
+    versionBId?: unknown
+    datasetId?: unknown
+    evaluatorId?: unknown
+    runProvider?: unknown
+    runModel?: unknown
+  }
+  try {
+    body = (await c.req.json()) as typeof body
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400)
+  }
+
+  const name = typeof body.name === 'string' ? body.name.trim() : ''
+  const promptName = typeof body.promptName === 'string' ? body.promptName.trim() : ''
+  const versionAId = typeof body.versionAId === 'string' ? body.versionAId.trim() : ''
+  const versionBId = typeof body.versionBId === 'string' ? body.versionBId.trim() : ''
+  const datasetId = typeof body.datasetId === 'string' ? body.datasetId.trim() : ''
+  const evaluatorId = typeof body.evaluatorId === 'string' && body.evaluatorId.trim()
+    ? body.evaluatorId.trim() : null
+  const runProvider = body.runProvider === 'anthropic' ? 'anthropic' : 'openai'
+  const runModel = typeof body.runModel === 'string' ? body.runModel.trim() : ''
+
+  if (!name) return c.json({ error: 'name is required' }, 400)
+  if (!promptName) return c.json({ error: 'promptName is required' }, 400)
+  if (!versionAId || !versionBId) return c.json({ error: 'versionAId and versionBId are required' }, 400)
+  if (versionAId === versionBId) return c.json({ error: 'versionA and versionB must differ' }, 400)
+  if (!datasetId) return c.json({ error: 'datasetId is required' }, 400)
+  if (!runModel) return c.json({ error: 'runModel is required' }, 400)
+
+  // Verify ownership
+  const { data: versions } = await supabaseAdmin
+    .from('prompt_versions')
+    .select('id')
+    .eq('organization_id', orgId)
+    .in('id', [versionAId, versionBId])
+  if (!versions || versions.length !== 2) {
+    return c.json({ error: 'Prompt versions not found' }, 404)
+  }
+
+  const { data: dataset } = await supabaseAdmin
+    .from('datasets')
+    .select('id')
+    .eq('id', datasetId)
+    .eq('organization_id', orgId)
+    .is('archived_at', null)
+    .maybeSingle()
+  if (!dataset) return c.json({ error: 'Dataset not found' }, 404)
+
+  if (evaluatorId) {
+    const { data: ev } = await supabaseAdmin
+      .from('evaluators')
+      .select('id')
+      .eq('id', evaluatorId)
+      .eq('organization_id', orgId)
+      .is('archived_at', null)
+      .maybeSingle()
+    if (!ev) return c.json({ error: 'Evaluator not found' }, 404)
+  }
+
+  const { data: exp, error: expErr } = await supabaseAdmin
+    .from('experiments')
+    .insert({
+      organization_id: orgId,
+      name,
+      prompt_name: promptName,
+      version_a_id: versionAId,
+      version_b_id: versionBId,
+      dataset_id: datasetId,
+      evaluator_id: evaluatorId,
+      run_provider: runProvider,
+      run_model: runModel,
+      status: 'pending',
+      created_by: userId ?? null,
+    })
+    .select()
+    .single()
+
+  if (expErr || !exp) {
+    return c.json({ error: expErr?.message ?? 'Failed to create experiment' }, 500)
+  }
+
+  fireAndForget(c, runExperiment({
+    experimentId: exp.id,
+    organizationId: orgId,
+    versionAId,
+    versionBId,
+    datasetId,
+    evaluatorId,
+    runProvider,
+    runModel,
+  }))
+
+  return c.json({ success: true, data: exp }, 202)
+})
+
+// GET /api/v1/experiments?promptName=...
+experimentsRouter.get('/', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const promptName = c.req.query('promptName')
+
+  let query = supabaseAdmin
+    .from('experiments')
+    .select('*')
+    .eq('organization_id', orgId)
+    .order('started_at', { ascending: false })
+    .limit(50)
+
+  if (promptName) query = query.eq('prompt_name', promptName)
+
+  const { data, error } = await query
+  if (error) return c.json({ error: error.message }, 500)
+  return c.json({ success: true, data: data ?? [] })
+})
+
+// GET /api/v1/experiments/:id
+experimentsRouter.get('/:id', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const id = c.req.param('id')
+  const { data, error } = await supabaseAdmin
+    .from('experiments')
+    .select('*')
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+
+  if (error || !data) return c.json({ error: 'Experiment not found' }, 404)
+  return c.json({ success: true, data })
+})
+
+// GET /api/v1/experiments/:id/results
+experimentsRouter.get('/:id/results', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const id = c.req.param('id')
+
+  // Verify ownership
+  const { data: exp } = await supabaseAdmin
+    .from('experiments')
+    .select('id')
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (!exp) return c.json({ error: 'Experiment not found' }, 404)
+
+  const { data, error } = await supabaseAdmin
+    .from('experiment_results')
+    .select('*, dataset_items(input, expected_output)')
+    .eq('experiment_id', id)
+    .order('created_at', { ascending: true })
+
+  if (error) return c.json({ error: error.message }, 500)
+  return c.json({ success: true, data: data ?? [] })
+})

--- a/apps/server/src/api/human-evals.ts
+++ b/apps/server/src/api/human-evals.ts
@@ -1,0 +1,288 @@
+import { Hono } from 'hono'
+import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { supabaseAdmin } from '../lib/db.js'
+
+export const humanEvalsRouter = new Hono<JwtContext>()
+
+humanEvalsRouter.use('*', authJwt)
+
+// ── Annotation queue ─────────────────────────────────────────────────────────
+
+// GET /api/v1/annotation/queue
+//   ?promptName=...           filter by prompt
+//   &promptVersionId=...      filter by specific version
+//   &unscoredOnly=true        only show requests not yet scored by current user
+//   &lowJudgeScoreOnly=true   only show requests with eval_results.score < 0.5
+//   &limit=50                 default 50, max 200
+// Mounted at /api/v1 — full paths are /api/v1/annotation/queue, /api/v1/human-evals[/:id|/correlation]
+humanEvalsRouter.get('/annotation/queue', async (c) => {
+  const orgId = c.get('orgId')
+  const userId = c.get('userId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const promptName = c.req.query('promptName')
+  const promptVersionId = c.req.query('promptVersionId')
+  const unscoredOnly = c.req.query('unscoredOnly') === 'true'
+  const lowJudgeScoreOnly = c.req.query('lowJudgeScoreOnly') === 'true'
+  const limit = Math.min(200, Math.max(1, parseInt(c.req.query('limit') ?? '50', 10)))
+
+  // Build query: scope to requests that have a prompt_version_id (i.e. were
+  // tagged with a prompt) and a response_body (otherwise there's nothing to
+  // score). We fetch prompt_versions metadata in a separate query below
+  // (avoids supabase-js's brittle inline-join type inference).
+  let query = supabaseAdmin
+    .from('requests')
+    .select('id, prompt_version_id, model, created_at, request_body, response_body')
+    .eq('organization_id', orgId)
+    .not('prompt_version_id', 'is', null)
+    .not('response_body', 'is', null)
+    .order('created_at', { ascending: false })
+    .limit(limit)
+
+  if (promptVersionId) query = query.eq('prompt_version_id', promptVersionId)
+
+  if (promptName) {
+    const { data: versions } = await supabaseAdmin
+      .from('prompt_versions')
+      .select('id')
+      .eq('organization_id', orgId)
+      .eq('name', promptName)
+    const vids = (versions ?? []).map((v) => v.id)
+    if (vids.length === 0) return c.json({ success: true, data: [] })
+    query = query.in('prompt_version_id', vids)
+  }
+
+  const { data: requests, error } = await query
+  if (error) return c.json({ error: error.message }, 500)
+  if (!requests || requests.length === 0) {
+    return c.json({ success: true, data: [] })
+  }
+
+  const requestIds = requests.map((r) => r.id)
+  const versionIds = [...new Set(requests.map((r) => r.prompt_version_id).filter((v): v is string => !!v))]
+
+  // Fetch prompt version metadata (name + version number)
+  const pvMap = new Map<string, { name: string; version: number }>()
+  if (versionIds.length > 0) {
+    const { data: pvs } = await supabaseAdmin
+      .from('prompt_versions')
+      .select('id, name, version')
+      .in('id', versionIds)
+    for (const pv of pvs ?? []) {
+      pvMap.set(pv.id, { name: pv.name, version: pv.version })
+    }
+  }
+
+  // Existing human scores by this user (to mark/filter "already scored")
+  const { data: existingHuman } = await supabaseAdmin
+    .from('human_evals')
+    .select('request_id, score, raw_score, comment')
+    .in('request_id', requestIds)
+    .eq('reviewer_id', userId ?? '')
+
+  const humanMap = new Map<string, { score: number; raw_score: number | null; comment: string | null }>()
+  for (const h of existingHuman ?? []) {
+    humanMap.set(h.request_id as string, {
+      score: h.score,
+      raw_score: h.raw_score,
+      comment: h.comment,
+    })
+  }
+
+  // Most recent LLM judge score per request (for context + lowJudgeScoreOnly filter)
+  const { data: evalResults } = await supabaseAdmin
+    .from('eval_results')
+    .select('request_id, score, created_at')
+    .in('request_id', requestIds)
+    .order('created_at', { ascending: false })
+
+  const judgeMap = new Map<string, number>()
+  for (const e of evalResults ?? []) {
+    if (e.request_id && !judgeMap.has(e.request_id)) {
+      judgeMap.set(e.request_id, e.score)
+    }
+  }
+
+  let enriched = requests.map((r) => {
+    const pv = r.prompt_version_id ? pvMap.get(r.prompt_version_id) : null
+    return {
+      id: r.id,
+      prompt_version_id: r.prompt_version_id,
+      prompt_name: pv?.name ?? null,
+      prompt_version: pv?.version ?? null,
+      model: r.model,
+      created_at: r.created_at,
+      request_body: r.request_body,
+      response_body: r.response_body,
+      llm_judge_score: judgeMap.get(r.id) ?? null,
+      human_eval: humanMap.get(r.id) ?? null,
+    }
+  })
+
+  if (unscoredOnly) {
+    enriched = enriched.filter((r) => r.human_eval === null)
+  }
+  if (lowJudgeScoreOnly) {
+    enriched = enriched.filter((r) => r.llm_judge_score != null && r.llm_judge_score < 0.5)
+  }
+
+  return c.json({ success: true, data: enriched })
+})
+
+// ── Human evals CRUD ────────────────────────────────────────────────────────
+
+// POST /api/v1/human-evals — upsert (request_id, reviewer_id) score
+humanEvalsRouter.post('/human-evals', async (c) => {
+  const orgId = c.get('orgId')
+  const userId = c.get('userId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!userId) return c.json({ error: 'User not authenticated' }, 401)
+
+  let body: { requestId?: unknown; score?: unknown; rawScore?: unknown; comment?: unknown }
+  try {
+    body = (await c.req.json()) as typeof body
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400)
+  }
+
+  const requestId = typeof body.requestId === 'string' ? body.requestId.trim() : ''
+  const score = typeof body.score === 'number' ? body.score : NaN
+  const rawScore = typeof body.rawScore === 'number' ? body.rawScore : null
+  const comment = typeof body.comment === 'string' ? body.comment.trim() || null : null
+
+  if (!requestId) return c.json({ error: 'requestId is required' }, 400)
+  if (!Number.isFinite(score) || score < 0 || score > 1) {
+    return c.json({ error: 'score must be a number between 0 and 1' }, 400)
+  }
+
+  // Look up prompt_version_id for denormalized filter
+  const { data: req } = await supabaseAdmin
+    .from('requests')
+    .select('id, prompt_version_id')
+    .eq('id', requestId)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (!req) return c.json({ error: 'Request not found' }, 404)
+
+  const { data, error } = await supabaseAdmin
+    .from('human_evals')
+    .upsert(
+      {
+        organization_id: orgId,
+        request_id: requestId,
+        prompt_version_id: req.prompt_version_id,
+        reviewer_id: userId,
+        score,
+        raw_score: rawScore,
+        comment,
+      },
+      { onConflict: 'request_id,reviewer_id' },
+    )
+    .select()
+    .single()
+
+  if (error || !data) {
+    return c.json({ error: error?.message ?? 'Failed to save score' }, 500)
+  }
+  return c.json({ success: true, data })
+})
+
+// GET /api/v1/human-evals?promptVersionId=...
+humanEvalsRouter.get('/human-evals', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const promptVersionId = c.req.query('promptVersionId')
+  let query = supabaseAdmin
+    .from('human_evals')
+    .select('*')
+    .eq('organization_id', orgId)
+    .order('created_at', { ascending: false })
+    .limit(200)
+
+  if (promptVersionId) query = query.eq('prompt_version_id', promptVersionId)
+
+  const { data, error } = await query
+  if (error) return c.json({ error: error.message }, 500)
+  return c.json({ success: true, data: data ?? [] })
+})
+
+// DELETE /api/v1/human-evals/:id
+humanEvalsRouter.delete('/human-evals/:id', async (c) => {
+  const orgId = c.get('orgId')
+  const userId = c.get('userId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!userId) return c.json({ error: 'User not authenticated' }, 401)
+
+  const id = c.req.param('id')
+  const { error } = await supabaseAdmin
+    .from('human_evals')
+    .delete()
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .eq('reviewer_id', userId)
+
+  if (error) return c.json({ error: error.message }, 500)
+  return c.json({ success: true })
+})
+
+// GET /api/v1/human-evals/correlation?promptName=...&promptVersionId=...
+// Returns per-request pairs (judge_score, human_score) for the matching scope.
+// Client computes Pearson r. Server just provides paired data.
+humanEvalsRouter.get('/human-evals/correlation', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const promptName = c.req.query('promptName')
+  const promptVersionId = c.req.query('promptVersionId')
+
+  // Resolve scope to prompt_version_ids
+  let versionIds: string[] = []
+  if (promptVersionId) {
+    versionIds = [promptVersionId]
+  } else if (promptName) {
+    const { data: versions } = await supabaseAdmin
+      .from('prompt_versions')
+      .select('id')
+      .eq('organization_id', orgId)
+      .eq('name', promptName)
+    versionIds = (versions ?? []).map((v) => v.id)
+  }
+  if (versionIds.length === 0) return c.json({ success: true, data: [] })
+
+  // Pull human evals for those versions
+  const { data: humans } = await supabaseAdmin
+    .from('human_evals')
+    .select('request_id, score')
+    .in('prompt_version_id', versionIds)
+  const humanMap = new Map<string, number>()
+  for (const h of humans ?? []) {
+    if (h.request_id) humanMap.set(h.request_id, h.score)
+  }
+  if (humanMap.size === 0) return c.json({ success: true, data: [] })
+
+  // Most recent judge score per request
+  const reqIds = [...humanMap.keys()]
+  const { data: evalResults } = await supabaseAdmin
+    .from('eval_results')
+    .select('request_id, score, created_at')
+    .in('request_id', reqIds)
+    .order('created_at', { ascending: false })
+
+  const judgeMap = new Map<string, number>()
+  for (const e of evalResults ?? []) {
+    if (e.request_id && !judgeMap.has(e.request_id)) {
+      judgeMap.set(e.request_id, e.score)
+    }
+  }
+
+  const pairs: Array<{ requestId: string; judgeScore: number; humanScore: number }> = []
+  for (const [requestId, humanScore] of humanMap.entries()) {
+    const judgeScore = judgeMap.get(requestId)
+    if (judgeScore != null) {
+      pairs.push({ requestId, judgeScore, humanScore })
+    }
+  }
+
+  return c.json({ success: true, data: pairs })
+})

--- a/apps/server/src/api/requests.ts
+++ b/apps/server/src/api/requests.ts
@@ -29,6 +29,8 @@ requestsRouter.get('/', async (c) => {
   // Optional new filter: provider_key_id ("show only requests that used this key")
   const providerKeyId    = c.req.query('providerKeyId')
   const promptVersionId  = c.req.query('promptVersionId')
+  const userIdFilter     = c.req.query('userId')
+  const sessionIdFilter  = c.req.query('sessionId')
   const status     = c.req.query('status')   // 'ok' | '4xx' | '5xx'
   const sortByRaw  = c.req.query('sortBy')   // 'latency_ms' | 'cost_usd' | 'total_tokens' | 'created_at'
   const sortDirRaw = c.req.query('sortDir')  // 'asc' | 'desc'
@@ -43,7 +45,7 @@ requestsRouter.get('/', async (c) => {
   let query = supabaseAdmin
     .from('requests')
     .select(
-      'id, project_id, provider, model, prompt_tokens, completion_tokens, total_tokens, cost_usd, latency_ms, status_code, error_message, trace_id, span_id, provider_key_id, provider_keys ( name ), created_at',
+      'id, project_id, provider, model, prompt_tokens, completion_tokens, total_tokens, cost_usd, latency_ms, status_code, error_message, trace_id, span_id, provider_key_id, user_id, session_id, provider_keys ( name ), created_at',
       { count: 'exact' },
     )
     .eq('organization_id', orgId)
@@ -55,6 +57,8 @@ requestsRouter.get('/', async (c) => {
   if (model)         query = query.ilike('model', `%${model}%`)
   if (providerKeyId)   query = query.eq('provider_key_id', providerKeyId)
   if (promptVersionId) query = query.eq('prompt_version_id', promptVersionId)
+  if (userIdFilter)    query = query.eq('user_id', userIdFilter)
+  if (sessionIdFilter) query = query.eq('session_id', sessionIdFilter)
   if (from)            query = query.gte('created_at', from)
   if (to)            query = query.lte('created_at', to)
   if (status === 'ok')   query = query.lt('status_code', 400)

--- a/apps/server/src/api/requests.ts
+++ b/apps/server/src/api/requests.ts
@@ -27,7 +27,8 @@ requestsRouter.get('/', async (c) => {
   const offset     = (page - 1) * limit
 
   // Optional new filter: provider_key_id ("show only requests that used this key")
-  const providerKeyId = c.req.query('providerKeyId')
+  const providerKeyId    = c.req.query('providerKeyId')
+  const promptVersionId  = c.req.query('promptVersionId')
   const status     = c.req.query('status')   // 'ok' | '4xx' | '5xx'
   const sortByRaw  = c.req.query('sortBy')   // 'latency_ms' | 'cost_usd' | 'total_tokens' | 'created_at'
   const sortDirRaw = c.req.query('sortDir')  // 'asc' | 'desc'
@@ -52,8 +53,9 @@ requestsRouter.get('/', async (c) => {
   if (projectId)     query = query.eq('project_id', projectId)
   if (provider)      query = query.eq('provider', provider)
   if (model)         query = query.ilike('model', `%${model}%`)
-  if (providerKeyId) query = query.eq('provider_key_id', providerKeyId)
-  if (from)          query = query.gte('created_at', from)
+  if (providerKeyId)   query = query.eq('provider_key_id', providerKeyId)
+  if (promptVersionId) query = query.eq('prompt_version_id', promptVersionId)
+  if (from)            query = query.gte('created_at', from)
   if (to)            query = query.lte('created_at', to)
   if (status === 'ok')   query = query.lt('status_code', 400)
   else if (status === '4xx') query = query.gte('status_code', 400).lt('status_code', 500)

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -27,6 +27,7 @@ import { promptsPlaygroundRouter } from './api/prompts-playground.js'
 import { promptExperimentsRouter } from './api/prompt-experiments.js'
 import { evalsRouter } from './api/evals.js'
 import { datasetsRouter } from './api/datasets.js'
+import { experimentsRouter } from './api/experiments.js'
 import { recommendationsRouter } from './api/recommendations.js'
 import { auditLogsRouter }     from './api/auditLogs.js'
 import { membersRouter }       from './api/members.js'
@@ -111,6 +112,7 @@ app.route('/api/v1/prompts',        promptsRouter)
 app.route('/api/v1/prompt-experiments', promptExperimentsRouter)
 app.route('/api/v1',                evalsRouter)
 app.route('/api/v1/datasets',       datasetsRouter)
+app.route('/api/v1/experiments',    experimentsRouter)
 app.route('/api/v1/recommendations', recommendationsRouter)
 app.route('/api/v1/audit-logs',     auditLogsRouter)
 app.route('/api/v1/organizations/:orgId/members', membersRouter)

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -28,6 +28,7 @@ import { promptExperimentsRouter } from './api/prompt-experiments.js'
 import { evalsRouter } from './api/evals.js'
 import { datasetsRouter } from './api/datasets.js'
 import { experimentsRouter } from './api/experiments.js'
+import { humanEvalsRouter } from './api/human-evals.js'
 import { recommendationsRouter } from './api/recommendations.js'
 import { auditLogsRouter }     from './api/auditLogs.js'
 import { membersRouter }       from './api/members.js'
@@ -113,6 +114,7 @@ app.route('/api/v1/prompt-experiments', promptExperimentsRouter)
 app.route('/api/v1',                evalsRouter)
 app.route('/api/v1/datasets',       datasetsRouter)
 app.route('/api/v1/experiments',    experimentsRouter)
+app.route('/api/v1',                humanEvalsRouter)
 app.route('/api/v1/recommendations', recommendationsRouter)
 app.route('/api/v1/audit-logs',     auditLogsRouter)
 app.route('/api/v1/organizations/:orgId/members', membersRouter)

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -26,6 +26,7 @@ import { promptsRouter }       from './api/prompts.js'
 import { promptsPlaygroundRouter } from './api/prompts-playground.js'
 import { promptExperimentsRouter } from './api/prompt-experiments.js'
 import { evalsRouter } from './api/evals.js'
+import { datasetsRouter } from './api/datasets.js'
 import { recommendationsRouter } from './api/recommendations.js'
 import { auditLogsRouter }     from './api/auditLogs.js'
 import { membersRouter }       from './api/members.js'
@@ -109,6 +110,7 @@ app.route('/api/v1/prompts/playground', promptsPlaygroundRouter)
 app.route('/api/v1/prompts',        promptsRouter)
 app.route('/api/v1/prompt-experiments', promptExperimentsRouter)
 app.route('/api/v1',                evalsRouter)
+app.route('/api/v1/datasets',       datasetsRouter)
 app.route('/api/v1/recommendations', recommendationsRouter)
 app.route('/api/v1/audit-logs',     auditLogsRouter)
 app.route('/api/v1/organizations/:orgId/members', membersRouter)

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -25,6 +25,7 @@ import { securityRouter }      from './api/security.js'
 import { promptsRouter }       from './api/prompts.js'
 import { promptsPlaygroundRouter } from './api/prompts-playground.js'
 import { promptExperimentsRouter } from './api/prompt-experiments.js'
+import { evalsRouter } from './api/evals.js'
 import { recommendationsRouter } from './api/recommendations.js'
 import { auditLogsRouter }     from './api/auditLogs.js'
 import { membersRouter }       from './api/members.js'
@@ -107,6 +108,7 @@ app.route('/api/v1/security',       securityRouter)
 app.route('/api/v1/prompts/playground', promptsPlaygroundRouter)
 app.route('/api/v1/prompts',        promptsRouter)
 app.route('/api/v1/prompt-experiments', promptExperimentsRouter)
+app.route('/api/v1',                evalsRouter)
 app.route('/api/v1/recommendations', recommendationsRouter)
 app.route('/api/v1/audit-logs',     auditLogsRouter)
 app.route('/api/v1/organizations/:orgId/members', membersRouter)

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -1,0 +1,381 @@
+/**
+ * LLM-as-judge evaluation runner.
+ *
+ * Executes an eval_run by:
+ *   1. Fetching the evaluator + prompt_version
+ *   2. Sampling N requests from production for that prompt_version
+ *   3. Calling the judge LLM (using the user's provider key) on each sample
+ *   4. Persisting per-sample scores + aggregate
+ *
+ * Concurrency: processes samples in a small concurrency window (default 5)
+ * to avoid burning rate limits while keeping latency reasonable.
+ */
+
+import { supabaseAdmin } from './db.js'
+import { aes256Decrypt } from './crypto.js'
+import { calculateCost } from './cost.js'
+
+const JUDGE_CONCURRENCY = 5
+const MAX_RESPONSE_CHARS = 4000 // truncate long responses fed to judge
+
+interface JudgeConfig {
+  criterion: string
+  judge_provider: 'openai' | 'anthropic'
+  judge_model: string
+  scale_min: number
+  scale_max: number
+}
+
+interface JudgeOutcome {
+  score: number          // normalized to 0..1
+  reasoning: string
+  cost: number
+  tokens: number
+}
+
+/** Extracts the assistant response text from a stored response_body. */
+function extractResponseText(body: unknown): string | null {
+  if (!body || typeof body !== 'object') return null
+  const obj = body as Record<string, unknown>
+
+  // OpenAI chat completion
+  const choices = obj.choices as Array<Record<string, unknown>> | undefined
+  if (Array.isArray(choices) && choices[0]) {
+    const msg = choices[0].message as Record<string, unknown> | undefined
+    const content = typeof msg?.content === 'string' ? msg.content : null
+    if (content) return content
+  }
+
+  // Anthropic messages
+  const content = obj.content as Array<Record<string, unknown>> | undefined
+  if (Array.isArray(content)) {
+    const textBlock = content.find((b) => b.type === 'text')
+    if (textBlock && typeof textBlock.text === 'string') return textBlock.text
+  }
+
+  // Gemini
+  const candidates = obj.candidates as Array<Record<string, unknown>> | undefined
+  if (Array.isArray(candidates) && candidates[0]) {
+    const candidate = candidates[0]
+    const cContent = candidate.content as Record<string, unknown> | undefined
+    const parts = cContent?.parts as Array<Record<string, unknown>> | undefined
+    if (Array.isArray(parts) && parts[0] && typeof parts[0].text === 'string') {
+      return parts[0].text
+    }
+  }
+
+  return null
+}
+
+/** Builds the judge prompt asking it to score `responseText` against `criterion`. */
+function buildJudgePrompt(criterion: string, responseText: string, scaleMin: number, scaleMax: number): string {
+  const truncated = responseText.length > MAX_RESPONSE_CHARS
+    ? responseText.slice(0, MAX_RESPONSE_CHARS) + '… [truncated]'
+    : responseText
+
+  return `You are an evaluator. Score the assistant response below against this criterion.
+
+Criterion: ${criterion}
+
+Response to evaluate:
+"""
+${truncated}
+"""
+
+Reply ONLY in JSON with this exact shape:
+{"score": <number between ${scaleMin} and ${scaleMax}>, "reasoning": "<one short sentence>"}
+
+No prose outside the JSON. No markdown fences.`
+}
+
+/** Parses the judge's JSON reply, tolerating common formatting drift. */
+function parseJudgeReply(text: string, scaleMin: number, scaleMax: number): { score: number; reasoning: string } | null {
+  // Strip markdown fences if present
+  let cleaned = text.trim()
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/, '').trim()
+  }
+
+  try {
+    const parsed = JSON.parse(cleaned) as { score?: unknown; reasoning?: unknown }
+    const rawScore = typeof parsed.score === 'number' ? parsed.score : Number(parsed.score)
+    if (!Number.isFinite(rawScore)) return null
+    const clamped = Math.max(scaleMin, Math.min(scaleMax, rawScore))
+    const reasoning = typeof parsed.reasoning === 'string' ? parsed.reasoning.trim() : ''
+    return { score: clamped, reasoning }
+  } catch {
+    return null
+  }
+}
+
+/** Calls the judge LLM once. Returns null on failure (caller skips the sample). */
+async function callJudge(
+  config: JudgeConfig,
+  responseText: string,
+  apiKey: string,
+): Promise<JudgeOutcome | null> {
+  const prompt = buildJudgePrompt(config.criterion, responseText, config.scale_min, config.scale_max)
+
+  if (config.judge_provider === 'openai') {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: config.judge_model,
+        messages: [{ role: 'user', content: prompt }],
+        temperature: 0,
+        max_tokens: 200,
+        response_format: { type: 'json_object' },
+      }),
+    })
+    if (!res.ok) return null
+    const json = await res.json() as {
+      choices: Array<{ message: { content: string } }>
+      usage: { prompt_tokens: number; completion_tokens: number }
+      model: string
+    }
+    const text = json.choices?.[0]?.message?.content ?? ''
+    const parsed = parseJudgeReply(text, config.scale_min, config.scale_max)
+    if (!parsed) return null
+    const tokens = (json.usage?.prompt_tokens ?? 0) + (json.usage?.completion_tokens ?? 0)
+    const cost = calculateCost('openai', json.model ?? config.judge_model, {
+      promptTokens: json.usage?.prompt_tokens ?? 0,
+      completionTokens: json.usage?.completion_tokens ?? 0,
+    })?.totalCost ?? 0
+    // Normalize to 0..1
+    const range = config.scale_max - config.scale_min || 1
+    return {
+      score: (parsed.score - config.scale_min) / range,
+      reasoning: parsed.reasoning,
+      cost,
+      tokens,
+    }
+  }
+
+  // Anthropic
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: config.judge_model,
+      max_tokens: 200,
+      temperature: 0,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  })
+  if (!res.ok) return null
+  const json = await res.json() as {
+    content: Array<{ type: string; text: string }>
+    usage: { input_tokens: number; output_tokens: number }
+    model: string
+  }
+  const text = json.content?.find((b) => b.type === 'text')?.text ?? ''
+  const parsed = parseJudgeReply(text, config.scale_min, config.scale_max)
+  if (!parsed) return null
+  const tokens = (json.usage?.input_tokens ?? 0) + (json.usage?.output_tokens ?? 0)
+  const cost = calculateCost('anthropic', json.model ?? config.judge_model, {
+    promptTokens: json.usage?.input_tokens ?? 0,
+    completionTokens: json.usage?.output_tokens ?? 0,
+  })?.totalCost ?? 0
+  const range = config.scale_max - config.scale_min || 1
+  return {
+    score: (parsed.score - config.scale_min) / range,
+    reasoning: parsed.reasoning,
+    cost,
+    tokens,
+  }
+}
+
+/** Runs a small async pool with concurrency cap. */
+async function pool<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let next = 0
+  async function run(): Promise<void> {
+    for (;;) {
+      const idx = next++
+      if (idx >= items.length) return
+      results[idx] = await worker(items[idx]!)
+    }
+  }
+  const runners = Array.from({ length: Math.min(concurrency, items.length) }, () => run())
+  await Promise.all(runners)
+  return results
+}
+
+interface RunInput {
+  evalRunId: string
+  organizationId: string
+  evaluatorId: string
+  promptVersionId: string
+  sampleSize: number
+  sampleFrom?: string | null
+  sampleTo?: string | null
+}
+
+/**
+ * Main entry point. Executes the eval_run end-to-end and updates DB rows.
+ * Designed to be invoked via `fireAndForget(c, runEvalRun(...))` so the HTTP
+ * caller gets an immediate 202 while work continues in the background.
+ */
+export async function runEvalRun(input: RunInput): Promise<void> {
+  const { evalRunId, organizationId, evaluatorId, promptVersionId, sampleSize, sampleFrom, sampleTo } = input
+
+  // Mark running
+  await supabaseAdmin
+    .from('eval_runs')
+    .update({ status: 'running' })
+    .eq('id', evalRunId)
+
+  try {
+    // Load evaluator config
+    const { data: evaluator, error: evErr } = await supabaseAdmin
+      .from('evaluators')
+      .select('id, config')
+      .eq('id', evaluatorId)
+      .eq('organization_id', organizationId)
+      .maybeSingle()
+
+    if (evErr || !evaluator) {
+      throw new Error('Evaluator not found')
+    }
+
+    const config = evaluator.config as unknown as JudgeConfig
+    if (!config?.criterion || !config?.judge_provider || !config?.judge_model) {
+      throw new Error('Evaluator config missing required fields (criterion / judge_provider / judge_model)')
+    }
+
+    // Find an active provider key matching the judge provider
+    const { data: pkRow, error: pkErr } = await supabaseAdmin
+      .from('provider_keys')
+      .select('id, provider, encrypted_key')
+      .eq('organization_id', organizationId)
+      .eq('provider', config.judge_provider)
+      .eq('is_active', true)
+      .limit(1)
+      .maybeSingle()
+
+    if (pkErr || !pkRow) {
+      throw new Error(`No active ${config.judge_provider} provider key found for judge`)
+    }
+
+    const judgeKey = await aes256Decrypt(pkRow.encrypted_key as string)
+    if (!judgeKey) throw new Error('Failed to decrypt judge provider key')
+
+    // Sample requests for this prompt version
+    let query = supabaseAdmin
+      .from('requests')
+      .select('id, response_body')
+      .eq('organization_id', organizationId)
+      .eq('prompt_version_id', promptVersionId)
+      .not('response_body', 'is', null)
+      .order('created_at', { ascending: false })
+      .limit(sampleSize)
+
+    if (sampleFrom) query = query.gte('created_at', sampleFrom)
+    if (sampleTo) query = query.lte('created_at', sampleTo)
+
+    const { data: samples, error: sampleErr } = await query
+    if (sampleErr) throw new Error(`Sample fetch failed: ${sampleErr.message}`)
+
+    if (!samples || samples.length === 0) {
+      await supabaseAdmin
+        .from('eval_runs')
+        .update({
+          status: 'completed',
+          scored_count: 0,
+          avg_score: null,
+          completed_at: new Date().toISOString(),
+        })
+        .eq('id', evalRunId)
+      return
+    }
+
+    // Score each sample with the judge LLM
+    const outcomes = await pool(samples, JUDGE_CONCURRENCY, async (sample) => {
+      const responseText = extractResponseText(sample.response_body)
+      if (!responseText) return null
+      try {
+        const outcome = await callJudge(config, responseText, judgeKey)
+        if (!outcome) return null
+        return { requestId: sample.id as string, ...outcome }
+      } catch {
+        return null
+      }
+    })
+
+    const scored = outcomes.filter((o): o is NonNullable<typeof o> => o !== null)
+
+    if (scored.length === 0) {
+      await supabaseAdmin
+        .from('eval_runs')
+        .update({
+          status: 'failed',
+          error: 'All judge calls failed. Check judge model name and provider key.',
+          completed_at: new Date().toISOString(),
+        })
+        .eq('id', evalRunId)
+      return
+    }
+
+    // Persist per-sample results
+    const resultRows = scored.map((s) => ({
+      organization_id: organizationId,
+      eval_run_id: evalRunId,
+      request_id: s.requestId,
+      score: s.score,
+      reasoning: s.reasoning,
+      judge_cost_usd: s.cost,
+      judge_tokens: s.tokens,
+    }))
+
+    const { error: insertErr } = await supabaseAdmin
+      .from('eval_results')
+      .insert(resultRows)
+
+    if (insertErr) throw new Error(`Result insert failed: ${insertErr.message}`)
+
+    const totalCost = scored.reduce((sum, s) => sum + s.cost, 0)
+    const avgScore = scored.reduce((sum, s) => sum + s.score, 0) / scored.length
+
+    await supabaseAdmin
+      .from('eval_runs')
+      .update({
+        status: 'completed',
+        scored_count: scored.length,
+        avg_score: avgScore,
+        total_cost_usd: totalCost,
+        completed_at: new Date().toISOString(),
+      })
+      .eq('id', evalRunId)
+  } catch (err) {
+    await supabaseAdmin
+      .from('eval_runs')
+      .update({
+        status: 'failed',
+        error: err instanceof Error ? err.message : 'Unknown error',
+        completed_at: new Date().toISOString(),
+      })
+      .eq('id', evalRunId)
+  }
+}
+
+/** Convenience: estimate judge cost before running (rough heuristic). */
+export function estimateJudgeCostUsd(sampleSize: number, judgeModel: string): number {
+  // Conservative: assume ~800 input + 100 output tokens per sample
+  const inputTokens = sampleSize * 800
+  const outputTokens = sampleSize * 100
+  const provider = judgeModel.startsWith('gpt-') ? 'openai' : 'anthropic'
+  const cost = calculateCost(provider, judgeModel, { promptTokens: inputTokens, completionTokens: outputTokens })
+  return cost?.totalCost ?? 0
+}

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -218,9 +218,18 @@ interface RunInput {
   organizationId: string
   evaluatorId: string
   promptVersionId: string
+  source: 'production' | 'dataset'
+  /** Required when source = 'dataset' */
+  datasetId?: string | null
   sampleSize: number
   sampleFrom?: string | null
   sampleTo?: string | null
+}
+
+/** Result of one sample's scoring, shared between production and dataset paths. */
+interface SampleOutcome extends JudgeOutcome {
+  requestId: string | null
+  datasetItemId: string | null
 }
 
 /**
@@ -229,7 +238,7 @@ interface RunInput {
  * caller gets an immediate 202 while work continues in the background.
  */
 export async function runEvalRun(input: RunInput): Promise<void> {
-  const { evalRunId, organizationId, evaluatorId, promptVersionId, sampleSize, sampleFrom, sampleTo } = input
+  const { evalRunId, organizationId, evaluatorId, promptVersionId, source, datasetId, sampleSize, sampleFrom, sampleTo } = input
 
   // Mark running
   await supabaseAdmin
@@ -272,29 +281,71 @@ export async function runEvalRun(input: RunInput): Promise<void> {
     const judgeKey = await aes256Decrypt(pkRow.encrypted_key as string)
     if (!judgeKey) throw new Error('Failed to decrypt judge provider key')
 
-    // Sample requests for this prompt version
-    let query = supabaseAdmin
-      .from('requests')
-      .select('id, response_body')
-      .eq('organization_id', organizationId)
-      .eq('prompt_version_id', promptVersionId)
-      .not('response_body', 'is', null)
-      .order('created_at', { ascending: false })
-      .limit(sampleSize)
+    // ── Gather samples (production requests OR dataset items) ──────────────
+    type SampleRow = {
+      responseText: string
+      requestId: string | null
+      datasetItemId: string | null
+    }
+    let preparedSamples: SampleRow[] = []
 
-    if (sampleFrom) query = query.gte('created_at', sampleFrom)
-    if (sampleTo) query = query.lte('created_at', sampleTo)
+    if (source === 'production') {
+      let query = supabaseAdmin
+        .from('requests')
+        .select('id, response_body')
+        .eq('organization_id', organizationId)
+        .eq('prompt_version_id', promptVersionId)
+        .not('response_body', 'is', null)
+        .order('created_at', { ascending: false })
+        .limit(sampleSize)
 
-    const { data: samples, error: sampleErr } = await query
-    if (sampleErr) throw new Error(`Sample fetch failed: ${sampleErr.message}`)
+      if (sampleFrom) query = query.gte('created_at', sampleFrom)
+      if (sampleTo) query = query.lte('created_at', sampleTo)
 
-    if (!samples || samples.length === 0) {
+      const { data: samples, error: sampleErr } = await query
+      if (sampleErr) throw new Error(`Sample fetch failed: ${sampleErr.message}`)
+
+      preparedSamples = (samples ?? [])
+        .map((s) => ({
+          responseText: extractResponseText(s.response_body) ?? '',
+          requestId: s.id as string,
+          datasetItemId: null,
+        }))
+        .filter((s) => s.responseText.length > 0)
+    } else {
+      // source === 'dataset'
+      if (!datasetId) throw new Error('datasetId is required when source = dataset')
+
+      const { data: items, error: itemsErr } = await supabaseAdmin
+        .from('dataset_items')
+        .select('id, expected_output')
+        .eq('dataset_id', datasetId)
+        .eq('organization_id', organizationId)
+        .not('expected_output', 'is', null)
+        .order('created_at', { ascending: false })
+        .limit(sampleSize)
+
+      if (itemsErr) throw new Error(`Dataset items fetch failed: ${itemsErr.message}`)
+
+      preparedSamples = (items ?? [])
+        .filter((i) => typeof i.expected_output === 'string' && i.expected_output.length > 0)
+        .map((i) => ({
+          responseText: i.expected_output as string,
+          requestId: null,
+          datasetItemId: i.id as string,
+        }))
+    }
+
+    if (preparedSamples.length === 0) {
       await supabaseAdmin
         .from('eval_runs')
         .update({
           status: 'completed',
           scored_count: 0,
           avg_score: null,
+          error: source === 'dataset'
+            ? 'Dataset has no items with expected_output. Add items first.'
+            : null,
           completed_at: new Date().toISOString(),
         })
         .eq('id', evalRunId)
@@ -302,19 +353,21 @@ export async function runEvalRun(input: RunInput): Promise<void> {
     }
 
     // Score each sample with the judge LLM
-    const outcomes = await pool(samples, JUDGE_CONCURRENCY, async (sample) => {
-      const responseText = extractResponseText(sample.response_body)
-      if (!responseText) return null
+    const outcomes = await pool(preparedSamples, JUDGE_CONCURRENCY, async (sample): Promise<SampleOutcome | null> => {
       try {
-        const outcome = await callJudge(config, responseText, judgeKey)
+        const outcome = await callJudge(config, sample.responseText, judgeKey)
         if (!outcome) return null
-        return { requestId: sample.id as string, ...outcome }
+        return {
+          requestId: sample.requestId,
+          datasetItemId: sample.datasetItemId,
+          ...outcome,
+        }
       } catch {
         return null
       }
     })
 
-    const scored = outcomes.filter((o): o is NonNullable<typeof o> => o !== null)
+    const scored = outcomes.filter((o): o is SampleOutcome => o !== null)
 
     if (scored.length === 0) {
       await supabaseAdmin
@@ -333,6 +386,7 @@ export async function runEvalRun(input: RunInput): Promise<void> {
       organization_id: organizationId,
       eval_run_id: evalRunId,
       request_id: s.requestId,
+      dataset_item_id: s.datasetItemId,
       score: s.score,
       reasoning: s.reasoning,
       judge_cost_usd: s.cost,

--- a/apps/server/src/lib/experiment-runner.ts
+++ b/apps/server/src/lib/experiment-runner.ts
@@ -1,0 +1,501 @@
+/**
+ * Experiment runner — offline side-by-side comparison of two prompt versions.
+ *
+ * For each dataset item:
+ *   1. Interpolate item.input.variables into prompt content (both versions)
+ *   2. Run BOTH versions through the configured run_model
+ *   3. Optionally judge each output with the evaluator
+ *   4. Persist outputs + scores per item
+ *
+ * Concurrency: items processed in a small pool. Within each item, the two arms
+ * run in parallel.
+ */
+
+import { supabaseAdmin } from './db.js'
+import { aes256Decrypt } from './crypto.js'
+import { calculateCost } from './cost.js'
+import { interpolate } from './playground-runner.js'
+
+const ITEM_CONCURRENCY = 3
+const MAX_TOKENS = 1024
+const TEMPERATURE = 0.7
+
+// JudgeConfig kept in sync with eval-runner.ts. Inlined to avoid circular imports.
+interface JudgeConfig {
+  criterion: string
+  judge_provider: 'openai' | 'anthropic'
+  judge_model: string
+  scale_min: number
+  scale_max: number
+}
+
+interface RunResult {
+  output: string
+  cost: number
+  latencyMs: number
+  tokens: number
+}
+
+interface JudgeResult {
+  score: number
+  reasoning: string
+  cost: number
+  tokens: number
+}
+
+interface DatasetItemRow {
+  id: string
+  input: { variables?: Record<string, string>; messages?: Array<{ role: string; content: string }> }
+}
+
+interface PromptVersionRow {
+  id: string
+  content: string
+}
+
+// ── Prompt execution ────────────────────────────────────────────────────────
+
+async function runPrompt(
+  content: string,
+  item: DatasetItemRow,
+  provider: 'openai' | 'anthropic',
+  model: string,
+  apiKey: string,
+): Promise<RunResult | { error: string }> {
+  // Build the user content for the LLM call.
+  // If item has messages, the last user message is interpolated against the prompt content.
+  // If item has variables, interpolate the prompt content directly.
+  let userContent: string
+  if (item.input.variables) {
+    const { result } = interpolate(content, item.input.variables)
+    userContent = result
+  } else if (item.input.messages && item.input.messages.length > 0) {
+    const lastUser = [...item.input.messages].reverse().find((m) => m.role === 'user')
+    userContent = lastUser?.content ?? ''
+    if (!userContent) return { error: 'Item has no user message' }
+  } else {
+    return { error: 'Item input has neither variables nor messages' }
+  }
+
+  const startMs = Date.now()
+  try {
+    if (provider === 'openai') {
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model,
+          messages: [{ role: 'system', content }, { role: 'user', content: userContent }],
+          temperature: TEMPERATURE,
+          max_tokens: MAX_TOKENS,
+        }),
+      })
+      const latencyMs = Date.now() - startMs
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        return { error: `OpenAI error (${res.status}): ${text.slice(0, 200)}` }
+      }
+      const json = await res.json() as {
+        choices: Array<{ message: { content: string } }>
+        usage: { prompt_tokens: number; completion_tokens: number }
+        model: string
+      }
+      const output = json.choices?.[0]?.message?.content ?? ''
+      const promptTokens = json.usage?.prompt_tokens ?? 0
+      const completionTokens = json.usage?.completion_tokens ?? 0
+      const cost = calculateCost('openai', json.model ?? model, { promptTokens, completionTokens })?.totalCost ?? 0
+      return { output, cost, latencyMs, tokens: promptTokens + completionTokens }
+    }
+
+    // Anthropic
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: MAX_TOKENS,
+        temperature: TEMPERATURE,
+        system: content,
+        messages: [{ role: 'user', content: userContent }],
+      }),
+    })
+    const latencyMs = Date.now() - startMs
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      return { error: `Anthropic error (${res.status}): ${text.slice(0, 200)}` }
+    }
+    const json = await res.json() as {
+      content: Array<{ type: string; text: string }>
+      usage: { input_tokens: number; output_tokens: number }
+      model: string
+    }
+    const output = json.content?.find((b) => b.type === 'text')?.text ?? ''
+    const promptTokens = json.usage?.input_tokens ?? 0
+    const completionTokens = json.usage?.output_tokens ?? 0
+    const cost = calculateCost('anthropic', json.model ?? model, { promptTokens, completionTokens })?.totalCost ?? 0
+    return { output, cost, latencyMs, tokens: promptTokens + completionTokens }
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'Unknown error' }
+  }
+}
+
+// ── Judge (subset of eval-runner.callJudge — local copy to avoid coupling) ──
+
+function buildJudgePrompt(criterion: string, responseText: string, scaleMin: number, scaleMax: number): string {
+  const truncated = responseText.length > 4000
+    ? responseText.slice(0, 4000) + '… [truncated]'
+    : responseText
+  return `You are an evaluator. Score the assistant response below against this criterion.
+
+Criterion: ${criterion}
+
+Response to evaluate:
+"""
+${truncated}
+"""
+
+Reply ONLY in JSON with this exact shape:
+{"score": <number between ${scaleMin} and ${scaleMax}>, "reasoning": "<one short sentence>"}
+
+No prose outside the JSON. No markdown fences.`
+}
+
+function parseJudgeReply(text: string, scaleMin: number, scaleMax: number): { score: number; reasoning: string } | null {
+  let cleaned = text.trim()
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/, '').trim()
+  }
+  try {
+    const parsed = JSON.parse(cleaned) as { score?: unknown; reasoning?: unknown }
+    const rawScore = typeof parsed.score === 'number' ? parsed.score : Number(parsed.score)
+    if (!Number.isFinite(rawScore)) return null
+    const clamped = Math.max(scaleMin, Math.min(scaleMax, rawScore))
+    const reasoning = typeof parsed.reasoning === 'string' ? parsed.reasoning.trim() : ''
+    return { score: clamped, reasoning }
+  } catch {
+    return null
+  }
+}
+
+async function callJudge(
+  config: JudgeConfig,
+  responseText: string,
+  apiKey: string,
+): Promise<JudgeResult | null> {
+  const prompt = buildJudgePrompt(config.criterion, responseText, config.scale_min, config.scale_max)
+  if (config.judge_provider === 'openai') {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        model: config.judge_model,
+        messages: [{ role: 'user', content: prompt }],
+        temperature: 0,
+        max_tokens: 200,
+        response_format: { type: 'json_object' },
+      }),
+    })
+    if (!res.ok) return null
+    const json = await res.json() as {
+      choices: Array<{ message: { content: string } }>
+      usage: { prompt_tokens: number; completion_tokens: number }
+      model: string
+    }
+    const text = json.choices?.[0]?.message?.content ?? ''
+    const parsed = parseJudgeReply(text, config.scale_min, config.scale_max)
+    if (!parsed) return null
+    const tokens = (json.usage?.prompt_tokens ?? 0) + (json.usage?.completion_tokens ?? 0)
+    const cost = calculateCost('openai', json.model ?? config.judge_model, {
+      promptTokens: json.usage?.prompt_tokens ?? 0,
+      completionTokens: json.usage?.completion_tokens ?? 0,
+    })?.totalCost ?? 0
+    const range = config.scale_max - config.scale_min || 1
+    return {
+      score: (parsed.score - config.scale_min) / range,
+      reasoning: parsed.reasoning,
+      cost,
+      tokens,
+    }
+  }
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: config.judge_model,
+      max_tokens: 200,
+      temperature: 0,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  })
+  if (!res.ok) return null
+  const json = await res.json() as {
+    content: Array<{ type: string; text: string }>
+    usage: { input_tokens: number; output_tokens: number }
+    model: string
+  }
+  const text = json.content?.find((b) => b.type === 'text')?.text ?? ''
+  const parsed = parseJudgeReply(text, config.scale_min, config.scale_max)
+  if (!parsed) return null
+  const tokens = (json.usage?.input_tokens ?? 0) + (json.usage?.output_tokens ?? 0)
+  const cost = calculateCost('anthropic', json.model ?? config.judge_model, {
+    promptTokens: json.usage?.input_tokens ?? 0,
+    completionTokens: json.usage?.output_tokens ?? 0,
+  })?.totalCost ?? 0
+  const range = config.scale_max - config.scale_min || 1
+  return {
+    score: (parsed.score - config.scale_min) / range,
+    reasoning: parsed.reasoning,
+    cost,
+    tokens,
+  }
+}
+
+// ── Concurrency pool ────────────────────────────────────────────────────────
+
+async function pool<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let next = 0
+  async function run(): Promise<void> {
+    for (;;) {
+      const idx = next++
+      if (idx >= items.length) return
+      results[idx] = await worker(items[idx]!)
+    }
+  }
+  const runners = Array.from({ length: Math.min(concurrency, items.length) }, () => run())
+  await Promise.all(runners)
+  return results
+}
+
+// ── Main entry point ───────────────────────────────────────────────────────
+
+interface RunInput {
+  experimentId: string
+  organizationId: string
+  versionAId: string
+  versionBId: string
+  datasetId: string
+  evaluatorId: string | null
+  runProvider: 'openai' | 'anthropic'
+  runModel: string
+}
+
+export async function runExperiment(input: RunInput): Promise<void> {
+  const { experimentId, organizationId, versionAId, versionBId, datasetId, evaluatorId, runProvider, runModel } = input
+
+  await supabaseAdmin
+    .from('experiments')
+    .update({ status: 'running' })
+    .eq('id', experimentId)
+
+  try {
+    // Load both prompt versions
+    const { data: versions, error: vErr } = await supabaseAdmin
+      .from('prompt_versions')
+      .select('id, content')
+      .in('id', [versionAId, versionBId])
+      .eq('organization_id', organizationId)
+
+    if (vErr || !versions || versions.length !== 2) {
+      throw new Error('Prompt versions not found')
+    }
+    const versionA = versions.find((v) => v.id === versionAId) as PromptVersionRow
+    const versionB = versions.find((v) => v.id === versionBId) as PromptVersionRow
+
+    // Load dataset items
+    const { data: items, error: iErr } = await supabaseAdmin
+      .from('dataset_items')
+      .select('id, input')
+      .eq('dataset_id', datasetId)
+      .eq('organization_id', organizationId)
+      .order('created_at', { ascending: false })
+      .limit(200) // hard cap for safety
+
+    if (iErr) throw new Error(`Dataset items fetch failed: ${iErr.message}`)
+    if (!items || items.length === 0) throw new Error('Dataset has no items')
+
+    // Load provider key for prompt runs
+    const { data: runKey, error: rkErr } = await supabaseAdmin
+      .from('provider_keys')
+      .select('id, encrypted_key')
+      .eq('organization_id', organizationId)
+      .eq('provider', runProvider)
+      .eq('is_active', true)
+      .limit(1)
+      .maybeSingle()
+
+    if (rkErr || !runKey) throw new Error(`No active ${runProvider} provider key for prompt runs`)
+    const runApiKey = await aes256Decrypt(runKey.encrypted_key as string)
+    if (!runApiKey) throw new Error('Failed to decrypt provider key')
+
+    // Optional: load evaluator config + judge key
+    let evaluatorConfig: JudgeConfig | null = null
+    let judgeApiKey: string | null = null
+    if (evaluatorId) {
+      const { data: ev } = await supabaseAdmin
+        .from('evaluators')
+        .select('config')
+        .eq('id', evaluatorId)
+        .eq('organization_id', organizationId)
+        .maybeSingle()
+      if (!ev) throw new Error('Evaluator not found')
+      evaluatorConfig = ev.config as unknown as JudgeConfig
+
+      if (evaluatorConfig.judge_provider === runProvider) {
+        judgeApiKey = runApiKey
+      } else {
+        const { data: jk } = await supabaseAdmin
+          .from('provider_keys')
+          .select('encrypted_key')
+          .eq('organization_id', organizationId)
+          .eq('provider', evaluatorConfig.judge_provider)
+          .eq('is_active', true)
+          .limit(1)
+          .maybeSingle()
+        if (!jk) throw new Error(`No active ${evaluatorConfig.judge_provider} provider key for judge`)
+        judgeApiKey = await aes256Decrypt(jk.encrypted_key as string)
+        if (!judgeApiKey) throw new Error('Failed to decrypt judge key')
+      }
+    }
+
+    // Initialize total_items so UI can show progress.
+    await supabaseAdmin
+      .from('experiments')
+      .update({ total_items: items.length })
+      .eq('id', experimentId)
+
+    // Process each item
+    type ItemOutcome = {
+      datasetItemId: string
+      outputA: string | null
+      outputB: string | null
+      costA: number
+      costB: number
+      latencyA: number | null
+      latencyB: number | null
+      tokensA: number
+      tokensB: number
+      scoreA: number | null
+      scoreB: number | null
+      reasoningA: string | null
+      reasoningB: string | null
+      errorA: string | null
+      errorB: string | null
+    }
+
+    const outcomes = await pool(items as DatasetItemRow[], ITEM_CONCURRENCY, async (item): Promise<ItemOutcome> => {
+      // Run both arms in parallel
+      const [aResult, bResult] = await Promise.all([
+        runPrompt(versionA.content, item, runProvider, runModel, runApiKey),
+        runPrompt(versionB.content, item, runProvider, runModel, runApiKey),
+      ])
+
+      const outcome: ItemOutcome = {
+        datasetItemId: item.id,
+        outputA: 'output' in aResult ? aResult.output : null,
+        outputB: 'output' in bResult ? bResult.output : null,
+        costA: 'cost' in aResult ? aResult.cost : 0,
+        costB: 'cost' in bResult ? bResult.cost : 0,
+        latencyA: 'latencyMs' in aResult ? aResult.latencyMs : null,
+        latencyB: 'latencyMs' in bResult ? bResult.latencyMs : null,
+        tokensA: 'tokens' in aResult ? aResult.tokens : 0,
+        tokensB: 'tokens' in bResult ? bResult.tokens : 0,
+        scoreA: null, scoreB: null,
+        reasoningA: null, reasoningB: null,
+        errorA: 'error' in aResult ? aResult.error : null,
+        errorB: 'error' in bResult ? bResult.error : null,
+      }
+
+      // Optionally judge both outputs
+      if (evaluatorConfig && judgeApiKey) {
+        if (outcome.outputA) {
+          const j = await callJudge(evaluatorConfig, outcome.outputA, judgeApiKey)
+          if (j) {
+            outcome.scoreA = j.score
+            outcome.reasoningA = j.reasoning
+            outcome.costA += j.cost
+          }
+        }
+        if (outcome.outputB) {
+          const j = await callJudge(evaluatorConfig, outcome.outputB, judgeApiKey)
+          if (j) {
+            outcome.scoreB = j.score
+            outcome.reasoningB = j.reasoning
+            outcome.costB += j.cost
+          }
+        }
+      }
+
+      return outcome
+    })
+
+    // Persist results
+    const resultRows = outcomes.map((o) => ({
+      organization_id: organizationId,
+      experiment_id: experimentId,
+      dataset_item_id: o.datasetItemId,
+      output_a: o.outputA,
+      output_b: o.outputB,
+      cost_a_usd: o.costA,
+      cost_b_usd: o.costB,
+      latency_a_ms: o.latencyA,
+      latency_b_ms: o.latencyB,
+      tokens_a: o.tokensA,
+      tokens_b: o.tokensB,
+      score_a: o.scoreA,
+      score_b: o.scoreB,
+      reasoning_a: o.reasoningA,
+      reasoning_b: o.reasoningB,
+      error_a: o.errorA,
+      error_b: o.errorB,
+    }))
+
+    const { error: insErr } = await supabaseAdmin
+      .from('experiment_results')
+      .insert(resultRows)
+    if (insErr) throw new Error(`Result insert failed: ${insErr.message}`)
+
+    // Compute aggregates
+    const totalCost = outcomes.reduce((s, o) => s + o.costA + o.costB, 0)
+    const scoresA = outcomes.map((o) => o.scoreA).filter((s): s is number => s != null)
+    const scoresB = outcomes.map((o) => o.scoreB).filter((s): s is number => s != null)
+    const avgA = scoresA.length > 0 ? scoresA.reduce((a, b) => a + b, 0) / scoresA.length : null
+    const avgB = scoresB.length > 0 ? scoresB.reduce((a, b) => a + b, 0) / scoresB.length : null
+
+    await supabaseAdmin
+      .from('experiments')
+      .update({
+        status: 'completed',
+        completed_items: outcomes.length,
+        avg_score_a: avgA,
+        avg_score_b: avgB,
+        total_cost_usd: totalCost,
+        completed_at: new Date().toISOString(),
+      })
+      .eq('id', experimentId)
+  } catch (err) {
+    await supabaseAdmin
+      .from('experiments')
+      .update({
+        status: 'failed',
+        error: err instanceof Error ? err.message : 'Unknown error',
+        completed_at: new Date().toISOString(),
+      })
+      .eq('id', experimentId)
+  }
+}

--- a/apps/server/src/lib/logger.ts
+++ b/apps/server/src/lib/logger.ts
@@ -23,6 +23,10 @@ export interface RequestLogData {
   spanId: string | null
   promptVersionId?: string | null
   providerKeyId?: string | null
+  /** Customer-supplied end-user ID (x-spanlens-user header). */
+  userId?: string | null
+  /** Customer-supplied session ID (x-spanlens-session header). */
+  sessionId?: string | null
   /**
    * Pre-computed request flags from the proxy (used for blocking).
    * If provided, logger skips re-scanning the request body.
@@ -173,6 +177,8 @@ export async function logRequestAsync(data: RequestLogData): Promise<void> {
     span_id: data.spanId,
     prompt_version_id: data.promptVersionId ?? null,
     provider_key_id: data.providerKeyId ?? null,
+    user_id: data.userId ?? null,
+    session_id: data.sessionId ?? null,
     flags: requestFlags,
     response_flags: responseFlags,
   })

--- a/apps/server/src/lib/prompt-compare-stats.ts
+++ b/apps/server/src/lib/prompt-compare-stats.ts
@@ -15,6 +15,10 @@ export interface VersionMetrics {
   totalCostUsd: number
   avgPromptTokens: number
   avgCompletionTokens: number
+  /** Average score from eval_results for this prompt version (0..1). Null if no evals run yet. */
+  avgQualityScore: number | null
+  /** Number of eval_results rows aggregated into avgQualityScore. */
+  qualitySampleCount: number
 }
 
 export interface PromptVersionRef {
@@ -32,11 +36,22 @@ export interface RequestMetricRow {
   completion_tokens: number | null
 }
 
+export interface QualityAggregate {
+  /** Sum of normalized scores (0..1) for this prompt version's eval_results. */
+  scoreSum: number
+  /** Number of eval_results rows. */
+  count: number
+}
+
 export function aggregate(
   version: PromptVersionRef,
   rows: readonly RequestMetricRow[],
+  quality?: QualityAggregate,
 ): VersionMetrics {
   const n = rows.length
+  const qualityCount = quality?.count ?? 0
+  const avgQuality = qualityCount > 0 && quality ? quality.scoreSum / qualityCount : null
+
   if (n === 0) {
     return {
       version: version.version,
@@ -49,6 +64,8 @@ export function aggregate(
       totalCostUsd: 0,
       avgPromptTokens: 0,
       avgCompletionTokens: 0,
+      avgQualityScore: avgQuality,
+      qualitySampleCount: qualityCount,
     }
   }
 
@@ -93,5 +110,7 @@ export function aggregate(
     totalCostUsd: costSum,
     avgPromptTokens: promptTokenCount > 0 ? promptTokenSum / promptTokenCount : 0,
     avgCompletionTokens: completionTokenCount > 0 ? completionTokenSum / completionTokenCount : 0,
+    avgQualityScore: avgQuality,
+    qualitySampleCount: qualityCount,
   }
 }

--- a/apps/server/src/lib/prompt-compare.ts
+++ b/apps/server/src/lib/prompt-compare.ts
@@ -4,6 +4,7 @@ import {
   type VersionMetrics,
   type PromptVersionRef,
   type RequestMetricRow,
+  type QualityAggregate,
 } from './prompt-compare-stats.js'
 
 /**
@@ -51,5 +52,36 @@ export async function comparePromptVersions(
     byVersion.set(r.prompt_version_id, bucket)
   }
 
-  return typedVersions.map((v) => aggregate(v, byVersion.get(v.id) ?? []))
+  // Aggregate eval_results scores per prompt version (LLM-as-judge quality).
+  // Joined here so calls-tab QUALITY column can display real values.
+  const { data: evalRows } = await supabaseAdmin
+    .from('eval_runs')
+    .select('prompt_version_id, eval_results ( score )')
+    .eq('organization_id', organizationId)
+    .in('prompt_version_id', versionIds)
+    .eq('status', 'completed')
+
+  type EvalRunRow = {
+    prompt_version_id: string | null
+    eval_results: Array<{ score: number | null }> | { score: number | null } | null
+  }
+  const qualityByVersion = new Map<string, QualityAggregate>()
+  for (const row of (evalRows ?? []) as unknown as EvalRunRow[]) {
+    if (!row.prompt_version_id) continue
+    const results = Array.isArray(row.eval_results)
+      ? row.eval_results
+      : row.eval_results ? [row.eval_results] : []
+    const agg = qualityByVersion.get(row.prompt_version_id) ?? { scoreSum: 0, count: 0 }
+    for (const r of results) {
+      if (typeof r.score === 'number') {
+        agg.scoreSum += r.score
+        agg.count += 1
+      }
+    }
+    qualityByVersion.set(row.prompt_version_id, agg)
+  }
+
+  return typedVersions.map((v) =>
+    aggregate(v, byVersion.get(v.id) ?? [], qualityByVersion.get(v.id)),
+  )
 }

--- a/apps/server/src/proxy/anthropic.ts
+++ b/apps/server/src/proxy/anthropic.ts
@@ -96,6 +96,8 @@ anthropicProxy.all('/*', async (c) => {
     spanId: c.req.header('x-span-id') ?? null,
     promptVersionId,
     providerKeyId: providerKey.id,
+    userId: c.req.header('x-spanlens-user') ?? null,
+    sessionId: c.req.header('x-spanlens-session') ?? null,
     preComputedRequestFlags: requestFlags,
   }
 

--- a/apps/server/src/proxy/gemini.ts
+++ b/apps/server/src/proxy/gemini.ts
@@ -133,6 +133,8 @@ geminiProxy.all('/*', async (c) => {
     spanId: c.req.header('x-span-id') ?? null,
     promptVersionId,
     providerKeyId: providerKey.id,
+    userId: c.req.header('x-spanlens-user') ?? null,
+    sessionId: c.req.header('x-spanlens-session') ?? null,
     preComputedRequestFlags: requestFlags,
   }))
 

--- a/apps/server/src/proxy/openai.ts
+++ b/apps/server/src/proxy/openai.ts
@@ -110,6 +110,8 @@ openaiProxy.all('/*', async (c) => {
     spanId: c.req.header('x-span-id') ?? null,
     promptVersionId,
     providerKeyId: providerKey.id,
+    userId: c.req.header('x-spanlens-user') ?? null,
+    sessionId: c.req.header('x-spanlens-session') ?? null,
     preComputedRequestFlags: requestFlags,
   }
 

--- a/apps/web/app/(dashboard)/annotation/annotation-client.tsx
+++ b/apps/web/app/(dashboard)/annotation/annotation-client.tsx
@@ -1,0 +1,341 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { Star, Filter, MessageSquare } from 'lucide-react'
+import { Topbar } from '@/components/layout/topbar'
+import { cn } from '@/lib/utils'
+import {
+  useAnnotationQueue,
+  useSaveHumanEval,
+  type AnnotationQueueItem,
+} from '@/lib/queries/use-human-evals'
+import { usePrompts } from '@/lib/queries/use-prompts'
+
+// Extract assistant response text from various provider shapes.
+function extractResponseText(body: Record<string, unknown> | null): string {
+  if (!body) return ''
+  // OpenAI
+  const choices = body.choices as Array<Record<string, unknown>> | undefined
+  if (Array.isArray(choices) && choices[0]) {
+    const msg = choices[0].message as Record<string, unknown> | undefined
+    if (typeof msg?.content === 'string') return msg.content
+  }
+  // Anthropic
+  const content = body.content as Array<Record<string, unknown>> | undefined
+  if (Array.isArray(content)) {
+    const textBlock = content.find((b) => b.type === 'text')
+    if (textBlock && typeof textBlock.text === 'string') return textBlock.text
+  }
+  // Gemini
+  const candidates = body.candidates as Array<Record<string, unknown>> | undefined
+  if (Array.isArray(candidates) && candidates[0]) {
+    const cContent = (candidates[0].content as Record<string, unknown> | undefined)
+    const parts = cContent?.parts as Array<Record<string, unknown>> | undefined
+    if (Array.isArray(parts) && parts[0] && typeof parts[0].text === 'string') return parts[0].text
+  }
+  return ''
+}
+
+function extractRequestUserText(body: Record<string, unknown> | null): string {
+  if (!body) return ''
+  const messages = body.messages as Array<Record<string, unknown>> | undefined
+  if (Array.isArray(messages)) {
+    const lastUser = [...messages].reverse().find((m) => m.role === 'user')
+    if (lastUser && typeof lastUser.content === 'string') return lastUser.content
+  }
+  return ''
+}
+
+function fmtScore(n: number | null | undefined): string {
+  if (n == null) return '—'
+  return (n * 100).toFixed(0)
+}
+
+// ── Star rating ─────────────────────────────────────────────────────────────
+
+function StarRating({
+  value,
+  onChange,
+  size = 18,
+}: {
+  value: number | null      // 1..5 or null
+  onChange: (v: number) => void
+  size?: number
+}) {
+  const [hover, setHover] = useState<number | null>(null)
+  const display = hover ?? value ?? 0
+  return (
+    <div className="flex items-center gap-0.5" onMouseLeave={() => setHover(null)}>
+      {[1, 2, 3, 4, 5].map((n) => (
+        <button
+          key={n}
+          type="button"
+          onClick={() => onChange(n)}
+          onMouseEnter={() => setHover(n)}
+          className="p-0.5"
+          aria-label={`Rate ${n}`}
+        >
+          <Star
+            size={size}
+            className={cn(
+              'transition-colors',
+              n <= display
+                ? 'fill-accent text-accent'
+                : 'fill-transparent text-text-faint hover:text-text-muted',
+            )}
+          />
+        </button>
+      ))}
+    </div>
+  )
+}
+
+// ── Scoring panel ───────────────────────────────────────────────────────────
+
+function ScoringPanel({
+  item,
+  onSaved,
+}: {
+  item: AnnotationQueueItem
+  onSaved: () => void
+}) {
+  const save = useSaveHumanEval()
+  const existingRaw = item.human_eval?.raw_score ?? null
+  const [stars, setStars] = useState<number | null>(existingRaw)
+  const [comment, setComment] = useState(item.human_eval?.comment ?? '')
+  const [error, setError] = useState('')
+
+  // Reset on item change
+  useEffect(() => {
+    setStars(item.human_eval?.raw_score ?? null)
+    setComment(item.human_eval?.comment ?? '')
+    setError('')
+  }, [item.id, item.human_eval?.raw_score, item.human_eval?.comment])
+
+  async function handleSave() {
+    setError('')
+    if (stars == null) { setError('Pick a rating first'); return }
+    try {
+      await save.mutateAsync({
+        requestId: item.id,
+        score: (stars - 1) / 4,   // 1..5 → 0..1
+        rawScore: stars,
+        ...(comment.trim() && { comment: comment.trim() }),
+      })
+      onSaved()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save')
+    }
+  }
+
+  const isUpdate = !!item.human_eval
+
+  return (
+    <div className="border-t border-border p-4 bg-bg-elev space-y-3">
+      <div className="flex items-center gap-3">
+        <span className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint">
+          Your rating
+        </span>
+        <StarRating value={stars} onChange={setStars} />
+        {stars != null && (
+          <span className="font-mono text-[11px] text-text-muted">
+            {stars}/5 ({(((stars - 1) / 4) * 100).toFixed(0)} normalized)
+          </span>
+        )}
+      </div>
+
+      <div>
+        <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+          Comment (optional)
+        </label>
+        <textarea
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          rows={2}
+          placeholder="Why this rating?"
+          className="w-full px-2 py-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong resize-none"
+        />
+      </div>
+
+      {error && <p className="font-mono text-[11.5px] text-bad">{error}</p>}
+
+      <div className="flex items-center justify-between">
+        <p className="font-mono text-[10.5px] text-text-faint">
+          {isUpdate ? 'You previously rated this. Save to overwrite.' : 'Not yet rated by you.'}
+        </p>
+        <button
+          type="button"
+          onClick={() => void handleSave()}
+          disabled={save.isPending || stars == null}
+          className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 disabled:opacity-40"
+        >
+          {save.isPending ? 'Saving…' : isUpdate ? 'Update' : 'Save rating'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ── Item card ───────────────────────────────────────────────────────────────
+
+function ItemCard({ item }: { item: AnnotationQueueItem }) {
+  const userMsg = useMemo(() => extractRequestUserText(item.request_body), [item.request_body])
+  const responseText = useMemo(() => extractResponseText(item.response_body), [item.response_body])
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div className="border border-border rounded-[6px] bg-bg overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center px-[14px] py-[10px] bg-bg-muted border-b border-border">
+        <div className="flex-1 min-w-0">
+          <p className="font-mono text-[12px] text-text font-medium truncate">
+            {item.prompt_name ?? '—'}{item.prompt_version != null ? ` · v${item.prompt_version}` : ''}
+          </p>
+          <p className="font-mono text-[10px] text-text-faint truncate">
+            {item.model} · {new Date(item.created_at).toLocaleString()}
+          </p>
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          {item.llm_judge_score != null && (
+            <div className="flex items-center gap-1 font-mono text-[10.5px] text-text-muted">
+              <span className="text-text-faint">Judge:</span>
+              <span className={cn(
+                'font-medium',
+                item.llm_judge_score < 0.4 ? 'text-bad' : item.llm_judge_score < 0.7 ? 'text-warn' : 'text-good',
+              )}>
+                {fmtScore(item.llm_judge_score)}
+              </span>
+            </div>
+          )}
+          {item.human_eval && (
+            <div className="flex items-center gap-1 font-mono text-[10.5px] text-good">
+              <span>You: {fmtScore(item.human_eval.score)}</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Body — user input + response */}
+      <div className="grid grid-cols-2 gap-3 p-3">
+        <div className="min-w-0">
+          <p className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-1">
+            User input
+          </p>
+          <p className={cn(
+            'font-mono text-[11.5px] text-text-muted leading-relaxed whitespace-pre-wrap',
+            !expanded && 'line-clamp-3',
+          )}>
+            {userMsg || '—'}
+          </p>
+        </div>
+        <div className="min-w-0">
+          <div className="flex items-center justify-between mb-1">
+            <p className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+              Response
+            </p>
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              className="font-mono text-[10px] text-text-faint hover:text-text"
+            >
+              {expanded ? 'collapse' : 'expand'}
+            </button>
+          </div>
+          <p className={cn(
+            'font-mono text-[12px] text-text leading-relaxed whitespace-pre-wrap',
+            !expanded && 'line-clamp-5',
+          )}>
+            {responseText || '—'}
+          </p>
+        </div>
+      </div>
+
+      <ScoringPanel item={item} onSaved={() => { /* react-query invalidation handles refresh */ }} />
+    </div>
+  )
+}
+
+// ── Main page ────────────────────────────────────────────────────────────────
+
+export function AnnotationClient() {
+  const prompts = usePrompts()
+  const [promptName, setPromptName] = useState<string>('')
+  const [unscoredOnly, setUnscoredOnly] = useState(false)
+  const [lowJudgeScoreOnly, setLowJudgeScoreOnly] = useState(false)
+
+  const queue = useAnnotationQueue({
+    ...(promptName && { promptName }),
+    unscoredOnly,
+    lowJudgeScoreOnly,
+  })
+
+  const items = queue.data ?? []
+  const scoredCount = items.filter((i) => !!i.human_eval).length
+
+  return (
+    <div className="flex flex-col h-full">
+      <Topbar
+        crumbs={[{ label: 'Workspace', href: '/dashboard' }, { label: 'Annotation' }]}
+      />
+
+      {/* Filter bar */}
+      <div className="flex items-center gap-3 px-[22px] py-[12px] border-b border-border bg-bg-muted">
+        <Filter className="h-3.5 w-3.5 text-text-faint" />
+        <select
+          value={promptName}
+          onChange={(e) => setPromptName(e.target.value)}
+          className="h-7 px-2 rounded-[4px] border border-border bg-bg font-mono text-[11.5px] text-text"
+        >
+          <option value="">All prompts</option>
+          {(prompts.data ?? []).map((p) => (
+            <option key={p.id} value={p.name}>{p.name}</option>
+          ))}
+        </select>
+        <label className="flex items-center gap-1.5 font-mono text-[11.5px] text-text-muted cursor-pointer">
+          <input
+            type="checkbox"
+            checked={unscoredOnly}
+            onChange={(e) => setUnscoredOnly(e.target.checked)}
+          />
+          Unscored only
+        </label>
+        <label className="flex items-center gap-1.5 font-mono text-[11.5px] text-text-muted cursor-pointer">
+          <input
+            type="checkbox"
+            checked={lowJudgeScoreOnly}
+            onChange={(e) => setLowJudgeScoreOnly(e.target.checked)}
+          />
+          Low judge score (&lt;50)
+        </label>
+        <span className="flex-1" />
+        <span className="font-mono text-[11px] text-text-faint">
+          {items.length} requests · {scoredCount} rated by you
+        </span>
+      </div>
+
+      {/* Intro */}
+      <div className="px-[22px] py-[10px] border-b border-border flex items-center gap-2 font-mono text-[11px] text-text-muted">
+        <MessageSquare className="h-3.5 w-3.5" />
+        <span>
+          Manually score responses. Your ratings calibrate against LLM judge scores —
+          a low correlation signals the judge needs work.
+        </span>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-[22px] py-[14px] space-y-3">
+        {queue.isLoading ? (
+          [1, 2, 3].map((i) => <div key={i} className="h-40 bg-bg-elev rounded animate-pulse" />)
+        ) : items.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-64 gap-2 text-text-muted">
+            <p className="font-mono text-[13px]">No requests match these filters.</p>
+            <p className="font-mono text-[11px] text-text-faint">
+              Loosen filters or send some requests tagged with a prompt version first.
+            </p>
+          </div>
+        ) : (
+          items.map((item) => <ItemCard key={item.id} item={item} />)
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/annotation/page.tsx
+++ b/apps/web/app/(dashboard)/annotation/page.tsx
@@ -1,0 +1,13 @@
+import { HydrationBoundary } from '@tanstack/react-query'
+import { prefetchAll } from '@/lib/server/dehydrate'
+import { annotationQueueSpec } from '@/lib/server/queries/human-evals'
+import { AnnotationClient } from './annotation-client'
+
+export default async function AnnotationPage() {
+  const state = await prefetchAll([annotationQueueSpec()])
+  return (
+    <HydrationBoundary state={state}>
+      <AnnotationClient />
+    </HydrationBoundary>
+  )
+}

--- a/apps/web/app/(dashboard)/datasets/[id]/dataset-detail-client.tsx
+++ b/apps/web/app/(dashboard)/datasets/[id]/dataset-detail-client.tsx
@@ -1,0 +1,328 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Plus, Trash2, ExternalLink, AlertTriangle } from 'lucide-react'
+import { Topbar } from '@/components/layout/topbar'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import {
+  useDataset,
+  useAddDatasetItem,
+  useDeleteDatasetItem,
+  type DatasetItem,
+} from '@/lib/queries/use-datasets'
+
+// ── Add item dialog (manual entry) ───────────────────────────────────────────
+
+function AddItemDialog({
+  datasetId,
+  onClose,
+}: {
+  datasetId: string
+  onClose: () => void
+}) {
+  const add = useAddDatasetItem()
+  const [mode, setMode] = useState<'variables' | 'messages'>('messages')
+  const [userMessage, setUserMessage] = useState('')
+  const [variablesJson, setVariablesJson] = useState('{\n  "name": "Alice"\n}')
+  const [expectedOutput, setExpectedOutput] = useState('')
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    let input: { variables?: Record<string, string>; messages?: Array<{ role: string; content: string }> }
+    try {
+      if (mode === 'variables') {
+        const parsed = JSON.parse(variablesJson)
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          throw new Error('Variables must be a JSON object')
+        }
+        input = { variables: parsed }
+      } else {
+        if (!userMessage.trim()) { setError('Message is required'); return }
+        input = { messages: [{ role: 'user', content: userMessage.trim() }] }
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Invalid input')
+      return
+    }
+
+    try {
+      const trimmedExpected = expectedOutput.trim()
+      await add.mutateAsync({
+        datasetId,
+        input,
+        ...(trimmedExpected && { expectedOutput: trimmedExpected }),
+      })
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add')
+    }
+  }
+
+  return (
+    <Dialog open={true} onOpenChange={(v) => { if (!v) onClose() }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add dataset item</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-3 mt-3">
+          <div className="flex gap-1 p-0.5 border border-border rounded-[5px] bg-bg-elev font-mono text-[11px] w-fit">
+            <button
+              type="button"
+              onClick={() => setMode('messages')}
+              className={`px-3 py-1 rounded-[3px] ${mode === 'messages' ? 'bg-text text-bg' : 'text-text-muted'}`}
+            >
+              User message
+            </button>
+            <button
+              type="button"
+              onClick={() => setMode('variables')}
+              className={`px-3 py-1 rounded-[3px] ${mode === 'variables' ? 'bg-text text-bg' : 'text-text-muted'}`}
+            >
+              Variables JSON
+            </button>
+          </div>
+
+          {mode === 'messages' ? (
+            <div>
+              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                User message
+              </label>
+              <textarea
+                value={userMessage}
+                onChange={(e) => setUserMessage(e.target.value)}
+                rows={3}
+                placeholder="Enter the user's input…"
+                required
+                className="w-full px-2 py-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text resize-none"
+              />
+            </div>
+          ) : (
+            <div>
+              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                Variables (JSON object)
+              </label>
+              <textarea
+                value={variablesJson}
+                onChange={(e) => setVariablesJson(e.target.value)}
+                rows={5}
+                className="w-full px-2 py-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text resize-none"
+              />
+              <p className="font-mono text-[10px] text-text-faint mt-1">
+                For prompts with {`{{var}}`} placeholders.
+              </p>
+            </div>
+          )}
+
+          <div>
+            <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+              Expected output (optional)
+            </label>
+            <textarea
+              value={expectedOutput}
+              onChange={(e) => setExpectedOutput(e.target.value)}
+              rows={3}
+              placeholder="The response the prompt should produce…"
+              className="w-full px-2 py-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text resize-none"
+            />
+            <p className="font-mono text-[10px] text-text-faint mt-1">
+              Required for Evals dataset source — judge scores this text against your criterion.
+            </p>
+          </div>
+
+          {error && <p className="font-mono text-[11.5px] text-bad">{error}</p>}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="font-mono text-[11.5px] px-3 py-[6px] border border-border rounded-[5px] text-text-muted hover:text-text"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={add.isPending}
+              className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 disabled:opacity-40"
+            >
+              {add.isPending ? 'Adding…' : 'Add'}
+            </button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ── Item row ─────────────────────────────────────────────────────────────────
+
+function ItemRow({ item, datasetId }: { item: DatasetItem; datasetId: string }) {
+  const del = useDeleteDatasetItem()
+  const [expanded, setExpanded] = useState(false)
+
+  function handleDelete(e: React.MouseEvent) {
+    e.stopPropagation()
+    if (!confirm('Delete this item?')) return
+    void del.mutateAsync({ datasetId, itemId: item.id })
+  }
+
+  const inputPreview = item.input.messages?.[0]?.content
+    ?? JSON.stringify(item.input.variables ?? {})
+  const hasExpected = !!item.expected_output
+
+  return (
+    <div className="border-b border-border last:border-0">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full flex items-start gap-3 px-[16px] py-[11px] hover:bg-bg-muted transition-colors text-left"
+      >
+        <div className="flex-1 min-w-0">
+          <p className="font-mono text-[12px] text-text truncate">{inputPreview}</p>
+          {item.expected_output && (
+            <p className="font-mono text-[11px] text-text-faint truncate mt-0.5">
+              → {item.expected_output}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {!hasExpected && (
+            <span className="font-mono text-[10px] text-warn flex items-center gap-1" title="No expected output — won't be evaluated">
+              <AlertTriangle className="h-3 w-3" />
+              no output
+            </span>
+          )}
+          {item.source_request_id && (
+            <Link
+              href={`/requests?id=${item.source_request_id}`}
+              onClick={(e) => e.stopPropagation()}
+              className="text-text-faint hover:text-text"
+              aria-label="View source request"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+            </Link>
+          )}
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="text-text-faint hover:text-bad transition-colors"
+            aria-label="Delete item"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </button>
+      {expanded && (
+        <div className="bg-bg-muted/50 px-[16px] py-[10px] border-t border-border space-y-2 font-mono text-[11.5px]">
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.05em] text-text-faint mb-1">Input</p>
+            <pre className="text-text-muted whitespace-pre-wrap break-all">
+              {JSON.stringify(item.input, null, 2)}
+            </pre>
+          </div>
+          {item.expected_output && (
+            <div>
+              <p className="text-[10px] uppercase tracking-[0.05em] text-text-faint mb-1">Expected output</p>
+              <pre className="text-text-muted whitespace-pre-wrap">{item.expected_output}</pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Main page ────────────────────────────────────────────────────────────────
+
+export function DatasetDetailClient({ datasetId }: { datasetId: string }) {
+  const ds = useDataset(datasetId)
+  const [addOpen, setAddOpen] = useState(false)
+
+  if (ds.isLoading) {
+    return (
+      <div className="flex flex-col h-full">
+        <Topbar crumbs={[{ label: 'Workspace', href: '/dashboard' }, { label: 'Datasets', href: '/datasets' }, { label: '...' }]} />
+        <div className="p-[22px] space-y-2">
+          <div className="h-12 bg-bg-elev rounded animate-pulse" />
+        </div>
+      </div>
+    )
+  }
+
+  if (!ds.data) {
+    return (
+      <div className="flex flex-col h-full">
+        <Topbar crumbs={[{ label: 'Workspace', href: '/dashboard' }, { label: 'Datasets', href: '/datasets' }, { label: 'Not found' }]} />
+        <div className="flex items-center justify-center h-64 text-text-muted font-mono text-[13px]">
+          Dataset not found.
+        </div>
+      </div>
+    )
+  }
+
+  const dataset = ds.data
+  const items = dataset.items ?? []
+  const itemsWithOutput = items.filter((i) => !!i.expected_output).length
+
+  return (
+    <div className="flex flex-col h-full">
+      <Topbar
+        crumbs={[
+          { label: 'Workspace', href: '/dashboard' },
+          { label: 'Datasets', href: '/datasets' },
+          { label: dataset.name },
+        ]}
+        right={
+          <button
+            type="button"
+            onClick={() => setAddOpen(true)}
+            className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 flex items-center gap-1.5"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Add item
+          </button>
+        }
+      />
+
+      <div className="flex-1 overflow-y-auto">
+        {/* Header info */}
+        <div className="px-[22px] py-[12px] border-b border-border space-y-1">
+          <p className="font-mono text-[15px] text-text font-medium">{dataset.name}</p>
+          {dataset.description && (
+            <p className="font-mono text-[12px] text-text-muted">{dataset.description}</p>
+          )}
+          <div className="flex items-center gap-4 font-mono text-[11px] text-text-faint pt-1">
+            <span>{items.length} items</span>
+            <span>{itemsWithOutput} with expected output</span>
+          </div>
+        </div>
+
+        {items.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-64 gap-3 text-text-muted">
+            <p className="font-mono text-[13px]">Empty dataset.</p>
+            <button
+              type="button"
+              onClick={() => setAddOpen(true)}
+              className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 flex items-center gap-1.5"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Add first item
+            </button>
+            <p className="font-mono text-[10.5px] text-text-faint text-center max-w-md">
+              You can also bulk import from the Requests page (multi-select → &quot;Add to dataset&quot;).
+              Coming next round.
+            </p>
+          </div>
+        ) : (
+          items.map((item) => <ItemRow key={item.id} item={item} datasetId={datasetId} />)
+        )}
+      </div>
+
+      {addOpen && (
+        <AddItemDialog datasetId={datasetId} onClose={() => setAddOpen(false)} />
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/datasets/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/datasets/[id]/page.tsx
@@ -1,0 +1,6 @@
+import { DatasetDetailClient } from './dataset-detail-client'
+
+export default async function DatasetDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  return <DatasetDetailClient datasetId={id} />
+}

--- a/apps/web/app/(dashboard)/datasets/datasets-client.tsx
+++ b/apps/web/app/(dashboard)/datasets/datasets-client.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Database, Plus, Trash2, FileText, Hash } from 'lucide-react'
+import { Topbar } from '@/components/layout/topbar'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+import {
+  useDatasets,
+  useCreateDataset,
+  useDeleteDataset,
+  type Dataset,
+} from '@/lib/queries/use-datasets'
+
+// ── New dataset dialog ───────────────────────────────────────────────────────
+
+function NewDatasetDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const create = useCreateDataset()
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    if (!name.trim()) { setError('Name is required'); return }
+    try {
+      const trimmedDesc = description.trim()
+      await create.mutateAsync({
+        name: name.trim(),
+        ...(trimmedDesc && { description: trimmedDesc }),
+      })
+      onClose()
+      setName(''); setDescription('')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create')
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose() }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>New dataset</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-3 mt-3">
+          <div>
+            <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+              Name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Customer support golden set"
+              required
+              className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong"
+            />
+          </div>
+          <div>
+            <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+              Description (optional)
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={2}
+              placeholder="What this dataset covers…"
+              className="w-full px-2 py-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong resize-none"
+            />
+          </div>
+          {error && <p className="font-mono text-[11.5px] text-bad">{error}</p>}
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="font-mono text-[11.5px] px-3 py-[6px] border border-border rounded-[5px] text-text-muted hover:text-text"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={create.isPending}
+              className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 disabled:opacity-40"
+            >
+              {create.isPending ? 'Creating…' : 'Create'}
+            </button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ── Dataset row ──────────────────────────────────────────────────────────────
+
+function DatasetRow({ dataset }: { dataset: Dataset }) {
+  const deleteMutation = useDeleteDataset()
+
+  function handleDelete(e: React.MouseEvent) {
+    e.preventDefault()
+    e.stopPropagation()
+    if (!confirm(`Delete dataset "${dataset.name}"?`)) return
+    void deleteMutation.mutateAsync(dataset.id)
+  }
+
+  return (
+    <Link
+      href={`/datasets/${dataset.id}`}
+      className="flex items-center px-[16px] py-[12px] border-b border-border last:border-0 hover:bg-bg-muted transition-colors"
+    >
+      <div className="flex-1 min-w-0">
+        <p className="font-mono text-[13px] text-text font-medium truncate">{dataset.name}</p>
+        {dataset.description && (
+          <p className="font-mono text-[11px] text-text-faint truncate mt-0.5">
+            {dataset.description}
+          </p>
+        )}
+      </div>
+      <div className="flex items-center gap-1 font-mono text-[11px] text-text-muted w-[80px] justify-end">
+        <Hash className="h-3 w-3" />
+        {dataset.item_count ?? 0}
+      </div>
+      <div className="font-mono text-[10.5px] text-text-faint w-[140px] text-right">
+        {new Date(dataset.created_at).toLocaleDateString()}
+      </div>
+      <button
+        type="button"
+        onClick={handleDelete}
+        className="ml-3 text-text-faint hover:text-bad transition-colors p-1"
+        aria-label="Delete dataset"
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+      </button>
+    </Link>
+  )
+}
+
+// ── Main page ────────────────────────────────────────────────────────────────
+
+export function DatasetsClient() {
+  const datasets = useDatasets()
+  const [newOpen, setNewOpen] = useState(false)
+  const list = datasets.data ?? []
+
+  return (
+    <div className="flex flex-col h-full">
+      <Topbar
+        crumbs={[{ label: 'Workspace', href: '/dashboard' }, { label: 'Datasets' }]}
+        right={
+          <button
+            type="button"
+            onClick={() => setNewOpen(true)}
+            className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 flex items-center gap-1.5"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New dataset
+          </button>
+        }
+      />
+
+      <div className="flex-1 overflow-y-auto">
+        <div className="px-[22px] py-[12px] bg-bg-muted border-b border-border flex items-center gap-2 font-mono text-[11px] text-text-muted">
+          <Database className="h-3.5 w-3.5" />
+          <span>
+            Datasets are reusable test inputs for Evals. Import production requests or add items manually.
+          </span>
+        </div>
+
+        {datasets.isLoading ? (
+          <div className="p-[22px] space-y-2">
+            {[1, 2].map((i) => <div key={i} className="h-14 bg-bg-elev rounded animate-pulse" />)}
+          </div>
+        ) : list.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-64 gap-3 text-text-muted">
+            <FileText className="h-10 w-10 text-text-faint" />
+            <p className="font-mono text-[13px]">No datasets yet.</p>
+            <button
+              type="button"
+              onClick={() => setNewOpen(true)}
+              className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 flex items-center gap-1.5"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Create your first dataset
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center px-[16px] py-[8px] bg-bg-muted border-b border-border font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+              <span className="flex-1">Name</span>
+              <span className="w-[80px] text-right">Items</span>
+              <span className="w-[140px] text-right">Created</span>
+              <span className="w-[40px]" />
+            </div>
+            {list.map((d) => <DatasetRow key={d.id} dataset={d} />)}
+          </>
+        )}
+      </div>
+
+      <NewDatasetDialog open={newOpen} onClose={() => setNewOpen(false)} />
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/datasets/datasets-client.tsx
+++ b/apps/web/app/(dashboard)/datasets/datasets-client.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link'
 import { Database, Plus, Trash2, FileText, Hash } from 'lucide-react'
 import { Topbar } from '@/components/layout/topbar'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import { cn } from '@/lib/utils'
 import {
   useDatasets,
   useCreateDataset,

--- a/apps/web/app/(dashboard)/datasets/page.tsx
+++ b/apps/web/app/(dashboard)/datasets/page.tsx
@@ -1,0 +1,13 @@
+import { HydrationBoundary } from '@tanstack/react-query'
+import { prefetchAll } from '@/lib/server/dehydrate'
+import { datasetsSpec } from '@/lib/server/queries/datasets'
+import { DatasetsClient } from './datasets-client'
+
+export default async function DatasetsPage() {
+  const state = await prefetchAll([datasetsSpec()])
+  return (
+    <HydrationBoundary state={state}>
+      <DatasetsClient />
+    </HydrationBoundary>
+  )
+}

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useMemo, useState } from 'react'
-import { Beaker, Play, Trash2, Plus, Loader2, AlertTriangle, CheckCircle2 } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { Beaker, Play, Trash2, Plus, Loader2, AlertTriangle } from 'lucide-react'
 import { Topbar } from '@/components/layout/topbar'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
@@ -15,7 +15,6 @@ import {
   useEvalResults,
   useEstimateEvalCost,
   type Evaluator,
-  type EvalRun,
   type EvalRunStatus,
 } from '@/lib/queries/use-evals'
 import { usePrompts, usePromptVersions } from '@/lib/queries/use-prompts'
@@ -231,21 +230,17 @@ function RunEvaluatorDialog({
   const [error, setError] = useState('')
 
   // Default to latest version
-  useMemo(() => {
+  useEffect(() => {
     if (!versionId && versions.data && versions.data.length > 0) {
       setVersionId(versions.data[0]!.id)
     }
   }, [versions.data, versionId])
 
-  async function loadEstimate() {
-    try {
-      await estimate.mutateAsync({ sampleSize, judgeModel: evaluator.config.judge_model })
-    } catch {
-      // ignore
-    }
-  }
-
-  useMemo(() => { void loadEstimate() /* eslint-disable-line */ }, [sampleSize, evaluator.config.judge_model])
+  const judgeModel = evaluator.config.judge_model
+  const estimateMutate = estimate.mutateAsync
+  useEffect(() => {
+    void estimateMutate({ sampleSize, judgeModel }).catch(() => null)
+  }, [sampleSize, judgeModel, estimateMutate])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -418,15 +413,8 @@ function RunDetailPanel({ runId, onClose }: { runId: string; onClose: () => void
     run.data?.status === 'completed' ? runId : null,
   )
 
-  if (!run.data) {
-    return (
-      <div className="border-l border-border w-[400px] shrink-0 flex items-center justify-center text-text-faint">
-        <Loader2 className="h-4 w-4 animate-spin" />
-      </div>
-    )
-  }
-
-  const r = run.data
+  // Hooks must be called unconditionally — compute histBuckets even when
+  // run.data is null, then early-return below.
   const histBuckets = useMemo(() => {
     const buckets = [0, 0, 0, 0, 0] // 0-0.2, 0.2-0.4, ...
     for (const result of results.data ?? []) {
@@ -436,6 +424,16 @@ function RunDetailPanel({ runId, onClose }: { runId: string; onClose: () => void
     return buckets
   }, [results.data])
   const maxBucket = Math.max(1, ...histBuckets)
+
+  if (!run.data) {
+    return (
+      <div className="border-l border-border w-[400px] shrink-0 flex items-center justify-center text-text-faint">
+        <Loader2 className="h-4 w-4 animate-spin" />
+      </div>
+    )
+  }
+
+  const r = run.data
 
   return (
     <div className="border-l border-border w-[420px] shrink-0 overflow-y-auto">

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -20,6 +20,7 @@ import {
 import { usePrompts, usePromptVersions } from '@/lib/queries/use-prompts'
 import type { PromptVersion } from '@/lib/queries/use-prompts'
 import { useDatasets } from '@/lib/queries/use-datasets'
+import { useCorrelation, pearsonR } from '@/lib/queries/use-human-evals'
 
 const JUDGE_MODELS = {
   openai: ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo'],
@@ -639,6 +640,110 @@ function EvaluatorRow({
 
 // ── Main page ────────────────────────────────────────────────────────────────
 
+// ── Correlation card (LLM judge vs Human) ───────────────────────────────────
+
+function CorrelationCard({ promptName }: { promptName: string }) {
+  const correlation = useCorrelation({ promptName })
+  const pairs = correlation.data ?? []
+  const r = pearsonR(pairs)
+
+  if (pairs.length === 0) return null
+
+  // Scatter plot bounds: 0..1 × 0..1, padded to 120×120
+  const W = 120, H = 120, PAD = 6
+  const dotX = (judge: number) => PAD + judge * (W - 2 * PAD)
+  const dotY = (human: number) => H - PAD - human * (H - 2 * PAD)
+
+  // Interpret r — same buckets as standard correlation rules of thumb.
+  const interpretation = r == null
+    ? '—'
+    : Math.abs(r) >= 0.7 ? 'Strong'
+    : Math.abs(r) >= 0.4 ? 'Moderate'
+    : Math.abs(r) >= 0.2 ? 'Weak'
+    : 'None'
+
+  const rColor = r == null
+    ? 'text-text-faint'
+    : r >= 0.7 ? 'text-good'
+    : r >= 0.4 ? 'text-warn'
+    : 'text-bad'
+
+  return (
+    <div className="bg-bg-elev border border-border rounded-[6px] p-4">
+      <div className="flex items-start gap-4">
+        {/* Scatter plot */}
+        <svg width={W} height={H} className="shrink-0 bg-bg rounded-[4px] border border-border">
+          {/* Diagonal reference line — perfect agreement */}
+          <line
+            x1={PAD} y1={H - PAD} x2={W - PAD} y2={PAD}
+            stroke="var(--border-strong, currentColor)"
+            strokeOpacity={0.3}
+            strokeDasharray="2 2"
+          />
+          {pairs.map((p) => (
+            <circle
+              key={p.requestId}
+              cx={dotX(p.judgeScore)}
+              cy={dotY(p.humanScore)}
+              r={2.5}
+              className="fill-text/70"
+            />
+          ))}
+        </svg>
+
+        {/* Metrics */}
+        <div className="flex-1 min-w-0 space-y-2">
+          <div>
+            <p className="font-mono text-[11px] text-text-faint mb-0.5 truncate">
+              {promptName}
+            </p>
+            <div className="flex items-baseline gap-2">
+              <span className={cn('font-mono text-[22px] font-medium', rColor)}>
+                {r == null ? '—' : r.toFixed(2)}
+              </span>
+              <span className="font-mono text-[10.5px] text-text-muted">
+                Pearson r · {interpretation}
+              </span>
+            </div>
+          </div>
+          <div className="font-mono text-[10.5px] text-text-faint">
+            {pairs.length} paired sample{pairs.length === 1 ? '' : 's'}
+            {pairs.length < 10 && ' (more data → more reliable)'}
+          </div>
+        </div>
+      </div>
+      <p className="font-mono text-[10.5px] text-text-faint mt-3 leading-relaxed">
+        Dot = one request judged by both. Dashed line = perfect agreement.
+        Low r means your LLM judge disagrees with humans → revise the criterion.
+      </p>
+    </div>
+  )
+}
+
+function CorrelationRow({ evaluators }: { evaluators: Evaluator[] }) {
+  // Unique prompt names that have at least one evaluator
+  const promptNames = useMemo(() => {
+    const set = new Set<string>()
+    for (const ev of evaluators) set.add(ev.prompt_name)
+    return [...set]
+  }, [evaluators])
+
+  if (promptNames.length === 0) return null
+
+  return (
+    <div className="px-[22px] py-[14px] border-b border-border">
+      <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-3">
+        <span>LLM judge vs Human agreement</span>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {promptNames.map((name) => (
+          <CorrelationCard key={name} promptName={name} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
 export function EvalsClient() {
   const evaluators = useEvaluators()
   const [newOpen, setNewOpen] = useState(false)
@@ -673,6 +778,9 @@ export function EvalsClient() {
               Cost is billed to your provider key.
             </span>
           </div>
+
+          {/* Correlation card — appears only if Annotation has paired samples */}
+          {list.length > 0 && <CorrelationRow evaluators={list} />}
 
           {evaluators.isLoading ? (
             <div className="p-[22px] space-y-2">

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/lib/queries/use-evals'
 import { usePrompts, usePromptVersions } from '@/lib/queries/use-prompts'
 import type { PromptVersion } from '@/lib/queries/use-prompts'
+import { useDatasets } from '@/lib/queries/use-datasets'
 
 const JUDGE_MODELS = {
   openai: ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo'],
@@ -218,10 +219,13 @@ function RunEvaluatorDialog({
   onRunCreated: (runId: string) => void
 }) {
   const versions = usePromptVersions(evaluator.prompt_name)
+  const datasets = useDatasets()
   const createRun = useCreateEvalRun()
   const estimate = useEstimateEvalCost()
 
   const [versionId, setVersionId] = useState('')
+  const [source, setSource] = useState<'production' | 'dataset'>('production')
+  const [datasetId, setDatasetId] = useState('')
   const [sampleSize, setSampleSize] = useState(50)
   const [days, setDays] = useState(7)
   const [error, setError] = useState('')
@@ -247,13 +251,17 @@ function RunEvaluatorDialog({
     e.preventDefault()
     setError('')
     if (!versionId) { setError('Select a version'); return }
+    if (source === 'dataset' && !datasetId) { setError('Select a dataset'); return }
     try {
-      const sampleFrom = new Date(Date.now() - days * 86400_000).toISOString()
       const run = await createRun.mutateAsync({
         evaluatorId: evaluator.id,
         promptVersionId: versionId,
+        source,
         sampleSize,
-        sampleFrom,
+        ...(source === 'dataset' && datasetId && { datasetId }),
+        ...(source === 'production' && {
+          sampleFrom: new Date(Date.now() - days * 86400_000).toISOString(),
+        }),
       })
       onRunCreated(run.id)
     } catch (err) {
@@ -285,23 +293,72 @@ function RunEvaluatorDialog({
             </select>
           </div>
 
-          <div className="grid grid-cols-2 gap-3">
+          {/* Source toggle */}
+          <div>
+            <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+              Sample source
+            </label>
+            <div className="flex gap-1 p-0.5 border border-border rounded-[5px] bg-bg-elev font-mono text-[11px]">
+              <button
+                type="button"
+                onClick={() => setSource('production')}
+                className={`flex-1 px-3 py-1 rounded-[3px] ${source === 'production' ? 'bg-text text-bg' : 'text-text-muted'}`}
+              >
+                Production
+              </button>
+              <button
+                type="button"
+                onClick={() => setSource('dataset')}
+                className={`flex-1 px-3 py-1 rounded-[3px] ${source === 'dataset' ? 'bg-text text-bg' : 'text-text-muted'}`}
+              >
+                Dataset
+              </button>
+            </div>
+          </div>
+
+          {source === 'dataset' && (
             <div>
               <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
-                Last N days
+                Dataset
               </label>
               <select
-                value={days}
-                onChange={(e) => setDays(Number(e.target.value))}
+                value={datasetId}
+                onChange={(e) => setDatasetId(e.target.value)}
+                required
                 className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text"
               >
-                <option value={1}>1 day</option>
-                <option value={7}>7 days</option>
-                <option value={30}>30 days</option>
-                <option value={90}>90 days</option>
+                <option value="">Select dataset…</option>
+                {(datasets.data ?? []).map((d) => (
+                  <option key={d.id} value={d.id}>
+                    {d.name} ({d.item_count ?? 0} items)
+                  </option>
+                ))}
               </select>
+              <p className="font-mono text-[10px] text-text-faint mt-1">
+                Only items with expected_output are scored.
+              </p>
             </div>
-            <div>
+          )}
+
+          <div className="grid grid-cols-2 gap-3">
+            {source === 'production' && (
+              <div>
+                <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                  Last N days
+                </label>
+                <select
+                  value={days}
+                  onChange={(e) => setDays(Number(e.target.value))}
+                  className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text"
+                >
+                  <option value={1}>1 day</option>
+                  <option value={7}>7 days</option>
+                  <option value={30}>30 days</option>
+                  <option value={90}>90 days</option>
+                </select>
+              </div>
+            )}
+            <div className={source === 'dataset' ? 'col-span-2' : ''}>
               <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
                 Sample size
               </label>

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -1,0 +1,679 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Beaker, Play, Trash2, Plus, Loader2, AlertTriangle, CheckCircle2 } from 'lucide-react'
+import { Topbar } from '@/components/layout/topbar'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+import {
+  useEvaluators,
+  useDeleteEvaluator,
+  useCreateEvaluator,
+  useCreateEvalRun,
+  useEvalRuns,
+  useEvalRun,
+  useEvalResults,
+  useEstimateEvalCost,
+  type Evaluator,
+  type EvalRun,
+  type EvalRunStatus,
+} from '@/lib/queries/use-evals'
+import { usePrompts, usePromptVersions } from '@/lib/queries/use-prompts'
+import type { PromptVersion } from '@/lib/queries/use-prompts'
+
+const JUDGE_MODELS = {
+  openai: ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo'],
+  anthropic: ['claude-3-5-haiku-20241022', 'claude-3-5-sonnet-20241022'],
+} as const
+
+function fmtUsd(n: number | null | undefined): string {
+  if (n == null) return '—'
+  return n >= 0.01 ? `$${n.toFixed(3)}` : `$${n.toFixed(5)}`
+}
+
+function fmtScore(n: number | null | undefined): string {
+  if (n == null) return '—'
+  return `${(n * 100).toFixed(1)}`
+}
+
+function StatusBadge({ status }: { status: EvalRunStatus }) {
+  const config = {
+    pending:   { label: 'Pending',   cls: 'bg-bg-elev text-text-faint' },
+    running:   { label: 'Running',   cls: 'bg-accent-bg text-accent border border-accent-border' },
+    completed: { label: 'Completed', cls: 'bg-good/10 text-good border border-good/30' },
+    failed:    { label: 'Failed',    cls: 'bg-bad/10 text-bad border border-bad/30' },
+  }[status]
+  return (
+    <span className={cn('font-mono text-[10px] px-[6px] py-[1.5px] rounded-[3px]', config.cls)}>
+      {config.label}
+    </span>
+  )
+}
+
+// ── New evaluator dialog ─────────────────────────────────────────────────────
+
+function NewEvaluatorDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const prompts = usePrompts()
+  const createMutation = useCreateEvaluator()
+
+  const [promptName, setPromptName] = useState('')
+  const [name, setName] = useState('')
+  const [criterion, setCriterion] = useState('')
+  const [judgeProvider, setJudgeProvider] = useState<'openai' | 'anthropic'>('openai')
+  const [judgeModel, setJudgeModel] = useState('gpt-4o-mini')
+  const [scaleMin] = useState(0)
+  const [scaleMax] = useState(1)
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    if (!promptName || !name.trim() || !criterion.trim()) {
+      setError('All fields required')
+      return
+    }
+    try {
+      await createMutation.mutateAsync({
+        promptName,
+        name: name.trim(),
+        config: {
+          criterion: criterion.trim(),
+          judge_provider: judgeProvider,
+          judge_model: judgeModel,
+          scale_min: scaleMin,
+          scale_max: scaleMax,
+        },
+      })
+      onClose()
+      setName(''); setCriterion(''); setPromptName('')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create')
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose() }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>New evaluator</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-3 mt-3">
+          <div>
+            <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+              Prompt
+            </label>
+            <select
+              value={promptName}
+              onChange={(e) => setPromptName(e.target.value)}
+              required
+              className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text focus:outline-none focus:border-border-strong"
+            >
+              <option value="">Select prompt…</option>
+              {(prompts.data ?? []).map((p: PromptVersion) => (
+                <option key={p.id} value={p.name}>{p.name}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+              Evaluator name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Friendliness"
+              required
+              className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong"
+            />
+          </div>
+
+          <div>
+            <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+              Criterion (what to score)
+            </label>
+            <textarea
+              value={criterion}
+              onChange={(e) => setCriterion(e.target.value)}
+              rows={3}
+              placeholder="e.g. Is the response friendly, polite, and clearly addresses the customer's question?"
+              required
+              className="w-full px-2 py-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong resize-none"
+            />
+            <p className="font-mono text-[10.5px] text-text-faint mt-1">
+              Judge model scores 0–1 against this criterion.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                Judge provider
+              </label>
+              <select
+                value={judgeProvider}
+                onChange={(e) => {
+                  const p = e.target.value as 'openai' | 'anthropic'
+                  setJudgeProvider(p)
+                  setJudgeModel(JUDGE_MODELS[p][0])
+                }}
+                className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text focus:outline-none focus:border-border-strong"
+              >
+                <option value="openai">OpenAI</option>
+                <option value="anthropic">Anthropic</option>
+              </select>
+            </div>
+            <div>
+              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                Judge model
+              </label>
+              <select
+                value={judgeModel}
+                onChange={(e) => setJudgeModel(e.target.value)}
+                className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text focus:outline-none focus:border-border-strong"
+              >
+                {JUDGE_MODELS[judgeProvider].map((m) => (
+                  <option key={m} value={m}>{m}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {error && (
+            <p className="font-mono text-[11.5px] text-bad">{error}</p>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="font-mono text-[11.5px] px-3 py-[6px] border border-border rounded-[5px] text-text-muted hover:text-text transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={createMutation.isPending}
+              className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 transition-opacity disabled:opacity-40"
+            >
+              {createMutation.isPending ? 'Creating…' : 'Create'}
+            </button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ── Run evaluator dialog ─────────────────────────────────────────────────────
+
+function RunEvaluatorDialog({
+  evaluator,
+  onClose,
+  onRunCreated,
+}: {
+  evaluator: Evaluator
+  onClose: () => void
+  onRunCreated: (runId: string) => void
+}) {
+  const versions = usePromptVersions(evaluator.prompt_name)
+  const createRun = useCreateEvalRun()
+  const estimate = useEstimateEvalCost()
+
+  const [versionId, setVersionId] = useState('')
+  const [sampleSize, setSampleSize] = useState(50)
+  const [days, setDays] = useState(7)
+  const [error, setError] = useState('')
+
+  // Default to latest version
+  useMemo(() => {
+    if (!versionId && versions.data && versions.data.length > 0) {
+      setVersionId(versions.data[0]!.id)
+    }
+  }, [versions.data, versionId])
+
+  async function loadEstimate() {
+    try {
+      await estimate.mutateAsync({ sampleSize, judgeModel: evaluator.config.judge_model })
+    } catch {
+      // ignore
+    }
+  }
+
+  useMemo(() => { void loadEstimate() /* eslint-disable-line */ }, [sampleSize, evaluator.config.judge_model])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    if (!versionId) { setError('Select a version'); return }
+    try {
+      const sampleFrom = new Date(Date.now() - days * 86400_000).toISOString()
+      const run = await createRun.mutateAsync({
+        evaluatorId: evaluator.id,
+        promptVersionId: versionId,
+        sampleSize,
+        sampleFrom,
+      })
+      onRunCreated(run.id)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to start')
+    }
+  }
+
+  return (
+    <Dialog open={true} onOpenChange={(v) => { if (!v) onClose() }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Run evaluation · {evaluator.name}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-3 mt-3">
+          <div>
+            <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+              Version
+            </label>
+            <select
+              value={versionId}
+              onChange={(e) => setVersionId(e.target.value)}
+              required
+              className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text"
+            >
+              <option value="">Select version…</option>
+              {(versions.data ?? []).map((v) => (
+                <option key={v.id} value={v.id}>v{v.version}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                Last N days
+              </label>
+              <select
+                value={days}
+                onChange={(e) => setDays(Number(e.target.value))}
+                className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text"
+              >
+                <option value={1}>1 day</option>
+                <option value={7}>7 days</option>
+                <option value={30}>30 days</option>
+                <option value={90}>90 days</option>
+              </select>
+            </div>
+            <div>
+              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                Sample size
+              </label>
+              <input
+                type="number"
+                min={1} max={1000}
+                value={sampleSize}
+                onChange={(e) => setSampleSize(Math.min(1000, Math.max(1, parseInt(e.target.value, 10) || 1)))}
+                className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text"
+              />
+            </div>
+          </div>
+
+          <div className="bg-bg-muted rounded-[5px] border border-border p-3 font-mono text-[11px] text-text-muted space-y-1">
+            <div className="flex justify-between">
+              <span>Judge model</span>
+              <span className="text-text">{evaluator.config.judge_model}</span>
+            </div>
+            <div className="flex justify-between">
+              <span>Estimated cost (your provider key)</span>
+              <span className="text-text">{fmtUsd(estimate.data?.estimateUsd ?? null)}</span>
+            </div>
+          </div>
+
+          {error && (
+            <p className="font-mono text-[11.5px] text-bad">{error}</p>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="font-mono text-[11.5px] px-3 py-[6px] border border-border rounded-[5px] text-text-muted hover:text-text transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={createRun.isPending || !versionId}
+              className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 transition-opacity disabled:opacity-40 flex items-center gap-1.5"
+            >
+              {createRun.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : <Play className="h-3 w-3" />}
+              Run
+            </button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ── Run detail panel ─────────────────────────────────────────────────────────
+
+function RunDetailPanel({ runId, onClose }: { runId: string; onClose: () => void }) {
+  const run = useEvalRun(runId, { pollWhilePending: true })
+  const results = useEvalResults(
+    run.data?.status === 'completed' ? runId : null,
+  )
+
+  if (!run.data) {
+    return (
+      <div className="border-l border-border w-[400px] shrink-0 flex items-center justify-center text-text-faint">
+        <Loader2 className="h-4 w-4 animate-spin" />
+      </div>
+    )
+  }
+
+  const r = run.data
+  const histBuckets = useMemo(() => {
+    const buckets = [0, 0, 0, 0, 0] // 0-0.2, 0.2-0.4, ...
+    for (const result of results.data ?? []) {
+      const idx = Math.min(4, Math.floor(result.score * 5))
+      buckets[idx] = (buckets[idx] ?? 0) + 1
+    }
+    return buckets
+  }, [results.data])
+  const maxBucket = Math.max(1, ...histBuckets)
+
+  return (
+    <div className="border-l border-border w-[420px] shrink-0 overflow-y-auto">
+      <div className="sticky top-0 bg-bg-elev border-b border-border px-4 py-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <StatusBadge status={r.status} />
+          <span className="font-mono text-[11px] text-text-muted">
+            {r.scored_count}/{r.sample_size} scored
+          </span>
+        </div>
+        <button onClick={onClose} className="text-text-faint hover:text-text text-xs">✕</button>
+      </div>
+
+      <div className="p-4 space-y-4">
+        {/* KPIs */}
+        <div className="grid grid-cols-3 gap-2">
+          <div className="bg-bg-muted border border-border rounded-[5px] px-3 py-2">
+            <p className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-text-faint">Avg score</p>
+            <p className="font-mono text-[16px] text-text font-medium">{fmtScore(r.avg_score)}</p>
+          </div>
+          <div className="bg-bg-muted border border-border rounded-[5px] px-3 py-2">
+            <p className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-text-faint">Samples</p>
+            <p className="font-mono text-[16px] text-text font-medium">{r.scored_count}</p>
+          </div>
+          <div className="bg-bg-muted border border-border rounded-[5px] px-3 py-2">
+            <p className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-text-faint">Cost</p>
+            <p className="font-mono text-[16px] text-text font-medium">{fmtUsd(r.total_cost_usd)}</p>
+          </div>
+        </div>
+
+        {/* Running spinner */}
+        {(r.status === 'pending' || r.status === 'running') && (
+          <div className="flex items-center gap-2 p-3 bg-accent-bg border border-accent-border rounded-[5px] font-mono text-[11.5px] text-accent">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Scoring samples… polling every 2s
+          </div>
+        )}
+
+        {/* Error */}
+        {r.status === 'failed' && r.error && (
+          <div className="flex items-start gap-2 p-3 bg-bad/10 border border-bad/30 rounded-[5px] font-mono text-[11.5px] text-bad">
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+            <span>{r.error}</span>
+          </div>
+        )}
+
+        {/* Histogram */}
+        {r.status === 'completed' && results.data && results.data.length > 0 && (
+          <>
+            <div>
+              <p className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-2">
+                Score distribution
+              </p>
+              <div className="flex items-end gap-1 h-20">
+                {histBuckets.map((c, i) => (
+                  <div key={i} className="flex-1 flex flex-col items-center gap-1">
+                    <div
+                      className="w-full bg-text/70 rounded-[2px]"
+                      style={{ height: `${(c / maxBucket) * 60}px` }}
+                    />
+                    <span className="font-mono text-[9px] text-text-faint">{c}</span>
+                  </div>
+                ))}
+              </div>
+              <div className="flex justify-between font-mono text-[9px] text-text-faint mt-1">
+                <span>0</span><span>0.2</span><span>0.4</span><span>0.6</span><span>0.8</span><span>1</span>
+              </div>
+            </div>
+
+            {/* Worst N */}
+            <div>
+              <p className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-2">
+                Lowest-scoring samples
+              </p>
+              <div className="space-y-2">
+                {results.data.slice(0, 5).map((res) => (
+                  <a
+                    key={res.id}
+                    href={res.request_id ? `/requests?id=${res.request_id}` : undefined}
+                    className="block p-2 rounded-[5px] border border-border hover:bg-bg-muted transition-colors"
+                  >
+                    <div className="flex justify-between items-center mb-1">
+                      <span className="font-mono text-[12px] text-text font-medium">
+                        {fmtScore(res.score)}
+                      </span>
+                      <span className="font-mono text-[10px] text-text-faint">
+                        {fmtUsd(res.judge_cost_usd)}
+                      </span>
+                    </div>
+                    {res.reasoning && (
+                      <p className="font-mono text-[10.5px] text-text-muted line-clamp-2">
+                        {res.reasoning}
+                      </p>
+                    )}
+                  </a>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Evaluator row ────────────────────────────────────────────────────────────
+
+function EvaluatorRow({
+  evaluator,
+  onRun,
+  onSelectRun,
+}: {
+  evaluator: Evaluator
+  onRun: (e: Evaluator) => void
+  onSelectRun: (runId: string) => void
+}) {
+  const runs = useEvalRuns({ evaluatorId: evaluator.id })
+  const deleteMutation = useDeleteEvaluator()
+  const [expanded, setExpanded] = useState(false)
+
+  const latestCompleted = (runs.data ?? []).find((r) => r.status === 'completed')
+
+  function handleDelete(e: React.MouseEvent) {
+    e.stopPropagation()
+    if (!confirm(`Delete evaluator "${evaluator.name}"?`)) return
+    void deleteMutation.mutateAsync(evaluator.id)
+  }
+
+  return (
+    <div className="border-b border-border last:border-0">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full flex items-center px-[16px] py-[12px] hover:bg-bg-muted transition-colors text-left"
+        style={{ gridTemplateColumns: '1fr 140px 100px 100px 120px' }}
+      >
+        <div className="flex-1 min-w-0">
+          <p className="font-mono text-[13px] text-text font-medium truncate">{evaluator.name}</p>
+          <p className="font-mono text-[11px] text-text-faint truncate">
+            {evaluator.prompt_name} · judge: {evaluator.config.judge_model}
+          </p>
+        </div>
+        <div className="font-mono text-[12px] text-text-muted w-[100px] text-right">
+          {latestCompleted ? fmtScore(latestCompleted.avg_score) : '—'}
+        </div>
+        <div className="font-mono text-[11px] text-text-faint w-[80px] text-right">
+          {runs.data?.length ?? 0} runs
+        </div>
+        <div className="flex items-center gap-2 ml-3">
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); onRun(evaluator) }}
+            className="font-mono text-[11px] px-2 py-1 rounded-[4px] border border-border hover:bg-bg-elev flex items-center gap-1 transition-colors"
+          >
+            <Play className="h-3 w-3" />
+            Run
+          </button>
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="text-text-faint hover:text-bad transition-colors p-1"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="bg-bg-muted/50 px-[16px] py-[10px] border-t border-border">
+          {!runs.data || runs.data.length === 0 ? (
+            <p className="font-mono text-[11.5px] text-text-faint">No runs yet.</p>
+          ) : (
+            <div className="space-y-1.5">
+              <p className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                Recent runs
+              </p>
+              {runs.data.map((r) => (
+                <button
+                  key={r.id}
+                  type="button"
+                  onClick={() => onSelectRun(r.id)}
+                  className="w-full flex items-center gap-3 px-2 py-1.5 rounded-[4px] hover:bg-bg-elev text-left transition-colors"
+                >
+                  <StatusBadge status={r.status} />
+                  <span className="font-mono text-[11.5px] text-text-muted">
+                    {new Date(r.started_at).toLocaleString()}
+                  </span>
+                  <span className="font-mono text-[11.5px] text-text-faint">
+                    {r.scored_count}/{r.sample_size}
+                  </span>
+                  <span className="font-mono text-[12px] text-text ml-auto">
+                    {fmtScore(r.avg_score)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Main page ────────────────────────────────────────────────────────────────
+
+export function EvalsClient() {
+  const evaluators = useEvaluators()
+  const [newOpen, setNewOpen] = useState(false)
+  const [runDialog, setRunDialog] = useState<Evaluator | null>(null)
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
+
+  const list = evaluators.data ?? []
+
+  return (
+    <div className="flex flex-col h-full">
+      <Topbar
+        crumbs={[{ label: 'Workspace', href: '/dashboard' }, { label: 'Evals' }]}
+        right={
+          <button
+            type="button"
+            onClick={() => setNewOpen(true)}
+            className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 flex items-center gap-1.5"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New evaluator
+          </button>
+        }
+      />
+
+      <div className="flex flex-1 min-h-0">
+        <div className="flex-1 overflow-y-auto">
+          {/* Info banner */}
+          <div className="px-[22px] py-[12px] bg-bg-muted border-b border-border flex items-center gap-2 font-mono text-[11px] text-text-muted">
+            <Beaker className="h-3.5 w-3.5" />
+            <span>
+              LLM-as-judge scores production responses against a criterion you define.
+              Cost is billed to your provider key.
+            </span>
+          </div>
+
+          {evaluators.isLoading ? (
+            <div className="p-[22px] space-y-2">
+              {[1, 2].map((i) => <div key={i} className="h-14 bg-bg-elev rounded animate-pulse" />)}
+            </div>
+          ) : list.length === 0 ? (
+            <div className="flex flex-col items-center justify-center h-64 gap-3 text-text-muted">
+              <Beaker className="h-10 w-10 text-text-faint" />
+              <p className="font-mono text-[13px]">No evaluators yet.</p>
+              <button
+                type="button"
+                onClick={() => setNewOpen(true)}
+                className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 flex items-center gap-1.5"
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Create your first evaluator
+              </button>
+            </div>
+          ) : (
+            <>
+              {/* Header row */}
+              <div className="flex items-center px-[16px] py-[8px] bg-bg-muted border-b border-border font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+                <span className="flex-1">Evaluator</span>
+                <span className="w-[100px] text-right">Avg score</span>
+                <span className="w-[80px] text-right">Runs</span>
+                <span className="w-[150px]" />
+              </div>
+              {list.map((ev) => (
+                <EvaluatorRow
+                  key={ev.id}
+                  evaluator={ev}
+                  onRun={(e) => setRunDialog(e)}
+                  onSelectRun={(rid) => setSelectedRunId(rid)}
+                />
+              ))}
+            </>
+          )}
+        </div>
+
+        {selectedRunId && (
+          <RunDetailPanel runId={selectedRunId} onClose={() => setSelectedRunId(null)} />
+        )}
+      </div>
+
+      <NewEvaluatorDialog open={newOpen} onClose={() => setNewOpen(false)} />
+
+      {runDialog && (
+        <RunEvaluatorDialog
+          evaluator={runDialog}
+          onClose={() => setRunDialog(null)}
+          onRunCreated={(rid) => {
+            setRunDialog(null)
+            setSelectedRunId(rid)
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/evals/page.tsx
+++ b/apps/web/app/(dashboard)/evals/page.tsx
@@ -1,0 +1,13 @@
+import { HydrationBoundary } from '@tanstack/react-query'
+import { prefetchAll } from '@/lib/server/dehydrate'
+import { evaluatorsSpec } from '@/lib/server/queries/evals'
+import { EvalsClient } from './evals-client'
+
+export default async function EvalsPage() {
+  const state = await prefetchAll([evaluatorsSpec()])
+  return (
+    <HydrationBoundary state={state}>
+      <EvalsClient />
+    </HydrationBoundary>
+  )
+}

--- a/apps/web/app/(dashboard)/experiments/[id]/experiment-detail-client.tsx
+++ b/apps/web/app/(dashboard)/experiments/[id]/experiment-detail-client.tsx
@@ -1,0 +1,280 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Loader2, AlertTriangle, ChevronDown, ChevronUp } from 'lucide-react'
+import { Topbar } from '@/components/layout/topbar'
+import { cn } from '@/lib/utils'
+import {
+  useExperiment,
+  useExperimentResults,
+  type ExperimentResult,
+} from '@/lib/queries/use-experiments'
+
+function fmtUsd(n: number | null | undefined): string {
+  if (n == null) return '—'
+  return n >= 0.01 ? `$${n.toFixed(3)}` : `$${n.toFixed(5)}`
+}
+
+function fmtScore(n: number | null | undefined): string {
+  if (n == null) return '—'
+  return (n * 100).toFixed(1)
+}
+
+function fmtMs(n: number | null | undefined): string {
+  if (n == null) return '—'
+  if (n >= 1000) return `${(n / 1000).toFixed(2)}s`
+  return `${Math.round(n)}ms`
+}
+
+// Lightweight word-level diff highlighter for two strings.
+function diffHighlight(a: string, b: string): { aTokens: Array<{ t: string; cls: string }>; bTokens: Array<{ t: string; cls: string }> } {
+  const aw = a.split(/(\s+)/)
+  const bw = b.split(/(\s+)/)
+  const aSet = new Set(aw)
+  const bSet = new Set(bw)
+  const aTokens = aw.map((t) => ({
+    t,
+    cls: bSet.has(t) ? '' : 'bg-bad/15 text-bad',
+  }))
+  const bTokens = bw.map((t) => ({
+    t,
+    cls: aSet.has(t) ? '' : 'bg-good/15 text-good',
+  }))
+  return { aTokens, bTokens }
+}
+
+// ── Result row (collapsible side-by-side) ────────────────────────────────────
+
+function ResultRow({ result, idx }: { result: ExperimentResult; idx: number }) {
+  const [expanded, setExpanded] = useState(false)
+
+  const inputPreview = useMemo(() => {
+    const input = result.dataset_items?.input
+    if (!input) return `Item ${idx + 1}`
+    if (input.messages?.[0]?.content) return input.messages[0].content
+    if (input.variables) return JSON.stringify(input.variables)
+    return `Item ${idx + 1}`
+  }, [result, idx])
+
+  const { aTokens, bTokens } = useMemo(
+    () => diffHighlight(result.output_a ?? '', result.output_b ?? ''),
+    [result.output_a, result.output_b],
+  )
+
+  const scoreDelta = result.score_a != null && result.score_b != null
+    ? result.score_b - result.score_a
+    : null
+
+  return (
+    <div className="border-b border-border last:border-0">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full flex items-center px-[16px] py-[10px] hover:bg-bg-muted transition-colors text-left"
+      >
+        <span className="font-mono text-[11px] text-text-faint w-[28px]">#{idx + 1}</span>
+        <span className="flex-1 font-mono text-[12px] text-text truncate min-w-0">{inputPreview}</span>
+        <span className="font-mono text-[11.5px] text-text-muted w-[60px] text-right">
+          {fmtScore(result.score_a)}
+        </span>
+        <span className="font-mono text-[11.5px] text-text-muted w-[60px] text-right">
+          {fmtScore(result.score_b)}
+        </span>
+        <span className={cn(
+          'font-mono text-[11.5px] w-[60px] text-right',
+          scoreDelta == null ? 'text-text-faint' : scoreDelta > 0 ? 'text-good' : scoreDelta < 0 ? 'text-bad' : 'text-text-muted',
+        )}>
+          {scoreDelta == null ? '—' : (scoreDelta > 0 ? '+' : '') + (scoreDelta * 100).toFixed(1)}
+        </span>
+        <span className="ml-3 text-text-faint">
+          {expanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="bg-bg-muted/50 border-t border-border p-3 space-y-3">
+          <div>
+            <p className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-1">Input</p>
+            <pre className="font-mono text-[11.5px] text-text-muted whitespace-pre-wrap break-all">
+              {JSON.stringify(result.dataset_items?.input ?? {}, null, 2)}
+            </pre>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="bg-bg rounded-[5px] border border-border p-3 min-w-0">
+              <div className="flex items-center justify-between mb-2">
+                <p className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+                  Output A
+                </p>
+                <span className="font-mono text-[10px] text-text-faint">
+                  {fmtUsd(result.cost_a_usd)} · {fmtMs(result.latency_a_ms)} · {result.tokens_a}t
+                </span>
+              </div>
+              {result.error_a ? (
+                <div className="flex items-start gap-1.5 font-mono text-[11px] text-bad">
+                  <AlertTriangle className="h-3 w-3 shrink-0 mt-0.5" />
+                  <span>{result.error_a}</span>
+                </div>
+              ) : (
+                <p className="font-mono text-[12px] leading-relaxed whitespace-pre-wrap break-words">
+                  {aTokens.map((token, i) => (
+                    <span key={i} className={token.cls}>{token.t}</span>
+                  ))}
+                </p>
+              )}
+              {result.reasoning_a && (
+                <p className="font-mono text-[10.5px] text-text-faint mt-2 pt-2 border-t border-border">
+                  Judge: {result.reasoning_a}
+                </p>
+              )}
+            </div>
+
+            <div className="bg-bg rounded-[5px] border border-border p-3 min-w-0">
+              <div className="flex items-center justify-between mb-2">
+                <p className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+                  Output B
+                </p>
+                <span className="font-mono text-[10px] text-text-faint">
+                  {fmtUsd(result.cost_b_usd)} · {fmtMs(result.latency_b_ms)} · {result.tokens_b}t
+                </span>
+              </div>
+              {result.error_b ? (
+                <div className="flex items-start gap-1.5 font-mono text-[11px] text-bad">
+                  <AlertTriangle className="h-3 w-3 shrink-0 mt-0.5" />
+                  <span>{result.error_b}</span>
+                </div>
+              ) : (
+                <p className="font-mono text-[12px] leading-relaxed whitespace-pre-wrap break-words">
+                  {bTokens.map((token, i) => (
+                    <span key={i} className={token.cls}>{token.t}</span>
+                  ))}
+                </p>
+              )}
+              {result.reasoning_b && (
+                <p className="font-mono text-[10.5px] text-text-faint mt-2 pt-2 border-t border-border">
+                  Judge: {result.reasoning_b}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {result.dataset_items?.expected_output && (
+            <div className="bg-bg-elev rounded-[5px] border border-border p-3">
+              <p className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-1">
+                Expected output (from dataset)
+              </p>
+              <p className="font-mono text-[11.5px] text-text-muted whitespace-pre-wrap">
+                {result.dataset_items.expected_output}
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Main page ────────────────────────────────────────────────────────────────
+
+export function ExperimentDetailClient({ experimentId }: { experimentId: string }) {
+  const exp = useExperiment(experimentId, { pollWhilePending: true })
+  const results = useExperimentResults(
+    exp.data?.status === 'completed' ? experimentId : null,
+  )
+
+  if (exp.isLoading || !exp.data) {
+    return (
+      <div className="flex flex-col h-full">
+        <Topbar crumbs={[{ label: 'Workspace', href: '/dashboard' }, { label: 'Experiments', href: '/experiments' }, { label: '...' }]} />
+        <div className="flex items-center justify-center h-64 text-text-faint">
+          <Loader2 className="h-4 w-4 animate-spin" />
+        </div>
+      </div>
+    )
+  }
+
+  const e = exp.data
+  const delta = e.avg_score_a != null && e.avg_score_b != null
+    ? e.avg_score_b - e.avg_score_a
+    : null
+
+  return (
+    <div className="flex flex-col h-full">
+      <Topbar
+        crumbs={[
+          { label: 'Workspace', href: '/dashboard' },
+          { label: 'Experiments', href: '/experiments' },
+          { label: e.name },
+        ]}
+      />
+
+      <div className="flex-1 overflow-y-auto">
+        {/* Header */}
+        <div className="px-[22px] py-[14px] border-b border-border">
+          <p className="font-mono text-[15px] text-text font-medium">{e.name}</p>
+          <p className="font-mono text-[11.5px] text-text-faint mt-0.5">
+            {e.prompt_name} · {e.run_model}
+          </p>
+        </div>
+
+        {/* Running banner */}
+        {(e.status === 'pending' || e.status === 'running') && (
+          <div className="mx-[22px] mt-3 p-3 bg-accent-bg border border-accent-border rounded-[5px] font-mono text-[11.5px] text-accent flex items-center gap-2">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Running… {e.completed_items}/{e.total_items} items completed
+          </div>
+        )}
+
+        {/* Error banner */}
+        {e.status === 'failed' && e.error && (
+          <div className="mx-[22px] mt-3 p-3 bg-bad/10 border border-bad/30 rounded-[5px] font-mono text-[11.5px] text-bad flex items-start gap-2">
+            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <span>{e.error}</span>
+          </div>
+        )}
+
+        {/* KPIs */}
+        {e.status === 'completed' && (
+          <div className="grid grid-cols-4 gap-3 px-[22px] py-[14px] border-b border-border">
+            <div className="bg-bg-muted border border-border rounded-[5px] px-3 py-2.5">
+              <p className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-text-faint mb-1">Avg score A</p>
+              <p className="font-mono text-[18px] text-text font-medium">{fmtScore(e.avg_score_a)}</p>
+            </div>
+            <div className="bg-bg-muted border border-border rounded-[5px] px-3 py-2.5">
+              <p className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-text-faint mb-1">Avg score B</p>
+              <p className="font-mono text-[18px] text-text font-medium">{fmtScore(e.avg_score_b)}</p>
+            </div>
+            <div className="bg-bg-muted border border-border rounded-[5px] px-3 py-2.5">
+              <p className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-text-faint mb-1">Δ (B − A)</p>
+              <p className={cn(
+                'font-mono text-[18px] font-medium',
+                delta == null ? 'text-text-faint' : delta > 0 ? 'text-good' : delta < 0 ? 'text-bad' : 'text-text',
+              )}>
+                {delta == null ? '—' : (delta > 0 ? '+' : '') + (delta * 100).toFixed(1)}
+              </p>
+            </div>
+            <div className="bg-bg-muted border border-border rounded-[5px] px-3 py-2.5">
+              <p className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-text-faint mb-1">Total cost</p>
+              <p className="font-mono text-[18px] text-text font-medium">{fmtUsd(e.total_cost_usd)}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Results */}
+        {e.status === 'completed' && results.data && results.data.length > 0 && (
+          <>
+            <div className="flex items-center px-[16px] py-[8px] bg-bg-muted border-b border-border font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+              <span className="w-[28px]" />
+              <span className="flex-1">Input</span>
+              <span className="w-[60px] text-right">A</span>
+              <span className="w-[60px] text-right">B</span>
+              <span className="w-[60px] text-right">Δ</span>
+              <span className="w-[16px] ml-3" />
+            </div>
+            {results.data.map((r, i) => <ResultRow key={r.id} result={r} idx={i} />)}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/experiments/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/experiments/[id]/page.tsx
@@ -1,0 +1,6 @@
+import { ExperimentDetailClient } from './experiment-detail-client'
+
+export default async function ExperimentDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  return <ExperimentDetailClient experimentId={id} />
+}

--- a/apps/web/app/(dashboard)/experiments/experiments-client.tsx
+++ b/apps/web/app/(dashboard)/experiments/experiments-client.tsx
@@ -1,0 +1,385 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { FlaskConical, Plus, Loader2 } from 'lucide-react'
+import { Topbar } from '@/components/layout/topbar'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+import {
+  useExperiments,
+  useCreateExperiment,
+  type Experiment,
+  type ExperimentStatus,
+} from '@/lib/queries/use-experiments'
+import { usePrompts, usePromptVersions } from '@/lib/queries/use-prompts'
+import { useDatasets } from '@/lib/queries/use-datasets'
+import { useEvaluators } from '@/lib/queries/use-evals'
+
+const RUN_MODELS = {
+  openai: ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo', 'gpt-3.5-turbo'],
+  anthropic: ['claude-3-5-haiku-20241022', 'claude-3-5-sonnet-20241022'],
+} as const
+
+function fmtUsd(n: number | null | undefined): string {
+  if (n == null) return '—'
+  return n >= 0.01 ? `$${n.toFixed(3)}` : `$${n.toFixed(5)}`
+}
+
+function fmtScore(n: number | null | undefined): string {
+  if (n == null) return '—'
+  return (n * 100).toFixed(1)
+}
+
+function StatusBadge({ status }: { status: ExperimentStatus }) {
+  const config = {
+    pending:   { label: 'Pending',   cls: 'bg-bg-elev text-text-faint' },
+    running:   { label: 'Running',   cls: 'bg-accent-bg text-accent border border-accent-border' },
+    completed: { label: 'Completed', cls: 'bg-good/10 text-good border border-good/30' },
+    failed:    { label: 'Failed',    cls: 'bg-bad/10 text-bad border border-bad/30' },
+  }[status]
+  return (
+    <span className={cn('font-mono text-[10px] px-[6px] py-[1.5px] rounded-[3px]', config.cls)}>
+      {config.label}
+    </span>
+  )
+}
+
+// ── New experiment dialog ────────────────────────────────────────────────────
+
+function NewExperimentDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const prompts = usePrompts()
+  const datasets = useDatasets()
+  const create = useCreateExperiment()
+
+  const [name, setName] = useState('')
+  const [promptName, setPromptName] = useState('')
+  const versions = usePromptVersions(promptName || null)
+  const evaluators = useEvaluators(promptName || undefined)
+  const [versionAId, setVersionAId] = useState('')
+  const [versionBId, setVersionBId] = useState('')
+  const [datasetId, setDatasetId] = useState('')
+  const [evaluatorId, setEvaluatorId] = useState('')
+  const [runProvider, setRunProvider] = useState<'openai' | 'anthropic'>('openai')
+  const [runModel, setRunModel] = useState<string>('gpt-4o-mini')
+  const [error, setError] = useState('')
+
+  // Reset downstream selections when prompt changes
+  function handlePromptChange(v: string) {
+    setPromptName(v)
+    setVersionAId('')
+    setVersionBId('')
+    setEvaluatorId('')
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    if (!name.trim()) { setError('Name required'); return }
+    if (!promptName) { setError('Select prompt'); return }
+    if (!versionAId || !versionBId) { setError('Select both versions'); return }
+    if (versionAId === versionBId) { setError('Versions must differ'); return }
+    if (!datasetId) { setError('Select dataset'); return }
+    if (!runModel) { setError('Select model'); return }
+    try {
+      await create.mutateAsync({
+        name: name.trim(),
+        promptName,
+        versionAId,
+        versionBId,
+        datasetId,
+        ...(evaluatorId && { evaluatorId }),
+        runProvider,
+        runModel,
+      })
+      onClose()
+      setName(''); setPromptName(''); setVersionAId(''); setVersionBId('')
+      setDatasetId(''); setEvaluatorId('')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create')
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose() }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>New experiment</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-3 mt-3">
+          <div>
+            <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+              Name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Friendliness v2 vs v3"
+              required
+              className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text focus:outline-none focus:border-border-strong"
+            />
+          </div>
+
+          <div>
+            <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+              Prompt
+            </label>
+            <select
+              value={promptName}
+              onChange={(e) => handlePromptChange(e.target.value)}
+              required
+              className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text"
+            >
+              <option value="">Select prompt…</option>
+              {(prompts.data ?? []).map((p) => (
+                <option key={p.id} value={p.name}>{p.name}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                Version A (control)
+              </label>
+              <select
+                value={versionAId}
+                onChange={(e) => setVersionAId(e.target.value)}
+                disabled={!promptName}
+                required
+                className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text disabled:opacity-40"
+              >
+                <option value="">Select…</option>
+                {(versions.data ?? []).map((v) => (
+                  <option key={v.id} value={v.id}>v{v.version}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                Version B (challenger)
+              </label>
+              <select
+                value={versionBId}
+                onChange={(e) => setVersionBId(e.target.value)}
+                disabled={!promptName}
+                required
+                className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text disabled:opacity-40"
+              >
+                <option value="">Select…</option>
+                {(versions.data ?? []).map((v) => (
+                  <option key={v.id} value={v.id}>v{v.version}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+              Dataset
+            </label>
+            <select
+              value={datasetId}
+              onChange={(e) => setDatasetId(e.target.value)}
+              required
+              className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text"
+            >
+              <option value="">Select dataset…</option>
+              {(datasets.data ?? []).map((d) => (
+                <option key={d.id} value={d.id}>
+                  {d.name} ({d.item_count ?? 0} items)
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+              Evaluator (optional — for side-by-side scoring)
+            </label>
+            <select
+              value={evaluatorId}
+              onChange={(e) => setEvaluatorId(e.target.value)}
+              disabled={!promptName}
+              className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text disabled:opacity-40"
+            >
+              <option value="">None (outputs only, no scoring)</option>
+              {(evaluators.data ?? []).map((ev) => (
+                <option key={ev.id} value={ev.id}>{ev.name}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                Run provider
+              </label>
+              <select
+                value={runProvider}
+                onChange={(e) => {
+                  const p = e.target.value as 'openai' | 'anthropic'
+                  setRunProvider(p)
+                  setRunModel(RUN_MODELS[p][0])
+                }}
+                className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text"
+              >
+                <option value="openai">OpenAI</option>
+                <option value="anthropic">Anthropic</option>
+              </select>
+            </div>
+            <div>
+              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                Run model
+              </label>
+              <select
+                value={runModel}
+                onChange={(e) => setRunModel(e.target.value)}
+                className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text"
+              >
+                {RUN_MODELS[runProvider].map((m) => (
+                  <option key={m} value={m}>{m}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="bg-bg-muted rounded-[5px] border border-border p-2.5 font-mono text-[10.5px] text-text-muted">
+            Both versions run on the same model. Cost charged to your provider key
+            (≈ 2× dataset items, + judge if evaluator selected).
+          </div>
+
+          {error && <p className="font-mono text-[11.5px] text-bad">{error}</p>}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="font-mono text-[11.5px] px-3 py-[6px] border border-border rounded-[5px] text-text-muted hover:text-text"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={create.isPending}
+              className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 disabled:opacity-40 flex items-center gap-1.5"
+            >
+              {create.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
+              Start experiment
+            </button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ── Experiment row ───────────────────────────────────────────────────────────
+
+function ExperimentRow({ exp }: { exp: Experiment }) {
+  const delta = useMemo(() => {
+    if (exp.avg_score_a == null || exp.avg_score_b == null) return null
+    return exp.avg_score_b - exp.avg_score_a
+  }, [exp.avg_score_a, exp.avg_score_b])
+
+  return (
+    <Link
+      href={`/experiments/${exp.id}`}
+      className="flex items-center px-[16px] py-[12px] border-b border-border last:border-0 hover:bg-bg-muted transition-colors"
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5">
+          <p className="font-mono text-[13px] text-text font-medium truncate">{exp.name}</p>
+          <StatusBadge status={exp.status} />
+        </div>
+        <p className="font-mono text-[11px] text-text-faint truncate">
+          {exp.prompt_name} · {exp.run_model}
+        </p>
+      </div>
+      <div className="font-mono text-[12px] text-text-muted w-[90px] text-right">
+        {fmtScore(exp.avg_score_a)}
+      </div>
+      <div className="font-mono text-[12px] text-text-muted w-[90px] text-right">
+        {fmtScore(exp.avg_score_b)}
+      </div>
+      <div className={cn(
+        'font-mono text-[12px] w-[80px] text-right',
+        delta == null ? 'text-text-faint' : delta > 0 ? 'text-good' : delta < 0 ? 'text-bad' : 'text-text-muted',
+      )}>
+        {delta == null ? '—' : (delta > 0 ? '+' : '') + (delta * 100).toFixed(1)}
+      </div>
+      <div className="font-mono text-[11px] text-text-faint w-[80px] text-right">
+        {fmtUsd(exp.total_cost_usd)}
+      </div>
+    </Link>
+  )
+}
+
+// ── Main page ────────────────────────────────────────────────────────────────
+
+export function ExperimentsClient() {
+  const experiments = useExperiments()
+  const [newOpen, setNewOpen] = useState(false)
+  const list = experiments.data ?? []
+
+  return (
+    <div className="flex flex-col h-full">
+      <Topbar
+        crumbs={[{ label: 'Workspace', href: '/dashboard' }, { label: 'Experiments' }]}
+        right={
+          <button
+            type="button"
+            onClick={() => setNewOpen(true)}
+            className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 flex items-center gap-1.5"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New experiment
+          </button>
+        }
+      />
+
+      <div className="flex-1 overflow-y-auto">
+        <div className="px-[22px] py-[12px] bg-bg-muted border-b border-border flex items-center gap-2 font-mono text-[11px] text-text-muted">
+          <FlaskConical className="h-3.5 w-3.5" />
+          <span>
+            Offline side-by-side: runs both prompt versions on a dataset and compares outputs.
+            Unlike A/B (Prompts), no production traffic is affected.
+          </span>
+        </div>
+
+        {experiments.isLoading ? (
+          <div className="p-[22px] space-y-2">
+            {[1, 2].map((i) => <div key={i} className="h-14 bg-bg-elev rounded animate-pulse" />)}
+          </div>
+        ) : list.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-64 gap-3 text-text-muted">
+            <FlaskConical className="h-10 w-10 text-text-faint" />
+            <p className="font-mono text-[13px]">No experiments yet.</p>
+            <button
+              type="button"
+              onClick={() => setNewOpen(true)}
+              className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 flex items-center gap-1.5"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Create your first experiment
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center px-[16px] py-[8px] bg-bg-muted border-b border-border font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+              <span className="flex-1">Name</span>
+              <span className="w-[90px] text-right">A score</span>
+              <span className="w-[90px] text-right">B score</span>
+              <span className="w-[80px] text-right">Δ</span>
+              <span className="w-[80px] text-right">Cost</span>
+            </div>
+            {list.map((exp) => <ExperimentRow key={exp.id} exp={exp} />)}
+          </>
+        )}
+      </div>
+
+      <NewExperimentDialog open={newOpen} onClose={() => setNewOpen(false)} />
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/experiments/page.tsx
+++ b/apps/web/app/(dashboard)/experiments/page.tsx
@@ -1,0 +1,13 @@
+import { HydrationBoundary } from '@tanstack/react-query'
+import { prefetchAll } from '@/lib/server/dehydrate'
+import { experimentsSpec } from '@/lib/server/queries/experiments'
+import { ExperimentsClient } from './experiments-client'
+
+export default async function ExperimentsPage() {
+  const state = await prefetchAll([experimentsSpec()])
+  return (
+    <HydrationBoundary state={state}>
+      <ExperimentsClient />
+    </HydrationBoundary>
+  )
+}

--- a/apps/web/app/(dashboard)/prompts/[name]/tabs/calls-tab.tsx
+++ b/apps/web/app/(dashboard)/prompts/[name]/tabs/calls-tab.tsx
@@ -92,13 +92,14 @@ export function CallsTab({ name }: Props) {
             {/* Per-version table */}
             <div className="bg-bg-elev border border-border rounded-[6px] overflow-x-auto">
               <div
-                className="grid font-mono text-[10px] text-text-faint uppercase tracking-[0.05em] px-[16px] py-[9px] bg-bg-muted border-b border-border min-w-[620px]"
-                style={{ gridTemplateColumns: '80px 70px 100px 100px 100px 110px 100px' }}
+                className="grid font-mono text-[10px] text-text-faint uppercase tracking-[0.05em] px-[16px] py-[9px] bg-bg-muted border-b border-border min-w-[720px]"
+                style={{ gridTemplateColumns: '80px 70px 100px 100px 80px 100px 110px 100px' }}
               >
                 <span>Version</span>
                 <span className="text-right">Calls</span>
                 <span className="text-right">Avg latency</span>
                 <span className="text-right">Error rate</span>
+                <span className="text-right">Quality</span>
                 <span className="text-right">Avg cost</span>
                 <span className="text-right">Prompt tokens</span>
                 <span className="text-right">Compl. tokens</span>
@@ -107,8 +108,8 @@ export function CallsTab({ name }: Props) {
                 <Link
                   key={m.promptVersionId}
                   href={`/requests?promptVersionId=${m.promptVersionId}`}
-                  className="grid items-center px-[16px] py-[11px] border-b border-border last:border-0 min-w-[620px] hover:bg-bg-muted transition-colors cursor-pointer"
-                  style={{ gridTemplateColumns: '80px 70px 100px 100px 100px 110px 100px' }}
+                  className="grid items-center px-[16px] py-[11px] border-b border-border last:border-0 min-w-[720px] hover:bg-bg-muted transition-colors cursor-pointer"
+                  style={{ gridTemplateColumns: '80px 70px 100px 100px 80px 100px 110px 100px' }}
                 >
                   <span className="font-mono text-[11px] text-text-muted">v{m.version}</span>
                   <span className="text-right font-mono text-[12px] text-text-muted">{m.sampleCount.toLocaleString()}</span>
@@ -118,6 +119,21 @@ export function CallsTab({ name }: Props) {
                     m.errorRate === 0 ? 'text-good' : m.errorRate < 0.05 ? 'text-warn' : 'text-bad',
                   )}>
                     {(m.errorRate * 100).toFixed(1)}%
+                  </span>
+                  <span
+                    className={cn(
+                      'text-right font-mono text-[12px]',
+                      m.avgQualityScore == null
+                        ? 'text-text-faint'
+                        : m.avgQualityScore >= 0.7
+                          ? 'text-good'
+                          : m.avgQualityScore >= 0.4
+                            ? 'text-warn'
+                            : 'text-bad',
+                    )}
+                    title={m.qualitySampleCount > 0 ? `${m.qualitySampleCount} eval samples` : 'No evals run'}
+                  >
+                    {m.avgQualityScore == null ? '—' : (m.avgQualityScore * 100).toFixed(0)}
                   </span>
                   <span className="text-right font-mono text-[12px] text-text-muted">{fmtUsd(m.avgCostUsd)}</span>
                   <span className="text-right font-mono text-[12px] text-text-muted">

--- a/apps/web/app/(dashboard)/prompts/[name]/tabs/calls-tab.tsx
+++ b/apps/web/app/(dashboard)/prompts/[name]/tabs/calls-tab.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState } from 'react'
+import Link from 'next/link'
 import { usePromptCompare } from '@/lib/queries/use-prompts'
 import { cn } from '@/lib/utils'
 
@@ -103,9 +104,10 @@ export function CallsTab({ name }: Props) {
                 <span className="text-right">Compl. tokens</span>
               </div>
               {metrics.map((m) => (
-                <div
+                <Link
                   key={m.promptVersionId}
-                  className="grid items-center px-[16px] py-[11px] border-b border-border last:border-0 min-w-[620px]"
+                  href={`/requests?promptVersionId=${m.promptVersionId}`}
+                  className="grid items-center px-[16px] py-[11px] border-b border-border last:border-0 min-w-[620px] hover:bg-bg-muted transition-colors cursor-pointer"
                   style={{ gridTemplateColumns: '80px 70px 100px 100px 100px 110px 100px' }}
                 >
                   <span className="font-mono text-[11px] text-text-muted">v{m.version}</span>
@@ -124,7 +126,7 @@ export function CallsTab({ name }: Props) {
                   <span className="text-right font-mono text-[12px] text-text-muted">
                     {m.avgCompletionTokens > 0 ? Math.round(m.avgCompletionTokens).toLocaleString() : '—'}
                   </span>
-                </div>
+                </Link>
               ))}
             </div>
           </div>

--- a/apps/web/app/(dashboard)/requests/requests-client.tsx
+++ b/apps/web/app/(dashboard)/requests/requests-client.tsx
@@ -807,6 +807,8 @@ export function RequestsClient() {
   }, [timeRange])
 
   const promptVersionId = searchParams.get('promptVersionId') ?? undefined
+  const userIdFilter = searchParams.get('userId') ?? undefined
+  const sessionIdFilter = searchParams.get('sessionId') ?? undefined
 
   const serverFilters = useMemo(
     () => ({
@@ -820,8 +822,10 @@ export function RequestsClient() {
       ...(sortField !== 'created_at' && { sortBy: sortField }),
       ...(sortDir !== 'desc' && { sortDir }),
       ...(promptVersionId && { promptVersionId }),
+      ...(userIdFilter && { userId: userIdFilter }),
+      ...(sessionIdFilter && { sessionId: sessionIdFilter }),
     }),
-    [page, filters.provider, filters.model, filters.providerKeyId, filters.status, fromIso, sortField, sortDir, promptVersionId],
+    [page, filters.provider, filters.model, filters.providerKeyId, filters.status, fromIso, sortField, sortDir, promptVersionId, userIdFilter, sessionIdFilter],
   )
 
   const { data, isLoading, isFetching, refetch } = useRequests(serverFilters)

--- a/apps/web/app/(dashboard)/requests/requests-client.tsx
+++ b/apps/web/app/(dashboard)/requests/requests-client.tsx
@@ -342,6 +342,34 @@ function RequestDrawer({ requestId, visible, onClose, onPrev, onNext, hasPrev, h
             </div>
           ))}
 
+          {/* User — clickable filter link */}
+          {req.user_id && (
+            <div>
+              <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-0.5">User</div>
+              <Link
+                href={`/requests?userId=${encodeURIComponent(req.user_id)}`}
+                className="font-mono text-[12.5px] text-text hover:underline truncate block"
+                title={`Filter by user: ${req.user_id}`}
+              >
+                {req.user_id}
+              </Link>
+            </div>
+          )}
+
+          {/* Session — clickable filter link */}
+          {req.session_id && (
+            <div>
+              <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-0.5">Session</div>
+              <Link
+                href={`/requests?sessionId=${encodeURIComponent(req.session_id)}`}
+                className="font-mono text-[12.5px] text-text hover:underline truncate block"
+                title={`Filter by session: ${req.session_id}`}
+              >
+                {req.session_id}
+              </Link>
+            </div>
+          )}
+
           {/* Trace — link to trace page + copy full ID */}
           <div>
             <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-0.5">Trace</div>
@@ -886,6 +914,36 @@ export function RequestsClient() {
 
       <StatStrip />
       <TrafficBars />
+
+      {/* Active URL filter banner — shown when ?promptVersionId / ?userId / ?sessionId
+         is present in the URL. Click × to clear and return to unfiltered view. */}
+      {(promptVersionId || userIdFilter || sessionIdFilter) && (
+        <div className="flex items-center gap-2 px-[22px] py-[8px] bg-accent-bg border-b border-accent-border font-mono text-[11px] flex-wrap">
+          <span className="text-text-faint uppercase tracking-[0.05em] text-[10px]">Filter:</span>
+          {promptVersionId && (
+            <span className="px-2 py-[2px] bg-bg border border-border rounded-[3px] text-text">
+              prompt version {promptVersionId.slice(0, 8)}…
+            </span>
+          )}
+          {userIdFilter && (
+            <span className="px-2 py-[2px] bg-bg border border-border rounded-[3px] text-text">
+              user: {userIdFilter}
+            </span>
+          )}
+          {sessionIdFilter && (
+            <span className="px-2 py-[2px] bg-bg border border-border rounded-[3px] text-text">
+              session: {sessionIdFilter}
+            </span>
+          )}
+          <Link
+            href="/requests"
+            className="ml-auto text-text-faint hover:text-text text-[11px]"
+            aria-label="Clear URL filters"
+          >
+            Clear ×
+          </Link>
+        </div>
+      )}
 
       {/* Filter row */}
       <div className="flex items-center gap-1.5 px-[22px] py-[10px] border-b border-border shrink-0 flex-wrap">

--- a/apps/web/app/(dashboard)/requests/requests-client.tsx
+++ b/apps/web/app/(dashboard)/requests/requests-client.tsx
@@ -806,6 +806,8 @@ export function RequestsClient() {
     return undefined
   }, [timeRange])
 
+  const promptVersionId = searchParams.get('promptVersionId') ?? undefined
+
   const serverFilters = useMemo(
     () => ({
       page,
@@ -817,8 +819,9 @@ export function RequestsClient() {
       ...(fromIso && { from: fromIso }),
       ...(sortField !== 'created_at' && { sortBy: sortField }),
       ...(sortDir !== 'desc' && { sortDir }),
+      ...(promptVersionId && { promptVersionId }),
     }),
-    [page, filters.provider, filters.model, filters.providerKeyId, filters.status, fromIso, sortField, sortDir],
+    [page, filters.provider, filters.model, filters.providerKeyId, filters.status, fromIso, sortField, sortDir, promptVersionId],
   )
 
   const { data, isLoading, isFetching, refetch } = useRequests(serverFilters)

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -219,6 +219,12 @@ const NAV_GROUPS = [
     ],
   },
   {
+    label: 'Review',
+    items: [
+      { href: '/annotation', label: 'Annotation' },
+    ],
+  },
+  {
     label: 'Admin',
     items: [
       { href: '/projects',  label: 'Projects & Keys' },

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -211,10 +211,11 @@ const NAV_GROUPS = [
   {
     label: 'Build',
     items: [
-      { href: '/prompts',  label: 'Prompts' },
-      { href: '/evals',    label: 'Evals' },
-      { href: '/datasets', label: 'Datasets' },
-      { href: '/alerts',   label: 'Alerts' },
+      { href: '/prompts',     label: 'Prompts' },
+      { href: '/evals',       label: 'Evals' },
+      { href: '/datasets',    label: 'Datasets' },
+      { href: '/experiments', label: 'Experiments' },
+      { href: '/alerts',      label: 'Alerts' },
     ],
   },
   {

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -212,6 +212,7 @@ const NAV_GROUPS = [
     label: 'Build',
     items: [
       { href: '/prompts', label: 'Prompts' },
+      { href: '/evals',   label: 'Evals' },
       { href: '/alerts',  label: 'Alerts' },
     ],
   },

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -211,9 +211,10 @@ const NAV_GROUPS = [
   {
     label: 'Build',
     items: [
-      { href: '/prompts', label: 'Prompts' },
-      { href: '/evals',   label: 'Evals' },
-      { href: '/alerts',  label: 'Alerts' },
+      { href: '/prompts',  label: 'Prompts' },
+      { href: '/evals',    label: 'Evals' },
+      { href: '/datasets', label: 'Datasets' },
+      { href: '/alerts',   label: 'Alerts' },
     ],
   },
   {

--- a/apps/web/lib/queries/types.ts
+++ b/apps/web/lib/queries/types.ts
@@ -88,6 +88,10 @@ export interface RequestRow {
   provider_key_id?: string | null
   /** Joined from provider_keys.name — null if the key was revoked or never set. */
   provider_key_name?: string | null
+  /** Customer-supplied end-user ID (x-spanlens-user header). */
+  user_id?: string | null
+  /** Customer-supplied session ID (x-spanlens-session header). */
+  session_id?: string | null
   created_at: string
 }
 

--- a/apps/web/lib/queries/use-datasets.ts
+++ b/apps/web/lib/queries/use-datasets.ts
@@ -1,0 +1,146 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiDelete, apiGet, apiPost } from '@/lib/api'
+import type { ApiEnvelope } from './types'
+
+export interface Dataset {
+  id: string
+  organization_id: string
+  name: string
+  description: string | null
+  created_by: string | null
+  created_at: string
+  archived_at: string | null
+  /** Populated only by GET /datasets list endpoint. */
+  item_count?: number
+}
+
+export interface DatasetItem {
+  id: string
+  organization_id: string
+  dataset_id: string
+  input: { variables?: Record<string, string>; messages?: Array<{ role: string; content: string }> }
+  expected_output: string | null
+  source_request_id: string | null
+  created_at: string
+}
+
+export interface DatasetWithItems extends Dataset {
+  items: DatasetItem[]
+}
+
+// ── Datasets ────────────────────────────────────────────────────────────────
+
+export function datasetsQueryKey() {
+  return ['datasets'] as const
+}
+
+export function useDatasets() {
+  return useQuery({
+    queryKey: datasetsQueryKey(),
+    queryFn: async () => {
+      const res = await apiGet<ApiEnvelope<Dataset[]>>('/api/v1/datasets')
+      return res.data ?? []
+    },
+    staleTime: 60_000,
+  })
+}
+
+export function useDataset(id: string | null) {
+  return useQuery({
+    queryKey: ['datasets', id] as const,
+    queryFn: async () => {
+      if (!id) return null
+      const res = await apiGet<ApiEnvelope<DatasetWithItems>>(`/api/v1/datasets/${id}`)
+      return res.data
+    },
+    enabled: !!id,
+    staleTime: 30_000,
+  })
+}
+
+export function useCreateDataset() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: { name: string; description?: string }) => {
+      const res = await apiPost<ApiEnvelope<Dataset>>('/api/v1/datasets', input)
+      return res.data
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: datasetsQueryKey() })
+    },
+  })
+}
+
+export function useDeleteDataset() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await apiDelete(`/api/v1/datasets/${id}`)
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: datasetsQueryKey() })
+    },
+  })
+}
+
+// ── Items ───────────────────────────────────────────────────────────────────
+
+export interface AddItemInput {
+  datasetId: string
+  input: { variables?: Record<string, string>; messages?: Array<{ role: string; content: string }> }
+  expectedOutput?: string
+  sourceRequestId?: string
+}
+
+export function useAddDatasetItem() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: AddItemInput) => {
+      const res = await apiPost<ApiEnvelope<DatasetItem>>(
+        `/api/v1/datasets/${input.datasetId}/items`,
+        {
+          input: input.input,
+          expectedOutput: input.expectedOutput,
+          sourceRequestId: input.sourceRequestId,
+        },
+      )
+      return res.data
+    },
+    onSuccess: (_data, vars) => {
+      void qc.invalidateQueries({ queryKey: ['datasets', vars.datasetId] })
+      void qc.invalidateQueries({ queryKey: datasetsQueryKey() })
+    },
+  })
+}
+
+export function useImportRequestsToDataset() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: { datasetId: string; requestIds: string[] }) => {
+      const res = await apiPost<ApiEnvelope<{ imported: number }>>(
+        `/api/v1/datasets/${input.datasetId}/items/import-requests`,
+        { requestIds: input.requestIds },
+      )
+      return res.data
+    },
+    onSuccess: (_data, vars) => {
+      void qc.invalidateQueries({ queryKey: ['datasets', vars.datasetId] })
+      void qc.invalidateQueries({ queryKey: datasetsQueryKey() })
+    },
+  })
+}
+
+export function useDeleteDatasetItem() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: { datasetId: string; itemId: string }) => {
+      await apiDelete(`/api/v1/datasets/${input.datasetId}/items/${input.itemId}`)
+    },
+    onSuccess: (_data, vars) => {
+      void qc.invalidateQueries({ queryKey: ['datasets', vars.datasetId] })
+      void qc.invalidateQueries({ queryKey: datasetsQueryKey() })
+    },
+  })
+}

--- a/apps/web/lib/queries/use-evals.ts
+++ b/apps/web/lib/queries/use-evals.ts
@@ -170,6 +170,8 @@ export function useEvalResults(runId: string | null) {
 export interface CreateEvalRunInput {
   evaluatorId: string
   promptVersionId: string
+  source?: 'production' | 'dataset'
+  datasetId?: string
   sampleSize: number
   sampleFrom?: string
   sampleTo?: string

--- a/apps/web/lib/queries/use-evals.ts
+++ b/apps/web/lib/queries/use-evals.ts
@@ -1,0 +1,201 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiDelete, apiGet, apiPost } from '@/lib/api'
+import type { ApiEnvelope } from './types'
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface JudgeConfig {
+  criterion: string
+  judge_provider: 'openai' | 'anthropic'
+  judge_model: string
+  scale_min: number
+  scale_max: number
+}
+
+export interface Evaluator {
+  id: string
+  organization_id: string
+  prompt_name: string
+  name: string
+  type: 'llm_judge'
+  config: JudgeConfig
+  created_by: string | null
+  created_at: string
+  archived_at: string | null
+}
+
+export type EvalRunStatus = 'pending' | 'running' | 'completed' | 'failed'
+
+export interface EvalRun {
+  id: string
+  organization_id: string
+  evaluator_id: string
+  prompt_version_id: string
+  source: 'production' | 'dataset'
+  sample_size: number
+  sample_from: string | null
+  sample_to: string | null
+  status: EvalRunStatus
+  scored_count: number
+  avg_score: number | null
+  total_cost_usd: number
+  error: string | null
+  created_by: string | null
+  started_at: string
+  completed_at: string | null
+  /** Embedded evaluator (from GET /eval-runs/:id) */
+  evaluators?: { name: string; config: JudgeConfig } | null
+}
+
+export interface EvalResult {
+  id: string
+  eval_run_id: string
+  request_id: string | null
+  dataset_item_id: string | null
+  score: number
+  reasoning: string | null
+  judge_cost_usd: number
+  judge_tokens: number
+  created_at: string
+}
+
+// ── Evaluators ──────────────────────────────────────────────────────────────
+
+export function evaluatorsQueryKey(promptName?: string) {
+  return promptName ? (['evaluators', promptName] as const) : (['evaluators'] as const)
+}
+
+export function useEvaluators(promptName?: string) {
+  return useQuery({
+    queryKey: evaluatorsQueryKey(promptName),
+    queryFn: async () => {
+      const qs = promptName ? `?promptName=${encodeURIComponent(promptName)}` : ''
+      const res = await apiGet<ApiEnvelope<Evaluator[]>>(`/api/v1/evaluators${qs}`)
+      return res.data ?? []
+    },
+    staleTime: 60_000,
+  })
+}
+
+export interface CreateEvaluatorInput {
+  promptName: string
+  name: string
+  config: JudgeConfig
+}
+
+export function useCreateEvaluator() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: CreateEvaluatorInput) => {
+      const res = await apiPost<ApiEnvelope<Evaluator>>('/api/v1/evaluators', {
+        promptName: input.promptName,
+        name: input.name,
+        type: 'llm_judge',
+        config: input.config,
+      })
+      return res.data
+    },
+    onSuccess: (_data, vars) => {
+      void qc.invalidateQueries({ queryKey: evaluatorsQueryKey(vars.promptName) })
+      void qc.invalidateQueries({ queryKey: evaluatorsQueryKey() })
+    },
+  })
+}
+
+export function useDeleteEvaluator() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await apiDelete(`/api/v1/evaluators/${id}`)
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['evaluators'] })
+    },
+  })
+}
+
+// ── Eval runs ───────────────────────────────────────────────────────────────
+
+export function evalRunsQueryKey(filters?: { evaluatorId?: string; promptVersionId?: string }) {
+  return filters ? (['eval-runs', filters] as const) : (['eval-runs'] as const)
+}
+
+export function useEvalRuns(filters?: { evaluatorId?: string; promptVersionId?: string }) {
+  return useQuery({
+    queryKey: evalRunsQueryKey(filters),
+    queryFn: async () => {
+      const qs = new URLSearchParams()
+      if (filters?.evaluatorId) qs.set('evaluatorId', filters.evaluatorId)
+      if (filters?.promptVersionId) qs.set('promptVersionId', filters.promptVersionId)
+      const suffix = qs.size > 0 ? `?${qs}` : ''
+      const res = await apiGet<ApiEnvelope<EvalRun[]>>(`/api/v1/eval-runs${suffix}`)
+      return res.data ?? []
+    },
+    staleTime: 30_000,
+  })
+}
+
+export function useEvalRun(id: string | null, options?: { pollWhilePending?: boolean }) {
+  return useQuery({
+    queryKey: ['eval-run', id] as const,
+    queryFn: async () => {
+      if (!id) return null
+      const res = await apiGet<ApiEnvelope<EvalRun>>(`/api/v1/eval-runs/${id}`)
+      return res.data
+    },
+    enabled: !!id,
+    refetchInterval: (query) => {
+      if (!options?.pollWhilePending) return false
+      const data = query.state.data
+      if (!data) return 2000
+      return data.status === 'pending' || data.status === 'running' ? 2000 : false
+    },
+  })
+}
+
+export function useEvalResults(runId: string | null) {
+  return useQuery({
+    queryKey: ['eval-results', runId] as const,
+    queryFn: async () => {
+      if (!runId) return []
+      const res = await apiGet<ApiEnvelope<EvalResult[]>>(`/api/v1/eval-runs/${runId}/results`)
+      return res.data ?? []
+    },
+    enabled: !!runId,
+  })
+}
+
+export interface CreateEvalRunInput {
+  evaluatorId: string
+  promptVersionId: string
+  sampleSize: number
+  sampleFrom?: string
+  sampleTo?: string
+}
+
+export function useCreateEvalRun() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: CreateEvalRunInput) => {
+      const res = await apiPost<ApiEnvelope<EvalRun>>('/api/v1/eval-runs', input)
+      return res.data
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['eval-runs'] })
+    },
+  })
+}
+
+export function useEstimateEvalCost() {
+  return useMutation({
+    mutationFn: async (input: { sampleSize: number; judgeModel: string }) => {
+      const res = await apiPost<ApiEnvelope<{ estimateUsd: number }>>(
+        '/api/v1/eval-runs/estimate',
+        input,
+      )
+      return res.data
+    },
+  })
+}

--- a/apps/web/lib/queries/use-experiments.ts
+++ b/apps/web/lib/queries/use-experiments.ts
@@ -1,0 +1,125 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiGet, apiPost } from '@/lib/api'
+import type { ApiEnvelope } from './types'
+
+export type ExperimentStatus = 'pending' | 'running' | 'completed' | 'failed'
+
+export interface Experiment {
+  id: string
+  organization_id: string
+  name: string
+  prompt_name: string
+  version_a_id: string
+  version_b_id: string
+  dataset_id: string
+  evaluator_id: string | null
+  run_provider: 'openai' | 'anthropic'
+  run_model: string
+  status: ExperimentStatus
+  total_items: number
+  completed_items: number
+  avg_score_a: number | null
+  avg_score_b: number | null
+  total_cost_usd: number
+  error: string | null
+  created_by: string | null
+  started_at: string
+  completed_at: string | null
+}
+
+export interface ExperimentResult {
+  id: string
+  experiment_id: string
+  dataset_item_id: string
+  output_a: string | null
+  output_b: string | null
+  cost_a_usd: number
+  cost_b_usd: number
+  latency_a_ms: number | null
+  latency_b_ms: number | null
+  tokens_a: number
+  tokens_b: number
+  score_a: number | null
+  score_b: number | null
+  reasoning_a: string | null
+  reasoning_b: string | null
+  error_a: string | null
+  error_b: string | null
+  created_at: string
+  dataset_items?: {
+    input: { variables?: Record<string, string>; messages?: Array<{ role: string; content: string }> }
+    expected_output: string | null
+  } | null
+}
+
+export function experimentsQueryKey(promptName?: string) {
+  return promptName ? (['experiments', promptName] as const) : (['experiments'] as const)
+}
+
+export function useExperiments(promptName?: string) {
+  return useQuery({
+    queryKey: experimentsQueryKey(promptName),
+    queryFn: async () => {
+      const qs = promptName ? `?promptName=${encodeURIComponent(promptName)}` : ''
+      const res = await apiGet<ApiEnvelope<Experiment[]>>(`/api/v1/experiments${qs}`)
+      return res.data ?? []
+    },
+    staleTime: 30_000,
+  })
+}
+
+export function useExperiment(id: string | null, options?: { pollWhilePending?: boolean }) {
+  return useQuery({
+    queryKey: ['experiment', id] as const,
+    queryFn: async () => {
+      if (!id) return null
+      const res = await apiGet<ApiEnvelope<Experiment>>(`/api/v1/experiments/${id}`)
+      return res.data
+    },
+    enabled: !!id,
+    refetchInterval: (query) => {
+      if (!options?.pollWhilePending) return false
+      const data = query.state.data
+      if (!data) return 2000
+      return data.status === 'pending' || data.status === 'running' ? 2000 : false
+    },
+  })
+}
+
+export function useExperimentResults(id: string | null) {
+  return useQuery({
+    queryKey: ['experiment-results', id] as const,
+    queryFn: async () => {
+      if (!id) return []
+      const res = await apiGet<ApiEnvelope<ExperimentResult[]>>(`/api/v1/experiments/${id}/results`)
+      return res.data ?? []
+    },
+    enabled: !!id,
+  })
+}
+
+export interface CreateExperimentInput {
+  name: string
+  promptName: string
+  versionAId: string
+  versionBId: string
+  datasetId: string
+  evaluatorId?: string
+  runProvider: 'openai' | 'anthropic'
+  runModel: string
+}
+
+export function useCreateExperiment() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: CreateExperimentInput) => {
+      const res = await apiPost<ApiEnvelope<Experiment>>('/api/v1/experiments', input)
+      return res.data
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['experiments'] })
+    },
+  })
+}

--- a/apps/web/lib/queries/use-human-evals.ts
+++ b/apps/web/lib/queries/use-human-evals.ts
@@ -1,0 +1,147 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiDelete, apiGet, apiPost } from '@/lib/api'
+import type { ApiEnvelope } from './types'
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface AnnotationQueueItem {
+  id: string
+  prompt_version_id: string | null
+  prompt_name: string | null
+  prompt_version: number | null
+  model: string
+  created_at: string
+  request_body: Record<string, unknown> | null
+  response_body: Record<string, unknown> | null
+  llm_judge_score: number | null
+  human_eval: {
+    score: number
+    raw_score: number | null
+    comment: string | null
+  } | null
+}
+
+export interface HumanEval {
+  id: string
+  organization_id: string
+  request_id: string
+  prompt_version_id: string | null
+  reviewer_id: string
+  score: number
+  raw_score: number | null
+  comment: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface CorrelationPair {
+  requestId: string
+  judgeScore: number
+  humanScore: number
+}
+
+// ── Queue filters ───────────────────────────────────────────────────────────
+
+export interface QueueFilters {
+  promptName?: string
+  promptVersionId?: string
+  unscoredOnly?: boolean
+  lowJudgeScoreOnly?: boolean
+  limit?: number
+}
+
+export function annotationQueueQueryKey(filters: QueueFilters) {
+  return ['annotation', 'queue', filters] as const
+}
+
+export function useAnnotationQueue(filters: QueueFilters = {}) {
+  return useQuery({
+    queryKey: annotationQueueQueryKey(filters),
+    queryFn: async () => {
+      const qs = new URLSearchParams()
+      if (filters.promptName) qs.set('promptName', filters.promptName)
+      if (filters.promptVersionId) qs.set('promptVersionId', filters.promptVersionId)
+      if (filters.unscoredOnly) qs.set('unscoredOnly', 'true')
+      if (filters.lowJudgeScoreOnly) qs.set('lowJudgeScoreOnly', 'true')
+      if (filters.limit) qs.set('limit', String(filters.limit))
+      const suffix = qs.size > 0 ? `?${qs}` : ''
+      const res = await apiGet<ApiEnvelope<AnnotationQueueItem[]>>(`/api/v1/annotation/queue${suffix}`)
+      return res.data ?? []
+    },
+    staleTime: 30_000,
+  })
+}
+
+// ── Mutations ───────────────────────────────────────────────────────────────
+
+export interface SaveHumanEvalInput {
+  requestId: string
+  score: number       // normalized 0..1
+  rawScore?: number   // UI value (e.g. 1..5)
+  comment?: string
+}
+
+export function useSaveHumanEval() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: SaveHumanEvalInput) => {
+      const res = await apiPost<ApiEnvelope<HumanEval>>('/api/v1/human-evals', input)
+      return res.data
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['annotation', 'queue'] })
+      void qc.invalidateQueries({ queryKey: ['human-evals'] })
+      void qc.invalidateQueries({ queryKey: ['correlation'] })
+    },
+  })
+}
+
+export function useDeleteHumanEval() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await apiDelete(`/api/v1/human-evals/${id}`)
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['annotation', 'queue'] })
+      void qc.invalidateQueries({ queryKey: ['human-evals'] })
+    },
+  })
+}
+
+// ── Correlation (LLM judge vs Human) ────────────────────────────────────────
+
+export function useCorrelation(scope: { promptName?: string; promptVersionId?: string }) {
+  return useQuery({
+    queryKey: ['correlation', scope] as const,
+    queryFn: async () => {
+      const qs = new URLSearchParams()
+      if (scope.promptName) qs.set('promptName', scope.promptName)
+      if (scope.promptVersionId) qs.set('promptVersionId', scope.promptVersionId)
+      const suffix = qs.size > 0 ? `?${qs}` : ''
+      const res = await apiGet<ApiEnvelope<CorrelationPair[]>>(`/api/v1/human-evals/correlation${suffix}`)
+      return res.data ?? []
+    },
+    enabled: !!(scope.promptName || scope.promptVersionId),
+  })
+}
+
+// Pearson correlation coefficient — runs on the data returned by useCorrelation.
+export function pearsonR(pairs: CorrelationPair[]): number | null {
+  if (pairs.length < 2) return null
+  const n = pairs.length
+  let sumA = 0, sumB = 0, sumA2 = 0, sumB2 = 0, sumAB = 0
+  for (const p of pairs) {
+    sumA += p.judgeScore
+    sumB += p.humanScore
+    sumA2 += p.judgeScore * p.judgeScore
+    sumB2 += p.humanScore * p.humanScore
+    sumAB += p.judgeScore * p.humanScore
+  }
+  const numer = n * sumAB - sumA * sumB
+  const denom = Math.sqrt((n * sumA2 - sumA * sumA) * (n * sumB2 - sumB * sumB))
+  if (denom === 0) return null
+  return numer / denom
+}

--- a/apps/web/lib/queries/use-prompts.ts
+++ b/apps/web/lib/queries/use-prompts.ts
@@ -45,6 +45,9 @@ export interface PromptVersionMetrics {
   totalCostUsd: number
   avgPromptTokens: number
   avgCompletionTokens: number
+  /** Average LLM-as-judge score (0..1) for this version. Null = no evals run. */
+  avgQualityScore: number | null
+  qualitySampleCount: number
 }
 
 // ── Experiment types ──────────────────────────────────────────────────────────

--- a/apps/web/lib/queries/use-requests.ts
+++ b/apps/web/lib/queries/use-requests.ts
@@ -13,6 +13,8 @@ export interface RequestsFilters {
   projectId?: string
   providerKeyId?: string
   promptVersionId?: string
+  userId?: string
+  sessionId?: string
   from?: string
   to?: string
   sortBy?: string
@@ -36,6 +38,8 @@ export function useRequests(filters: RequestsFilters) {
       if (filters.projectId) params.set('projectId', filters.projectId)
       if (filters.providerKeyId) params.set('providerKeyId', filters.providerKeyId)
       if (filters.promptVersionId) params.set('promptVersionId', filters.promptVersionId)
+      if (filters.userId) params.set('userId', filters.userId)
+      if (filters.sessionId) params.set('sessionId', filters.sessionId)
       if (filters.from) params.set('from', filters.from)
       if (filters.to) params.set('to', filters.to)
       if (filters.sortBy) params.set('sortBy', filters.sortBy)

--- a/apps/web/lib/queries/use-requests.ts
+++ b/apps/web/lib/queries/use-requests.ts
@@ -12,6 +12,7 @@ export interface RequestsFilters {
   status?: string
   projectId?: string
   providerKeyId?: string
+  promptVersionId?: string
   from?: string
   to?: string
   sortBy?: string
@@ -34,6 +35,7 @@ export function useRequests(filters: RequestsFilters) {
       if (filters.status) params.set('status', filters.status)
       if (filters.projectId) params.set('projectId', filters.projectId)
       if (filters.providerKeyId) params.set('providerKeyId', filters.providerKeyId)
+      if (filters.promptVersionId) params.set('promptVersionId', filters.promptVersionId)
       if (filters.from) params.set('from', filters.from)
       if (filters.to) params.set('to', filters.to)
       if (filters.sortBy) params.set('sortBy', filters.sortBy)

--- a/apps/web/lib/server/queries/datasets.ts
+++ b/apps/web/lib/server/queries/datasets.ts
@@ -1,0 +1,16 @@
+import 'server-only'
+import { apiGetServer } from '@/lib/server/api'
+import type { ApiEnvelope } from '@/lib/queries/types'
+import type { Dataset } from '@/lib/queries/use-datasets'
+import type { QuerySpec } from '@/lib/server/dehydrate'
+
+// Must match ['datasets'] in use-datasets.ts
+export function datasetsSpec(): QuerySpec {
+  return {
+    queryKey: ['datasets'] as const,
+    queryFn: async () => {
+      const res = await apiGetServer<ApiEnvelope<Dataset[]>>('/api/v1/datasets')
+      return res.data ?? []
+    },
+  }
+}

--- a/apps/web/lib/server/queries/evals.ts
+++ b/apps/web/lib/server/queries/evals.ts
@@ -1,0 +1,32 @@
+import 'server-only'
+import { apiGetServer } from '@/lib/server/api'
+import type { ApiEnvelope } from '@/lib/queries/types'
+import type { Evaluator, EvalRun } from '@/lib/queries/use-evals'
+import type { QuerySpec } from '@/lib/server/dehydrate'
+
+// Must match ['evaluators'] in use-evals.ts evaluatorsQueryKey()
+export function evaluatorsSpec(promptName?: string): QuerySpec {
+  return {
+    queryKey: promptName ? (['evaluators', promptName] as const) : (['evaluators'] as const),
+    queryFn: async () => {
+      const qs = promptName ? `?promptName=${encodeURIComponent(promptName)}` : ''
+      const res = await apiGetServer<ApiEnvelope<Evaluator[]>>(`/api/v1/evaluators${qs}`)
+      return res.data ?? []
+    },
+  }
+}
+
+// Must match ['eval-runs'] / ['eval-runs', filters] in use-evals.ts
+export function evalRunsSpec(filters?: { evaluatorId?: string; promptVersionId?: string }): QuerySpec {
+  return {
+    queryKey: filters ? (['eval-runs', filters] as const) : (['eval-runs'] as const),
+    queryFn: async () => {
+      const qs = new URLSearchParams()
+      if (filters?.evaluatorId) qs.set('evaluatorId', filters.evaluatorId)
+      if (filters?.promptVersionId) qs.set('promptVersionId', filters.promptVersionId)
+      const suffix = qs.size > 0 ? `?${qs}` : ''
+      const res = await apiGetServer<ApiEnvelope<EvalRun[]>>(`/api/v1/eval-runs${suffix}`)
+      return res.data ?? []
+    },
+  }
+}

--- a/apps/web/lib/server/queries/experiments.ts
+++ b/apps/web/lib/server/queries/experiments.ts
@@ -1,0 +1,16 @@
+import 'server-only'
+import { apiGetServer } from '@/lib/server/api'
+import type { ApiEnvelope } from '@/lib/queries/types'
+import type { Experiment } from '@/lib/queries/use-experiments'
+import type { QuerySpec } from '@/lib/server/dehydrate'
+
+export function experimentsSpec(promptName?: string): QuerySpec {
+  return {
+    queryKey: promptName ? (['experiments', promptName] as const) : (['experiments'] as const),
+    queryFn: async () => {
+      const qs = promptName ? `?promptName=${encodeURIComponent(promptName)}` : ''
+      const res = await apiGetServer<ApiEnvelope<Experiment[]>>(`/api/v1/experiments${qs}`)
+      return res.data ?? []
+    },
+  }
+}

--- a/apps/web/lib/server/queries/human-evals.ts
+++ b/apps/web/lib/server/queries/human-evals.ts
@@ -1,0 +1,22 @@
+import 'server-only'
+import { apiGetServer } from '@/lib/server/api'
+import type { ApiEnvelope } from '@/lib/queries/types'
+import type { AnnotationQueueItem, QueueFilters } from '@/lib/queries/use-human-evals'
+import type { QuerySpec } from '@/lib/server/dehydrate'
+
+export function annotationQueueSpec(filters: QueueFilters = {}): QuerySpec {
+  return {
+    queryKey: ['annotation', 'queue', filters] as const,
+    queryFn: async () => {
+      const qs = new URLSearchParams()
+      if (filters.promptName) qs.set('promptName', filters.promptName)
+      if (filters.promptVersionId) qs.set('promptVersionId', filters.promptVersionId)
+      if (filters.unscoredOnly) qs.set('unscoredOnly', 'true')
+      if (filters.lowJudgeScoreOnly) qs.set('lowJudgeScoreOnly', 'true')
+      if (filters.limit) qs.set('limit', String(filters.limit))
+      const suffix = qs.size > 0 ? `?${qs}` : ''
+      const res = await apiGetServer<ApiEnvelope<AnnotationQueueItem[]>>(`/api/v1/annotation/queue${suffix}`)
+      return res.data ?? []
+    },
+  }
+}

--- a/docs/plans/prompts_evals_roadmap.md
+++ b/docs/plans/prompts_evals_roadmap.md
@@ -1,0 +1,476 @@
+# Spanlens 사이드바 확장 로드맵 — Evals · Datasets · Experiments · Annotation
+
+**작성일**: 2026-05-13
+**상태**: 확정 (Phase 1 착수 예정)
+**관련 영역**: `apps/web/app/(dashboard)/`, `apps/server/src/api/`, `supabase/migrations/`
+
+---
+
+## 1. 최종 사이드바 구조
+
+```
+📁 [상단 그룹]
+  ├── Dashboard            ✅ 기존
+  ├── Requests             🔧 user/session 필터 추가
+  └── Traces               ✅ 기존
+
+📁 OBSERVE
+  ├── Anomalies            ✅ 기존
+  ├── Security             ✅ 기존
+  └── Savings              ✅ 기존
+
+📁 BUILD                   (이름 변경 검토 — "IMPROVE" 후보)
+  ├── Prompts              ✅ 기존 (Playground 서브탭 포함)
+  ├── Evals                🆕 신규
+  ├── Datasets             🆕 신규
+  ├── Experiments          🆕 신규
+  └── Alerts               ✅ 기존
+
+📁 REVIEW                  🆕 신규 섹션
+  └── Annotation           🆕 신규
+```
+
+### 변경점 요약
+- BUILD 섹션에 3개 탭 추가 (Evals / Datasets / Experiments)
+- REVIEW 섹션 신규 + Annotation 1개 탭
+- **Playground 독립 탭 추가 안 함** — 이미 `Prompts → [name] → Playground` 서브탭으로 구현됨, 분리 가치 없음
+- Requests 탭은 신규 탭 아님 — 기존 탭에 user/session 필터만 추가
+
+---
+
+## 2. 사전 확인 사항 (완료)
+
+### 2-1. response_body 저장 여부 ✅
+
+```sql
+-- 지난 30일 데이터
+total                93
+has_response_body    67  (72%)
+non_empty_response   67  (72%)
+```
+
+→ Evals MVP가 production 데이터로 동작 가능함이 확인됨.
+28%가 비어있는 이유는 스트리밍 파서 실패·옛 데이터·에러 응답 등 추정. 신규 데이터는 정상 저장 중.
+
+### 2-2. Playground 기능 확인 ✅
+
+- 위치: `apps/web/app/(dashboard)/prompts/[name]/tabs/playground-tab.tsx`
+- 서버: `POST /api/v1/prompts/playground/run` (rate limit 20/min/user)
+- 기능: 버전·provider key·model·temperature·max_tokens·variables 설정 → 즉시 실행 → 응답·비용·토큰·레이턴시 표시
+- **`requests` 테이블에 저장 안 됨** (production 로깅 대상 아님)
+
+---
+
+## 3. 각 탭의 책임 및 기능 정의
+
+### 3-1. Evals (가장 시급)
+
+**목적**: LLM 응답의 *품질*을 수치화. 비용/레이턴시(이미 측정 중)에 더해 "잘 답했나"를 답한다.
+
+**MVP 범위**:
+- Evaluator 타입: **LLM-as-judge 1개만** (다른 LLM이 응답을 0–1점으로 채점)
+- 샘플 소스: **production data** (`requests` 테이블의 response_body, prompt_version_id 기준)
+- 결과: 점수 분포 히스토그램 + 낮은 점수 응답 드릴다운
+
+**제외 (Phase 2+)**:
+- Heuristic evaluator (regex / JSON schema / length)
+- Multi-evaluator 동시 실행
+- Dataset 기반 평가 (Datasets 탭 안착 후)
+
+**워크플로우**:
+```
+Evals 탭 진입
+→ "+ New evaluator"
+  - Prompt: [support_reply ▼]
+  - Name: "친절도 평가"
+  - Criterion: "응답이 친절하고 명확한가?"
+  - Judge model: gpt-4o-mini
+→ Run on:
+  - Version: [v2 ▼]
+  - Sample: Last 7 days, random 50
+→ [Run] (예상 비용 $0.02, 30s)
+→ 결과: 평균 0.78, 분포 차트, 낮은 점수 5개 클릭 → request 상세
+```
+
+**Calls 탭 통합**: Evals 실행 결과가 `prompt_versions`에 묶이므로, 기존 Calls 탭의 비어있던 "QUALITY" 컬럼이 자동으로 의미를 가짐.
+
+---
+
+### 3-2. Datasets
+
+**목적**: 반복 평가를 위한 *입력 세트* 관리. production data가 부족하거나 민감할 때 사용.
+
+**MVP 범위**:
+- Dataset 생성: 이름, 설명
+- Item 추가: (input, expected_output?) 쌍
+  - input: prompt에 들어갈 변수값 또는 메시지
+  - expected_output: 정답 (선택, accuracy 평가 시 필요)
+- Item 가져오기:
+  - 수동 입력 (form)
+  - Production request에서 import ("이 호출을 dataset에 추가")
+  - CSV 업로드 (Phase 2.5)
+
+**Evals와의 연결**:
+- Evals 실행 시 샘플 소스를 "production" 대신 "dataset" 선택 가능
+- → "v2를 내가 정의한 50개 케이스에 대해 평가"
+
+**워크플로우**:
+```
+Datasets 탭 진입
+→ "+ New dataset"
+  - Name: "Customer support golden set"
+  - Description: "실패했던 30개 케이스 + 정상 20개"
+→ Items 추가:
+  - "[Import from requests]" → Requests 탭 다중 선택
+  - 또는 "[Add item]" → input·expected output 직접 입력
+→ Evals 탭에서 이 dataset 선택 가능해짐
+```
+
+---
+
+### 3-3. Experiments
+
+**목적**: 여러 prompt version을 *동일 입력*으로 실행해서 결과를 side-by-side 비교.
+
+**A/B와의 차이점 (중요)**:
+
+| | A/B (Prompts 내) | Experiments (신규) |
+|---|---|---|
+| 데이터 | production 트래픽 | dataset 또는 production 샘플 |
+| 시점 | 실시간, 실제 사용자 노출 | 오프라인, 사용자 노출 없음 |
+| 비교 단위 | 통계적 유의성 (welch test) | 출력 텍스트 직접 비교 + 점수 |
+| 위험 | 나쁜 버전이 사용자에게 감 | 없음 |
+| 순서 | 마지막 검증 | A/B 전에 사전 검증 |
+
+**MVP 범위**:
+- 비교 가능 버전: 2개 (v_a vs v_b)
+- 입력 소스: dataset 또는 production sample
+- 결과 뷰:
+  - Side-by-side 텍스트 비교 (한 줄에 input | v_a output | v_b output)
+  - 평균 점수 비교 (Evals evaluator 적용 시)
+  - 비용·레이턴시 비교
+- Diff 하이라이트 (v_a output vs v_b output에서 달라진 단어)
+
+**Phase 2 확장**:
+- 3개 이상 버전 동시 비교
+- Cross-prompt 비교 (다른 prompt 간 비교 — 드물지만 가능)
+
+---
+
+### 3-4. Annotation (REVIEW 섹션)
+
+**목적**: 사람이 직접 응답을 채점. LLM judge가 못 잡는 미묘한 품질 이슈 포착.
+
+**MVP 범위**:
+- Review queue: 채점 대기 응답 목록
+  - 필터: 프롬프트, 버전, 기간, "낮은 LLM judge 점수만"
+- 채점 UI:
+  - 응답 본문 표시
+  - 별점 1–5 또는 thumbs up/down
+  - 자유 입력 코멘트
+  - 단축키 (j/k 다음/이전, 1–5 점수)
+- 결과 저장: `human_evals` 테이블에 prompt_version_id, request_id, score, comment, reviewer_id
+
+**Evals와의 연결**:
+- LLM judge 점수와 human 점수 *간의 상관관계* 표시 → "내 LLM judge가 사람 평가와 얼마나 일치하는가" 검증
+- 불일치 케이스 강조
+
+**MVP 제외**:
+- 다중 reviewer 평균 / 일치도 계산
+- Reviewer 권한 관리 (다 admin 가정)
+- Annotation 결과를 Evals fine-tuning에 활용
+
+---
+
+### 3-5. Requests user/session 필터
+
+**현재**: provider, model, status, providerKey, prompt_version (방금 추가) 필터만 지원
+**추가 필터**:
+- `user_id`: 어떤 최종 사용자의 호출인가
+- `session_id`: 어떤 세션 흐름의 호출인가
+
+**전제 조건**:
+- `requests` 테이블에 `user_id`, `session_id` 컬럼이 있어야 함 → 확인 필요
+- SDK / 헤더로 user_id를 전달하는 메커니즘 필요 (`x-spanlens-user`, `x-spanlens-session`)
+
+**Dashboard 위젯**: "Top users by cost", "Top sessions by request count" 추가
+
+---
+
+### 3-6. BUILD → IMPROVE 섹션명 변경
+
+**결정 필요**. 현재 입장:
+- BUILD: 직관적, 익숙 (Langfuse도 BUILD 사용)
+- IMPROVE: Evals/Annotation이 "개선" 의미에 더 가까움. Prompts 만들기보다는 *기존을 더 좋게 만드는* 도구들.
+
+→ **권장: 일단 BUILD 유지**, Phase 1·2 끝난 후 사용자 인터뷰에서 다시 검토.
+
+---
+
+## 4. DB 스키마
+
+### 4-1. Evals
+
+```sql
+-- 평가 기준 정의 (재사용 가능)
+CREATE TABLE evaluators (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  prompt_name text NOT NULL,
+  name text NOT NULL,                  -- "친절도 평가"
+  type text NOT NULL DEFAULT 'llm_judge',
+  config jsonb NOT NULL,               -- {judge_model, criterion, scale, ...}
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz DEFAULT now(),
+  archived_at timestamptz
+);
+CREATE INDEX evaluators_org_prompt_idx ON evaluators(organization_id, prompt_name);
+ALTER TABLE evaluators ENABLE ROW LEVEL SECURITY;
+
+-- 평가 실행 (한 번의 Run = 여러 eval_results)
+CREATE TABLE eval_runs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  evaluator_id uuid NOT NULL REFERENCES evaluators(id) ON DELETE CASCADE,
+  prompt_version_id uuid NOT NULL REFERENCES prompt_versions(id),
+  source text NOT NULL,                -- 'production' | 'dataset'
+  dataset_id uuid REFERENCES datasets(id),
+  sample_size int NOT NULL,
+  status text NOT NULL DEFAULT 'pending',  -- pending | running | completed | failed
+  avg_score numeric,
+  total_cost_usd numeric DEFAULT 0,
+  started_at timestamptz DEFAULT now(),
+  completed_at timestamptz,
+  error text
+);
+ALTER TABLE eval_runs ENABLE ROW LEVEL SECURITY;
+
+-- 개별 응답 채점 결과
+CREATE TABLE eval_results (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  eval_run_id uuid NOT NULL REFERENCES eval_runs(id) ON DELETE CASCADE,
+  request_id uuid REFERENCES requests(id),       -- production 소스인 경우
+  dataset_item_id uuid REFERENCES dataset_items(id),  -- dataset 소스인 경우
+  score numeric NOT NULL,
+  reasoning text,
+  judge_cost_usd numeric,
+  created_at timestamptz DEFAULT now()
+);
+ALTER TABLE eval_results ENABLE ROW LEVEL SECURITY;
+```
+
+### 4-2. Datasets
+
+```sql
+CREATE TABLE datasets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  description text,
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz DEFAULT now(),
+  UNIQUE(organization_id, name)
+);
+ALTER TABLE datasets ENABLE ROW LEVEL SECURITY;
+
+CREATE TABLE dataset_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  dataset_id uuid NOT NULL REFERENCES datasets(id) ON DELETE CASCADE,
+  input jsonb NOT NULL,                -- {variables: {...}, messages: [...]}
+  expected_output text,                 -- nullable
+  source_request_id uuid REFERENCES requests(id),  -- import에서 왔으면 추적
+  created_at timestamptz DEFAULT now()
+);
+CREATE INDEX dataset_items_dataset_idx ON dataset_items(dataset_id);
+ALTER TABLE dataset_items ENABLE ROW LEVEL SECURITY;
+```
+
+### 4-3. Experiments
+
+```sql
+CREATE TABLE experiments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  prompt_name text NOT NULL,
+  version_a_id uuid NOT NULL REFERENCES prompt_versions(id),
+  version_b_id uuid NOT NULL REFERENCES prompt_versions(id),
+  source text NOT NULL,                -- 'production' | 'dataset'
+  dataset_id uuid REFERENCES datasets(id),
+  evaluator_id uuid REFERENCES evaluators(id),  -- 선택, 점수 비교 시
+  status text NOT NULL DEFAULT 'pending',
+  started_at timestamptz DEFAULT now(),
+  completed_at timestamptz,
+  CHECK (version_a_id != version_b_id)
+);
+ALTER TABLE experiments ENABLE ROW LEVEL SECURITY;
+
+CREATE TABLE experiment_results (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  experiment_id uuid NOT NULL REFERENCES experiments(id) ON DELETE CASCADE,
+  arm text NOT NULL,                   -- 'a' | 'b'
+  input jsonb NOT NULL,
+  output text NOT NULL,
+  cost_usd numeric,
+  latency_ms int,
+  score numeric,                       -- evaluator 적용 시
+  created_at timestamptz DEFAULT now()
+);
+ALTER TABLE experiment_results ENABLE ROW LEVEL SECURITY;
+```
+
+### 4-4. Annotation
+
+```sql
+CREATE TABLE human_evals (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  request_id uuid REFERENCES requests(id),
+  experiment_result_id uuid REFERENCES experiment_results(id),
+  prompt_version_id uuid REFERENCES prompt_versions(id),
+  reviewer_id uuid NOT NULL REFERENCES auth.users(id),
+  score numeric NOT NULL,              -- 1–5 또는 0/1
+  comment text,
+  created_at timestamptz DEFAULT now(),
+  CHECK (
+    (request_id IS NOT NULL)::int +
+    (experiment_result_id IS NOT NULL)::int >= 1
+  )
+);
+ALTER TABLE human_evals ENABLE ROW LEVEL SECURITY;
+```
+
+### 4-5. Requests (user/session 필터용)
+
+```sql
+ALTER TABLE requests ADD COLUMN IF NOT EXISTS user_id text;
+ALTER TABLE requests ADD COLUMN IF NOT EXISTS session_id text;
+CREATE INDEX IF NOT EXISTS requests_user_idx ON requests(organization_id, user_id);
+CREATE INDEX IF NOT EXISTS requests_session_idx ON requests(organization_id, session_id);
+```
+
+→ 헤더 `x-spanlens-user`, `x-spanlens-session` 처리도 proxy 미들웨어에 추가 필요.
+
+---
+
+## 5. 구현 의존성 그래프
+
+```
+                   [Evals MVP]
+                    │     │
+              ┌─────┘     └─────┐
+              ▼                 ▼
+         [Datasets]      [Annotation]
+              │
+              ▼
+         [Experiments]
+
+
+[Requests user/session 필터]  ← 독립 (병렬 진행 가능)
+```
+
+**Evals가 모든 것의 출발점**. 평가 인프라가 없으면 Datasets는 단순 저장소, Experiments는 텍스트 비교만 가능, Annotation은 LLM 점수와 비교할 게 없음.
+
+---
+
+## 6. 구현 순서 (Phase별)
+
+### Phase 1 (지금 — 2주 예상)
+**목표**: Evals 사이드바 탭 신규 + production data 기반 LLM-judge MVP
+
+- [ ] DB 마이그레이션: `evaluators`, `eval_runs`, `eval_results` 테이블
+- [ ] 서버 API: `apps/server/src/api/evals.ts`
+  - `POST /api/v1/evaluators`
+  - `GET /api/v1/evaluators?promptName=...`
+  - `POST /api/v1/eval-runs` (실행 트리거)
+  - `GET /api/v1/eval-runs/:id` (결과 폴링)
+- [ ] LLM judge worker: `apps/server/src/lib/eval-runner.ts`
+  - `requests` SELECT → judge 호출 (사용자 provider key) → 점수 저장
+  - 배치 N개씩 (cost·rate limit 고려)
+- [ ] 사이드바 추가: BUILD 섹션에 Evals 항목
+- [ ] 페이지: `apps/web/app/(dashboard)/evals/`
+  - List view (evaluator 목록)
+  - Detail view (실행 결과, 점수 분포, 드릴다운)
+- [ ] Calls 탭의 QUALITY 컬럼이 `eval_results` 평균 표시하도록 연결
+
+### Phase 2 (Phase 1 안착 후 — 2주)
+**목표**: Datasets 탭 + Evals/Experiments에서 dataset 입력 지원
+
+- [ ] DB: `datasets`, `dataset_items` 테이블
+- [ ] 서버 API: `apps/server/src/api/datasets.ts`
+- [ ] 사이드바 추가: BUILD 섹션에 Datasets 항목
+- [ ] 페이지: `apps/web/app/(dashboard)/datasets/`
+- [ ] Import from requests 통합 (Requests 탭에서 "Add to dataset" 액션)
+- [ ] Evals UI에서 sample source 옵션에 dataset 추가
+
+### Phase 3 (Phase 2 안착 후 — 2주)
+**목표**: Experiments 탭 + side-by-side 비교
+
+- [ ] DB: `experiments`, `experiment_results`
+- [ ] 서버 API: `apps/server/src/api/experiments.ts`
+- [ ] Experiment runner: 양쪽 버전을 dataset에 대해 실행
+- [ ] 사이드바 추가: BUILD 섹션에 Experiments
+- [ ] 페이지: `apps/web/app/(dashboard)/experiments/`
+  - Side-by-side 텍스트 diff
+  - 점수 비교 차트
+  - Evaluator 연결 (선택)
+
+### Phase 4 (Phase 3 안착 후 — 2주)
+**목표**: Annotation 탭 + LLM-vs-human 일치도
+
+- [ ] DB: `human_evals`
+- [ ] 서버 API: `apps/server/src/api/human-evals.ts`
+- [ ] 사이드바: REVIEW 섹션 + Annotation 항목
+- [ ] 페이지: `apps/web/app/(dashboard)/annotation/`
+  - Queue UI (필터, 단축키 j/k/1-5)
+  - 채점 결과 → Evals 페이지에 "LLM-judge vs Human" 상관도 표시
+
+### Phase 5 (병렬 가능 — 언제든)
+**Requests user/session 필터**
+
+- [ ] DB 마이그레이션: `user_id`, `session_id` 컬럼
+- [ ] Proxy 미들웨어: `x-spanlens-user`, `x-spanlens-session` 헤더 → 컬럼 저장
+- [ ] SDK: 헤더 자동 주입 헬퍼 (`withUser(userId)`, `withSession(sessionId)`)
+- [ ] Requests UI: 필터 드롭다운 + URL param 지원
+- [ ] Dashboard: "Top users by cost" 위젯
+
+---
+
+## 7. 핵심 비목표 (만들지 않을 것)
+
+- **Playground 독립 탭** — `Prompts → [name] → Playground` 서브탭으로 충분
+- **별도 Costs 탭** — Dashboard + Savings로 커버 (Helicone과 차별)
+- **다중 evaluator 동시 실행 (MVP)** — Phase 2 이후
+- **Annotation 다중 reviewer 일치도 (MVP)** — Phase 4 이후 별도 검토
+- **Cross-organization eval 공유** — 권한·법적 복잡도 큼, 영구 보류
+
+---
+
+## 8. 위험 요소
+
+1. **LLM judge 비용 폭주** — 50건 × $0.0005 = $0.025지만, 사용자가 1000건 × 매일이면 $0.50/일. 안전장치 필요:
+   - 평가당 max sample size 제한 (예: 1000)
+   - Org당 일일 judge 호출 한도 설정
+2. **response_body 없는 28% 처리** — null인 row는 자동 스킵, 사용자에게 "47/50 채점됨" 표시
+3. **Evals 결과의 신뢰도** — LLM judge 자체가 부정확할 수 있음. Phase 4 Annotation으로 검증.
+4. **prompt_versions 간 비교 시 다른 변수** — 같은 version에 다른 변수값이 들어간 호출들의 점수를 평균낼지, 그룹핑할지 결정 필요. MVP는 그냥 평균.
+
+---
+
+## 9. 다음 즉시 액션
+
+1. 이 문서 검토·승인
+2. BUILD → IMPROVE 결정 (안 바꿔도 됨, 한 줄 결정)
+3. Phase 1 착수:
+   - DB 마이그레이션 작성: `supabase/migrations/{YYYYMMDDHHMMSS}_evals.sql`
+   - 서버 API 스켈레톤
+   - UI 라우트 추가
+
+---
+
+## 10. 변경 이력
+
+| 날짜 | 변경 | 사유 |
+|---|---|---|
+| 2026-05-13 | 초안 작성 | 사용자 검증 우선 원칙으로 로드맵 재정렬 |
+| 2026-05-13 | **재작성** | 사용자 결정: 검증 스킵, 전 기능 사이드바 독립 탭으로 구현 (Playground 제외). Phase 별 의존성 그래프 추가. |

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/__tests__/user-session.test.ts
+++ b/packages/sdk/src/__tests__/user-session.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import {
+  withUser as withUserOpenAI,
+  withSession as withSessionOpenAI,
+  USER_HEADER as OPENAI_USER_HEADER,
+  SESSION_HEADER as OPENAI_SESSION_HEADER,
+} from '../integrations/openai.js'
+import {
+  withUser as withUserAnthropic,
+  withSession as withSessionAnthropic,
+  USER_HEADER as ANTHROPIC_USER_HEADER,
+  SESSION_HEADER as ANTHROPIC_SESSION_HEADER,
+} from '../integrations/anthropic.js'
+
+describe('withUser', () => {
+  it('openai helper sets x-spanlens-user', () => {
+    expect(withUserOpenAI('user_42')).toEqual({
+      headers: { 'x-spanlens-user': 'user_42' },
+    })
+  })
+
+  it('anthropic helper has identical shape', () => {
+    expect(withUserAnthropic('user_42')).toEqual({
+      headers: { 'x-spanlens-user': 'user_42' },
+    })
+  })
+
+  it('header constants are stable across both integrations', () => {
+    expect(OPENAI_USER_HEADER).toBe('x-spanlens-user')
+    expect(ANTHROPIC_USER_HEADER).toBe('x-spanlens-user')
+  })
+})
+
+describe('withSession', () => {
+  it('openai helper sets x-spanlens-session', () => {
+    expect(withSessionOpenAI('sess_abc')).toEqual({
+      headers: { 'x-spanlens-session': 'sess_abc' },
+    })
+  })
+
+  it('anthropic helper has identical shape', () => {
+    expect(withSessionAnthropic('sess_abc')).toEqual({
+      headers: { 'x-spanlens-session': 'sess_abc' },
+    })
+  })
+
+  it('header constants are stable across both integrations', () => {
+    expect(OPENAI_SESSION_HEADER).toBe('x-spanlens-session')
+    expect(ANTHROPIC_SESSION_HEADER).toBe('x-spanlens-session')
+  })
+})
+
+describe('helpers can be merged', () => {
+  it('combining withUser + withSession headers via spread works', () => {
+    const merged = {
+      headers: {
+        ...withUserOpenAI('u1').headers,
+        ...withSessionOpenAI('s1').headers,
+      },
+    }
+    expect(merged.headers).toEqual({
+      'x-spanlens-user': 'u1',
+      'x-spanlens-session': 's1',
+    })
+  })
+})

--- a/packages/sdk/src/integrations/anthropic.ts
+++ b/packages/sdk/src/integrations/anthropic.ts
@@ -11,6 +11,8 @@ import Anthropic from '@anthropic-ai/sdk'
 import type { ClientOptions } from '@anthropic-ai/sdk'
 
 export const PROMPT_VERSION_HEADER = 'x-spanlens-prompt-version'
+export const USER_HEADER = 'x-spanlens-user'
+export const SESSION_HEADER = 'x-spanlens-session'
 
 export const DEFAULT_SPANLENS_ANTHROPIC_PROXY =
   'https://spanlens-server.vercel.app/proxy/anthropic'
@@ -56,4 +58,14 @@ function readEnv(name: string): string | undefined {
  */
 export function withPromptVersion(id: string): { headers: Record<string, string> } {
   return { headers: { [PROMPT_VERSION_HEADER]: id } }
+}
+
+/** Tag a request with an end-user ID. Same semantics as the OpenAI helper. */
+export function withUser(userId: string): { headers: Record<string, string> } {
+  return { headers: { [USER_HEADER]: userId } }
+}
+
+/** Tag a request with a session ID. Same semantics as the OpenAI helper. */
+export function withSession(sessionId: string): { headers: Record<string, string> } {
+  return { headers: { [SESSION_HEADER]: sessionId } }
 }

--- a/packages/sdk/src/integrations/openai.ts
+++ b/packages/sdk/src/integrations/openai.ts
@@ -27,6 +27,8 @@ export const DEFAULT_SPANLENS_OPENAI_PROXY =
   'https://spanlens-server.vercel.app/proxy/openai/v1'
 
 export const PROMPT_VERSION_HEADER = 'x-spanlens-prompt-version'
+export const USER_HEADER = 'x-spanlens-user'
+export const SESSION_HEADER = 'x-spanlens-session'
 
 /**
  * Build an OpenAI client whose requests flow through the Spanlens proxy.
@@ -82,4 +84,41 @@ function readEnv(name: string): string | undefined {
  */
 export function withPromptVersion(id: string): { headers: Record<string, string> } {
   return { headers: { [PROMPT_VERSION_HEADER]: id } }
+}
+
+/**
+ * Tag a request with an end-user ID — populates `requests.user_id` so the
+ * dashboard can filter and aggregate by user.
+ *
+ * @example
+ *   import { createOpenAI, withUser } from '@spanlens/sdk/openai'
+ *   const openai = createOpenAI()
+ *
+ *   const res = await openai.chat.completions.create(
+ *     { model: 'gpt-4o-mini', messages: [...] },
+ *     withUser(currentUser.id),
+ *   )
+ */
+export function withUser(userId: string): { headers: Record<string, string> } {
+  return { headers: { [USER_HEADER]: userId } }
+}
+
+/**
+ * Tag a request with a session ID — groups requests that belong to the same
+ * conversation or workflow for end-user attribution.
+ *
+ * @example
+ *   import { createOpenAI, withSession } from '@spanlens/sdk/openai'
+ *   const openai = createOpenAI()
+ *
+ *   const res = await openai.chat.completions.create(
+ *     { model: 'gpt-4o-mini', messages: [...] },
+ *     withSession(currentSession.id),
+ *   )
+ *
+ * Combine with `withUser` and `withPromptVersion` by merging headers:
+ *   { headers: { ...withUser(u).headers, ...withSession(s).headers } }
+ */
+export function withSession(sessionId: string): { headers: Record<string, string> } {
+  return { headers: { [SESSION_HEADER]: sessionId } }
 }

--- a/supabase/migrations/20260513000000_evals.sql
+++ b/supabase/migrations/20260513000000_evals.sql
@@ -1,0 +1,129 @@
+-- Evals: LLM-as-judge evaluation infrastructure for prompt versions.
+--
+-- An evaluator defines "how to score" (criterion + judge model).
+-- An eval_run is a single execution of that evaluator over N samples.
+-- An eval_result is the score for one sample (one request or one dataset item).
+--
+-- MVP scope:
+--   - Evaluator type: 'llm_judge' only (heuristic etc. in Phase 2)
+--   - Source: 'production' only (dataset support comes with Datasets tab)
+
+CREATE TABLE IF NOT EXISTS public.evaluators (
+  id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid        NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  prompt_name     text        NOT NULL,
+  name            text        NOT NULL,
+  type            text        NOT NULL DEFAULT 'llm_judge'
+                              CHECK (type IN ('llm_judge')),
+  -- For llm_judge: { criterion, judge_provider, judge_model, scale_min, scale_max }
+  config          jsonb       NOT NULL,
+  created_by      uuid        REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  archived_at     timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_evaluators_org_prompt
+  ON public.evaluators (organization_id, prompt_name)
+  WHERE archived_at IS NULL;
+
+ALTER TABLE public.evaluators ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "evaluators_select_member" ON public.evaluators
+  FOR SELECT TO authenticated
+  USING (public.is_org_member(organization_id));
+
+CREATE POLICY "evaluators_insert_member" ON public.evaluators
+  FOR INSERT TO authenticated
+  WITH CHECK (public.is_org_member(organization_id));
+
+CREATE POLICY "evaluators_update_member" ON public.evaluators
+  FOR UPDATE TO authenticated
+  USING (public.is_org_member(organization_id));
+
+COMMENT ON TABLE public.evaluators IS
+  'Defines how to score prompt outputs (criterion + judge model). One row per reusable evaluator.';
+
+-- ── eval_runs ────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.eval_runs (
+  id                 uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id    uuid        NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  evaluator_id       uuid        NOT NULL REFERENCES public.evaluators(id) ON DELETE CASCADE,
+  prompt_version_id  uuid        NOT NULL REFERENCES public.prompt_versions(id) ON DELETE CASCADE,
+  source             text        NOT NULL DEFAULT 'production'
+                                 CHECK (source IN ('production', 'dataset')),
+  sample_size        int         NOT NULL CHECK (sample_size > 0 AND sample_size <= 1000),
+  -- Time window for production sampling (NULL for dataset source).
+  sample_from        timestamptz,
+  sample_to          timestamptz,
+  status             text        NOT NULL DEFAULT 'pending'
+                                 CHECK (status IN ('pending', 'running', 'completed', 'failed')),
+  -- Populated when status = 'completed'.
+  scored_count       int         NOT NULL DEFAULT 0,
+  avg_score          numeric,
+  total_cost_usd     numeric     NOT NULL DEFAULT 0,
+  error              text,
+  created_by         uuid        REFERENCES auth.users(id) ON DELETE SET NULL,
+  started_at         timestamptz NOT NULL DEFAULT now(),
+  completed_at       timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_eval_runs_evaluator
+  ON public.eval_runs (evaluator_id, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_eval_runs_prompt_version
+  ON public.eval_runs (prompt_version_id, status, started_at DESC);
+
+ALTER TABLE public.eval_runs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "eval_runs_select_member" ON public.eval_runs
+  FOR SELECT TO authenticated
+  USING (public.is_org_member(organization_id));
+
+CREATE POLICY "eval_runs_insert_member" ON public.eval_runs
+  FOR INSERT TO authenticated
+  WITH CHECK (public.is_org_member(organization_id));
+
+CREATE POLICY "eval_runs_update_member" ON public.eval_runs
+  FOR UPDATE TO authenticated
+  USING (public.is_org_member(organization_id));
+
+COMMENT ON TABLE public.eval_runs IS
+  'One execution of an evaluator over N samples. Holds aggregate score and run metadata.';
+
+-- ── eval_results ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.eval_results (
+  id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid        NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  eval_run_id     uuid        NOT NULL REFERENCES public.eval_runs(id) ON DELETE CASCADE,
+  -- Exactly one of request_id / dataset_item_id is set (dataset_items table
+  -- comes in Phase 2; column is nullable now so the schema is forward-compatible).
+  request_id      uuid        REFERENCES public.requests(id) ON DELETE SET NULL,
+  dataset_item_id uuid,
+  score           numeric     NOT NULL,
+  reasoning       text,
+  judge_cost_usd  numeric     NOT NULL DEFAULT 0,
+  judge_tokens    int         NOT NULL DEFAULT 0,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_eval_results_run
+  ON public.eval_results (eval_run_id);
+
+CREATE INDEX IF NOT EXISTS idx_eval_results_request
+  ON public.eval_results (request_id)
+  WHERE request_id IS NOT NULL;
+
+ALTER TABLE public.eval_results ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "eval_results_select_member" ON public.eval_results
+  FOR SELECT TO authenticated
+  USING (public.is_org_member(organization_id));
+
+CREATE POLICY "eval_results_insert_member" ON public.eval_results
+  FOR INSERT TO authenticated
+  WITH CHECK (public.is_org_member(organization_id));
+
+COMMENT ON TABLE public.eval_results IS
+  'One score per sample (request or dataset_item). Aggregated into eval_runs.avg_score.';

--- a/supabase/migrations/20260513010000_datasets.sql
+++ b/supabase/migrations/20260513010000_datasets.sql
@@ -1,0 +1,113 @@
+-- Datasets: reusable input sets for offline evaluation.
+--
+-- A dataset is a named collection of (input, expected_output?) pairs.
+-- Used by Evals to run a prompt version against a fixed test set instead of
+-- production traffic. Future: Experiments will compare versions on a dataset.
+--
+-- dataset_items.input is jsonb to allow both "variables only" and "messages"
+-- shapes. expected_output is optional — only required for accuracy-style evals.
+
+CREATE TABLE IF NOT EXISTS public.datasets (
+  id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid        NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  name            text        NOT NULL,
+  description     text,
+  created_by      uuid        REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  archived_at     timestamptz,
+  UNIQUE (organization_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_datasets_org
+  ON public.datasets (organization_id)
+  WHERE archived_at IS NULL;
+
+ALTER TABLE public.datasets ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "datasets_select_member" ON public.datasets
+  FOR SELECT TO authenticated
+  USING (public.is_org_member(organization_id));
+
+CREATE POLICY "datasets_insert_member" ON public.datasets
+  FOR INSERT TO authenticated
+  WITH CHECK (public.is_org_member(organization_id));
+
+CREATE POLICY "datasets_update_member" ON public.datasets
+  FOR UPDATE TO authenticated
+  USING (public.is_org_member(organization_id));
+
+CREATE POLICY "datasets_delete_member" ON public.datasets
+  FOR DELETE TO authenticated
+  USING (public.is_org_member(organization_id));
+
+COMMENT ON TABLE public.datasets IS
+  'Named collection of (input, expected_output?) test cases for offline evaluation.';
+
+-- ── dataset_items ────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.dataset_items (
+  id                uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id   uuid        NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  dataset_id        uuid        NOT NULL REFERENCES public.datasets(id) ON DELETE CASCADE,
+  -- Two shapes accepted:
+  --   { "variables": { "name": "Alice", ... } }     ← for variable-based prompts
+  --   { "messages": [{role,content}, ...] }         ← for raw chat input
+  input             jsonb       NOT NULL,
+  -- Optional reference answer (for accuracy-style judging).
+  expected_output   text,
+  -- If this item was imported from production traffic.
+  source_request_id uuid        REFERENCES public.requests(id) ON DELETE SET NULL,
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_dataset_items_dataset
+  ON public.dataset_items (dataset_id, created_at DESC);
+
+ALTER TABLE public.dataset_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "dataset_items_select_member" ON public.dataset_items
+  FOR SELECT TO authenticated
+  USING (public.is_org_member(organization_id));
+
+CREATE POLICY "dataset_items_insert_member" ON public.dataset_items
+  FOR INSERT TO authenticated
+  WITH CHECK (public.is_org_member(organization_id));
+
+CREATE POLICY "dataset_items_delete_member" ON public.dataset_items
+  FOR DELETE TO authenticated
+  USING (public.is_org_member(organization_id));
+
+COMMENT ON TABLE public.dataset_items IS
+  'Individual test case in a dataset. input is jsonb (variables or messages shape).';
+
+-- Now wire eval_results.dataset_item_id (added forward-compatibly in 20260513000000_evals.sql).
+-- The column already exists but lacked an FK. Add the FK now so the relationship is enforced.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'eval_results_dataset_item_id_fkey'
+      AND table_name = 'eval_results'
+  ) THEN
+    ALTER TABLE public.eval_results
+      ADD CONSTRAINT eval_results_dataset_item_id_fkey
+      FOREIGN KEY (dataset_item_id)
+      REFERENCES public.dataset_items(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- And give eval_runs.dataset_id a proper FK too.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'eval_runs' AND column_name = 'dataset_id'
+  ) THEN
+    ALTER TABLE public.eval_runs
+      ADD COLUMN dataset_id uuid REFERENCES public.datasets(id) ON DELETE SET NULL;
+    CREATE INDEX IF NOT EXISTS idx_eval_runs_dataset
+      ON public.eval_runs (dataset_id)
+      WHERE dataset_id IS NOT NULL;
+  END IF;
+END $$;

--- a/supabase/migrations/20260513020000_experiments.sql
+++ b/supabase/migrations/20260513020000_experiments.sql
@@ -1,0 +1,101 @@
+-- Experiments: offline side-by-side comparison of two prompt versions on a dataset.
+--
+-- DIFFERS FROM Prompts A/B (prompt_ab_experiments):
+--   - A/B routes production traffic, takes days, exposes real users
+--   - Experiments runs offline on a fixed dataset, takes minutes, no user exposure
+--
+-- Workflow:
+--   1. Pick version_a, version_b, dataset, optional evaluator
+--   2. Runner re-runs each dataset item through BOTH prompt versions
+--   3. Optionally judges each output with the evaluator
+--   4. UI shows side-by-side output comparison + score deltas
+
+CREATE TABLE IF NOT EXISTS public.experiments (
+  id                uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id   uuid        NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  name              text        NOT NULL,
+  prompt_name       text        NOT NULL,
+  version_a_id      uuid        NOT NULL REFERENCES public.prompt_versions(id) ON DELETE RESTRICT,
+  version_b_id      uuid        NOT NULL REFERENCES public.prompt_versions(id) ON DELETE RESTRICT,
+  dataset_id        uuid        NOT NULL REFERENCES public.datasets(id) ON DELETE RESTRICT,
+  evaluator_id      uuid        REFERENCES public.evaluators(id) ON DELETE SET NULL,
+  -- Model / provider used to run the prompts (both arms use same setup so the
+  -- only variable is the prompt content).
+  run_provider      text        NOT NULL CHECK (run_provider IN ('openai', 'anthropic')),
+  run_model         text        NOT NULL,
+  status            text        NOT NULL DEFAULT 'pending'
+                                CHECK (status IN ('pending', 'running', 'completed', 'failed')),
+  -- Aggregates populated when status = 'completed'
+  total_items       int         NOT NULL DEFAULT 0,
+  completed_items   int         NOT NULL DEFAULT 0,
+  avg_score_a       numeric,
+  avg_score_b       numeric,
+  total_cost_usd    numeric     NOT NULL DEFAULT 0,
+  error             text,
+  created_by        uuid        REFERENCES auth.users(id) ON DELETE SET NULL,
+  started_at        timestamptz NOT NULL DEFAULT now(),
+  completed_at      timestamptz,
+  CONSTRAINT exp_version_a_ne_b CHECK (version_a_id <> version_b_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_experiments_org_prompt
+  ON public.experiments (organization_id, prompt_name, started_at DESC);
+
+ALTER TABLE public.experiments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "experiments_select_member" ON public.experiments
+  FOR SELECT TO authenticated
+  USING (public.is_org_member(organization_id));
+
+CREATE POLICY "experiments_insert_member" ON public.experiments
+  FOR INSERT TO authenticated
+  WITH CHECK (public.is_org_member(organization_id));
+
+CREATE POLICY "experiments_update_member" ON public.experiments
+  FOR UPDATE TO authenticated
+  USING (public.is_org_member(organization_id));
+
+COMMENT ON TABLE public.experiments IS
+  'Offline side-by-side comparison: runs dataset items through two prompt versions.';
+
+-- ── experiment_results ──────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.experiment_results (
+  id               uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id  uuid        NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  experiment_id    uuid        NOT NULL REFERENCES public.experiments(id) ON DELETE CASCADE,
+  dataset_item_id  uuid        NOT NULL REFERENCES public.dataset_items(id) ON DELETE CASCADE,
+  -- Per-arm outputs and metrics
+  output_a         text,
+  output_b         text,
+  cost_a_usd       numeric     NOT NULL DEFAULT 0,
+  cost_b_usd       numeric     NOT NULL DEFAULT 0,
+  latency_a_ms     int,
+  latency_b_ms     int,
+  tokens_a         int         NOT NULL DEFAULT 0,
+  tokens_b         int         NOT NULL DEFAULT 0,
+  -- Optional judge scores (when experiment.evaluator_id is set)
+  score_a          numeric,
+  score_b          numeric,
+  reasoning_a      text,
+  reasoning_b      text,
+  error_a          text,
+  error_b          text,
+  created_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_experiment_results_exp
+  ON public.experiment_results (experiment_id);
+
+ALTER TABLE public.experiment_results ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "experiment_results_select_member" ON public.experiment_results
+  FOR SELECT TO authenticated
+  USING (public.is_org_member(organization_id));
+
+CREATE POLICY "experiment_results_insert_member" ON public.experiment_results
+  FOR INSERT TO authenticated
+  WITH CHECK (public.is_org_member(organization_id));
+
+COMMENT ON TABLE public.experiment_results IS
+  'Per dataset-item result for an experiment: outputs from both arms + optional judge scores.';

--- a/supabase/migrations/20260513030000_human_evals.sql
+++ b/supabase/migrations/20260513030000_human_evals.sql
@@ -1,0 +1,72 @@
+-- Human evals: manual scoring of individual requests by team members.
+--
+-- Complements LLM-as-judge (eval_results) by capturing human ground truth.
+-- The aggregate over LLM vs human scores tells you whether your LLM judge
+-- is actually trustworthy.
+--
+-- Score is stored normalized to 0..1 to match eval_results. raw_score holds
+-- the UI value (e.g. 1–5 stars) for re-display.
+
+CREATE TABLE IF NOT EXISTS public.human_evals (
+  id                 uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id    uuid        NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  request_id         uuid        NOT NULL REFERENCES public.requests(id) ON DELETE CASCADE,
+  -- Denormalized for fast filtering / correlation queries by prompt_version.
+  prompt_version_id  uuid        REFERENCES public.prompt_versions(id) ON DELETE SET NULL,
+  reviewer_id        uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  -- Normalized 0..1 — same scale as eval_results.score so correlation is direct.
+  score              numeric     NOT NULL CHECK (score >= 0 AND score <= 1),
+  -- Raw UI value (e.g. 1..5 stars) for re-rendering.
+  raw_score          numeric,
+  comment            text,
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  updated_at         timestamptz NOT NULL DEFAULT now(),
+  -- One reviewer scores each request at most once. Update overwrites prior.
+  UNIQUE (request_id, reviewer_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_human_evals_org
+  ON public.human_evals (organization_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_human_evals_prompt_version
+  ON public.human_evals (prompt_version_id)
+  WHERE prompt_version_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_human_evals_request
+  ON public.human_evals (request_id);
+
+ALTER TABLE public.human_evals ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "human_evals_select_member" ON public.human_evals
+  FOR SELECT TO authenticated
+  USING (public.is_org_member(organization_id));
+
+CREATE POLICY "human_evals_insert_member" ON public.human_evals
+  FOR INSERT TO authenticated
+  WITH CHECK (public.is_org_member(organization_id));
+
+CREATE POLICY "human_evals_update_own" ON public.human_evals
+  FOR UPDATE TO authenticated
+  USING (reviewer_id = auth.uid() AND public.is_org_member(organization_id));
+
+CREATE POLICY "human_evals_delete_own" ON public.human_evals
+  FOR DELETE TO authenticated
+  USING (reviewer_id = auth.uid() AND public.is_org_member(organization_id));
+
+COMMENT ON TABLE public.human_evals IS
+  'Per-request human scoring. Score normalized 0..1 to match eval_results for direct correlation.';
+
+-- Auto-update updated_at on row changes.
+CREATE OR REPLACE FUNCTION public.human_evals_set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_human_evals_updated_at ON public.human_evals;
+CREATE TRIGGER trg_human_evals_updated_at
+  BEFORE UPDATE ON public.human_evals
+  FOR EACH ROW
+  EXECUTE FUNCTION public.human_evals_set_updated_at();

--- a/supabase/migrations/20260513040000_requests_user_session.sql
+++ b/supabase/migrations/20260513040000_requests_user_session.sql
@@ -1,0 +1,18 @@
+-- Add user_id / session_id to requests for end-user attribution.
+--
+-- Populated from the x-spanlens-user / x-spanlens-session headers at proxy time.
+-- Both are text (not FK) — these are the CUSTOMER's user IDs, not ours.
+
+ALTER TABLE public.requests ADD COLUMN IF NOT EXISTS user_id    text;
+ALTER TABLE public.requests ADD COLUMN IF NOT EXISTS session_id text;
+
+CREATE INDEX IF NOT EXISTS idx_requests_user_id
+  ON public.requests (organization_id, user_id, created_at DESC)
+  WHERE user_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_requests_session_id
+  ON public.requests (organization_id, session_id, created_at DESC)
+  WHERE session_id IS NOT NULL;
+
+COMMENT ON COLUMN public.requests.user_id    IS 'Customer-supplied end-user ID via x-spanlens-user header.';
+COMMENT ON COLUMN public.requests.session_id IS 'Customer-supplied session ID via x-spanlens-session header.';

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -350,6 +350,96 @@ export type Database = {
           },
         ]
       }
+      dataset_items: {
+        Row: {
+          created_at: string
+          dataset_id: string
+          expected_output: string | null
+          id: string
+          input: Json
+          organization_id: string
+          source_request_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          dataset_id: string
+          expected_output?: string | null
+          id?: string
+          input: Json
+          organization_id: string
+          source_request_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          dataset_id?: string
+          expected_output?: string | null
+          id?: string
+          input?: Json
+          organization_id?: string
+          source_request_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "dataset_items_dataset_id_fkey"
+            columns: ["dataset_id"]
+            isOneToOne: false
+            referencedRelation: "datasets"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "dataset_items_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "dataset_items_source_request_id_fkey"
+            columns: ["source_request_id"]
+            isOneToOne: false
+            referencedRelation: "requests"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      datasets: {
+        Row: {
+          archived_at: string | null
+          created_at: string
+          created_by: string | null
+          description: string | null
+          id: string
+          name: string
+          organization_id: string
+        }
+        Insert: {
+          archived_at?: string | null
+          created_at?: string
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          name: string
+          organization_id: string
+        }
+        Update: {
+          archived_at?: string | null
+          created_at?: string
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          name?: string
+          organization_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "datasets_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       eval_results: {
         Row: {
           created_at: string
@@ -389,6 +479,13 @@ export type Database = {
         }
         Relationships: [
           {
+            foreignKeyName: "eval_results_dataset_item_id_fkey"
+            columns: ["dataset_item_id"]
+            isOneToOne: false
+            referencedRelation: "dataset_items"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "eval_results_eval_run_id_fkey"
             columns: ["eval_run_id"]
             isOneToOne: false
@@ -416,6 +513,7 @@ export type Database = {
           avg_score: number | null
           completed_at: string | null
           created_by: string | null
+          dataset_id: string | null
           error: string | null
           evaluator_id: string
           id: string
@@ -434,6 +532,7 @@ export type Database = {
           avg_score?: number | null
           completed_at?: string | null
           created_by?: string | null
+          dataset_id?: string | null
           error?: string | null
           evaluator_id: string
           id?: string
@@ -452,6 +551,7 @@ export type Database = {
           avg_score?: number | null
           completed_at?: string | null
           created_by?: string | null
+          dataset_id?: string | null
           error?: string | null
           evaluator_id?: string
           id?: string
@@ -467,6 +567,13 @@ export type Database = {
           total_cost_usd?: number
         }
         Relationships: [
+          {
+            foreignKeyName: "eval_runs_dataset_id_fkey"
+            columns: ["dataset_id"]
+            isOneToOne: false
+            referencedRelation: "datasets"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "eval_runs_evaluator_id_fkey"
             columns: ["evaluator_id"]

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -1493,10 +1493,12 @@ export type Database = {
           request_body: Json | null
           response_body: Json | null
           response_flags: Json
+          session_id: string | null
           span_id: string | null
           status_code: number
           total_tokens: number
           trace_id: string | null
+          user_id: string | null
         }
         Insert: {
           api_key_id?: string | null
@@ -1519,10 +1521,12 @@ export type Database = {
           request_body?: Json | null
           response_body?: Json | null
           response_flags?: Json
+          session_id?: string | null
           span_id?: string | null
           status_code: number
           total_tokens?: number
           trace_id?: string | null
+          user_id?: string | null
         }
         Update: {
           api_key_id?: string | null
@@ -1545,10 +1549,12 @@ export type Database = {
           request_body?: Json | null
           response_body?: Json | null
           response_flags?: Json
+          session_id?: string | null
           span_id?: string | null
           status_code?: number
           total_tokens?: number
           trace_id?: string | null
+          user_id?: string | null
         }
         Relationships: [
           {

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -641,6 +641,199 @@ export type Database = {
           },
         ]
       }
+      experiment_results: {
+        Row: {
+          cost_a_usd: number
+          cost_b_usd: number
+          created_at: string
+          dataset_item_id: string
+          error_a: string | null
+          error_b: string | null
+          experiment_id: string
+          id: string
+          latency_a_ms: number | null
+          latency_b_ms: number | null
+          organization_id: string
+          output_a: string | null
+          output_b: string | null
+          reasoning_a: string | null
+          reasoning_b: string | null
+          score_a: number | null
+          score_b: number | null
+          tokens_a: number
+          tokens_b: number
+        }
+        Insert: {
+          cost_a_usd?: number
+          cost_b_usd?: number
+          created_at?: string
+          dataset_item_id: string
+          error_a?: string | null
+          error_b?: string | null
+          experiment_id: string
+          id?: string
+          latency_a_ms?: number | null
+          latency_b_ms?: number | null
+          organization_id: string
+          output_a?: string | null
+          output_b?: string | null
+          reasoning_a?: string | null
+          reasoning_b?: string | null
+          score_a?: number | null
+          score_b?: number | null
+          tokens_a?: number
+          tokens_b?: number
+        }
+        Update: {
+          cost_a_usd?: number
+          cost_b_usd?: number
+          created_at?: string
+          dataset_item_id?: string
+          error_a?: string | null
+          error_b?: string | null
+          experiment_id?: string
+          id?: string
+          latency_a_ms?: number | null
+          latency_b_ms?: number | null
+          organization_id?: string
+          output_a?: string | null
+          output_b?: string | null
+          reasoning_a?: string | null
+          reasoning_b?: string | null
+          score_a?: number | null
+          score_b?: number | null
+          tokens_a?: number
+          tokens_b?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "experiment_results_dataset_item_id_fkey"
+            columns: ["dataset_item_id"]
+            isOneToOne: false
+            referencedRelation: "dataset_items"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "experiment_results_experiment_id_fkey"
+            columns: ["experiment_id"]
+            isOneToOne: false
+            referencedRelation: "experiments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "experiment_results_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      experiments: {
+        Row: {
+          avg_score_a: number | null
+          avg_score_b: number | null
+          completed_at: string | null
+          completed_items: number
+          created_by: string | null
+          dataset_id: string
+          error: string | null
+          evaluator_id: string | null
+          id: string
+          name: string
+          organization_id: string
+          prompt_name: string
+          run_model: string
+          run_provider: string
+          started_at: string
+          status: string
+          total_cost_usd: number
+          total_items: number
+          version_a_id: string
+          version_b_id: string
+        }
+        Insert: {
+          avg_score_a?: number | null
+          avg_score_b?: number | null
+          completed_at?: string | null
+          completed_items?: number
+          created_by?: string | null
+          dataset_id: string
+          error?: string | null
+          evaluator_id?: string | null
+          id?: string
+          name: string
+          organization_id: string
+          prompt_name: string
+          run_model: string
+          run_provider: string
+          started_at?: string
+          status?: string
+          total_cost_usd?: number
+          total_items?: number
+          version_a_id: string
+          version_b_id: string
+        }
+        Update: {
+          avg_score_a?: number | null
+          avg_score_b?: number | null
+          completed_at?: string | null
+          completed_items?: number
+          created_by?: string | null
+          dataset_id?: string
+          error?: string | null
+          evaluator_id?: string | null
+          id?: string
+          name?: string
+          organization_id?: string
+          prompt_name?: string
+          run_model?: string
+          run_provider?: string
+          started_at?: string
+          status?: string
+          total_cost_usd?: number
+          total_items?: number
+          version_a_id?: string
+          version_b_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "experiments_dataset_id_fkey"
+            columns: ["dataset_id"]
+            isOneToOne: false
+            referencedRelation: "datasets"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "experiments_evaluator_id_fkey"
+            columns: ["evaluator_id"]
+            isOneToOne: false
+            referencedRelation: "evaluators"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "experiments_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "experiments_version_a_id_fkey"
+            columns: ["version_a_id"]
+            isOneToOne: false
+            referencedRelation: "prompt_versions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "experiments_version_b_id_fkey"
+            columns: ["version_b_id"]
+            isOneToOne: false
+            referencedRelation: "prompt_versions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       model_prices: {
         Row: {
           completion_price_per_1m: number

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -1,4 +1,3 @@
-Initialising login role...
 export type Json =
   | string
   | number
@@ -12,31 +11,6 @@ export type Database = {
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
     PostgrestVersion: "14.5"
-  }
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
   }
   public: {
     Tables: {
@@ -369,6 +343,190 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "audit_logs_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      eval_results: {
+        Row: {
+          created_at: string
+          dataset_item_id: string | null
+          eval_run_id: string
+          id: string
+          judge_cost_usd: number
+          judge_tokens: number
+          organization_id: string
+          reasoning: string | null
+          request_id: string | null
+          score: number
+        }
+        Insert: {
+          created_at?: string
+          dataset_item_id?: string | null
+          eval_run_id: string
+          id?: string
+          judge_cost_usd?: number
+          judge_tokens?: number
+          organization_id: string
+          reasoning?: string | null
+          request_id?: string | null
+          score: number
+        }
+        Update: {
+          created_at?: string
+          dataset_item_id?: string | null
+          eval_run_id?: string
+          id?: string
+          judge_cost_usd?: number
+          judge_tokens?: number
+          organization_id?: string
+          reasoning?: string | null
+          request_id?: string | null
+          score?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "eval_results_eval_run_id_fkey"
+            columns: ["eval_run_id"]
+            isOneToOne: false
+            referencedRelation: "eval_runs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "eval_results_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "eval_results_request_id_fkey"
+            columns: ["request_id"]
+            isOneToOne: false
+            referencedRelation: "requests"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      eval_runs: {
+        Row: {
+          avg_score: number | null
+          completed_at: string | null
+          created_by: string | null
+          error: string | null
+          evaluator_id: string
+          id: string
+          organization_id: string
+          prompt_version_id: string
+          sample_from: string | null
+          sample_size: number
+          sample_to: string | null
+          scored_count: number
+          source: string
+          started_at: string
+          status: string
+          total_cost_usd: number
+        }
+        Insert: {
+          avg_score?: number | null
+          completed_at?: string | null
+          created_by?: string | null
+          error?: string | null
+          evaluator_id: string
+          id?: string
+          organization_id: string
+          prompt_version_id: string
+          sample_from?: string | null
+          sample_size: number
+          sample_to?: string | null
+          scored_count?: number
+          source?: string
+          started_at?: string
+          status?: string
+          total_cost_usd?: number
+        }
+        Update: {
+          avg_score?: number | null
+          completed_at?: string | null
+          created_by?: string | null
+          error?: string | null
+          evaluator_id?: string
+          id?: string
+          organization_id?: string
+          prompt_version_id?: string
+          sample_from?: string | null
+          sample_size?: number
+          sample_to?: string | null
+          scored_count?: number
+          source?: string
+          started_at?: string
+          status?: string
+          total_cost_usd?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "eval_runs_evaluator_id_fkey"
+            columns: ["evaluator_id"]
+            isOneToOne: false
+            referencedRelation: "evaluators"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "eval_runs_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "eval_runs_prompt_version_id_fkey"
+            columns: ["prompt_version_id"]
+            isOneToOne: false
+            referencedRelation: "prompt_versions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      evaluators: {
+        Row: {
+          archived_at: string | null
+          config: Json
+          created_at: string
+          created_by: string | null
+          id: string
+          name: string
+          organization_id: string
+          prompt_name: string
+          type: string
+        }
+        Insert: {
+          archived_at?: string | null
+          config: Json
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          name: string
+          organization_id: string
+          prompt_name: string
+          type?: string
+        }
+        Update: {
+          archived_at?: string | null
+          config?: Json
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          name?: string
+          organization_id?: string
+          prompt_name?: string
+          type?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "evaluators_organization_id_fkey"
             columns: ["organization_id"]
             isOneToOne: false
             referencedRelation: "organizations"
@@ -1646,6 +1804,33 @@ export type Database = {
           total_cost_usd: number
         }[]
       }
+      get_model_percentiles: {
+        Args: {
+          p_model: string
+          p_organization_id: string
+          p_provider: string
+          p_window_start: string
+        }
+        Returns: {
+          p50_completion: number
+          p50_prompt: number
+          p95_completion: number
+          p95_prompt: number
+          p99_completion: number
+          p99_prompt: number
+          sample_count: number
+        }[]
+      }
+      get_model_prior_window_cost: {
+        Args: {
+          p_model: string
+          p_organization_id: string
+          p_provider: string
+          p_window_end: string
+          p_window_start: string
+        }
+        Returns: number
+      }
       get_prompts_quality_sparklines: {
         Args: {
           p_buckets?: number
@@ -1853,14 +2038,9 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
-  graphql_public: {
-    Enums: {},
-  },
   public: {
     Enums: {
       org_role: ["admin", "editor", "viewer"],
     },
   },
 } as const
-A new version of Supabase CLI is available: v2.98.1 (currently installed v2.90.0)
-We recommend updating regularly for new features and bug fixes: https://supabase.com/docs/guides/cli/getting-started#updating-the-supabase-cli

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -834,6 +834,67 @@ export type Database = {
           },
         ]
       }
+      human_evals: {
+        Row: {
+          comment: string | null
+          created_at: string
+          id: string
+          organization_id: string
+          prompt_version_id: string | null
+          raw_score: number | null
+          request_id: string
+          reviewer_id: string
+          score: number
+          updated_at: string
+        }
+        Insert: {
+          comment?: string | null
+          created_at?: string
+          id?: string
+          organization_id: string
+          prompt_version_id?: string | null
+          raw_score?: number | null
+          request_id: string
+          reviewer_id: string
+          score: number
+          updated_at?: string
+        }
+        Update: {
+          comment?: string | null
+          created_at?: string
+          id?: string
+          organization_id?: string
+          prompt_version_id?: string | null
+          raw_score?: number | null
+          request_id?: string
+          reviewer_id?: string
+          score?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "human_evals_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "human_evals_prompt_version_id_fkey"
+            columns: ["prompt_version_id"]
+            isOneToOne: false
+            referencedRelation: "prompt_versions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "human_evals_request_id_fkey"
+            columns: ["request_id"]
+            isOneToOne: false
+            referencedRelation: "requests"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       model_prices: {
         Row: {
           completion_price_per_1m: number


### PR DESCRIPTION
## Summary

Phase 1~5 + 통합 마무리. 신규 4개 사이드바 탭(Evals · Datasets · Experiments · Annotation) 추가하고 Calls 탭 QUALITY 컬럼, Evals 상관도 카드, Requests user/session 필터, SDK 헬퍼까지 연결.

## 커밋 (9개)

1. **e2bc1f1** — Calls 탭 버전별 request 드릴다운 (이전 라운드 수정 포함)
2. **a9f4348** — 로드맵 문서 (docs/plans/prompts_evals_roadmap.md)
3. **32bffb4** — Phase 1: Evals (LLM-as-judge, evaluators/eval_runs/eval_results)
4. **1b5ccc3** — Phase 2: Datasets + Evals dataset source
5. **be9b446** — Phase 3: Experiments (오프라인 side-by-side 비교)
6. **c1cc66f** — Vercel build 차단하던 ESLint 위반 4건 수정
7. **389bff6** — Phase 4: REVIEW 섹션 + Annotation 탭
8. **d2086fb** — Phase 5: Requests user_id / session_id 필터
9. **36eb038** — Calls QUALITY 연결, Evals 상관도 카드, Requests UI, SDK 0.2.7

## 새 DB 테이블 (5개)

- \`evaluators\` — 평가 기준 정의
- \`eval_runs\`, \`eval_results\` — 평가 실행/결과
- \`datasets\`, \`dataset_items\` — 테스트 입력 세트
- \`experiments\`, \`experiment_results\` — 오프라인 비교
- \`human_evals\` — 사람 채점

기존 \`requests\`에 \`user_id\`, \`session_id\` 컬럼 추가.

## SDK 0.2.7
\`withUser(id)\`, \`withSession(id)\` 헬퍼 추가. \`withPromptVersion\`과 동일 패턴.

PR 머지 후 \`sdk-v0.2.7\` 태그 push로 npm publish 워크플로우 트리거 예정.

## Test plan

- [ ] Vercel 프리뷰 빌드 통과 확인
- [ ] DB 마이그레이션 4건이 production에 이미 적용됨 (Supabase MCP로 직접 적용했음 — 마이그레이션 파일은 기록용)
- [ ] /evals, /datasets, /experiments, /annotation 페이지가 빈 상태에서도 에러 없이 렌더
- [ ] Prompts → support_reply → Calls 탭에서 QUALITY 컬럼 표시
- [ ] /requests?userId=test 진입 시 활성 필터 배너 표시
- [ ] 머지 후 \`sdk-v0.2.7\` 태그로 npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)