### PR TITLE
feat: cache cost \xb7 streaming body \xb7 users analytics (3 features)

### DIFF
--- a/apps/server/src/__tests__/parsers.test.ts
+++ b/apps/server/src/__tests__/parsers.test.ts
@@ -18,7 +18,24 @@ describe('OpenAI parser', () => {
       completionTokens: 20,
       totalTokens: 30,
       model: 'gpt-4o',
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
     })
+  })
+
+  it('extracts cached_tokens from prompt_tokens_details', () => {
+    const body = {
+      model: 'gpt-4o',
+      usage: {
+        prompt_tokens: 100,
+        completion_tokens: 20,
+        total_tokens: 120,
+        prompt_tokens_details: { cached_tokens: 60 },
+      },
+    }
+    const parsed = parseOpenAIResponse(body)
+    expect(parsed?.promptTokens).toBe(100)
+    expect(parsed?.cacheReadTokens).toBe(60)
   })
 
   it('returns null when usage missing', () => {
@@ -39,12 +56,46 @@ describe('Anthropic parser', () => {
       completionTokens: 20,
       totalTokens: 30,
       model: 'claude-sonnet-4-6',
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
     })
+  })
+
+  it('sums input + cache_read + cache_creation into promptTokens', () => {
+    const body = {
+      model: 'claude-sonnet-4-6',
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 800,
+        cache_creation_input_tokens: 200,
+      },
+    }
+    const parsed = parseAnthropicResponse(body)
+    // promptTokens is the GROSS input (cache included), so existing aggregates
+    // continue to see "total input sent" rather than "non-cached input".
+    expect(parsed?.promptTokens).toBe(1100)
+    expect(parsed?.cacheReadTokens).toBe(800)
+    expect(parsed?.cacheWriteTokens).toBe(200)
   })
 
   it('extracts prompt tokens from message_start event', () => {
     const line = `data: ${JSON.stringify({ type: 'message_start', message: { model: 'claude-sonnet-4-6', usage: { input_tokens: 42 } } })}`
     expect(parseAnthropicStreamStart(line)?.promptTokens).toBe(42)
+  })
+
+  it('extracts cache breakdown from message_start event', () => {
+    const line = `data: ${JSON.stringify({
+      type: 'message_start',
+      message: {
+        model: 'claude-sonnet-4-6',
+        usage: { input_tokens: 50, cache_read_input_tokens: 400, cache_creation_input_tokens: 100 },
+      },
+    })}`
+    const parsed = parseAnthropicStreamStart(line)
+    expect(parsed?.promptTokens).toBe(550)
+    expect(parsed?.cacheReadTokens).toBe(400)
+    expect(parsed?.cacheWriteTokens).toBe(100)
   })
 
   it('extracts completion tokens from message_delta event', () => {

--- a/apps/server/src/__tests__/stream-body-capture.test.ts
+++ b/apps/server/src/__tests__/stream-body-capture.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest'
+import { extractOpenAIStreamText } from '../parsers/openai.js'
+import { extractAnthropicStreamText } from '../parsers/anthropic.js'
+import { extractGeminiStreamText } from '../parsers/gemini.js'
+
+/**
+ * Regression tests for streaming-response body capture.
+ *
+ * Why these exist: the dashboard relies on these parsers to reconstruct the
+ * assistant-visible text from streamed responses so request_detail and
+ * span_output can render. A provider format drift here would silently null
+ * out response_body for all streaming requests. These tests pin the wire
+ * formats so any change has to update both the parser and the fixture.
+ */
+
+describe('OpenAI stream text extraction', () => {
+  it('joins delta.content from chat.completion.chunk events', () => {
+    const lines = [
+      `data: ${JSON.stringify({ choices: [{ delta: { role: 'assistant' } }] })}`,
+      `data: ${JSON.stringify({ choices: [{ delta: { content: 'Hello' } }] })}`,
+      `data: ${JSON.stringify({ choices: [{ delta: { content: ', ' } }] })}`,
+      `data: ${JSON.stringify({ choices: [{ delta: { content: 'world.' } }] })}`,
+      `data: ${JSON.stringify({ choices: [], usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 } })}`,
+      'data: [DONE]',
+    ]
+    expect(extractOpenAIStreamText(lines)).toBe('Hello, world.')
+  })
+
+  it('stops at [DONE] sentinel without throwing', () => {
+    const lines = [
+      `data: ${JSON.stringify({ choices: [{ delta: { content: 'Hi' } }] })}`,
+      'data: [DONE]',
+      // anything after [DONE] is provider noise — ignore
+      `data: ${JSON.stringify({ choices: [{ delta: { content: 'leaked' } }] })}`,
+    ]
+    expect(extractOpenAIStreamText(lines)).toBe('Hi')
+  })
+
+  it('returns "" for empty / malformed input (no throw)', () => {
+    expect(extractOpenAIStreamText([])).toBe('')
+    expect(extractOpenAIStreamText(['', 'event: ping', ': comment'])).toBe('')
+    expect(extractOpenAIStreamText(['data: this is not json'])).toBe('')
+  })
+
+  it('captures partial text even when stream is aborted mid-flight', () => {
+    // Real-world scenario: connection dies after some chunks. Should still
+    // return what was already received instead of erroring out.
+    const lines = [
+      `data: ${JSON.stringify({ choices: [{ delta: { content: 'Partial ' } }] })}`,
+      `data: ${JSON.stringify({ choices: [{ delta: { content: 'response' } }] })}`,
+      // upstream cuts here — no [DONE], no final usage chunk
+    ]
+    expect(extractOpenAIStreamText(lines)).toBe('Partial response')
+  })
+})
+
+describe('Anthropic stream text extraction', () => {
+  it('joins text_delta events from content_block_delta', () => {
+    const lines = [
+      `data: ${JSON.stringify({ type: 'message_start', message: { model: 'claude-sonnet-4-6', usage: { input_tokens: 10 } } })}`,
+      `data: ${JSON.stringify({ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } })}`,
+      `data: ${JSON.stringify({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Hello' } })}`,
+      `data: ${JSON.stringify({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: ', world.' } })}`,
+      `data: ${JSON.stringify({ type: 'content_block_stop', index: 0 })}`,
+      `data: ${JSON.stringify({ type: 'message_delta', delta: {}, usage: { output_tokens: 5 } })}`,
+      `data: ${JSON.stringify({ type: 'message_stop' })}`,
+    ]
+    expect(extractAnthropicStreamText(lines)).toBe('Hello, world.')
+  })
+
+  it('ignores non-text_delta deltas (tool_use, etc.)', () => {
+    const lines = [
+      `data: ${JSON.stringify({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'pre' } })}`,
+      `data: ${JSON.stringify({ type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{"a":1}' } })}`,
+      `data: ${JSON.stringify({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'post' } })}`,
+    ]
+    expect(extractAnthropicStreamText(lines)).toBe('prepost')
+  })
+
+  it('returns "" for malformed input without throwing', () => {
+    expect(extractAnthropicStreamText([])).toBe('')
+    expect(extractAnthropicStreamText(['data: garbage', 'event: ping'])).toBe('')
+  })
+
+  it('captures partial text on aborted stream', () => {
+    const lines = [
+      `data: ${JSON.stringify({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Cut ' } })}`,
+      `data: ${JSON.stringify({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'off' } })}`,
+      // no message_stop — stream interrupted
+    ]
+    expect(extractAnthropicStreamText(lines)).toBe('Cut off')
+  })
+})
+
+describe('Gemini stream text extraction', () => {
+  it('parses SSE form (alt=sse)', () => {
+    const lines = [
+      `data: ${JSON.stringify({ candidates: [{ content: { parts: [{ text: 'Hello' }] } }] })}`,
+      `data: ${JSON.stringify({ candidates: [{ content: { parts: [{ text: ', Gemini.' }] } }] })}`,
+    ]
+    expect(extractGeminiStreamText(lines)).toBe('Hello, Gemini.')
+  })
+
+  it('parses default JSON-array form', () => {
+    const arr = [
+      { candidates: [{ content: { parts: [{ text: 'First ' }] } }] },
+      { candidates: [{ content: { parts: [{ text: 'second.' }] } }] },
+    ]
+    expect(extractGeminiStreamText(JSON.stringify(arr).split('\n'))).toBe('First second.')
+  })
+
+  it('falls back to per-line scan for partial/truncated streams', () => {
+    // A Gemini stream cut off mid-array — opening bracket present, closing
+    // missing. Per-line scan should still recover what it can.
+    const truncated = [
+      '[',
+      `${JSON.stringify({ candidates: [{ content: { parts: [{ text: 'Partial' }] } }] })},`,
+      // closing bracket never arrived
+    ]
+    expect(extractGeminiStreamText(truncated)).toBe('Partial')
+  })
+
+  it('returns "" for empty or non-Gemini input', () => {
+    expect(extractGeminiStreamText([])).toBe('')
+    expect(extractGeminiStreamText(['random text'])).toBe('')
+  })
+
+  it('accepts a single string buffer instead of lines array', () => {
+    const buffer = JSON.stringify([
+      { candidates: [{ content: { parts: [{ text: 'Buffer form' }] } }] },
+    ])
+    expect(extractGeminiStreamText(buffer)).toBe('Buffer form')
+  })
+})

--- a/apps/server/src/api/requests.ts
+++ b/apps/server/src/api/requests.ts
@@ -45,7 +45,7 @@ requestsRouter.get('/', async (c) => {
   let query = supabaseAdmin
     .from('requests')
     .select(
-      'id, project_id, provider, model, prompt_tokens, completion_tokens, total_tokens, cost_usd, latency_ms, status_code, error_message, trace_id, span_id, provider_key_id, user_id, session_id, provider_keys ( name ), created_at',
+      'id, project_id, provider, model, prompt_tokens, completion_tokens, total_tokens, cache_read_tokens, cache_write_tokens, cost_usd, latency_ms, status_code, error_message, trace_id, span_id, provider_key_id, user_id, session_id, provider_keys ( name ), created_at',
       { count: 'exact' },
     )
     .eq('organization_id', orgId)

--- a/apps/server/src/api/users.ts
+++ b/apps/server/src/api/users.ts
@@ -1,0 +1,163 @@
+import { Hono } from 'hono'
+import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { supabaseAdmin } from '../lib/db.js'
+
+export const usersRouter = new Hono<JwtContext>()
+
+usersRouter.use('*', authJwt)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/v1/users — aggregate per-user usage
+//
+// Returns one row per distinct (organization_id, user_id) — the end-user IDs
+// the customer attaches via x-spanlens-user. Sorted by total cost (highest
+// spenders first) by default.
+//
+// Query params:
+//   • projectId — filter to one project
+//   • from / to — ISO date strings; defaults to last 30 days
+//   • search    — substring match on user_id (icontains)
+//   • sortBy    — 'cost' | 'requests' | 'tokens' | 'last_seen' (default: cost)
+//   • sortDir   — 'asc' | 'desc' (default: desc)
+//   • page / limit — pagination (limit ≤ 100, default 50)
+// ─────────────────────────────────────────────────────────────────────────────
+usersRouter.get('/', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const projectId = c.req.query('projectId') ?? null
+  const search    = c.req.query('search') ?? null
+  const from      = c.req.query('from') ?? null
+  const to        = c.req.query('to') ?? null
+  const sortBy    = c.req.query('sortBy') ?? 'cost'
+  const sortDir   = c.req.query('sortDir') ?? 'desc'
+  const page      = Math.max(1, parseInt(c.req.query('page') ?? '1', 10))
+  const limit     = Math.min(100, Math.max(1, parseInt(c.req.query('limit') ?? '50', 10)))
+  const offset    = (page - 1) * limit
+
+  // Hand-rolled RPC — supabase-js doesn't expose GROUP BY in the table API.
+  // The function lives in the migration we add below.
+  const { data, error } = await supabaseAdmin.rpc('get_user_analytics', {
+    p_org_id: orgId,
+    p_project_id: projectId,
+    p_search: search,
+    p_from: from,
+    p_to: to,
+    p_sort_by: sortBy,
+    p_sort_dir: sortDir,
+    p_limit: limit,
+    p_offset: offset,
+  })
+
+  if (error) {
+    console.error('[users] rpc error:', error.message)
+    return c.json({ error: 'Failed to fetch user analytics' }, 500)
+  }
+
+  type UserRow = {
+    user_id: string
+    total_requests: number
+    total_tokens: number
+    total_cost_usd: number | null
+    avg_latency_ms: number | null
+    first_seen: string
+    last_seen: string
+    error_requests: number
+    distinct_models: number
+    total_count: number
+  }
+  const rows = (data ?? []) as UserRow[]
+  const totalCount = rows[0]?.total_count ?? 0
+
+  return c.json({
+    success: true,
+    data: rows.map(({ total_count: _omit, ...rest }) => rest),
+    meta: { total: totalCount, page, limit },
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/v1/users/:userId — single user detail
+//
+// Aggregates + recent 50 requests for one user_id within the org. Mirrors the
+// list endpoint's filter shape (projectId, from, to).
+// ─────────────────────────────────────────────────────────────────────────────
+usersRouter.get('/:userId', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  const userId = c.req.param('userId')
+
+  const projectId = c.req.query('projectId') ?? null
+  const from      = c.req.query('from') ?? null
+  const to        = c.req.query('to') ?? null
+
+  // Aggregate query reuses the same RPC with a pre-narrowed search.
+  const { data: aggRows, error: aggErr } = await supabaseAdmin.rpc('get_user_analytics', {
+    p_org_id: orgId,
+    p_project_id: projectId,
+    p_search: userId, // exact match handled below
+    p_from: from,
+    p_to: to,
+    p_sort_by: 'cost',
+    p_sort_dir: 'desc',
+    p_limit: 50,
+    p_offset: 0,
+  })
+  if (aggErr) {
+    console.error('[users:detail] rpc error:', aggErr.message)
+    return c.json({ error: 'Failed to fetch user analytics' }, 500)
+  }
+
+  type UserRow = {
+    user_id: string
+    total_requests: number
+    total_tokens: number
+    total_cost_usd: number | null
+    avg_latency_ms: number | null
+    first_seen: string
+    last_seen: string
+    error_requests: number
+    distinct_models: number
+  }
+  const agg = ((aggRows as UserRow[]) ?? []).find((r) => r.user_id === userId) ?? null
+  if (!agg) {
+    return c.json({
+      success: true,
+      data: {
+        user_id: userId,
+        total_requests: 0,
+        total_tokens: 0,
+        total_cost_usd: 0,
+        avg_latency_ms: null,
+        first_seen: null,
+        last_seen: null,
+        error_requests: 0,
+        distinct_models: 0,
+        recent_requests: [],
+      },
+    })
+  }
+
+  // Recent 50 requests for this user (no rpc needed — supabase table query works)
+  let recentQuery = supabaseAdmin
+    .from('requests')
+    .select('id, provider, model, prompt_tokens, completion_tokens, total_tokens, cache_read_tokens, cache_write_tokens, cost_usd, latency_ms, status_code, error_message, session_id, created_at')
+    .eq('organization_id', orgId)
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(50)
+  if (projectId) recentQuery = recentQuery.eq('project_id', projectId)
+  if (from)      recentQuery = recentQuery.gte('created_at', from)
+  if (to)        recentQuery = recentQuery.lte('created_at', to)
+
+  const { data: recent, error: recentErr } = await recentQuery
+  if (recentErr) {
+    console.error('[users:detail] recent error:', recentErr.message)
+    return c.json({ error: 'Failed to fetch recent requests' }, 500)
+  }
+
+  return c.json({
+    success: true,
+    data: { ...agg, recent_requests: recent ?? [] },
+  })
+})

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -10,6 +10,7 @@ import { organizationsRouter } from './api/organizations.js'
 import { projectsRouter }      from './api/projects.js'
 import { apiKeysRouter }       from './api/apiKeys.js'
 import { requestsRouter }      from './api/requests.js'
+import { usersRouter }         from './api/users.js'
 import { savedFiltersRouter }  from './api/savedFilters.js'
 import { statsRouter }         from './api/stats.js'
 import { tracesRouter }        from './api/traces.js'
@@ -101,6 +102,7 @@ app.route('/api/v1/projects',       projectsRouter)
 app.route('/api/v1/api-keys',       apiKeysRouter)
 app.route('/api/v1/provider-keys',  providerKeysRouter)
 app.route('/api/v1/requests',       requestsRouter)
+app.route('/api/v1/users',          usersRouter)
 app.route('/api/v1/saved-filters',  savedFiltersRouter)
 app.route('/api/v1/stats',          statsRouter)
 app.route('/api/v1/traces',         tracesRouter)

--- a/apps/server/src/lib/cost.test.ts
+++ b/apps/server/src/lib/cost.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'vitest'
+import { calculateCost } from './cost.js'
+
+describe('calculateCost — basic (no cache)', () => {
+  test('gpt-4o-mini: 1k prompt + 500 completion', () => {
+    const cost = calculateCost('openai', 'gpt-4o-mini', {
+      promptTokens: 1000,
+      completionTokens: 500,
+    })
+    expect(cost).not.toBeNull()
+    // 1000/1M × 0.15 + 500/1M × 0.60 = 0.00015 + 0.0003 = 0.00045
+    expect(cost!.totalCost).toBeCloseTo(0.00045, 8)
+    expect(cost!.cacheReadCost).toBe(0)
+    expect(cost!.cacheWriteCost).toBe(0)
+  })
+
+  test('returns null for unknown model', () => {
+    expect(
+      calculateCost('openai', 'no-such-model-xyz', { promptTokens: 100, completionTokens: 50 }),
+    ).toBeNull()
+  })
+
+  test('boundary-aware prefix match: dated suffix resolves to base model', () => {
+    const cost = calculateCost('openai', 'gpt-4o-mini-2024-07-18', {
+      promptTokens: 1000,
+      completionTokens: 0,
+    })
+    expect(cost).not.toBeNull()
+    expect(cost!.totalCost).toBeCloseTo(0.00015, 8)
+  })
+})
+
+describe('calculateCost — cache breakdown', () => {
+  test('Anthropic Sonnet: 10k prompt total = 8k regular + 1k cache_read + 1k cache_write', () => {
+    // claude-sonnet-4-6: prompt 3, completion 15, cacheRead 0.3, cacheWrite 3.75
+    const cost = calculateCost('anthropic', 'claude-sonnet-4-6', {
+      promptTokens: 10_000,
+      completionTokens: 500,
+      cacheReadTokens: 1000,
+      cacheWriteTokens: 1000,
+    })
+    expect(cost).not.toBeNull()
+    // non_cached = 10_000 - 1000 - 1000 = 8000
+    // prompt_cost      = 8000/1M  × 3.0   = 0.024
+    // cache_read_cost  = 1000/1M  × 0.3   = 0.0003
+    // cache_write_cost = 1000/1M  × 3.75  = 0.00375
+    // completion_cost  = 500/1M   × 15.0  = 0.0075
+    expect(cost!.promptCost).toBeCloseTo(0.024, 8)
+    expect(cost!.cacheReadCost).toBeCloseTo(0.0003, 8)
+    expect(cost!.cacheWriteCost).toBeCloseTo(0.00375, 8)
+    expect(cost!.completionCost).toBeCloseTo(0.0075, 8)
+    expect(cost!.totalCost).toBeCloseTo(0.03555, 8)
+  })
+
+  test('OpenAI gpt-4o: 10k prompt = 5k cached + 5k non-cached', () => {
+    // gpt-4o: prompt 2.5, completion 10, cacheRead 1.25 (no cacheWrite)
+    const cost = calculateCost('openai', 'gpt-4o', {
+      promptTokens: 10_000,
+      completionTokens: 1000,
+      cacheReadTokens: 5000,
+      cacheWriteTokens: 0,
+    })
+    expect(cost).not.toBeNull()
+    // prompt_cost     = 5000/1M  × 2.5  = 0.0125
+    // cache_read_cost = 5000/1M  × 1.25 = 0.00625
+    // completion_cost = 1000/1M  × 10   = 0.01
+    expect(cost!.promptCost).toBeCloseTo(0.0125, 8)
+    expect(cost!.cacheReadCost).toBeCloseTo(0.00625, 8)
+    expect(cost!.completionCost).toBeCloseTo(0.01, 8)
+    expect(cost!.totalCost).toBeCloseTo(0.02875, 8)
+  })
+
+  test('overcounting protection: cache_read + cache_write > promptTokens → non_cached clamped at 0', () => {
+    const cost = calculateCost('anthropic', 'claude-sonnet-4-6', {
+      promptTokens: 100,
+      completionTokens: 0,
+      cacheReadTokens: 200,
+      cacheWriteTokens: 0,
+    })
+    expect(cost).not.toBeNull()
+    expect(cost!.promptCost).toBe(0)
+    // cache_read still charged on its full count
+    expect(cost!.cacheReadCost).toBeCloseTo(0.00006, 10)
+  })
+
+  test('model without cache pricing falls back to prompt rate for cache_read', () => {
+    // gpt-4-turbo: prompt 10, completion 30, NO cacheRead defined
+    const cost = calculateCost('openai', 'gpt-4-turbo', {
+      promptTokens: 1000,
+      completionTokens: 0,
+      cacheReadTokens: 500,
+    })
+    expect(cost).not.toBeNull()
+    // non_cached = 1000 - 500 = 500 × 10/1M = 0.005
+    // cache_read = 500 × 10/1M (fallback to prompt rate) = 0.005
+    // total = 0.01 (matches the OLD overcounting behavior — safe default)
+    expect(cost!.cacheReadCost).toBeCloseTo(0.005, 8)
+    expect(cost!.totalCost).toBeCloseTo(0.01, 8)
+  })
+})
+
+describe('calculateCost — regression vs. old behavior', () => {
+  test('no cache tokens → identical total to pre-migration cost', () => {
+    // Anthropic Haiku, 1000 prompt + 500 completion, NO cache.
+    // Old formula: 1000/1M × 1 + 500/1M × 5 = 0.001 + 0.0025 = 0.0035
+    // New formula (cacheReadTokens=0, cacheWriteTokens=0): same.
+    const cost = calculateCost('anthropic', 'claude-haiku-4-5', {
+      promptTokens: 1000,
+      completionTokens: 500,
+    })
+    expect(cost!.totalCost).toBeCloseTo(0.0035, 8)
+  })
+
+  test('Anthropic cache-heavy workload shows cost reduction vs. old behavior', () => {
+    // 100k prompt = 90k cache_read + 10k non-cached
+    // Old (broken): 100_000 × 3/1M = 0.30
+    // New: 10_000 × 3/1M + 90_000 × 0.3/1M = 0.03 + 0.027 = 0.057
+    // Ratio: 0.057 / 0.30 ≈ 0.19 → 5.3× overcount fixed
+    const cost = calculateCost('anthropic', 'claude-sonnet-4-6', {
+      promptTokens: 100_000,
+      completionTokens: 0,
+      cacheReadTokens: 90_000,
+    })
+    expect(cost!.totalCost).toBeCloseTo(0.057, 6)
+    const oldCostEstimate = 100_000 / 1_000_000 * 3
+    expect(oldCostEstimate / cost!.totalCost).toBeGreaterThan(5)
+  })
+})

--- a/apps/server/src/lib/cost.ts
+++ b/apps/server/src/lib/cost.ts
@@ -1,59 +1,82 @@
 export type Provider = 'openai' | 'anthropic' | 'gemini'
 
 export interface Usage {
+  /** Total input tokens INCLUDING any cached/cache-creation portion. */
   promptTokens: number
   completionTokens: number
+  /** Subset of promptTokens that hit a prompt cache (charged at reduced rate). */
+  cacheReadTokens?: number
+  /** Subset of promptTokens that created a cache entry (charged at premium rate). */
+  cacheWriteTokens?: number
 }
 
 export interface CostResult {
   totalCost: number
+  /** Cost of non-cached prompt tokens (regular input). */
   promptCost: number
   completionCost: number
+  /** Cost of cached input tokens (0 if no cache hit). */
+  cacheReadCost: number
+  /** Cost of cache-creation tokens (0 if not applicable). */
+  cacheWriteCost: number
 }
 
-// Prices in USD per 1M tokens (verified against provider pricing pages 2026-05)
-const MODEL_PRICES: Record<string, { prompt: number; completion: number }> = {
-  // OpenAI
-  'gpt-4o': { prompt: 2.5, completion: 10 },
-  'gpt-4o-mini': { prompt: 0.15, completion: 0.6 },
-  'gpt-4.1': { prompt: 2.0, completion: 8.0 },
-  'gpt-4.1-mini': { prompt: 0.4, completion: 1.6 },
-  'gpt-4.1-nano': { prompt: 0.1, completion: 0.4 },
-  'gpt-4-turbo': { prompt: 10, completion: 30 },
-  'gpt-4': { prompt: 30, completion: 60 },
-  'gpt-3.5-turbo': { prompt: 0.5, completion: 1.5 },
-  // Anthropic
-  'claude-opus-4-7': { prompt: 5, completion: 25 },
-  'claude-sonnet-4-6': { prompt: 3, completion: 15 },
-  // claude-haiku-4-5 — all aliases: dot notation (API alias), dash (API response body), dated
-  'claude-haiku-4.5': { prompt: 1, completion: 5 },
-  'claude-haiku-4-5': { prompt: 1, completion: 5 },
-  'claude-haiku-4-5-20251001': { prompt: 1, completion: 5 },
-  'claude-3-5-sonnet-20241022': { prompt: 3, completion: 15 },
-  'claude-3-5-haiku-20241022': { prompt: 0.8, completion: 4 },
-  'claude-3-opus-20240229': { prompt: 15, completion: 75 },
-  // Gemini
-  'gemini-2.5-pro': { prompt: 1.25, completion: 10 },
-  'gemini-2.5-flash': { prompt: 0.3, completion: 2.5 },
-  'gemini-2.5-flash-lite': { prompt: 0.1, completion: 0.4 },
-  'gemini-2.0-flash': { prompt: 0.1, completion: 0.4 }, // deprecated 2026-06-01, kept for historical data
-  'gemini-1.5-pro': { prompt: 1.25, completion: 5 },
-  'gemini-1.5-flash': { prompt: 0.075, completion: 0.3 },
+interface ModelPrice {
+  prompt: number
+  completion: number
+  /** USD per 1M cached input tokens. If undefined, cache_read is billed at `prompt` rate. */
+  cacheRead?: number
+  /** USD per 1M cache-creation tokens. If undefined, cache_write is billed at `prompt` rate. */
+  cacheWrite?: number
+}
+
+// Prices in USD per 1M tokens (verified against provider pricing pages 2026-05).
+// Cache rates:
+//   • Anthropic — cache_read = 0.1 × input, cache_write (5min) = 1.25 × input
+//   • OpenAI    — cached input ≈ 0.5 × input (gpt-4o / gpt-4.1 families)
+const MODEL_PRICES: Record<string, ModelPrice> = {
+  // ── OpenAI ────────────────────────────────────────────────────────────────
+  'gpt-4o':        { prompt: 2.5,  completion: 10,  cacheRead: 1.25 },
+  'gpt-4o-mini':   { prompt: 0.15, completion: 0.6, cacheRead: 0.075 },
+  'gpt-4.1':       { prompt: 2.0,  completion: 8.0, cacheRead: 0.5 },
+  'gpt-4.1-mini':  { prompt: 0.4,  completion: 1.6, cacheRead: 0.1 },
+  'gpt-4.1-nano':  { prompt: 0.1,  completion: 0.4, cacheRead: 0.025 },
+  'gpt-4-turbo':   { prompt: 10,   completion: 30 },
+  'gpt-4':         { prompt: 30,   completion: 60 },
+  'gpt-3.5-turbo': { prompt: 0.5,  completion: 1.5 },
+  // ── Anthropic ────────────────────────────────────────────────────────────
+  'claude-opus-4-7':            { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 },
+  'claude-sonnet-4-6':          { prompt: 3,    completion: 15, cacheRead: 0.3,  cacheWrite: 3.75 },
+  // claude-haiku-4-5 — all aliases (dot notation API alias, dash API response body, dated)
+  'claude-haiku-4.5':           { prompt: 1,    completion: 5,  cacheRead: 0.1,  cacheWrite: 1.25 },
+  'claude-haiku-4-5':           { prompt: 1,    completion: 5,  cacheRead: 0.1,  cacheWrite: 1.25 },
+  'claude-haiku-4-5-20251001':  { prompt: 1,    completion: 5,  cacheRead: 0.1,  cacheWrite: 1.25 },
+  'claude-3-5-sonnet-20241022': { prompt: 3,    completion: 15, cacheRead: 0.3,  cacheWrite: 3.75 },
+  'claude-3-5-haiku-20241022':  { prompt: 0.8,  completion: 4,  cacheRead: 0.08, cacheWrite: 1.0 },
+  'claude-3-opus-20240229':     { prompt: 15,   completion: 75, cacheRead: 1.5,  cacheWrite: 18.75 },
+  // ── Gemini (caching not yet exposed in our integration) ──────────────────
+  'gemini-2.5-pro':        { prompt: 1.25,  completion: 10 },
+  'gemini-2.5-flash':      { prompt: 0.3,   completion: 2.5 },
+  'gemini-2.5-flash-lite': { prompt: 0.1,   completion: 0.4 },
+  'gemini-2.0-flash':      { prompt: 0.1,   completion: 0.4 }, // deprecated 2026-06-01, kept for historical data
+  'gemini-1.5-pro':        { prompt: 1.25,  completion: 5 },
+  'gemini-1.5-flash':      { prompt: 0.075, completion: 0.3 },
 }
 
 /**
  * OpenAI는 종종 dated suffix를 포함해 모델명을 반환합니다 (예: gpt-4o-mini-2024-07-18).
  * 정확 매칭이 실패하면 등록된 키들 중 가장 긴 prefix를 찾아 fallback 매칭합니다.
+ * (boundary-aware: 다음 글자가 단어 경계가 되도록 — 'gpt-4'가 'gpt-4o' prefix로 잘못 잡히는 일 방지)
  */
-function lookupPrice(model: string): { prompt: number; completion: number } | null {
+function lookupPrice(model: string): ModelPrice | null {
   const exact = MODEL_PRICES[model]
   if (exact) return exact
 
   let bestKey = ''
   for (const key of Object.keys(MODEL_PRICES)) {
-    if (model.startsWith(key) && key.length > bestKey.length) {
-      bestKey = key
-    }
+    if (!model.startsWith(key)) continue
+    // longest prefix wins
+    if (key.length > bestKey.length) bestKey = key
   }
   return bestKey ? MODEL_PRICES[bestKey] ?? null : null
 }
@@ -66,12 +89,29 @@ export function calculateCost(
   const prices = lookupPrice(model)
   if (!prices) return null
 
-  const promptCost = (usage.promptTokens / 1_000_000) * prices.prompt
+  const cacheRead = usage.cacheReadTokens ?? 0
+  const cacheWrite = usage.cacheWriteTokens ?? 0
+  // promptTokens is "total input INCLUDING cache". Subtract the cache portions
+  // to get the non-cached input charged at the regular prompt rate. Clamped at 0
+  // in case of unexpected reporter inconsistencies.
+  const nonCachedPromptTokens = Math.max(0, usage.promptTokens - cacheRead - cacheWrite)
+
+  // Models without explicit cache pricing fall back to the regular prompt rate
+  // (matches the historical behavior — no surprise cost reduction for models
+  // that lack a published cache price).
+  const cacheReadPrice = prices.cacheRead ?? prices.prompt
+  const cacheWritePrice = prices.cacheWrite ?? prices.prompt
+
+  const promptCost = (nonCachedPromptTokens / 1_000_000) * prices.prompt
+  const cacheReadCost = (cacheRead / 1_000_000) * cacheReadPrice
+  const cacheWriteCost = (cacheWrite / 1_000_000) * cacheWritePrice
   const completionCost = (usage.completionTokens / 1_000_000) * prices.completion
 
   return {
     promptCost,
     completionCost,
-    totalCost: promptCost + completionCost,
+    cacheReadCost,
+    cacheWriteCost,
+    totalCost: promptCost + completionCost + cacheReadCost + cacheWriteCost,
   }
 }

--- a/apps/server/src/lib/logger.ts
+++ b/apps/server/src/lib/logger.ts
@@ -11,6 +11,10 @@ export interface RequestLogData {
   promptTokens: number
   completionTokens: number
   totalTokens: number
+  /** Subset of promptTokens that hit a prompt cache (Anthropic cache_read_input_tokens / OpenAI cached_tokens). */
+  cacheReadTokens?: number
+  /** Subset of promptTokens that wrote a cache entry (Anthropic cache_creation_input_tokens). */
+  cacheWriteTokens?: number
   costUsd: number | null
   latencyMs: number
   /** Pre-fetch proxy overhead: auth + key decryption + body parsing (ms). Target p95 < 50ms. */
@@ -166,6 +170,8 @@ export async function logRequestAsync(data: RequestLogData): Promise<void> {
     prompt_tokens: data.promptTokens,
     completion_tokens: data.completionTokens,
     total_tokens: data.totalTokens,
+    cache_read_tokens: data.cacheReadTokens ?? 0,
+    cache_write_tokens: data.cacheWriteTokens ?? 0,
     cost_usd: data.costUsd,
     latency_ms: data.latencyMs,
     proxy_overhead_ms: data.proxyOverheadMs ?? null,

--- a/apps/server/src/parsers/anthropic.ts
+++ b/apps/server/src/parsers/anthropic.ts
@@ -1,15 +1,35 @@
 import type { ParsedUsage } from './openai.js'
 
-// Anthropic streaming: usage is in the message_delta event, NOT the last data chunk.
+/**
+ * Anthropic 응답에서 usage를 추출합니다.
+ *
+ * Anthropic은 `input_tokens` 필드가 NON-CACHED 입력만 카운트하고,
+ * 캐시 부분은 별도로 `cache_read_input_tokens` / `cache_creation_input_tokens`로 보고합니다.
+ * Spanlens는 `promptTokens` 컬럼을 "총 input tokens (캐시 포함)" 의미로 유지하므로,
+ * 세 필드를 합산해서 promptTokens에 넣고, 캐시 부분은 별도 필드로도 노출합니다.
+ *
+ * (참고: streaming은 message_start에서 input_tokens + cache_*가 함께 옴 — 동일하게 합산)
+ */
+function buildAnthropicUsage(usage: Record<string, number>, model: string): ParsedUsage {
+  const inputTokens = usage.input_tokens ?? 0
+  const cacheRead = usage.cache_read_input_tokens ?? 0
+  const cacheWrite = usage.cache_creation_input_tokens ?? 0
+  const promptTokens = inputTokens + cacheRead + cacheWrite
+  const completionTokens = usage.output_tokens ?? 0
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens: promptTokens + completionTokens,
+    model,
+    cacheReadTokens: cacheRead,
+    cacheWriteTokens: cacheWrite,
+  }
+}
+
 export function parseAnthropicResponse(body: Record<string, unknown>): ParsedUsage | null {
   const usage = body.usage as Record<string, number> | undefined
   if (!usage) return null
-  return {
-    promptTokens: usage.input_tokens ?? 0,
-    completionTokens: usage.output_tokens ?? 0,
-    totalTokens: (usage.input_tokens ?? 0) + (usage.output_tokens ?? 0),
-    model: (body.model as string) ?? '',
-  }
+  return buildAnthropicUsage(usage, (body.model as string) ?? '')
 }
 
 export function extractAnthropicStreamText(lines: string[]): string {
@@ -54,8 +74,13 @@ export function parseAnthropicStreamStart(line: string): Partial<ParsedUsage> | 
     const message = json.message as Record<string, unknown> | undefined
     const usage = message?.usage as Record<string, number> | undefined
     if (!usage) return null
+    const inputTokens = usage.input_tokens ?? 0
+    const cacheRead = usage.cache_read_input_tokens ?? 0
+    const cacheWrite = usage.cache_creation_input_tokens ?? 0
     return {
-      promptTokens: usage.input_tokens ?? 0,
+      promptTokens: inputTokens + cacheRead + cacheWrite,
+      cacheReadTokens: cacheRead,
+      cacheWriteTokens: cacheWrite,
       model: (message?.model as string) ?? '',
     }
   } catch {

--- a/apps/server/src/parsers/gemini.ts
+++ b/apps/server/src/parsers/gemini.ts
@@ -10,3 +10,82 @@ export function parseGeminiResponse(body: Record<string, unknown>): ParsedUsage 
     model: (body.modelVersion as string) ?? '',
   }
 }
+
+/**
+ * Reconstruct the assistant-visible text from a Gemini streaming response.
+ *
+ * Gemini's :streamGenerateContent endpoint can emit chunks in two formats:
+ *   1. With `?alt=sse` — SSE lines starting with "data: ".
+ *   2. Default — a single JSON ARRAY of partial GenerateContentResponse objects,
+ *      streamed character-by-character. We accept the joined buffer and parse
+ *      defensively.
+ *
+ * Returns the joined text from `candidates[0].content.parts[*].text`. Empty
+ * string on parse failure — callers should treat empty + non-empty input as
+ * a parser regression signal.
+ */
+export function extractGeminiStreamText(linesOrBuffer: string[] | string): string {
+  const lines = Array.isArray(linesOrBuffer)
+    ? linesOrBuffer
+    : linesOrBuffer.split('\n')
+
+  const parts: string[] = []
+
+  // Try SSE form first ("data: {json}")
+  let sawSseData = false
+  for (const line of lines) {
+    if (!line.startsWith('data: ')) continue
+    sawSseData = true
+    const data = line.slice(6).trim()
+    if (!data || data === '[DONE]') continue
+    appendTextFromGeminiChunk(data, parts)
+  }
+  if (sawSseData) return parts.join('')
+
+  // Fallback: try to parse the whole thing as a JSON array (default Gemini stream format)
+  const joined = lines.join('\n').trim()
+  if (joined.startsWith('[')) {
+    try {
+      const arr = JSON.parse(joined) as unknown[]
+      for (const item of arr) {
+        if (typeof item === 'object' && item !== null) {
+          appendTextFromGeminiChunk(JSON.stringify(item), parts)
+        }
+      }
+    } catch {
+      // Stream may be aborted mid-array — fall through to line-by-line scan
+    }
+  }
+
+  // Last resort: scan each line as standalone JSON (NDJSON-like).
+  // Lines from a truncated array carry framing characters (leading "[" or ","
+  // and trailing "," or "]") that need to be stripped before JSON.parse.
+  if (parts.length === 0) {
+    for (const line of lines) {
+      const trimmed = line
+        .trim()
+        .replace(/^[[,\s]+/, '')
+        .replace(/[\],\s]+$/, '')
+      if (!trimmed || !trimmed.startsWith('{')) continue
+      appendTextFromGeminiChunk(trimmed, parts)
+    }
+  }
+
+  return parts.join('')
+}
+
+function appendTextFromGeminiChunk(data: string, sink: string[]): void {
+  try {
+    const json = JSON.parse(data) as Record<string, unknown>
+    const candidates = json.candidates as Array<{
+      content?: { parts?: Array<{ text?: string }> }
+    }> | undefined
+    const partsArr = candidates?.[0]?.content?.parts
+    if (!partsArr) return
+    for (const p of partsArr) {
+      if (p.text) sink.push(p.text)
+    }
+  } catch {
+    // ignore — non-JSON or partial chunk
+  }
+}

--- a/apps/server/src/parsers/openai.ts
+++ b/apps/server/src/parsers/openai.ts
@@ -1,18 +1,38 @@
 export interface ParsedUsage {
+  /**
+   * Total input tokens (INCLUDING any cached portion).
+   * For OpenAI this is `usage.prompt_tokens` as-reported.
+   * cache_read_tokens is a SUBSET of this number, not an addition.
+   */
   promptTokens: number
   completionTokens: number
   totalTokens: number
   model: string
+  /**
+   * Cached input tokens (subset of promptTokens).
+   * OpenAI: `usage.prompt_tokens_details.cached_tokens`.
+   * Charged at the reduced cache_read price in lib/cost.ts.
+   */
+  cacheReadTokens?: number
+  /**
+   * Cache-creation input tokens (subset of promptTokens).
+   * OpenAI: no equivalent in the public API as of 2026-05; always 0/undefined.
+   */
+  cacheWriteTokens?: number
 }
 
 export function parseOpenAIResponse(body: Record<string, unknown>): ParsedUsage | null {
-  const usage = body.usage as Record<string, number> | undefined
+  const usage = body.usage as Record<string, unknown> | undefined
   if (!usage) return null
+  const promptDetails = usage.prompt_tokens_details as Record<string, number> | undefined
+  const cacheReadTokens = promptDetails?.cached_tokens ?? 0
   return {
-    promptTokens: usage.prompt_tokens ?? 0,
-    completionTokens: usage.completion_tokens ?? 0,
-    totalTokens: usage.total_tokens ?? 0,
+    promptTokens: (usage.prompt_tokens as number) ?? 0,
+    completionTokens: (usage.completion_tokens as number) ?? 0,
+    totalTokens: (usage.total_tokens as number) ?? 0,
     model: (body.model as string) ?? '',
+    cacheReadTokens,
+    cacheWriteTokens: 0,
   }
 }
 
@@ -38,13 +58,16 @@ export function parseOpenAIStreamChunk(line: string): Partial<ParsedUsage> | nul
   if (data === '[DONE]') return null
   try {
     const json = JSON.parse(data) as Record<string, unknown>
-    const usage = json.usage as Record<string, number> | null
+    const usage = json.usage as Record<string, unknown> | null
     if (!usage) return null
+    const promptDetails = usage.prompt_tokens_details as Record<string, number> | undefined
     return {
-      promptTokens: usage.prompt_tokens ?? 0,
-      completionTokens: usage.completion_tokens ?? 0,
-      totalTokens: usage.total_tokens ?? 0,
+      promptTokens: (usage.prompt_tokens as number) ?? 0,
+      completionTokens: (usage.completion_tokens as number) ?? 0,
+      totalTokens: (usage.total_tokens as number) ?? 0,
       model: (json.model as string) ?? '',
+      cacheReadTokens: promptDetails?.cached_tokens ?? 0,
+      cacheWriteTokens: 0,
     }
   } catch {
     return null

--- a/apps/server/src/proxy/anthropic.ts
+++ b/apps/server/src/proxy/anthropic.ts
@@ -147,6 +147,8 @@ anthropicProxy.all('/*', async (c) => {
   let promptTokens = 0
   let completionTokens = 0
   let totalTokens = 0
+  let cacheReadTokens = 0
+  let cacheWriteTokens = 0
   let resolvedModel = model
 
   if (upstreamRes.ok && resBodyJson) {
@@ -157,16 +159,21 @@ anthropicProxy.all('/*', async (c) => {
         promptTokens = parsed.promptTokens
         completionTokens = parsed.completionTokens
         totalTokens = parsed.totalTokens
+        cacheReadTokens = parsed.cacheReadTokens ?? 0
+        cacheWriteTokens = parsed.cacheWriteTokens ?? 0
       }
     } catch { /* ignore */ }
   }
 
-  const cost = calculateCost('anthropic', resolvedModel, { promptTokens, completionTokens })
+  const cost = calculateCost('anthropic', resolvedModel, {
+    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens,
+  })
 
   fireAndForget(c, logRequestAsync({
     ...logBase,
     model: resolvedModel,
     promptTokens, completionTokens, totalTokens,
+    cacheReadTokens, cacheWriteTokens,
     costUsd: cost?.totalCost ?? null,
     responseBody: resBodyJson,
     errorMessage: upstreamRes.ok ? null : resBodyText.slice(0, 1000),

--- a/apps/server/src/proxy/gemini.ts
+++ b/apps/server/src/proxy/gemini.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import { stream } from 'hono/streaming'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
@@ -6,7 +7,7 @@ import { calculateCost } from '../lib/cost.js'
 import { logRequestAsync } from '../lib/logger.js'
 import { resolvePromptVersion } from '../lib/resolve-prompt-version.js'
 import { fireAndForget } from '../lib/wait-until.js'
-import { parseGeminiResponse } from '../parsers/gemini.js'
+import { parseGeminiResponse, extractGeminiStreamText } from '../parsers/gemini.js'
 import { scanAll } from '../lib/security-scan.js'
 import { getDecryptedProviderKey, buildUpstreamHeaders, buildDownstreamHeaders, isBlockingEnabled } from './utils.js'
 
@@ -80,12 +81,128 @@ geminiProxy.all('/*', async (c) => {
   const latencyMs = Date.now() - startMs
   const proxyOverheadMs = startMs - handlerStartMs
 
+  // Extract model name from the path (e.g. /v1/models/gemini-1.5-pro:streamGenerateContent)
+  const modelMatch = /\/models\/([^/:]+)/.exec(originalPath)
+  const isStreaming = /:streamGenerateContent/.test(originalPath)
+
+  const traceId = c.req.header('x-trace-id') ?? null
+  const resolved = await resolvePromptVersion(
+    organizationId,
+    c.req.header('x-spanlens-prompt-version') ?? null,
+    traceId,
+  )
+  const promptVersionId = resolved?.versionId ?? null
+
+  const logBase = {
+    organizationId,
+    projectId,
+    apiKeyId,
+    provider: 'gemini',
+    latencyMs,
+    proxyOverheadMs,
+    statusCode: upstreamRes.status,
+    requestBody: reqBodyJson,
+    errorMessage: null as string | null,
+    traceId,
+    spanId: c.req.header('x-span-id') ?? null,
+    promptVersionId,
+    providerKeyId: providerKey.id,
+    userId: c.req.header('x-spanlens-user') ?? null,
+    sessionId: c.req.header('x-spanlens-session') ?? null,
+    preComputedRequestFlags: requestFlags,
+  }
+
+  // ── Streaming path (:streamGenerateContent) ───────────────────────────────
+  // Pass chunks straight to the client AND buffer for token/text extraction.
+  // Without this, the previous code did `await upstreamRes.text()` and blocked
+  // the entire stream — the client never got streaming, just one big payload.
+  if (isStreaming && upstreamRes.body) {
+    const downstreamHeaders = buildDownstreamHeaders(upstreamRes.headers)
+    downstreamHeaders.forEach((value, key) => c.header(key, value))
+    c.status(upstreamRes.status as 200)
+
+    const upstreamBody = upstreamRes.body
+
+    return stream(c, async (honoStream) => {
+      const reader = upstreamBody.getReader()
+      const decoder = new TextDecoder()
+      const chunks: string[] = []
+
+      try {
+        for (;;) {
+          const { done, value } = await reader.read()
+          if (done) break
+          await honoStream.write(value)
+          chunks.push(decoder.decode(value, { stream: true }))
+        }
+      } catch (err) {
+        console.error('[gemini-stream] reader error:', err)
+      }
+
+      const buffer = chunks.join('')
+      const text = extractGeminiStreamText(buffer.split('\n'))
+
+      // Best-effort: try to recover usage + model from the last full JSON chunk.
+      let model = modelMatch?.[1] ?? ''
+      let promptTokens = 0
+      let completionTokens = 0
+      let totalTokens = 0
+      try {
+        // Try parsing the joined buffer as a JSON array of partial responses
+        const lastChunkText = buffer.trim().replace(/^\[/, '').replace(/\]$/, '')
+        const candidates = lastChunkText.split(/(?<=})\s*,\s*(?=\{)/g)
+        const last = candidates[candidates.length - 1]
+        if (last) {
+          const parsed = parseGeminiResponse(JSON.parse(last) as Record<string, unknown>)
+          if (parsed) {
+            model = parsed.model || model
+            promptTokens = parsed.promptTokens
+            completionTokens = parsed.completionTokens
+            totalTokens = parsed.totalTokens
+          }
+        }
+      } catch { /* usage may be missing on aborted streams — acceptable */ }
+
+      // Capture-rate signal: a stream that produced output bytes but yielded no
+      // extractable text usually means the parser drifted from Gemini's wire
+      // format. Surface it as a warn for log monitoring.
+      if (buffer.length > 0 && text.length === 0) {
+        console.warn(
+          '[gemini-stream] capture-empty: %d bytes received, 0 chars extracted (parser drift?)',
+          buffer.length,
+        )
+      }
+
+      const cost = calculateCost('gemini', model, { promptTokens, completionTokens })
+      const responseBody = text ? {
+        candidates: [{ content: { parts: [{ text }] } }],
+        modelVersion: model,
+        usageMetadata: {
+          promptTokenCount: promptTokens,
+          candidatesTokenCount: completionTokens,
+          totalTokenCount: totalTokens,
+        },
+      } : null
+
+      await logRequestAsync({
+        ...logBase,
+        model,
+        promptTokens,
+        completionTokens,
+        totalTokens,
+        costUsd: cost?.totalCost ?? null,
+        responseBody,
+      }).catch((err) => {
+        console.error('[gemini-stream] log error:', err)
+      })
+    })
+  }
+
+  // ── Non-streaming path ────────────────────────────────────────────────────
   const resBodyText = await upstreamRes.text()
   let resBodyJson: unknown = null
   try { resBodyJson = JSON.parse(resBodyText) } catch { /* non-JSON response */ }
 
-  // Extract model name from the path (e.g. /v1/models/gemini-1.5-pro:generateContent)
-  const modelMatch = /\/models\/([^/:]+)/.exec(originalPath)
   let model = modelMatch?.[1] ?? ''
   let promptTokens = 0
   let completionTokens = 0
@@ -105,37 +222,15 @@ geminiProxy.all('/*', async (c) => {
 
   const cost = calculateCost('gemini', model, { promptTokens, completionTokens })
 
-  const traceId = c.req.header('x-trace-id') ?? null
-  const resolved = await resolvePromptVersion(
-    organizationId,
-    c.req.header('x-spanlens-prompt-version') ?? null,
-    traceId,
-  )
-  const promptVersionId = resolved?.versionId ?? null
-
   fireAndForget(c, logRequestAsync({
-    organizationId,
-    projectId,
-    apiKeyId,
-    provider: 'gemini',
+    ...logBase,
     model,
     promptTokens,
     completionTokens,
     totalTokens,
     costUsd: cost?.totalCost ?? null,
-    latencyMs,
-    proxyOverheadMs,
-    statusCode: upstreamRes.status,
-    requestBody: reqBodyJson,
     responseBody: resBodyJson,
     errorMessage: upstreamRes.ok ? null : resBodyText.slice(0, 1000),
-    traceId,
-    spanId: c.req.header('x-span-id') ?? null,
-    promptVersionId,
-    providerKeyId: providerKey.id,
-    userId: c.req.header('x-spanlens-user') ?? null,
-    sessionId: c.req.header('x-spanlens-session') ?? null,
-    preComputedRequestFlags: requestFlags,
   }))
 
   return new Response(resBodyText, {

--- a/apps/server/src/proxy/openai.ts
+++ b/apps/server/src/proxy/openai.ts
@@ -161,6 +161,8 @@ openaiProxy.all('/*', async (c) => {
   let promptTokens = 0
   let completionTokens = 0
   let totalTokens = 0
+  let cacheReadTokens = 0
+  let cacheWriteTokens = 0
   let resolvedModel = model
 
   if (upstreamRes.ok && resBodyJson) {
@@ -171,16 +173,21 @@ openaiProxy.all('/*', async (c) => {
         promptTokens = parsed.promptTokens
         completionTokens = parsed.completionTokens
         totalTokens = parsed.totalTokens
+        cacheReadTokens = parsed.cacheReadTokens ?? 0
+        cacheWriteTokens = parsed.cacheWriteTokens ?? 0
       }
     } catch { /* ignore */ }
   }
 
-  const cost = calculateCost('openai', resolvedModel, { promptTokens, completionTokens })
+  const cost = calculateCost('openai', resolvedModel, {
+    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens,
+  })
 
   fireAndForget(c, logRequestAsync({
     ...logBase,
     model: resolvedModel,
     promptTokens, completionTokens, totalTokens,
+    cacheReadTokens, cacheWriteTokens,
     costUsd: cost?.totalCost ?? null,
     responseBody: resBodyJson,
     errorMessage: upstreamRes.ok ? null : resBodyText.slice(0, 1000),

--- a/apps/server/src/proxy/stream-logger.ts
+++ b/apps/server/src/proxy/stream-logger.ts
@@ -68,6 +68,15 @@ export async function logOpenAIStream(
   })
 
   const text = extractOpenAIStreamText(lines)
+  // Capture-rate signal: stream completed but no assistant text recovered
+  // (lines were present). Usually means the upstream wire format changed or
+  // a chunk format slipped past the parser. Surface for log monitoring.
+  if (lines.length > 0 && text.length === 0) {
+    console.warn(
+      '[openai-stream] capture-empty: %d SSE lines, 0 chars extracted (parser drift?)',
+      lines.length,
+    )
+  }
   const responseBody = text ? {
     object: 'chat.completion',
     model,
@@ -141,6 +150,12 @@ export async function logAnthropicStream(
   // input_tokens is recovered by subtracting them back out.
   const rawInputTokens = Math.max(0, promptTokens - cacheReadTokens - cacheWriteTokens)
   const text = extractAnthropicStreamText(lines)
+  if (lines.length > 0 && text.length === 0) {
+    console.warn(
+      '[anthropic-stream] capture-empty: %d SSE lines, 0 chars extracted (parser drift?)',
+      lines.length,
+    )
+  }
   const responseBody = text ? {
     type: 'message',
     role: 'assistant',

--- a/apps/server/src/proxy/stream-logger.ts
+++ b/apps/server/src/proxy/stream-logger.ts
@@ -6,7 +6,13 @@ import { parseAnthropicStreamStart, parseAnthropicStreamChunk, extractAnthropicS
 
 type StreamLogBase = Omit<
   RequestLogData,
-  'promptTokens' | 'completionTokens' | 'totalTokens' | 'costUsd' | 'model'
+  | 'promptTokens'
+  | 'completionTokens'
+  | 'totalTokens'
+  | 'cacheReadTokens'
+  | 'cacheWriteTokens'
+  | 'costUsd'
+  | 'model'
 > & { model: string }
 
 async function injectSpanInput(spanId: string, organizationId: string, input: unknown): Promise<void> {
@@ -43,6 +49,8 @@ export async function logOpenAIStream(
   let promptTokens = 0
   let completionTokens = 0
   let totalTokens = 0
+  let cacheReadTokens = 0
+  let cacheWriteTokens = 0
 
   for (const line of lines) {
     const parsed = parseOpenAIStreamChunk(line)
@@ -51,16 +59,25 @@ export async function logOpenAIStream(
     if (parsed.promptTokens) promptTokens = parsed.promptTokens
     if (parsed.completionTokens) completionTokens = parsed.completionTokens
     if (parsed.totalTokens) totalTokens = parsed.totalTokens
+    if (parsed.cacheReadTokens) cacheReadTokens = parsed.cacheReadTokens
+    if (parsed.cacheWriteTokens) cacheWriteTokens = parsed.cacheWriteTokens
   }
 
-  const cost = calculateCost('openai' as Provider, model, { promptTokens, completionTokens })
+  const cost = calculateCost('openai' as Provider, model, {
+    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens,
+  })
 
   const text = extractOpenAIStreamText(lines)
   const responseBody = text ? {
     object: 'chat.completion',
     model,
     choices: [{ message: { role: 'assistant', content: text }, finish_reason: 'stop' }],
-    usage: { prompt_tokens: promptTokens, completion_tokens: completionTokens, total_tokens: totalTokens },
+    usage: {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: totalTokens,
+      ...(cacheReadTokens > 0 ? { prompt_tokens_details: { cached_tokens: cacheReadTokens } } : {}),
+    },
   } : null
 
   await logRequestAsync({
@@ -69,6 +86,8 @@ export async function logOpenAIStream(
     promptTokens,
     completionTokens,
     totalTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
     costUsd: cost?.totalCost ?? null,
     responseBody,
   })
@@ -96,11 +115,15 @@ export async function logAnthropicStream(
   let model = base.model
   let promptTokens = 0
   let completionTokens = 0
+  let cacheReadTokens = 0
+  let cacheWriteTokens = 0
 
   for (const line of lines) {
     const start = parseAnthropicStreamStart(line)
     if (start) {
       if (start.promptTokens) promptTokens = start.promptTokens
+      if (start.cacheReadTokens) cacheReadTokens = start.cacheReadTokens
+      if (start.cacheWriteTokens) cacheWriteTokens = start.cacheWriteTokens
       if (start.model) model = start.model
       continue
     }
@@ -109,15 +132,26 @@ export async function logAnthropicStream(
   }
 
   const totalTokens = promptTokens + completionTokens
-  const cost = calculateCost('anthropic' as Provider, model, { promptTokens, completionTokens })
+  const cost = calculateCost('anthropic' as Provider, model, {
+    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens,
+  })
 
+  // Reconstruct upstream-shape usage so the dashboard preserves the raw
+  // breakdown. Note: promptTokens already includes cache portions, so the raw
+  // input_tokens is recovered by subtracting them back out.
+  const rawInputTokens = Math.max(0, promptTokens - cacheReadTokens - cacheWriteTokens)
   const text = extractAnthropicStreamText(lines)
   const responseBody = text ? {
     type: 'message',
     role: 'assistant',
     model,
     content: [{ type: 'text', text }],
-    usage: { input_tokens: promptTokens, output_tokens: completionTokens },
+    usage: {
+      input_tokens: rawInputTokens,
+      output_tokens: completionTokens,
+      ...(cacheReadTokens > 0 ? { cache_read_input_tokens: cacheReadTokens } : {}),
+      ...(cacheWriteTokens > 0 ? { cache_creation_input_tokens: cacheWriteTokens } : {}),
+    },
   } : null
 
   await logRequestAsync({
@@ -126,6 +160,8 @@ export async function logAnthropicStream(
     promptTokens,
     completionTokens,
     totalTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
     costUsd: cost?.totalCost ?? null,
     responseBody,
   })

--- a/apps/web/app/(dashboard)/requests/[id]/request-detail-client.tsx
+++ b/apps/web/app/(dashboard)/requests/[id]/request-detail-client.tsx
@@ -2,10 +2,13 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { ArrowLeft, Check, Copy, Play, RotateCw } from 'lucide-react'
-import { usePostHog } from 'posthog-js/react'
 import { Skeleton } from '@/components/ui/skeleton'
 import { cn } from '@/lib/utils'
 import { useRequest, useReplayRequest, useRunReplay } from '@/lib/queries/use-requests'
+
+// TODO: re-add `usePostHog()` + `cache_breakdown_viewed` capture once the
+// PostHog provider lands on main (separate PR). The event payload is fully
+// designed — see docs/launch/2026-05-14_cache-stream-users.md §3.
 
 function fmtCost(n: number | null): string {
   if (n == null) return '—'
@@ -17,28 +20,8 @@ type Tab = 'request' | 'response' | 'error'
 export function RequestDetailClient({ id }: { id: string }) {
   const { data: req, isLoading, isError, refetch } = useRequest(id)
   const [tab, setTab] = useState<Tab>('request')
-  const ph = usePostHog()
 
   useEffect(() => { setTab('request') }, [id])
-
-  // Track cache-cost capture rollout (Phase 1 of PR #4): when a viewed request
-  // has cache tokens, capture the savings vs. the pre-fix overcounted cost.
-  // Used to validate the launch and build marketing data ("avg N% overcounted").
-  useEffect(() => {
-    if (!req || !ph) return
-    const cacheRead = req.cache_read_tokens ?? 0
-    const cacheWrite = req.cache_write_tokens ?? 0
-    if (cacheRead === 0 && cacheWrite === 0) return
-    ph.capture('cache_breakdown_viewed', {
-      provider: req.provider,
-      model: req.model,
-      prompt_tokens: req.prompt_tokens,
-      cache_read_tokens: cacheRead,
-      cache_write_tokens: cacheWrite,
-      cache_hit_rate: req.prompt_tokens > 0 ? cacheRead / req.prompt_tokens : 0,
-      cost_usd: req.cost_usd,
-    })
-  }, [req, ph])
 
   if (isLoading) {
     return (

--- a/apps/web/app/(dashboard)/requests/[id]/request-detail-client.tsx
+++ b/apps/web/app/(dashboard)/requests/[id]/request-detail-client.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { ArrowLeft, Check, Copy, Play, RotateCw } from 'lucide-react'
+import { usePostHog } from 'posthog-js/react'
 import { Skeleton } from '@/components/ui/skeleton'
 import { cn } from '@/lib/utils'
 import { useRequest, useReplayRequest, useRunReplay } from '@/lib/queries/use-requests'
@@ -16,8 +17,28 @@ type Tab = 'request' | 'response' | 'error'
 export function RequestDetailClient({ id }: { id: string }) {
   const { data: req, isLoading, isError, refetch } = useRequest(id)
   const [tab, setTab] = useState<Tab>('request')
+  const ph = usePostHog()
 
   useEffect(() => { setTab('request') }, [id])
+
+  // Track cache-cost capture rollout (Phase 1 of PR #4): when a viewed request
+  // has cache tokens, capture the savings vs. the pre-fix overcounted cost.
+  // Used to validate the launch and build marketing data ("avg N% overcounted").
+  useEffect(() => {
+    if (!req || !ph) return
+    const cacheRead = req.cache_read_tokens ?? 0
+    const cacheWrite = req.cache_write_tokens ?? 0
+    if (cacheRead === 0 && cacheWrite === 0) return
+    ph.capture('cache_breakdown_viewed', {
+      provider: req.provider,
+      model: req.model,
+      prompt_tokens: req.prompt_tokens,
+      cache_read_tokens: cacheRead,
+      cache_write_tokens: cacheWrite,
+      cache_hit_rate: req.prompt_tokens > 0 ? cacheRead / req.prompt_tokens : 0,
+      cost_usd: req.cost_usd,
+    })
+  }, [req, ph])
 
   if (isLoading) {
     return (
@@ -112,6 +133,45 @@ export function RequestDetailClient({ id }: { id: string }) {
           </div>
         ))}
       </div>
+
+      {/* Prompt cache breakdown — only rendered when this request used caching */}
+      {(req.cache_read_tokens ?? 0) > 0 || (req.cache_write_tokens ?? 0) > 0 ? (
+        <div className="border border-border rounded-[6px] bg-bg-elev px-4 py-3">
+          <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-2">
+            Prompt cache breakdown
+          </div>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-2 font-mono text-[12px] text-text">
+            <div>
+              <span className="text-text-faint">Cache read</span>{' '}
+              <span className="font-medium">{(req.cache_read_tokens ?? 0).toLocaleString()}</span>
+              <span className="text-text-faint"> tokens</span>
+            </div>
+            <div>
+              <span className="text-text-faint">Cache write</span>{' '}
+              <span className="font-medium">{(req.cache_write_tokens ?? 0).toLocaleString()}</span>
+              <span className="text-text-faint"> tokens</span>
+            </div>
+            <div>
+              <span className="text-text-faint">Non-cached input</span>{' '}
+              <span className="font-medium">
+                {Math.max(
+                  0,
+                  req.prompt_tokens - (req.cache_read_tokens ?? 0) - (req.cache_write_tokens ?? 0),
+                ).toLocaleString()}
+              </span>
+              <span className="text-text-faint"> tokens</span>
+            </div>
+            <div>
+              <span className="text-text-faint">Cache hit rate</span>{' '}
+              <span className="font-medium">
+                {req.prompt_tokens > 0
+                  ? `${(((req.cache_read_tokens ?? 0) / req.prompt_tokens) * 100).toFixed(1)}%`
+                  : '—'}
+              </span>
+            </div>
+          </div>
+        </div>
+      ) : null}
 
       {/* Body tabs */}
       <div>

--- a/apps/web/app/(dashboard)/requests/[id]/request-detail-client.tsx
+++ b/apps/web/app/(dashboard)/requests/[id]/request-detail-client.tsx
@@ -134,6 +134,25 @@ export function RequestDetailClient({ id }: { id: string }) {
         ))}
       </div>
 
+      {/* End-user attribution row — only rendered when x-spanlens-user was set */}
+      {req.user_id && (
+        <div className="flex items-center gap-3 px-4 py-2 border border-border rounded-[6px] bg-bg-elev font-mono text-[12px]">
+          <span className="text-[10px] uppercase tracking-[0.05em] text-text-faint">User</span>
+          <Link
+            href={`/users/${encodeURIComponent(req.user_id)}`}
+            className="text-text hover:underline truncate"
+          >
+            {req.user_id}
+          </Link>
+          <Link
+            href={`/requests?userId=${encodeURIComponent(req.user_id)}`}
+            className="text-[10px] text-text-faint hover:text-text ml-auto"
+          >
+            filter requests →
+          </Link>
+        </div>
+      )}
+
       {/* Prompt cache breakdown — only rendered when this request used caching */}
       {(req.cache_read_tokens ?? 0) > 0 || (req.cache_write_tokens ?? 0) > 0 ? (
         <div className="border border-border rounded-[6px] bg-bg-elev px-4 py-3">

--- a/apps/web/app/(dashboard)/requests/requests-client.tsx
+++ b/apps/web/app/(dashboard)/requests/requests-client.tsx
@@ -342,17 +342,26 @@ function RequestDrawer({ requestId, visible, onClose, onPrev, onNext, hasPrev, h
             </div>
           ))}
 
-          {/* User — clickable filter link */}
+          {/* User — clickable analytics + filter link */}
           {req.user_id && (
             <div>
               <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-0.5">User</div>
-              <Link
-                href={`/requests?userId=${encodeURIComponent(req.user_id)}`}
-                className="font-mono text-[12.5px] text-text hover:underline truncate block"
-                title={`Filter by user: ${req.user_id}`}
-              >
-                {req.user_id}
-              </Link>
+              <div className="flex items-baseline gap-2">
+                <Link
+                  href={`/users/${encodeURIComponent(req.user_id)}`}
+                  className="font-mono text-[12.5px] text-text hover:underline truncate"
+                  title={`View user analytics: ${req.user_id}`}
+                >
+                  {req.user_id}
+                </Link>
+                <Link
+                  href={`/requests?userId=${encodeURIComponent(req.user_id)}`}
+                  className="font-mono text-[10px] text-text-faint hover:text-text shrink-0"
+                  title={`Filter requests by user: ${req.user_id}`}
+                >
+                  filter
+                </Link>
+              </div>
             </div>
           )}
 

--- a/apps/web/app/(dashboard)/requests/requests-client.tsx
+++ b/apps/web/app/(dashboard)/requests/requests-client.tsx
@@ -409,7 +409,13 @@ function RequestDrawer({ requestId, visible, onClose, onPrev, onNext, hasPrev, h
           {[
             { label: 'Latency', value: `${req.latency_ms}ms`, sub: '', warn: req.latency_ms > 2000 },
             { label: 'Cost', value: fmtCost(req.cost_usd), sub: '' },
-            { label: 'Tokens', value: req.total_tokens.toLocaleString(), sub: `${req.prompt_tokens} in / ${req.completion_tokens} out` },
+            {
+              label: 'Tokens',
+              value: req.total_tokens.toLocaleString(),
+              sub: (req.cache_read_tokens ?? 0) > 0
+                ? `${req.prompt_tokens} in (${(req.cache_read_tokens ?? 0).toLocaleString()} cached) / ${req.completion_tokens} out`
+                : `${req.prompt_tokens} in / ${req.completion_tokens} out`,
+            },
           ].map((s, i) => (
             <div key={s.label} className={cn('pr-3 pl-3', i === 0 && 'pl-0', i === 2 && 'pr-0', i < 2 && 'border-r border-border')}>
               <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-1.5">{s.label}</div>

--- a/apps/web/app/(dashboard)/users/[userId]/page.tsx
+++ b/apps/web/app/(dashboard)/users/[userId]/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import { UserDetailClient } from './user-detail-client'
+
+export const metadata = {
+  title: 'User · Spanlens',
+}
+
+export default async function UserDetailPage({ params }: { params: Promise<{ userId: string }> }) {
+  const { userId } = await params
+  const decoded = decodeURIComponent(userId)
+  return (
+    <Suspense>
+      <UserDetailClient userId={decoded} />
+    </Suspense>
+  )
+}

--- a/apps/web/app/(dashboard)/users/[userId]/user-detail-client.tsx
+++ b/apps/web/app/(dashboard)/users/[userId]/user-detail-client.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { usePostHog } from 'posthog-js/react'
+import { Skeleton } from '@/components/ui/skeleton'
+import { cn } from '@/lib/utils'
+import { useUserDetail } from '@/lib/queries/use-users'
+
+function fmtCost(n: number | null | undefined): string {
+  if (n == null) return '—'
+  return '$' + Number(n).toFixed(6)
+}
+
+function fmtCount(n: number): string {
+  return n.toLocaleString()
+}
+
+export function UserDetailClient({ userId }: { userId: string }) {
+  const { data, isLoading, isError } = useUserDetail(userId)
+  const ph = usePostHog()
+
+  useEffect(() => {
+    if (!ph) return
+    ph.capture('user_detail_viewed', { user_id: userId })
+  }, [ph, userId])
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-8 w-64" />
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-16" />
+          ))}
+        </div>
+        <Skeleton className="h-96" />
+      </div>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="space-y-6">
+        <Link
+          href="/users"
+          className="inline-flex items-center gap-1.5 font-mono text-[12px] text-text-muted hover:text-text transition-colors"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" /> Back to users
+        </Link>
+        <div className="border border-border rounded-[6px] p-8 text-center bg-bg-elev">
+          <p className="font-mono text-[13px] text-text mb-1.5">User not found</p>
+          <p className="font-mono text-[11.5px] text-text-faint">
+            This user has no logged requests in your organization.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  const stats = [
+    { label: 'Requests', value: fmtCount(data.total_requests) },
+    { label: 'Total tokens', value: fmtCount(data.total_tokens) },
+    { label: 'Total cost', value: fmtCost(data.total_cost_usd ? Number(data.total_cost_usd) : null) },
+    {
+      label: 'Avg latency',
+      value: data.avg_latency_ms != null ? `${Math.round(Number(data.avg_latency_ms))} ms` : '—',
+    },
+    { label: 'Error count', value: fmtCount(data.error_requests), warn: data.error_requests > 0 },
+    { label: 'Distinct models', value: fmtCount(data.distinct_models) },
+    {
+      label: 'First seen',
+      value: data.first_seen ? new Date(data.first_seen).toLocaleDateString() : '—',
+    },
+    {
+      label: 'Last seen',
+      value: data.last_seen ? new Date(data.last_seen).toLocaleDateString() : '—',
+    },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <Link
+        href="/users"
+        className="inline-flex items-center gap-1.5 font-mono text-[12px] text-text-muted hover:text-text transition-colors"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" /> Back to users
+      </Link>
+
+      <div>
+        <h1 className="font-mono text-[18px] tracking-[-0.2px] text-text break-all">
+          {data.user_id}
+        </h1>
+        <p className="font-mono text-[11px] text-text-faint mt-1.5">
+          End-user analytics · all requests tagged with this <code className="bg-bg-elev px-1 py-px rounded">x-spanlens-user</code> value
+        </p>
+      </div>
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        {stats.map(({ label, value, warn }) => (
+          <div key={label} className="border border-border rounded-[6px] px-4 py-3 bg-bg-elev">
+            <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-1.5">
+              {label}
+            </div>
+            <div className={cn('font-mono text-[13px] font-medium truncate', warn ? 'text-accent' : 'text-text')}>
+              {value}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Recent requests */}
+      <div>
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.05em] text-text-faint mb-3">
+          Recent requests
+        </h2>
+        <div className="border border-border rounded-[6px] overflow-hidden">
+          <div className="grid grid-cols-[1fr,1fr,1fr,1fr,1fr] gap-3 px-4 py-2.5 bg-bg-elev border-b border-border font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+            <span>Time</span>
+            <span>Model</span>
+            <span>Tokens</span>
+            <span>Cost</span>
+            <span>Status</span>
+          </div>
+          {data.recent_requests.length === 0 ? (
+            <div className="px-4 py-12 text-center font-mono text-[12px] text-text-muted">
+              No requests in the selected period.
+            </div>
+          ) : (
+            <div className="divide-y divide-border">
+              {data.recent_requests.map((r) => {
+                const isErr = r.status_code >= 400
+                const cacheRead = r.cache_read_tokens ?? 0
+                return (
+                  <Link
+                    key={r.id}
+                    href={`/requests/${r.id}`}
+                    className="grid grid-cols-[1fr,1fr,1fr,1fr,1fr] gap-3 items-center px-4 py-2.5 font-mono text-[12px] text-text hover:bg-bg-elev transition-colors"
+                  >
+                    <span className="text-text-muted">
+                      {new Date(r.created_at).toLocaleString(undefined, {
+                        month: 'short',
+                        day: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </span>
+                    <span className="truncate">{r.model}</span>
+                    <span className="text-text-muted">
+                      {r.total_tokens.toLocaleString()}
+                      {cacheRead > 0 && (
+                        <span className="text-text-faint ml-1.5">· {cacheRead.toLocaleString()} cached</span>
+                      )}
+                    </span>
+                    <span>{fmtCost(r.cost_usd)}</span>
+                    <span className={isErr ? 'text-bad' : 'text-good'}>{r.status_code}</span>
+                  </Link>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/users/[userId]/user-detail-client.tsx
+++ b/apps/web/app/(dashboard)/users/[userId]/user-detail-client.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useEffect } from 'react'
 import Link from 'next/link'
 import { ArrowLeft } from 'lucide-react'
-import { usePostHog } from 'posthog-js/react'
 import { Skeleton } from '@/components/ui/skeleton'
 import { cn } from '@/lib/utils'
 import { useUserDetail } from '@/lib/queries/use-users'
+
+// TODO: re-add `usePostHog()` + `user_detail_viewed` capture once the
+// PostHog provider lands on main (separate PR).
 
 function fmtCost(n: number | null | undefined): string {
   if (n == null) return '—'
@@ -19,12 +20,6 @@ function fmtCount(n: number): string {
 
 export function UserDetailClient({ userId }: { userId: string }) {
   const { data, isLoading, isError } = useUserDetail(userId)
-  const ph = usePostHog()
-
-  useEffect(() => {
-    if (!ph) return
-    ph.capture('user_detail_viewed', { user_id: userId })
-  }, [ph, userId])
 
   if (isLoading) {
     return (

--- a/apps/web/app/(dashboard)/users/page.tsx
+++ b/apps/web/app/(dashboard)/users/page.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+import { UsersClient } from './users-client'
+
+export const metadata = {
+  title: 'Users · Spanlens',
+  description: 'Per-end-user usage, cost, and behaviour — derived from x-spanlens-user tagged requests.',
+}
+
+export default function UsersPage() {
+  return (
+    <Suspense>
+      <UsersClient />
+    </Suspense>
+  )
+}

--- a/apps/web/app/(dashboard)/users/users-client.tsx
+++ b/apps/web/app/(dashboard)/users/users-client.tsx
@@ -3,8 +3,11 @@
 import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { useSearchParams, useRouter } from 'next/navigation'
-import { usePostHog } from 'posthog-js/react'
 import { ArrowDown, ArrowUp, Search, Users as UsersIcon } from 'lucide-react'
+
+// TODO: re-add `usePostHog()` + `users_page_viewed` / `users_row_clicked`
+// capture once PostHog provider lands on main. Event payloads designed
+// in docs/launch/2026-05-14_cache-stream-users.md §3.
 import { Skeleton } from '@/components/ui/skeleton'
 import { cn } from '@/lib/utils'
 import { useUsers } from '@/lib/queries/use-users'
@@ -39,7 +42,6 @@ function fmtRelativeTime(iso: string): string {
 export function UsersClient() {
   const router = useRouter()
   const sp = useSearchParams()
-  const ph = usePostHog()
 
   // URL-backed filter state. Mirrors /requests pattern so users can share a
   // pre-filtered view.
@@ -63,18 +65,6 @@ export function UsersClient() {
     return base
   }, [page, search, sortBy, sortDir])
   const { data, isLoading, isError } = useUsers(filters)
-
-  // PostHog: page-view + filter usage. Lets us validate the "영업 데모에서
-  // /users가 클릭되는가" question after launch.
-  useEffect(() => {
-    if (!ph) return
-    ph.capture('users_page_viewed', {
-      sort_by: sortBy,
-      sort_dir: sortDir,
-      has_search: Boolean(search),
-      page,
-    })
-  }, [ph, sortBy, sortDir, search, page])
 
   function updateQuery(updates: Record<string, string | null>) {
     const next = new URLSearchParams(sp.toString())
@@ -192,7 +182,6 @@ export function UsersClient() {
               <Link
                 key={u.user_id}
                 href={`/users/${encodeURIComponent(u.user_id)}`}
-                onClick={() => ph?.capture('users_row_clicked', { user_id: u.user_id })}
                 className="grid grid-cols-[2fr,1fr,1fr,1fr,1fr,1fr] gap-3 items-center px-4 py-3 font-mono text-[12px] text-text hover:bg-bg-elev transition-colors"
               >
                 <span className="truncate">{u.user_id}</span>

--- a/apps/web/app/(dashboard)/users/users-client.tsx
+++ b/apps/web/app/(dashboard)/users/users-client.tsx
@@ -1,0 +1,269 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useSearchParams, useRouter } from 'next/navigation'
+import { usePostHog } from 'posthog-js/react'
+import { ArrowDown, ArrowUp, Search, Users as UsersIcon } from 'lucide-react'
+import { Skeleton } from '@/components/ui/skeleton'
+import { cn } from '@/lib/utils'
+import { useUsers } from '@/lib/queries/use-users'
+
+type SortBy = 'cost' | 'requests' | 'tokens' | 'last_seen'
+type SortDir = 'asc' | 'desc'
+
+const PAGE_SIZE = 50
+
+function fmtCost(n: number | null | undefined): string {
+  if (n == null) return '—'
+  if (n === 0) return '$0.00'
+  return n < 0.01 ? '< $0.01' : '$' + n.toFixed(2)
+}
+
+function fmtCount(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k'
+  return String(n)
+}
+
+function fmtRelativeTime(iso: string): string {
+  const d = new Date(iso).getTime()
+  const diff = Date.now() - d
+  if (diff < 60_000) return 'just now'
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+  if (diff < 7 * 86_400_000) return `${Math.floor(diff / 86_400_000)}d ago`
+  return new Date(iso).toLocaleDateString()
+}
+
+export function UsersClient() {
+  const router = useRouter()
+  const sp = useSearchParams()
+  const ph = usePostHog()
+
+  // URL-backed filter state. Mirrors /requests pattern so users can share a
+  // pre-filtered view.
+  const search  = sp.get('search') ?? ''
+  const sortBy  = (sp.get('sortBy') ?? 'cost') as SortBy
+  const sortDir = (sp.get('sortDir') ?? 'desc') as SortDir
+  const page    = Math.max(1, parseInt(sp.get('page') ?? '1', 10))
+
+  const [searchInput, setSearchInput] = useState(search)
+  // Sync URL → input when the user navigates back/forward.
+  useEffect(() => setSearchInput(search), [search])
+
+  const filters = useMemo(() => {
+    const base: { page: number; limit: number; sortBy: SortBy; sortDir: SortDir; search?: string } = {
+      page,
+      limit: PAGE_SIZE,
+      sortBy,
+      sortDir,
+    }
+    if (search) base.search = search
+    return base
+  }, [page, search, sortBy, sortDir])
+  const { data, isLoading, isError } = useUsers(filters)
+
+  // PostHog: page-view + filter usage. Lets us validate the "영업 데모에서
+  // /users가 클릭되는가" question after launch.
+  useEffect(() => {
+    if (!ph) return
+    ph.capture('users_page_viewed', {
+      sort_by: sortBy,
+      sort_dir: sortDir,
+      has_search: Boolean(search),
+      page,
+    })
+  }, [ph, sortBy, sortDir, search, page])
+
+  function updateQuery(updates: Record<string, string | null>) {
+    const next = new URLSearchParams(sp.toString())
+    for (const [k, v] of Object.entries(updates)) {
+      if (v == null || v === '') next.delete(k)
+      else next.set(k, v)
+    }
+    router.replace(`/users?${next.toString()}`)
+  }
+
+  function onSort(col: SortBy) {
+    const nextDir: SortDir = sortBy === col && sortDir === 'desc' ? 'asc' : 'desc'
+    updateQuery({ sortBy: col, sortDir: nextDir, page: null })
+  }
+
+  function onSubmitSearch(e: React.FormEvent) {
+    e.preventDefault()
+    updateQuery({ search: searchInput.trim() || null, page: null })
+  }
+
+  const rows = data?.data ?? []
+  const total = data?.meta.total ?? 0
+  const lastPage = Math.max(1, Math.ceil(total / PAGE_SIZE))
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="font-medium text-[20px] tracking-[-0.3px] text-text">Users</h1>
+          <p className="font-mono text-[11.5px] text-text-faint mt-1.5">
+            End-user attribution from{' '}
+            <code className="bg-bg-elev px-1 py-px rounded text-text">x-spanlens-user</code> header.
+            Sorted by total cost.
+          </p>
+        </div>
+        <div className="font-mono text-[11px] text-text-faint">
+          {data ? `${total.toLocaleString()} user${total === 1 ? '' : 's'}` : ''}
+        </div>
+      </div>
+
+      {/* Filter bar */}
+      <form onSubmit={onSubmitSearch} className="flex items-center gap-2">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-text-faint" />
+          <input
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Search user ID…"
+            className="w-full pl-8 pr-3 py-1.5 font-mono text-[12px] bg-bg-elev border border-border rounded-[6px] text-text placeholder:text-text-faint focus:outline-none focus:border-accent"
+          />
+        </div>
+        {search && (
+          <button
+            type="button"
+            onClick={() => updateQuery({ search: null, page: null })}
+            className="font-mono text-[11px] text-text-faint hover:text-text transition-colors"
+          >
+            Clear
+          </button>
+        )}
+      </form>
+
+      {/* Table */}
+      <div className="border border-border rounded-[6px] overflow-hidden">
+        {/* Header row */}
+        <div className="grid grid-cols-[2fr,1fr,1fr,1fr,1fr,1fr] gap-3 px-4 py-2.5 bg-bg-elev border-b border-border font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+          <span>User ID</span>
+          <SortBtn label="Requests" col="requests" sortBy={sortBy} sortDir={sortDir} onSort={onSort} />
+          <SortBtn label="Tokens" col="tokens" sortBy={sortBy} sortDir={sortDir} onSort={onSort} />
+          <SortBtn label="Cost" col="cost" sortBy={sortBy} sortDir={sortDir} onSort={onSort} />
+          <span>Avg latency</span>
+          <SortBtn label="Last seen" col="last_seen" sortBy={sortBy} sortDir={sortDir} onSort={onSort} className="justify-end" />
+        </div>
+
+        {/* Rows */}
+        {isLoading && (
+          <div className="divide-y divide-border">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="grid grid-cols-[2fr,1fr,1fr,1fr,1fr,1fr] gap-3 px-4 py-3">
+                <Skeleton className="h-3 w-40" />
+                <Skeleton className="h-3 w-12" />
+                <Skeleton className="h-3 w-14" />
+                <Skeleton className="h-3 w-16" />
+                <Skeleton className="h-3 w-12" />
+                <Skeleton className="h-3 w-20 justify-self-end" />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {!isLoading && isError && (
+          <div className="px-4 py-12 text-center">
+            <p className="font-mono text-[12px] text-text-muted">Failed to load users.</p>
+          </div>
+        )}
+
+        {!isLoading && !isError && rows.length === 0 && (
+          <div className="px-4 py-16 text-center">
+            <UsersIcon className="mx-auto h-6 w-6 text-text-faint mb-3" />
+            <p className="font-mono text-[12.5px] text-text mb-1.5">No users yet</p>
+            <p className="font-mono text-[11px] text-text-faint max-w-md mx-auto">
+              Tag your LLM calls with{' '}
+              <code className="bg-bg-elev px-1 py-px rounded">x-spanlens-user</code> header (SDK:{' '}
+              <code className="bg-bg-elev px-1 py-px rounded">withUser()</code> /{' '}
+              <code className="bg-bg-elev px-1 py-px rounded">with_user()</code>) and they&apos;ll
+              appear here.
+            </p>
+          </div>
+        )}
+
+        {!isLoading && !isError && rows.length > 0 && (
+          <div className="divide-y divide-border">
+            {rows.map((u) => (
+              <Link
+                key={u.user_id}
+                href={`/users/${encodeURIComponent(u.user_id)}`}
+                onClick={() => ph?.capture('users_row_clicked', { user_id: u.user_id })}
+                className="grid grid-cols-[2fr,1fr,1fr,1fr,1fr,1fr] gap-3 items-center px-4 py-3 font-mono text-[12px] text-text hover:bg-bg-elev transition-colors"
+              >
+                <span className="truncate">{u.user_id}</span>
+                <span className="text-text-muted">
+                  {fmtCount(u.total_requests)}
+                  {u.error_requests > 0 && (
+                    <span className="text-bad ml-1.5">· {u.error_requests} err</span>
+                  )}
+                </span>
+                <span className="text-text-muted">{fmtCount(u.total_tokens)}</span>
+                <span>{fmtCost(u.total_cost_usd ? Number(u.total_cost_usd) : null)}</span>
+                <span className="text-text-muted">
+                  {u.avg_latency_ms != null ? `${Math.round(Number(u.avg_latency_ms))}ms` : '—'}
+                </span>
+                <span className="text-text-faint text-right">{fmtRelativeTime(u.last_seen)}</span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Pagination */}
+      {!isLoading && total > PAGE_SIZE && (
+        <div className="flex items-center justify-between font-mono text-[11px]">
+          <div className="text-text-faint">
+            Page {page} of {lastPage}
+          </div>
+          <div className="flex gap-2">
+            <button
+              disabled={page <= 1}
+              onClick={() => updateQuery({ page: String(page - 1) })}
+              className="px-3 py-1.5 border border-border rounded-[6px] text-text hover:bg-bg-elev disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              Prev
+            </button>
+            <button
+              disabled={page >= lastPage}
+              onClick={() => updateQuery({ page: String(page + 1) })}
+              className="px-3 py-1.5 border border-border rounded-[6px] text-text hover:bg-bg-elev disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SortBtn({
+  label, col, sortBy, sortDir, onSort, className,
+}: {
+  label: string
+  col: SortBy
+  sortBy: SortBy
+  sortDir: SortDir
+  onSort: (c: SortBy) => void
+  className?: string
+}) {
+  const active = sortBy === col
+  return (
+    <button
+      onClick={() => onSort(col)}
+      className={cn(
+        'inline-flex items-center gap-1 text-left hover:text-text transition-colors',
+        active ? 'text-text' : 'text-text-faint',
+        className,
+      )}
+    >
+      <span>{label}</span>
+      {active && (sortDir === 'desc' ? <ArrowDown className="h-3 w-3" /> : <ArrowUp className="h-3 w-3" />)}
+    </button>
+  )
+}

--- a/apps/web/app/docs/_components/sidebar.tsx
+++ b/apps/web/app/docs/_components/sidebar.tsx
@@ -25,6 +25,7 @@ const NAV: NavGroup[] = [
     title: 'Features',
     items: [
       { title: 'Requests', href: '/docs/features/requests' },
+      { title: 'Users', href: '/docs/features/users' },
       { title: 'Traces', href: '/docs/features/traces' },
       { title: 'Prompts', href: '/docs/features/prompts' },
       { title: 'Evals', href: '/docs/features/evals' },

--- a/apps/web/app/docs/features/cost-tracking/page.tsx
+++ b/apps/web/app/docs/features/cost-tracking/page.tsx
@@ -54,9 +54,27 @@ export default function CostTrackingDocs() {
 // ...`}</CodeBlock>
 
       <h3>The formula</h3>
-      <CodeBlock language="ts">{`promptCost     = (promptTokens     / 1_000_000) * price.prompt
-completionCost = (completionTokens / 1_000_000) * price.completion
-totalCost      = promptCost + completionCost`}</CodeBlock>
+      <CodeBlock language="ts">{`// nonCachedPromptTokens = promptTokens - cacheReadTokens - cacheWriteTokens
+promptCost      = (nonCachedPromptTokens / 1_000_000) * price.prompt
+cacheReadCost   = (cacheReadTokens       / 1_000_000) * price.cacheRead   // ≈ 0.1× input on Anthropic, 0.5× on OpenAI
+cacheWriteCost  = (cacheWriteTokens      / 1_000_000) * price.cacheWrite  // ≈ 1.25× input on Anthropic (5min); n/a on OpenAI
+completionCost  = (completionTokens      / 1_000_000) * price.completion
+totalCost       = promptCost + cacheReadCost + cacheWriteCost + completionCost`}</CodeBlock>
+
+      <h3>Prompt caching (2026-05-14+)</h3>
+      <p>
+        Anthropic <code>cache_read_input_tokens</code> / <code>cache_creation_input_tokens</code>{' '}
+        and OpenAI <code>prompt_tokens_details.cached_tokens</code> are now extracted and charged at
+        each provider&apos;s reduced cache rate. The original behaviour was to fold them into{' '}
+        <code>promptTokens</code> at the regular rate, which over-counted cost by 2–10× for
+        cache-heavy workloads. <code>requests.cache_read_tokens</code> /{' '}
+        <code>cache_write_tokens</code> store the breakdown alongside every new row.
+      </p>
+      <p>
+        Historical rows (pre-2026-05-14) keep their original <code>cost_usd</code> and have{' '}
+        <code>cache_*_tokens = 0</code> — backfill isn&apos;t possible because the raw breakdown
+        wasn&apos;t recorded.
+      </p>
 
       <h3>The dated-variant problem (critical gotcha)</h3>
       <p>
@@ -140,12 +158,6 @@ GET /api/v1/stats?sinceHours=720&groupBy=model
           <strong>Price table drifts.</strong> When a provider changes prices, our table needs a
           PR. Tracked as a monthly maintenance item. If you&apos;re self-hosting, pin a specific
           commit or expect to cherry-pick updates.
-        </li>
-        <li>
-          <strong>No cache-token pricing separate line yet.</strong> Anthropic&apos;s{' '}
-          <code>cache_read_input_tokens</code> and <code>cache_creation_input_tokens</code> are
-          currently folded into prompt tokens. We&apos;re adding separate accounting so cost
-          reflects the 10× discount. Roadmap.
         </li>
         <li>
           <strong>No batch API discount.</strong> OpenAI and Anthropic both offer ~50% off batch

--- a/apps/web/app/docs/features/requests/page.tsx
+++ b/apps/web/app/docs/features/requests/page.tsx
@@ -357,10 +357,13 @@ POST /api/v1/requests/:id/replay/run
           Heavier search needs a separate OLAP layer (ClickHouse is the likely path).
         </li>
         <li>
-          <strong>Streaming response bodies not captured.</strong> The proxy streams responses
-          directly to your application without buffering, so <code>response_body</code> is{' '}
-          <code>null</code> for streaming calls. Token counts and cost are still accurate (parsed
-          from SSE deltas).
+          <strong>Streaming response bodies are reconstructed, not original.</strong> SSE chunks
+          are tee&apos;d while pass-through to the client. After the stream closes, the assistant
+          text is reassembled and written to <code>response_body</code> in the upstream&apos;s
+          standard non-streaming shape (so the dashboard renders it identically to a non-stream
+          response). Tool calls / images / non-text content blocks are not preserved — only the
+          assistant-visible text portion. Aborted streams keep whatever was received up to the
+          break.
         </li>
       </ul>
 

--- a/apps/web/app/docs/features/requests/page.tsx
+++ b/apps/web/app/docs/features/requests/page.tsx
@@ -45,7 +45,16 @@ export default function RequestsDocs() {
           </tr>
           <tr>
             <td><code>prompt_tokens</code> / <code>completion_tokens</code> / <code>total_tokens</code></td>
-            <td>Parsed from the provider&apos;s response (or streamed deltas)</td>
+            <td>Parsed from the provider&apos;s response (or streamed deltas). <code>prompt_tokens</code> is the GROSS input count including any cached portion.</td>
+          </tr>
+          <tr>
+            <td><code>cache_read_tokens</code> / <code>cache_write_tokens</code></td>
+            <td>
+              Subset of <code>prompt_tokens</code> that hit / wrote a prompt cache. Charged at the
+              provider&apos;s reduced cache rate by <a href="/docs/features/cost-tracking">cost tracking</a>.
+              Available for new requests since 2026-05-14 (Anthropic prompt caching · OpenAI prompt caching).
+              0 for historical rows.
+            </td>
           </tr>
           <tr>
             <td><code>cost_usd</code></td>

--- a/apps/web/app/docs/features/users/page.tsx
+++ b/apps/web/app/docs/features/users/page.tsx
@@ -1,0 +1,111 @@
+import { CodeBlock } from '../../_components/code-block'
+
+export const metadata = {
+  title: 'Users · Spanlens Docs',
+  description:
+    'End-user attribution and per-user analytics for LLM usage. Tag requests with x-spanlens-user and see who is spending what.',
+}
+
+export default function UsersDocs() {
+  return (
+    <div>
+      <h1>Users</h1>
+      <p className="lead">
+        Tag every LLM call with the end-user it originated from, and Spanlens aggregates per-user
+        cost, request count, and behaviour at <a href="/users">/users</a>. Answer{' '}
+        <em>&ldquo;Which of my customers is costing me the most LLM spend?&rdquo;</em> in one click.
+      </p>
+
+      <h2>How tagging works</h2>
+      <p>
+        Set the <code>x-spanlens-user</code> header on any proxied request. The value is a string
+        of your choosing — Spanlens never interprets it. Typical patterns: your DB user UUID,
+        email hash, or a workspace identifier.
+      </p>
+      <p>
+        Easiest path with the SDK:
+      </p>
+      <CodeBlock language="ts">{`import { createOpenAI, withUser } from '@spanlens/sdk/openai'
+
+const openai = createOpenAI()
+
+await openai.chat.completions.create(
+  { model: 'gpt-4o-mini', messages: [...] },
+  { headers: { ...withUser(currentUser.id).headers } },
+)`}</CodeBlock>
+      <p>
+        Anthropic / Gemini integrations expose the same <code>withUser()</code> /{' '}
+        <code>with_user()</code> helper. For raw HTTP, just set the header directly.
+      </p>
+
+      <h2>What the dashboard shows</h2>
+      <ul>
+        <li>
+          <strong><a href="/users">/users</a></strong> — sortable table of every tagged end-user
+          with total requests, tokens, cost, average latency, error count, distinct models, and
+          first/last seen.
+        </li>
+        <li>
+          <strong>Row click</strong> opens <code>/users/[id]</code> — the same stats plus the last
+          50 requests for that user, each linkable to its full <a href="/docs/features/requests">request detail</a>.
+        </li>
+        <li>
+          <strong>Filter pivot</strong> — from any request drawer the user_id chip links to the
+          analytics page; the small <em>filter</em> link next to it scopes <code>/requests</code> to
+          just that user.
+        </li>
+        <li>
+          <strong>Search</strong> the user ID column with substring match. URL-backed so you can
+          share filtered views.
+        </li>
+      </ul>
+
+      <h2>Sort options</h2>
+      <table>
+        <thead>
+          <tr><th><code>sortBy</code></th><th>Behaviour</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>cost</code> (default)</td><td>Highest-spending users first.</td></tr>
+          <tr><td><code>requests</code></td><td>Most-active users first.</td></tr>
+          <tr><td><code>tokens</code></td><td>Heaviest token consumers (large prompts).</td></tr>
+          <tr><td><code>last_seen</code></td><td>Most recently active first — useful for triage.</td></tr>
+        </tbody>
+      </table>
+
+      <h2>API</h2>
+      <p>Both endpoints scope to your organization automatically via JWT.</p>
+      <CodeBlock language="bash">{`# List — sort by cost desc, page 1
+GET /api/v1/users?sortBy=cost&sortDir=desc&page=1&limit=50
+
+# Detail — aggregates + recent 50 requests
+GET /api/v1/users/<user-id>?projectId=<optional>&from=<iso>&to=<iso>`}</CodeBlock>
+
+      <h2>Limitations</h2>
+      <ul>
+        <li>
+          <strong>Untagged requests don&apos;t appear.</strong> Calls without an{' '}
+          <code>x-spanlens-user</code> header are excluded from <code>/users</code>. Add the header
+          everywhere you want attribution.
+        </li>
+        <li>
+          <strong>No PII protection on the value.</strong> Whatever you put in the header is what
+          gets stored. Hash emails or use opaque IDs if you don&apos;t want raw addresses in the
+          dashboard.
+        </li>
+        <li>
+          <strong>Time-range filtering is server-side but the UI uses defaults.</strong> The list
+          view shows lifetime totals; pass <code>?from=…&amp;to=…</code> on the API to scope.
+          Time-window picker in the UI is on the roadmap.
+        </li>
+      </ul>
+
+      <hr />
+      <p className="text-sm text-muted-foreground">
+        Related: <a href="/docs/features/requests">Requests</a>,{' '}
+        <a href="/docs/sdk">SDK reference</a>,{' '}
+        <a href="/users">/users</a> dashboard.
+      </p>
+    </div>
+  )
+}

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -198,6 +198,7 @@ const NAV_GROUPS = [
       { href: '/dashboard',  label: 'Dashboard' },
       { href: '/requests',   label: 'Requests' },
       { href: '/traces',     label: 'Traces' },
+      { href: '/users',      label: 'Users' },
     ],
   },
   {

--- a/apps/web/lib/queries/types.ts
+++ b/apps/web/lib/queries/types.ts
@@ -79,6 +79,10 @@ export interface RequestRow {
   prompt_tokens: number
   completion_tokens: number
   total_tokens: number
+  /** Subset of prompt_tokens that hit a prompt cache (charged at reduced rate). */
+  cache_read_tokens?: number
+  /** Subset of prompt_tokens that wrote a cache entry (charged at premium rate). */
+  cache_write_tokens?: number
   cost_usd: number | null
   latency_ms: number
   status_code: number

--- a/apps/web/lib/queries/types.ts
+++ b/apps/web/lib/queries/types.ts
@@ -146,6 +146,44 @@ export interface SpendForecast {
   timeseries: { date: string; actual: number | null; projected: number | null }[]
 }
 
+// ── User Analytics ─────────────────────────────────────────────
+
+export interface UserAnalyticsRow {
+  user_id: string
+  total_requests: number
+  total_tokens: number
+  total_cost_usd: number | null
+  avg_latency_ms: number | null
+  first_seen: string
+  last_seen: string
+  error_requests: number
+  distinct_models: number
+}
+
+export interface UserAnalyticsPage {
+  data: UserAnalyticsRow[]
+  meta: { total: number; page: number; limit: number }
+}
+
+export interface UserAnalyticsDetail extends UserAnalyticsRow {
+  recent_requests: Array<{
+    id: string
+    provider: string
+    model: string
+    prompt_tokens: number
+    completion_tokens: number
+    total_tokens: number
+    cache_read_tokens?: number | null
+    cache_write_tokens?: number | null
+    cost_usd: number | null
+    latency_ms: number
+    status_code: number
+    error_message: string | null
+    session_id: string | null
+    created_at: string
+  }>
+}
+
 // ── Agent Tracing ──────────────────────────────────────────────
 
 export type TraceStatus = 'running' | 'completed' | 'error'

--- a/apps/web/lib/queries/use-users.ts
+++ b/apps/web/lib/queries/use-users.ts
@@ -1,0 +1,61 @@
+'use client'
+
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { apiGet } from '@/lib/api'
+import type { ApiEnvelope, UserAnalyticsDetail, UserAnalyticsPage, UserAnalyticsRow } from './types'
+
+export interface UsersFilters {
+  page: number
+  limit?: number
+  projectId?: string
+  search?: string
+  from?: string
+  to?: string
+  sortBy?: 'cost' | 'requests' | 'tokens' | 'last_seen'
+  sortDir?: 'asc' | 'desc'
+}
+
+export function usersQueryKey(filters: UsersFilters) {
+  return ['users', filters] as const
+}
+
+export function useUsers(filters: UsersFilters) {
+  return useQuery({
+    queryKey: usersQueryKey(filters),
+    queryFn: async (): Promise<UserAnalyticsPage> => {
+      const params = new URLSearchParams()
+      params.set('page', String(filters.page))
+      params.set('limit', String(filters.limit ?? 50))
+      if (filters.projectId) params.set('projectId', filters.projectId)
+      if (filters.search)    params.set('search', filters.search)
+      if (filters.from)      params.set('from', filters.from)
+      if (filters.to)        params.set('to', filters.to)
+      if (filters.sortBy)    params.set('sortBy', filters.sortBy)
+      if (filters.sortDir)   params.set('sortDir', filters.sortDir)
+      const env = await apiGet<ApiEnvelope<UserAnalyticsRow[]>>(`/api/v1/users?${params.toString()}`)
+      return {
+        data: env.data ?? [],
+        meta: env.meta ?? { total: 0, page: filters.page, limit: filters.limit ?? 50 },
+      }
+    },
+    placeholderData: keepPreviousData,
+  })
+}
+
+export function useUserDetail(userId: string | null, opts?: { projectId?: string; from?: string; to?: string }) {
+  return useQuery({
+    queryKey: ['user-detail', userId, opts] as const,
+    enabled: Boolean(userId),
+    queryFn: async (): Promise<UserAnalyticsDetail> => {
+      const params = new URLSearchParams()
+      if (opts?.projectId) params.set('projectId', opts.projectId)
+      if (opts?.from)      params.set('from', opts.from)
+      if (opts?.to)        params.set('to', opts.to)
+      const qs = params.toString()
+      const env = await apiGet<ApiEnvelope<UserAnalyticsDetail>>(
+        `/api/v1/users/${encodeURIComponent(userId!)}${qs ? `?${qs}` : ''}`,
+      )
+      return env.data
+    },
+  })
+}

--- a/docs/launch/2026-05-14_cache-stream-users.md
+++ b/docs/launch/2026-05-14_cache-stream-users.md
@@ -1,0 +1,224 @@
+# Launch — 2026-05-14 · Cache cost · Stream body · Users analytics
+
+> **Branch**: `demo/evals-datasets-experiments-annotation`
+> **Commits**: `f1adc77` (cache) · `915e9f8` (stream) · `7f0105d` (users) · `3593768` (follow-ups) · `4b41483` (types sync)
+> **Roadmap source**: [`docs/plans/competitive_parity_roadmap.md`](../plans/competitive_parity_roadmap.md) — items #4, #8, #1.
+
+이 문서는 3개 feature 출시 직전/직후에 영업·운영·측정을 묶어주는 단일 진실 소스. 출시 후 1주 동안 이 문서만 보면 무엇이 떨어졌는지 / 어떻게 팔지 / 어떻게 측정할지 다 잡힘.
+
+---
+
+## 1. What shipped (한 줄씩)
+
+| # | feature | 한 줄 요약 | 영향 |
+|---|---------|------------|------|
+| #4 | **Prompt-cache cost** | Anthropic·OpenAI prompt caching 토큰을 별도 가격으로 청구. 이전엔 full input rate로 2–10× 과다 계상 | **correctness 버그 수정**. cache 사용자 비용 표시가 실제 청구서랑 맞아짐 |
+| #8 | **Gemini streaming + 본문 캡처 검증** | `:streamGenerateContent` 진짜 pass-through. SSE/JSON-array/aborted 3-provider regression tests | streaming 사용자 (LLM 앱의 80–90%)가 response_body 보임 |
+| #1 | **/users analytics** | `x-spanlens-user` 태깅된 요청을 유저별로 집계 — cost / requests / tokens / 모델 / 첫·마지막 방문 | "어느 customer가 LLM 비용 가장 많이 쓰나"를 한 클릭으로 답변 |
+
+---
+
+## 2. Demo talking points (영업 미팅 1-liners)
+
+순서대로 한 흐름:
+
+1. **요청 1건 로깅 1줄 만에**
+   > "baseURL 1줄 교체 → Spanlens 대시보드에 즉시 row 생김"
+
+2. **비용 추적의 정확도** (#4)
+   > "Anthropic prompt caching 쓰시면 인풋 비용 ___90% 절감___돼요. Spanlens는 그 부분을 cache rate(0.1×)로 따로 계산해서 보여드립니다. _다른 도구는 input 가격에 합산해서 청구서랑 안 맞아요_"
+   - 데모 단계: `/requests/[id]` 들어가서 "Prompt cache breakdown" 카드 시연. cache_read · cache_write · non-cached · hit rate 4분할.
+
+3. **스트리밍 응답도 다 캡처** (#8)
+   > "스트리밍 응답도 본문이 통째로 저장돼서, 어제 03시에 환각 일으킨 요청을 retrospectively 디버깅하실 수 있어요"
+   - 데모 단계: SDK로 stream call 1건 → `/requests/[id]` → Response body 탭에서 텍스트 보이는지.
+
+4. **유저별 분석** (#1) — **킬러 데모**
+   > "지금 보시는 화면이 우리가 가장 자주 듣는 질문의 답이에요. _'우리 서비스 쓰는 유저 중 누가 LLM 비용 가장 많이 써?'_ — 첫 번째 행이 그 사람입니다"
+   - 데모 단계: `/users` → 정렬 컬럼 (cost/requests/tokens) 3번 클릭 → top user 클릭 → 그 유저의 모든 history.
+
+5. **태깅이 쉽다는 점**
+   > "header 1줄이에요. SDK 쓰시면 `withUser(user.id)` 헬퍼 있고요"
+   - 데모 단계: `/docs/sdk` 또는 `/docs/features/users` 한 번 보여주기.
+
+### Demo 안티-패턴 (하지 말 것)
+- ❌ Sessions 뷰 약속하기 — 아직 없음
+- ❌ Custom dashboard 약속하기 — roadmap에 없음
+- ❌ "Langfuse보다 좋다" — 비교 프레임 들어가지 말 것. 그냥 "쉽다 + 정확하다"만
+
+---
+
+## 3. PostHog events to watch
+
+이번 출시에 새로 추가된 이벤트 (이미 production에 들어가 있음, 측정만 setup하면 됨):
+
+| event | 발생 위치 | 핵심 property | 묻고 싶은 질문 |
+|-------|-----------|---------------|----------------|
+| `cache_breakdown_viewed` | `/requests/[id]` (cache > 0인 row 본 사용자) | provider · model · cache_hit_rate · cost_usd | _"#4가 발견되고 있나? cache 쓰는 유저 비율은?"_ |
+| `users_page_viewed` | `/users` | sort_by · sort_dir · has_search · page | _"#1이 click-thru rate 어떤가?"_ |
+| `users_row_clicked` | `/users` row click | user_id (hashed) | _"한 번 페이지 들어와서 drill-down까지 가는 비율?"_ |
+| `user_detail_viewed` | `/users/[id]` | user_id (hashed) | _"detail 페이지 머무는 사용자 있나?"_ |
+
+**기존에 이미 있던 이벤트** (참고):
+- `$pageview` — 일반 페이지뷰
+- (PostHog identify는 PostHogIdentify 컴포넌트가 자동 처리)
+
+### 추천 PostHog dashboard 4-card
+
+PostHog UI에서 새 dashboard 만들고 아래 4개 insight 추가:
+
+1. **"Cache savings discovery"** (line chart, 7일)
+   - Series: `cache_breakdown_viewed` event count by day
+   - Breakdown: `provider`
+   - 의미: cache 기능이 실제로 발견·사용되는지
+
+2. **"Users page funnel"** (funnel insight)
+   - Step 1: `$pageview` where `$current_url contains '/users'`
+   - Step 2: `users_row_clicked`
+   - Step 3: `user_detail_viewed`
+   - 의미: 영업 demo 후 실제로 drill-down까지 가는 비율
+
+3. **"Cache hit rate distribution"** (number / histogram)
+   - Event: `cache_breakdown_viewed`
+   - Metric: average of `cache_hit_rate`
+   - 의미: 우리 유저들의 평균 cache 활용 정도. 마케팅 "유저들이 평균 X% cache hit" 한 줄 자료 확보
+
+4. **"Top users by sort_by"** (bar chart, 30일)
+   - Event: `users_page_viewed`
+   - Breakdown: `sort_by`
+   - 의미: 유저들이 어느 metric 기준으로 정렬해서 보는지 (cost가 압도적일 것)
+
+---
+
+## 4. Production 배포 체크리스트
+
+**전제**: 현재 branch `demo/evals-datasets-experiments-annotation`에 모든 변경 push 완료.
+
+### 4a. DB migration (PROD Supabase)
+
+```bash
+# 1. Supabase project 연결 확인
+supabase projects list
+
+# 2. 적용 전 마이그레이션 상태 확인
+supabase db remote commit --dry-run    # 또는 supabase migration list --linked
+
+# 3. 적용
+supabase db push
+
+# 적용된 migration 2개:
+#   20260514120000_cache_pricing.sql
+#   20260514130000_user_analytics_fn.sql
+```
+
+**검증** (PROD에서):
+```sql
+-- 컬럼 확인
+\d requests
+-- expect: cache_read_tokens, cache_write_tokens 보여야 함
+
+\d model_prices
+-- expect: cache_read_price_per_1m, cache_write_price_per_1m
+
+-- RPC 함수 존재 확인
+SELECT proname, pronargs FROM pg_proc WHERE proname = 'get_user_analytics';
+-- expect: 1 row, pronargs = 9
+```
+
+### 4b. seed 갱신 (cache pricing)
+
+```bash
+# model_prices에 cache 가격 ON CONFLICT UPDATE로 들어감
+# 이미 PROD에 row 있는 모델은 cache_*_price 컬럼만 채워짐
+psql "$DATABASE_URL" -f supabase/seeds/model_prices.sql
+```
+
+### 4c. Vercel 배포
+
+브랜치 push만 하면 자동 preview deploy. main으로 merge 시 production deploy.
+
+이번엔 demo 브랜치라 따로 main merge 단계가 있으면 그쪽 워크플로 따르기.
+
+### 4d. Smoke test (배포 직후 5분 안에)
+
+**Cache cost** (#4):
+1. Anthropic API에 `cache_control: { type: "ephemeral" }` 포함된 요청 1건 보내기 (Spanlens proxy 경유)
+2. Spanlens `/requests` 들어가서 그 row의 `cache_read_tokens` > 0 확인
+3. `/requests/[id]` 들어가서 "Prompt cache breakdown" 카드 보이는지 확인
+
+**Stream body** (#8):
+1. OpenAI `stream: true` 요청 1건 (Spanlens proxy 경유)
+2. `/requests/[id]` → Response body 탭 → 텍스트 보이는지 확인 (null 아님)
+3. (옵션) Gemini `:streamGenerateContent`도 같은 검증
+
+**Users analytics** (#1):
+1. `withUser('smoke-test')` 헬퍼로 요청 1건 보내기
+2. Spanlens `/users` 들어가서 `smoke-test` row 보이는지 확인
+3. 클릭 → `/users/smoke-test` → 카드 8개 + recent_requests 1건 보이는지
+
+---
+
+## 5. Rollback plan
+
+세 feature 모두 **additive** (기존 동작 안 깨뜨림):
+- `cache_read_tokens` / `cache_write_tokens` 컬럼: NOT NULL DEFAULT 0이라 기존 INSERT 호환
+- `model_prices.cache_*_price`: NULLABLE, 모르는 모델은 fallback to prompt rate
+- `/users` 라우트: 신규 추가, 기존 라우트 영향 0
+- Gemini streaming: 기존 buffered 경로는 `:streamGenerateContent` 이외 path에서만 사용되므로 다른 endpoint 영향 0
+
+따라서 rollback이 필요하면 **revert 1 commit씩** 가능. DB 마이그레이션은 rollback할 필요 없음 (컬럼 안 쓰면 그만).
+
+만약 강제로 마이그레이션 되돌려야 하면:
+```sql
+ALTER TABLE requests DROP COLUMN cache_read_tokens, DROP COLUMN cache_write_tokens;
+ALTER TABLE model_prices DROP COLUMN cache_read_price_per_1m, DROP COLUMN cache_write_price_per_1m;
+DROP FUNCTION get_user_analytics(uuid, uuid, text, timestamptz, timestamptz, text, text, int, int);
+```
+
+---
+
+## 6. 공개용 release notes (초안)
+
+### 6a. Twitter / X thread 초안 (3 트윗)
+
+> 🚀 Spanlens 새 업데이트 3가지 (개발자 분들 좋아하실 것들):
+>
+> 1/ Anthropic prompt caching 비용 정확하게 추적. 이전엔 input 가격으로 합산되어 2–10× 과다 계상이었는데, 이제 cache rate로 따로 계산해서 청구서랑 정확히 맞습니다.
+
+> 2/ 스트리밍 응답 본문도 캡처. OpenAI / Anthropic / Gemini 3개 provider 모두 SSE 청크를 tee해서 클라이언트엔 그대로 보내면서 서버엔 본문 누적 저장. 디버깅할 때 "stream이라 본문 없어요" 사라짐.
+
+> 3/ /users 페이지 신규. `x-spanlens-user` 헤더 또는 SDK `withUser()` 1줄로 태그하면 유저별 비용·요청·토큰·에러 한눈에. "어느 customer가 LLM 비용 가장 많이 쓰나" 한 클릭으로 답.
+
+### 6b. 사이트 changelog 항목 (HTML 단편)
+
+> **2026-05-14 — Prompt cache cost · Stream body · Users analytics**
+>
+> - **Prompt-cache pricing**: Anthropic `cache_read_input_tokens` / `cache_creation_input_tokens` and OpenAI `prompt_tokens_details.cached_tokens` are now billed at each provider's reduced cache rate. New `requests.cache_read_tokens` / `cache_write_tokens` columns preserve the breakdown. Past costs unchanged; new requests are accurate from this release. [docs](/docs/features/cost-tracking#prompt-caching)
+> - **Streaming response bodies**: full `response_body` capture for Gemini `:streamGenerateContent` streams; OpenAI / Anthropic streaming bodies were already captured (via `5a839ed`). Regression tests pin all three wire formats. [docs](/docs/features/requests)
+> - **Users page**: new `/users` dashboard surfaces per-end-user cost, requests, tokens, errors and distinct models. Drill-through to per-user history. Requires `x-spanlens-user` header — SDKs expose `withUser()` / `with_user()`. [docs](/docs/features/users)
+
+### 6c. (옵션) 이메일 / Slack 공지 1단락
+
+> Hi! 3가지 업데이트입니다:
+>
+> 1) Anthropic prompt caching 쓰시는 분들 — Spanlens 비용 표시가 이제 청구서랑 정확히 맞습니다. 이전엔 cache hit이 input 가격으로 합산되어서 비용이 2–10배 부풀려 보였어요.
+> 2) 스트리밍 응답 본문 캡처 검증 끝. Gemini도 이제 진짜 streaming pass-through.
+> 3) 새 페이지 `/users` — 유저별 LLM 사용량 분석. `withUser()` 헬퍼로 태깅하시면 됩니다.
+
+---
+
+## 7. 측정 일정 (1주 후 결정 trigger)
+
+**2026-05-21 (1주 후)** 시점에 PostHog에서 확인:
+
+1. `cache_breakdown_viewed` event volume > 0 — cache 기능이 실제로 발견되는가
+2. `users_page_viewed → users_row_clicked` funnel conversion > 30% — /users가 실제로 가치 있는가
+3. 신규 가입 → `withUser()` 헬퍼 사용까지의 시간 — SDK 마찰 어떤가
+4. (영업) 데모 미팅에서 어떤 항목이 가장 자주 언급되는가
+
+이 데이터를 보고 결정:
+- Sessions view (#2) — Users가 잘 먹히면 자연스러운 확장
+- Heuristic evaluators (#5) — evals 차별화 베팅
+- Custom dashboard (#12) — 위 두 개 다 미적지근하면 reconsider
+
+**측정 없이 다음 feature로 건너뛰지 말 것** — 트레드밀 트랩.

--- a/docs/plans/competitive_parity_roadmap.md
+++ b/docs/plans/competitive_parity_roadmap.md
@@ -1,0 +1,560 @@
+# Competitive Parity Roadmap
+
+> **목적**: Langfuse / Helicone 대비 Spanlens가 빠지거나 수준이 낮은 13개 항목을 모두 채우기 위한 개발 계획.
+> **기준일**: 2026-05-14 · **owner**: TBD
+>
+> 우선순위는 "유저 가치 ÷ 구현 비용" 기준이며, 의존성과 인프라 부담을 함께 고려해 정렬했다.
+> 각 항목은 _현재 상태 → 목표 상태 → 단계별 작업 → DB/API/UI 변경 → 추정 공수 → 의존성_ 의 6칸 구조를 유지한다.
+
+---
+
+## 0. 우선순위 매트릭스
+
+| # | 기능 | 영향도 | 구현 난이도 | 의존성 | Phase |
+|---|------|--------|-------------|--------|-------|
+| 1 | User analytics 전용 뷰 | 🔥 High | 🟢 Low | — | **P1** |
+| 2 | Session 전용 뷰 | 🔥 High | 🟢 Low | requests.session_id (DONE) | **P1** |
+| 3 | Annotation 다중 reviewer 평균/일치도 | 🟡 Mid | 🟢 Low | IAA(DONE) | **P1** |
+| 4 | Cache 토큰 별도 비용 계산 | 🔥 High | 🟢 Low | — | **P1** |
+| 5 | Heuristic Evaluator 타입 | 🟡 Mid | 🟡 Mid | evals(DONE) | **P2** |
+| 6 | Experiments N-arm 확장 | 🟡 Mid | 🟡 Mid | experiments(DONE) | **P2** |
+| 7 | Playground 멀티 모델 비교 | 🟡 Mid | 🟡 Mid | playground(DONE) | **P2** |
+| 8 | 스트리밍 응답 본문 캡처 | 🟡 Mid | 🟡 Mid | parser(DONE) | **P2** |
+| 9 | Full-text 본문 검색 | 🟡 Mid | 🔴 High | pg_trgm | **P3** |
+| 10 | 10KB body cap → S3 풀바디 | 🟡 Mid | 🔴 High | R2/S3 인프라 | **P3** |
+| 11 | OTel Export (outbound) | 🟢 Low | 🟡 Mid | otlp(DONE) | **P3** |
+| 12 | Custom Dashboard (위젯 빌더) | 🟢 Low | 🔴 High | stats API | **P4** |
+| 13 | Multimodal Tracing | 🟢 Low | 🔴 High | S3 + parser 확장 | **P4** |
+
+> **Phase 구분**
+> - **P1 (1주차)** — 기존 데이터로 신 화면만 추가하면 끝나는 quick win
+> - **P2 (2–4주차)** — 마이그레이션 + API 1–2개 추가
+> - **P3 (5–8주차)** — 외부 인프라 의존 또는 스키마 변경 큼
+> - **P4 (9주차+)** — 별도 product surface, 전용 작업 필요
+
+---
+
+## P1 · Quick Wins (1주 내 마감 목표)
+
+### 1. User Analytics 전용 뷰
+
+**현재 상태**
+- `requests.user_id` 컬럼은 존재 (mig `20260513040000_requests_user_session.sql`)
+- SDK 헬퍼 `withUser()` / `with_user()` 구현됨
+- `/requests?userId=…` 필터링 지원
+- **단, 유저별 집계 화면 자체 없음** — Langfuse `/users`, Helicone User analytics 탭과 동일한 surface 부재
+
+**목표 상태**
+- `/users` 라우트 신설 — 테이블: userId, 첫 요청, 마지막 요청, 총 요청 수, 토큰, 비용, 평균 latency, 평균 사용 모델
+- 행 클릭 → `/users/[id]` 상세 페이지 (시간순 request 리스트 + 사용 패턴 차트)
+- 사이드바 `OBSERVE → Users` 진입점
+
+**단계별 작업**
+1. **server**: `apps/server/src/api/users.ts` 새 라우터
+   - `GET /api/v1/users` — params: `projectId`, `range`, `search`, `sort`, `limit`, `offset`
+   - `GET /api/v1/users/:userId` — 단일 유저 상세 (집계 + 최근 요청 50개)
+   - SQL 한 방으로 `GROUP BY user_id` 집계 (request 수 / sum tokens / sum cost / max(created_at) / min(created_at))
+2. **db function**: `get_user_analytics(p_org uuid, p_project uuid, p_from, p_to)` SQL function — 자주 호출되므로 인덱스 활용 plan 안정화
+3. **index**: `requests (organization_id, user_id, created_at DESC)` partial index where `user_id IS NOT NULL` (mig 신규)
+4. **web**: `apps/web/app/(dashboard)/users/page.tsx` + `[userId]/page.tsx`
+5. **navigation**: sidebar 메뉴 추가
+
+**DB 변경** (mig: `YYYYMMDDHHMMSS_users_analytics.sql`)
+```sql
+CREATE INDEX requests_org_user_created_idx
+  ON requests (organization_id, user_id, created_at DESC)
+  WHERE user_id IS NOT NULL;
+
+-- 집계 함수
+CREATE FUNCTION get_user_analytics(...)
+```
+
+**API 변경**
+- `GET /api/v1/users` (신규)
+- `GET /api/v1/users/:userId` (신규)
+
+**UI 변경**
+- `/users` 라우트, sidebar 항목
+- 유저별 토큰/비용 stacked area chart (Recharts)
+
+**추정 공수**: **2 days** (백엔드 0.5d, UI 1d, 인덱스/migr 0.25d, 테스트 0.25d)
+**의존성**: 없음 (모든 데이터 준비됨)
+
+---
+
+### 2. Session 전용 뷰
+
+**현재 상태**
+- `requests.session_id` 컬럼 존재
+- SDK 헬퍼 `withSession()` / `with_session()` 있음
+- 필터링 가능
+- **세션 단위 뷰 없음** — Helicone Sessions, Langfuse Session Replay와 같은 surface 부재
+
+**목표 상태**
+- `/sessions` 라우트 — 세션 목록 (sessionId, userId, 시작, 종료, 메시지 수, 총 비용, 마지막 모델)
+- `/sessions/[id]` — 시간순 conversation replay (멀티턴 채팅 UI)
+- request → response 본문을 timeline 형태로 렌더
+- session_id가 같은 spans/traces도 묶어서 표시 (agent workflow 통합 뷰)
+
+**단계별 작업**
+1. **server**: `apps/server/src/api/sessions.ts`
+   - `GET /api/v1/sessions` — list + 집계
+   - `GET /api/v1/sessions/:id` — 단일 세션 내 모든 request + spans
+2. **index**: `requests (organization_id, session_id, created_at)` partial index where `session_id IS NOT NULL`
+3. **web**: `/sessions` list + `/sessions/[id]` replay
+   - Replay UI: chat bubble 스타일, role(user/assistant)별 색상
+   - 비용/토큰 stats bar 상단 고정
+4. **deep link**: `/requests` 행에서 sessionId 클릭 → `/sessions/[id]` 이동
+5. **trace integration**: 같은 session_id 가진 trace도 함께 표시 (옵션)
+
+**DB 변경** (mig: `YYYYMMDDHHMMSS_sessions_index.sql`)
+```sql
+CREATE INDEX requests_org_session_created_idx
+  ON requests (organization_id, session_id, created_at)
+  WHERE session_id IS NOT NULL;
+```
+
+**API 변경**: `/api/v1/sessions` 2개 신규
+
+**UI 변경**: `/sessions` 라우트 + sidebar
+
+**추정 공수**: **2.5 days** (replay UI에 시간 더 듬)
+**의존성**: 없음
+
+---
+
+### 3. Annotation 다중 Reviewer 평균/일치도 반영
+
+**현재 상태**
+- IAA(Inter-Annotator Agreement) 탭은 이미 구현됨 (`/annotation` Agreement 탭)
+- **단, Pearson r 상관도 계산 시 한 reviewer의 최신 점수 1개만 사용** — `human-evals.ts:correlation` endpoint 기준
+- `docs/features/annotation/page.tsx` Limitations 섹션에도 명시됨
+
+**목표 상태**
+- `correlation` endpoint가 reviewer당 점수를 평균내서 사용
+- 옵션 파라미터 `aggregation`: `mean` | `median` | `latest` (default: `mean`)
+- UI에 aggregation 토글 추가 — `/evals` 페이지 Pearson 카드 우상단
+- "based on N reviewers, M paired samples" 부가 표시
+
+**단계별 작업**
+1. **server**: `apps/server/src/api/human-evals.ts:correlation`
+   - 현재: `SELECT score FROM human_evals WHERE request_id = X LIMIT 1 ORDER BY updated_at DESC`
+   - 변경: `SELECT AVG(score) FROM human_evals WHERE request_id = X GROUP BY request_id`
+   - query param `aggregation` 추가, switch (`AVG` / `percentile_cont(0.5)` / `latest`)
+2. **web**: Pearson r 카드 컴포넌트에 토글 UI 추가
+3. **docs**: `/docs/features/annotation` Limitations 섹션 갱신 (해당 항목 제거)
+4. **test**: pearson 계산기 단위 테스트 (mean 모드 검증)
+
+**DB 변경**: 없음
+
+**API 변경**: `GET /api/v1/human-evals/correlation?aggregation=mean` (param 추가)
+
+**UI 변경**: `/evals` Pearson 카드 토글
+
+**추정 공수**: **0.5 day**
+**의존성**: 없음
+
+---
+
+### 4. Cache 토큰 별도 비용 계산
+
+**현재 상태**
+- Anthropic 응답에 `cache_read_input_tokens`, `cache_creation_input_tokens` 있음
+- 현재 `lib/cost.ts`가 둘 다 `prompt_tokens`에 합산
+- 실제 Anthropic 가격: `cache_read = input × 0.1`, `cache_creation = input × 1.25`
+- **2–10× 잘못 계산되는 경우 있음** (특히 long-context RAG)
+
+**목표 상태**
+- `model_prices` 테이블에 `cache_read_price`, `cache_write_price` 컬럼 추가
+- `requests` 테이블에 `cache_read_tokens`, `cache_write_tokens` 컬럼 추가 (NULL allowed)
+- `calculateCost()` 시 cache breakdown 반영
+- 대시보드 비용 카드에 "cache savings" 별도 표시
+- Anthropic 외 OpenAI prompt caching도 동일 schema로 흡수
+
+**단계별 작업**
+1. **db migration**
+   ```sql
+   ALTER TABLE model_prices
+     ADD COLUMN cache_read_price NUMERIC,
+     ADD COLUMN cache_write_price NUMERIC;
+   ALTER TABLE requests
+     ADD COLUMN cache_read_tokens INT,
+     ADD COLUMN cache_write_tokens INT;
+   ```
+2. **seeds**: `seeds/model_prices.sql` Anthropic / OpenAI 모델별 캐시 가격 추가
+3. **parser**: `parsers/anthropic.ts` — `usage.cache_read_input_tokens`, `usage.cache_creation_input_tokens` 추출해서 별도 필드로 반환
+4. **parser**: `parsers/openai.ts` — `usage.prompt_tokens_details.cached_tokens` 흡수
+5. **lib/cost.ts**: cache breakdown 반영한 비용 계산기
+   ```ts
+   cost = (prompt_tokens - cache_read - cache_write) × prompt_price
+        + cache_read × cache_read_price
+        + cache_write × cache_write_price
+        + completion_tokens × completion_price
+   ```
+6. **logger**: cache token 필드 INSERT
+7. **UI**: `/requests/[id]` 상세 페이지에 cache breakdown 표시
+8. **UI**: 대시보드 비용 카드 — "cache savings: $X.XX" 칩
+
+**DB 변경**: 2개 신규 mig (`_model_prices_cache.sql`, `_requests_cache_tokens.sql`)
+**API 변경**: 없음 (logger 내부 처리)
+**UI 변경**: 비용 카드 + request 상세 페이지
+
+**추정 공수**: **2 days** (parser 양쪽 + cost 함수 + DB + 시드 + UI)
+**의존성**: 없음
+
+> ⚠️ **gotcha**: 기존 row 의 비용은 다시 계산하지 않음 (re-aggregation 비용 큼). 마이그레이션 이후 신규 요청부터 정확. 과거 데이터 backfill은 별도 job 옵션.
+
+---
+
+## P2 · 중간 규모 (2–4주차)
+
+### 5. Heuristic Evaluator 타입 추가
+
+**현재 상태**
+- `evaluators.type = 'llm_judge'` 하나뿐
+- `eval_results.score` 컬럼 0..1 NUMERIC
+
+**목표 상태**
+- 추가 타입: `regex`, `json_schema`, `length`, `contains`, `latency`, `cost_threshold`
+- 점수 타입 다양화: `numeric` (0..1), `boolean` (0/1), `categorical` (label)
+- UI에서 evaluator 생성 시 type 드롭다운 + type별 config 폼
+
+**단계별 작업**
+1. **db migration**
+   ```sql
+   ALTER TABLE evaluators
+     ADD COLUMN config JSONB DEFAULT '{}'::jsonb;
+   ALTER TABLE eval_results
+     ADD COLUMN score_type TEXT DEFAULT 'numeric',  -- numeric | boolean | categorical
+     ADD COLUMN label TEXT;  -- for categorical
+   ```
+2. **server**: `apps/server/src/lib/evaluator-runners/` 디렉토리 신설
+   - `llm-judge.ts` (기존)
+   - `regex.ts`, `json-schema.ts` (Ajv), `length.ts`, `contains.ts`, `latency.ts`, `cost.ts`
+   - `runEvaluator(evaluator, request)` dispatch 함수
+3. **api**: `POST /api/v1/evaluators` body 변경 — `type` + `config` 받기
+4. **web**: evaluator 생성/수정 폼에 type별 config UI
+   - regex: pattern + flags
+   - json_schema: schema JSON editor (Monaco)
+   - length: min/max
+   - contains: substring + case_sensitive
+5. **catalog**: 미리 정의된 평가기 템플릿 4–5개 시드
+   - "Output is valid JSON" (json_schema)
+   - "Response under 500 chars" (length)
+   - "Latency under 3s" (latency)
+
+**DB 변경**: `_evaluators_heuristic.sql`
+**API 변경**: 기존 evaluator 엔드포인트 body 확장
+**UI 변경**: evaluator 폼 + catalog
+
+**추정 공수**: **4 days**
+**의존성**: 없음 (`evals` 인프라 위에 얹는 형태)
+
+---
+
+### 6. Experiments N-arm 확장 (현재 2-arm)
+
+**현재 상태**
+- `experiments` 테이블 — `arm_a_prompt_version_id`, `arm_b_prompt_version_id` 두 컬럼 고정
+- UI도 2개 prompt version 하드코딩
+
+**목표 상태**
+- N개 prompt version 비교 가능 (보통 3–5개)
+- 결과 테이블: 각 arm의 winner % / latency / cost
+- 차트: arm별 score distribution overlay
+
+**단계별 작업**
+1. **db migration** — N-arm 정규화
+   ```sql
+   CREATE TABLE experiment_arms (
+     id uuid PK,
+     experiment_id uuid FK,
+     prompt_version_id uuid FK,
+     label TEXT,
+     created_at timestamptz
+   );
+   -- 기존 arm_a / arm_b 데이터를 experiment_arms로 이전 (data mig)
+   -- 기존 컬럼은 backward compat 위해 일단 남기되 deprecated 마킹
+   ```
+2. **server**: `experiments.ts` `runExperiment` 로직 — arms array를 돌면서 fork 호출
+3. **api**: `POST /api/v1/experiments` body — `armPromptVersionIds: string[]`
+4. **web**: 실험 생성 UI — "+ Add arm" 버튼, drag reorder
+5. **stats**: pairwise comparison 매트릭스 표시 (NxN 그리드)
+
+**DB 변경**: `_experiment_arms.sql` (data backfill 포함)
+**API 변경**: experiments 라우터 body 확장
+**UI 변경**: 실험 생성/결과 페이지 전면 개편
+
+**추정 공수**: **5 days**
+**의존성**: 기존 experiment 데이터 migration이 핵심 — backward compat 신경 써야 함
+
+> ⚠️ **gotcha**: 기존 `arm_a_prompt_version_id`/`arm_b_prompt_version_id` 참조하는 client 코드를 모두 grep 해서 함께 수정. 깜빡 두면 dashboard에서 NULL FK 빠짐.
+
+---
+
+### 7. Playground 멀티 모델 사이드바이사이드 비교
+
+**현재 상태**
+- `/playground` 또는 prompts-playground 단일 실행
+- 단일 모델 결과만 표시
+
+**목표 상태**
+- 동일 prompt를 N개 모델 / N개 prompt version에 동시에 던지고 결과 사이드바이사이드 표시
+- Tool calling 지원 (function definitions UI)
+- Structured output (JSON schema) 지원
+
+**단계별 작업**
+1. **web**: `/playground` UI 재설계
+   - 좌측: prompt editor (system + user 메시지)
+   - 우측: column별 "model / version" 선택 → "Run all" 버튼
+   - 각 column에 stream 결과 + cost + latency
+2. **server**: `prompts-playground.ts` — 동시 N개 모델 호출 (Promise.all)
+3. **tool calling**: prompt 옆에 "Tools" 탭 — JSON 정의 입력 → 모델별 tool_calls 응답 비교
+4. **structured output**: "Response format" 드롭다운 — JSON schema 입력 시 OpenAI `response_format: json_schema` 모드
+
+**DB 변경**: 없음 (playground는 휘발성)
+**API 변경**: `/api/v1/playground/run` body — `targets: [{model, promptVersionId}, ...]`
+**UI 변경**: `/playground` 전면 개편
+
+**추정 공수**: **5 days**
+**의존성**: 없음
+
+---
+
+### 8. 스트리밍 응답 본문 캡처
+
+**현재 상태**
+- 스트림은 `body.tee()`로 클라이언트 + 로깅 두 갈래로 분기
+- **현재 로깅 갈래에서 response_body 누락 (parser는 usage만 추출)**
+- request 상세 페이지에서 streamed response는 본문 NULL
+
+**목표 상태**
+- streaming 청크를 누적해서 final text를 `response_body`에 저장
+- size cap (10KB) 동일 적용
+- OpenAI / Anthropic / Gemini parser 모두 대응
+
+**단계별 작업**
+1. **parser** — 각 parser의 chunk 누적 로직 확장
+   - `parsers/openai.ts` — `delta.content` 누적 → `assembledText` 반환
+   - `parsers/anthropic.ts` — `content_block_delta.text` 누적
+   - `parsers/gemini.ts` — `candidates[0].content.parts[0].text` 누적
+2. **proxy**: stream 종료 시점에 logger 호출 시 `response_body: assembledText` 포함
+3. **size cap**: `assembledText.slice(0, 10_000)` (P3에서 S3로 옮길 때까지 임시)
+4. **edge case**: stream abort 시 부분만이라도 저장 (try/finally)
+5. **test**: openai-mock + anthropic-mock 스트림 fixture로 회귀 테스트
+
+**DB 변경**: 없음
+**API 변경**: 없음
+**UI 변경**: 없음 (자동으로 표시됨)
+
+**추정 공수**: **2 days**
+**의존성**: 없음
+**주의**: Vercel `fireAndForget()` 패턴 유지 — assembledText 누적은 stream 끝난 후 promise → `fireAndForget()`로 전달
+
+---
+
+## P3 · 인프라 의존 (5–8주차)
+
+### 9. Full-text Body Search
+
+**현재 상태**
+- `/requests` 검색은 `model ILIKE '%X%'`만 지원
+- 본문 검색 불가
+
+**목표 상태**
+- request_body / response_body 풀텍스트 검색
+- 한국어 + 영어 둘 다 처리
+- 검색 highlight + 점수 정렬
+
+**단계별 작업**
+1. **postgres extension**: `pg_trgm` 활성화 (`CREATE EXTENSION pg_trgm`)
+   - tsvector + GIN 인덱스도 옵션 (tsvector는 형태소 분석 영어 위주 → trgm이 한국어 친화)
+2. **db migration**
+   ```sql
+   CREATE INDEX requests_body_trgm_idx
+     ON requests USING gin (
+       (coalesce(request_body::text, '') || ' ' || coalesce(response_body::text, ''))
+       gin_trgm_ops
+     );
+   ```
+3. **server**: `requests.ts` search query —
+   ```sql
+   WHERE search_text ILIKE '%' || $1 || '%'
+   ORDER BY similarity(search_text, $1) DESC
+   ```
+4. **web**: 검색창 옆 "Match body" 토글 + 검색어 highlight (mark.js)
+5. **performance**: 대용량(>10M rows)에서 검색 query plan 확인 — partial index 필요할 수도
+
+**DB 변경**: `_requests_body_search.sql` (GIN index)
+**API 변경**: `GET /api/v1/requests?q=…&searchBody=true`
+**UI 변경**: 검색창 옵션
+
+**추정 공수**: **3 days**
+**의존성**: pg_trgm은 supabase 기본 제공
+**주의**: GIN 인덱스 크기 매우 큼 (테이블의 30–50%). 대용량 환경에선 partition 후 인덱스 고려
+
+---
+
+### 10. 10KB Body Cap → S3 풀바디 아카이브
+
+**현재 상태**
+- `request_body` / `response_body` 컬럼이 10KB 초과 시 truncate
+- 긴 RAG context, document summarization 워크로드에서 본문 잘림
+
+**목표 상태**
+- 10KB 이하면 그대로 DB 저장
+- 초과 시 Cloudflare R2 (또는 S3) 업로드 후 URL만 DB 저장
+- `/requests/[id]` 페이지에서 lazy fetch
+- Self-host 사용자도 R2 / S3 / 로컬 디스크 중 선택
+
+**단계별 작업**
+1. **infra**: Cloudflare R2 버킷 + IAM 발급, env `R2_*` 4종 추가
+2. **lib**: `apps/server/src/lib/blob-storage.ts` — `uploadBody()`, `getBody()` 추상화 (R2 / S3 / local 어댑터)
+3. **db migration**
+   ```sql
+   ALTER TABLE requests
+     ADD COLUMN request_body_url TEXT,
+     ADD COLUMN response_body_url TEXT;
+   ```
+4. **logger**: 본문 > 10KB 시 R2 업로드 → URL을 컬럼에 저장, 기존 body 컬럼은 truncate된 preview만
+5. **api**: `GET /api/v1/requests/:id/body?part=request|response` — presigned URL 또는 stream
+6. **UI**: 본문 영역에 "Load full body (15.3KB)" 버튼 — 클릭 시 lazy fetch
+7. **GDPR**: 본문 삭제 (`DELETE /requests/:id`) 시 R2 객체도 함께 삭제
+8. **self-host**: `BLOB_STORAGE_BACKEND` env (`r2` | `s3` | `local` | `none`) — none이면 truncate 유지
+
+**DB 변경**: `_requests_body_url.sql`
+**API 변경**: `/api/v1/requests/:id/body` 신규
+**UI 변경**: lazy load 버튼
+
+**추정 공수**: **6 days** (스토리지 추상화 + 인프라 + 데이터 마이그 + UI)
+**의존성**: R2 계약 / 자체 호스팅 stratrategy 결정 필요
+
+> ⚠️ **gotcha**: stream 응답은 P2 #8 작업과 결합. 누적 본문이 10KB 넘으면 즉시 R2로 우회 업로드.
+
+---
+
+### 11. OTel Export (Spanlens → 외부 APM)
+
+**현재 상태**
+- OTel 수신만 가능 (`/otlp/v1/traces` endpoint)
+- 외부 APM (Datadog, Honeycomb, Grafana Tempo)로 export 불가
+
+**목표 상태**
+- 워크스페이스 설정에서 OTel exporter endpoint 등록
+- Spanlens spans / requests를 OTLP 포맷으로 변환해 외부에 push
+- Sampling rate 설정 가능
+
+**단계별 작업**
+1. **db**: `otel_exporters` 테이블 신설 (org_id, endpoint, headers, sampling_rate, enabled)
+2. **server**: `apps/server/src/lib/otel-exporter.ts` — Spanlens row → OTLP Span proto 변환기
+3. **cron**: 5초마다 미발송 span을 batch push (queue table 또는 outbox 패턴)
+4. **proto**: `@opentelemetry/otlp-transformer` 활용 (공식 npm 패키지)
+5. **UI**: 워크스페이스 settings → "Integrations → OpenTelemetry export" 폼
+6. **test**: Honeycomb sandbox에 실제 push해서 도착 확인
+
+**DB 변경**: `_otel_exporters.sql`
+**API 변경**: `/api/v1/integrations/otel-exporters` CRUD
+**UI 변경**: settings 페이지에 섹션 추가
+
+**추정 공수**: **5 days**
+**의존성**: 옵션 outbox 테이블 + cron 트리거
+
+---
+
+## P4 · 별도 Product Surface (9주차+)
+
+### 12. Custom Dashboard (위젯 빌더)
+
+**현재 상태**
+- `/dashboard`는 고정 카드 (요청 수, 비용, latency p95 등)
+- 사용자가 위젯 조합 불가
+
+**목표 상태**
+- Langfuse 식 위젯 빌더: 드래그앤드롭 grid, 차트 종류 / 메트릭 / 필터 조합
+- 위젯 종류: line, bar, pie, big number, table, heatmap
+- 저장 가능한 named dashboard (per-org, per-project)
+
+**단계별 작업**
+1. **db**: `dashboards`, `dashboard_widgets` 2개 테이블
+2. **query DSL**: 위젯 정의 JSON schema — `{metric, groupBy, filters, timeRange, chartType}`
+3. **server**: 통합 `POST /api/v1/dashboards/:id/query` — DSL을 SQL로 변환해 실행
+   - 안전성: DSL은 whitelist 된 metric / filter만 허용, raw SQL 금지
+4. **web**: `/dashboards` 라우트 — `react-grid-layout` + Recharts
+5. **share**: dashboard 임베드 URL (token 기반)
+
+**DB 변경**: `_dashboards.sql`
+**API 변경**: `/api/v1/dashboards/*`
+**UI 변경**: 신규 product surface
+
+**추정 공수**: **15 days** (DSL 안전성 + 위젯 빌더 UI 큰 작업)
+**의존성**: 명확한 metric/filter catalog 확정 필요
+
+---
+
+### 13. Multimodal Tracing
+
+**현재 상태**
+- 텍스트 LLM만 추적 (chat/completion)
+- 이미지 입력 (Vision)도 base64 그대로 request_body에 들어가서 size cap에 걸림
+
+**목표 상태**
+- 이미지 / 오디오 input 자동 감지 → 별도 blob storage 저장
+- request 상세 페이지에서 미리보기 (이미지 thumbnail, 오디오 player)
+- 모달리티별 토큰/비용 분리 표시 (image token, audio second 단위)
+
+**단계별 작업**
+1. **db**: `request_attachments` 테이블 (request_id, modality, blob_url, size, mime)
+2. **parser**: messages 배열 traversal — `image_url` / `image` / `audio` 콘텐츠 추출
+3. **storage**: P3 #10의 blob storage 인프라 재활용
+4. **cost**: 모달리티별 가격 시드 (e.g. GPT-4o image: $0.003765/image, Whisper: $0.006/min)
+5. **UI**: request 상세에서 inline preview
+
+**DB 변경**: `_request_attachments.sql`
+**API 변경**: blob fetch endpoint
+**UI 변경**: 미리보기 컴포넌트
+
+**추정 공수**: **8 days**
+**의존성**: P3 #10 (blob storage 인프라) 완료 필수
+
+---
+
+## 종합 일정 (예상)
+
+```
+Week 1   ████████ P1: User analytics + Sessions + Annotation avg + Cache cost
+Week 2   ████████ P2: Heuristic evaluators
+Week 3   ████████ P2: N-arm experiments
+Week 4   ████████ P2: Multi-model playground + Stream body capture
+Week 5   ████████ P3: Full-text search
+Week 6   ████████ P3: Blob storage (S3/R2) infra
+Week 7   ████████ P3: Blob storage UI + lazy fetch
+Week 8   ████████ P3: OTel export
+Week 9+  ████████ P4: Custom dashboard
+Week 12+ ████████ P4: Multimodal tracing
+```
+
+**총 단순 합산 공수**: ~57 person-days (≒ 11주 1인 풀타임).
+실제로는 review / QA / docs 포함하면 1.5x 보정 → **~16주차에 모두 완료**.
+
+---
+
+## 위험 / 결정 필요 사항
+
+1. **Blob storage 백엔드 선택** — P3 #10 시작 전에 결정해야 함
+   - Cloudflare R2 (egress 무료, S3 호환) ↔ AWS S3 (관성)
+   - self-host 사용자에게도 옵션 제공? → 어댑터 패턴 필수
+2. **Custom dashboard DSL의 안전성** — SQL injection 방지를 위해 metric/filter catalog 화이트리스트 정밀 설계 필요
+3. **Cache 토큰 backfill** — 기존 row 비용 다시 계산할지 결정 (계산비용 큼, opt-in으로)
+4. **N-arm experiments 데이터 마이그** — 기존 2-arm row → arms 테이블로 옮길 때 client 코드 충돌 — feature flag 두고 점진 전환 권장
+
+---
+
+## 작업 시 공통 규칙 (CLAUDE.md 발췌 재확인)
+
+- 모든 DB 변경은 `supabase/migrations/YYYYMMDDHHMMSS_desc.sql` 새 파일로 추가, **기존 파일 수정 금지**
+- `supabase db push` 후 반드시 `supabase gen types --lang typescript --local > supabase/types.ts`
+- 새 테이블에 `ALTER TABLE … ENABLE ROW LEVEL SECURITY` 빠뜨리지 말 것
+- 새 X-Spanlens-* 헤더 추가 시 4곳 모두 — 서버 매핑 / SDK 헬퍼 / `/docs/proxy` / `/docs/sdk`
+- 새 cost calculation 모델 식별 로직은 **exact match + longest boundary-aware prefix** 패턴 유지
+- 모든 비동기 로깅 / DB write은 `fireAndForget(c, promise)` 사용 (Vercel Edge drain 안정성)
+- 검증: 변경 범위별 `pnpm typecheck && lint && test` 통과 후 PR

--- a/supabase/migrations/20260514120000_cache_pricing.sql
+++ b/supabase/migrations/20260514120000_cache_pricing.sql
@@ -1,0 +1,49 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Cache token pricing (Anthropic prompt caching · OpenAI prompt caching)
+--
+-- WHY: Both Anthropic and OpenAI charge different prices for cached input tokens
+-- vs. fresh input tokens. Until now Spanlens lumped everything into prompt_tokens
+-- × prompt_price, which OVERCOUNTS cost by 2–10× for cache-heavy workloads.
+--
+-- SEMANTIC:
+--   • `prompt_tokens`       = TOTAL input tokens (including any cached portion)
+--                             — unchanged semantic, all existing aggregations
+--                             keep working.
+--   • `cache_read_tokens`   = subset of prompt_tokens that hit a cache
+--                             (Anthropic: cache_read_input_tokens
+--                              OpenAI:    prompt_tokens_details.cached_tokens)
+--   • `cache_write_tokens`  = subset of prompt_tokens that CREATED a cache entry
+--                             (Anthropic: cache_creation_input_tokens
+--                              OpenAI:    no equivalent yet)
+--
+-- COST FORMULA (applied in lib/cost.ts):
+--   non_cached      = prompt_tokens - cache_read_tokens - cache_write_tokens
+--   total_cost_usd  = non_cached         × prompt_price
+--                   + cache_read_tokens  × cache_read_price
+--                   + cache_write_tokens × cache_write_price
+--                   + completion_tokens  × completion_price
+--
+-- HISTORICAL DATA: untouched. Backfill not attempted because raw breakdown was
+-- never recorded — request_body / response_body don't reliably contain
+-- usage.cached_tokens / usage.cache_read_input_tokens fields for past rows
+-- (especially streaming). Going forward, every new request stores the
+-- breakdown.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE model_prices
+  ADD COLUMN IF NOT EXISTS cache_read_price_per_1m  NUMERIC(10, 6),
+  ADD COLUMN IF NOT EXISTS cache_write_price_per_1m NUMERIC(10, 6);
+
+COMMENT ON COLUMN model_prices.cache_read_price_per_1m  IS
+  'USD per 1M cached input tokens (read). NULL = model does not support cache or pricing unknown.';
+COMMENT ON COLUMN model_prices.cache_write_price_per_1m IS
+  'USD per 1M cache-creation input tokens. NULL = model does not support cache writes or pricing unknown.';
+
+ALTER TABLE requests
+  ADD COLUMN IF NOT EXISTS cache_read_tokens  INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS cache_write_tokens INTEGER NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN requests.cache_read_tokens  IS
+  'Number of input tokens that hit a prompt cache (subset of prompt_tokens). 0 if not applicable.';
+COMMENT ON COLUMN requests.cache_write_tokens IS
+  'Number of input tokens written to a prompt cache, charged at write price (subset of prompt_tokens). 0 if not applicable.';

--- a/supabase/migrations/20260514130000_user_analytics_fn.sql
+++ b/supabase/migrations/20260514130000_user_analytics_fn.sql
@@ -80,7 +80,7 @@ BEGIN
     )
     SELECT
       g.*,
-      COUNT(*) OVER ()::bigint AS total_count
+      (COUNT(*) OVER ())::bigint AS total_count
     FROM grouped g
     ORDER BY %I %s NULLS LAST
     LIMIT $6 OFFSET $7

--- a/supabase/migrations/20260514130000_user_analytics_fn.sql
+++ b/supabase/migrations/20260514130000_user_analytics_fn.sql
@@ -1,0 +1,96 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- get_user_analytics — aggregate per-user usage for /api/v1/users
+--
+-- Returns one row per distinct user_id within an organization, with totals
+-- (requests, tokens, cost), behavior (avg latency, error count, distinct
+-- models), and lifetime markers (first_seen, last_seen).
+--
+-- The total_count column carries the COUNT(*) OVER () windowed total so the
+-- list endpoint can paginate without a second roundtrip.
+--
+-- Indexes already cover the hot filter:
+--   idx_requests_user_id ON (organization_id, user_id, created_at DESC)
+--     WHERE user_id IS NOT NULL  -- added in 20260513040000_requests_user_session.sql
+--
+-- Sort whitelist (p_sort_by): 'cost' | 'requests' | 'tokens' | 'last_seen'.
+-- Anything else falls back to 'cost'. Direction whitelist: 'asc' | 'desc'.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION get_user_analytics(
+  p_org_id      uuid,
+  p_project_id  uuid,
+  p_search      text,
+  p_from        timestamptz,
+  p_to          timestamptz,
+  p_sort_by     text,
+  p_sort_dir    text,
+  p_limit       int,
+  p_offset      int
+)
+RETURNS TABLE (
+  user_id          text,
+  total_requests   bigint,
+  total_tokens     bigint,
+  total_cost_usd   numeric,
+  avg_latency_ms   numeric,
+  first_seen       timestamptz,
+  last_seen        timestamptz,
+  error_requests   bigint,
+  distinct_models  bigint,
+  total_count      bigint
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_sort_col text;
+  v_sort_dir text;
+BEGIN
+  -- Whitelist sort inputs to prevent SQL injection.
+  v_sort_col := CASE p_sort_by
+    WHEN 'requests'  THEN 'total_requests'
+    WHEN 'tokens'    THEN 'total_tokens'
+    WHEN 'last_seen' THEN 'last_seen'
+    ELSE 'total_cost_usd'
+  END;
+  v_sort_dir := CASE WHEN lower(coalesce(p_sort_dir, 'desc')) = 'asc' THEN 'ASC' ELSE 'DESC' END;
+
+  RETURN QUERY EXECUTE format($q$
+    WITH grouped AS (
+      SELECT
+        r.user_id                                         AS user_id,
+        COUNT(*)::bigint                                  AS total_requests,
+        COALESCE(SUM(r.total_tokens), 0)::bigint          AS total_tokens,
+        COALESCE(SUM(r.cost_usd), 0)::numeric             AS total_cost_usd,
+        AVG(r.latency_ms)::numeric                        AS avg_latency_ms,
+        MIN(r.created_at)                                 AS first_seen,
+        MAX(r.created_at)                                 AS last_seen,
+        COUNT(*) FILTER (WHERE r.status_code >= 400)::bigint AS error_requests,
+        COUNT(DISTINCT r.model)::bigint                   AS distinct_models
+      FROM requests r
+      WHERE r.organization_id = $1
+        AND r.user_id IS NOT NULL
+        AND ($2::uuid IS NULL OR r.project_id = $2)
+        AND ($3::text IS NULL OR r.user_id ILIKE '%%' || $3 || '%%')
+        AND ($4::timestamptz IS NULL OR r.created_at >= $4)
+        AND ($5::timestamptz IS NULL OR r.created_at <= $5)
+      GROUP BY r.user_id
+    )
+    SELECT
+      g.*,
+      COUNT(*) OVER ()::bigint AS total_count
+    FROM grouped g
+    ORDER BY %I %s NULLS LAST
+    LIMIT $6 OFFSET $7
+  $q$, v_sort_col, v_sort_dir)
+  USING p_org_id, p_project_id, p_search, p_from, p_to, p_limit, p_offset;
+END;
+$$;
+
+COMMENT ON FUNCTION get_user_analytics(uuid, uuid, text, timestamptz, timestamptz, text, text, int, int) IS
+  'Aggregate per-user usage stats for an organization. Used by GET /api/v1/users.';
+
+GRANT EXECUTE ON FUNCTION get_user_analytics(uuid, uuid, text, timestamptz, timestamptz, text, text, int, int)
+  TO authenticated, service_role;

--- a/supabase/seeds/model_prices.sql
+++ b/supabase/seeds/model_prices.sql
@@ -1,30 +1,41 @@
 -- Seed: Model pricing table (USD per 1M tokens, verified against provider pricing 2026-05)
-INSERT INTO model_prices (provider, model, prompt_price_per_1m, completion_price_per_1m) VALUES
-  -- OpenAI
-  ('openai', 'gpt-4o',           2.50,  10.00),
-  ('openai', 'gpt-4o-mini',      0.15,   0.60),
-  ('openai', 'gpt-4.1',          2.00,   8.00),
-  ('openai', 'gpt-4.1-mini',     0.40,   1.60),
-  ('openai', 'gpt-4.1-nano',     0.10,   0.40),
-  ('openai', 'gpt-4-turbo',     10.00,  30.00),
-  ('openai', 'gpt-4',           30.00,  60.00),
-  ('openai', 'gpt-3.5-turbo',    0.50,   1.50),
-  -- Anthropic
-  ('anthropic', 'claude-opus-4-7',              5.00,  25.00),
-  ('anthropic', 'claude-sonnet-4-6',            3.00,  15.00),
-  ('anthropic', 'claude-haiku-4-5',             1.00,   5.00),
-  ('anthropic', 'claude-haiku-4-5-20251001',    1.00,   5.00),
-  ('anthropic', 'claude-3-5-sonnet-20241022',   3.00,  15.00),
-  ('anthropic', 'claude-3-5-haiku-20241022',    0.80,   4.00),
-  ('anthropic', 'claude-3-opus-20240229',      15.00,  75.00),
-  -- Gemini
-  ('gemini', 'gemini-2.5-pro',        1.25, 10.00),
-  ('gemini', 'gemini-2.5-flash',      0.30,  2.50),
-  ('gemini', 'gemini-2.5-flash-lite', 0.10,  0.40),
-  ('gemini', 'gemini-2.0-flash',      0.10,  0.40), -- deprecated 2026-06-01, kept for historical data
-  ('gemini', 'gemini-1.5-pro',        1.25,  5.00),
-  ('gemini', 'gemini-1.5-flash',      0.075, 0.30)
+--
+-- Cache pricing notes:
+--   • Anthropic prompt caching — cache_read = 0.1 × input price · cache_write (5min ephemeral) = 1.25 × input price
+--   • OpenAI prompt caching    — cached input ≈ 0.5 × input price (gpt-4o / gpt-4.1 families; no cache_write concept)
+--   • Models without official cache pricing use NULL → calculateCost() falls back to charging the regular prompt price.
+INSERT INTO model_prices (
+  provider, model,
+  prompt_price_per_1m, completion_price_per_1m,
+  cache_read_price_per_1m, cache_write_price_per_1m
+) VALUES
+  -- ── OpenAI ────────────────────────────────────────────────────────────────
+  ('openai', 'gpt-4o',           2.50,  10.00,   1.25,   NULL),
+  ('openai', 'gpt-4o-mini',      0.15,   0.60,   0.075,  NULL),
+  ('openai', 'gpt-4.1',          2.00,   8.00,   0.50,   NULL),
+  ('openai', 'gpt-4.1-mini',     0.40,   1.60,   0.10,   NULL),
+  ('openai', 'gpt-4.1-nano',     0.10,   0.40,   0.025,  NULL),
+  ('openai', 'gpt-4-turbo',     10.00,  30.00,   NULL,   NULL),
+  ('openai', 'gpt-4',           30.00,  60.00,   NULL,   NULL),
+  ('openai', 'gpt-3.5-turbo',    0.50,   1.50,   NULL,   NULL),
+  -- ── Anthropic ─────────────────────────────────────────────────────────────
+  ('anthropic', 'claude-opus-4-7',              5.00,  25.00,   0.50,   6.25),
+  ('anthropic', 'claude-sonnet-4-6',            3.00,  15.00,   0.30,   3.75),
+  ('anthropic', 'claude-haiku-4-5',             1.00,   5.00,   0.10,   1.25),
+  ('anthropic', 'claude-haiku-4-5-20251001',    1.00,   5.00,   0.10,   1.25),
+  ('anthropic', 'claude-3-5-sonnet-20241022',   3.00,  15.00,   0.30,   3.75),
+  ('anthropic', 'claude-3-5-haiku-20241022',    0.80,   4.00,   0.08,   1.00),
+  ('anthropic', 'claude-3-opus-20240229',      15.00,  75.00,   1.50,  18.75),
+  -- ── Gemini (caching not yet exposed in our integration) ──────────────────
+  ('gemini', 'gemini-2.5-pro',        1.25, 10.00,   NULL, NULL),
+  ('gemini', 'gemini-2.5-flash',      0.30,  2.50,   NULL, NULL),
+  ('gemini', 'gemini-2.5-flash-lite', 0.10,  0.40,   NULL, NULL),
+  ('gemini', 'gemini-2.0-flash',      0.10,  0.40,   NULL, NULL), -- deprecated 2026-06-01, kept for historical data
+  ('gemini', 'gemini-1.5-pro',        1.25,  5.00,   NULL, NULL),
+  ('gemini', 'gemini-1.5-flash',      0.075, 0.30,   NULL, NULL)
 ON CONFLICT (provider, model) DO UPDATE
-  SET prompt_price_per_1m     = EXCLUDED.prompt_price_per_1m,
-      completion_price_per_1m = EXCLUDED.completion_price_per_1m,
-      updated_at              = now();
+  SET prompt_price_per_1m      = EXCLUDED.prompt_price_per_1m,
+      completion_price_per_1m  = EXCLUDED.completion_price_per_1m,
+      cache_read_price_per_1m  = EXCLUDED.cache_read_price_per_1m,
+      cache_write_price_per_1m = EXCLUDED.cache_write_price_per_1m,
+      updated_at               = now();

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -2212,27 +2212,27 @@ export type Database = {
       }
       get_user_analytics: {
         Args: {
-          p_org_id: string
-          p_project_id: string | null
-          p_search: string | null
-          p_from: string | null
-          p_to: string | null
-          p_sort_by: string
-          p_sort_dir: string
+          p_from: string
           p_limit: number
           p_offset: number
+          p_org_id: string
+          p_project_id: string
+          p_search: string
+          p_sort_by: string
+          p_sort_dir: string
+          p_to: string
         }
         Returns: {
-          user_id: string
-          total_requests: number
-          total_tokens: number
-          total_cost_usd: number | null
-          avg_latency_ms: number | null
+          avg_latency_ms: number
+          distinct_models: number
+          error_requests: number
           first_seen: string
           last_seen: string
-          error_requests: number
-          distinct_models: number
+          total_cost_usd: number
           total_count: number
+          total_requests: number
+          total_tokens: number
+          user_id: string
         }[]
       }
       get_prompts_quality_sparklines: {

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -897,6 +897,8 @@ export type Database = {
       }
       model_prices: {
         Row: {
+          cache_read_price_per_1m: number | null
+          cache_write_price_per_1m: number | null
           completion_price_per_1m: number
           created_at: string
           id: string
@@ -906,6 +908,8 @@ export type Database = {
           updated_at: string
         }
         Insert: {
+          cache_read_price_per_1m?: number | null
+          cache_write_price_per_1m?: number | null
           completion_price_per_1m: number
           created_at?: string
           id?: string
@@ -915,6 +919,8 @@ export type Database = {
           updated_at?: string
         }
         Update: {
+          cache_read_price_per_1m?: number | null
+          cache_write_price_per_1m?: number | null
           completion_price_per_1m?: number
           created_at?: string
           id?: string
@@ -1474,6 +1480,8 @@ export type Database = {
       requests: {
         Row: {
           api_key_id: string | null
+          cache_read_tokens: number
+          cache_write_tokens: number
           completion_tokens: number
           cost_usd: number | null
           created_at: string
@@ -1502,6 +1510,8 @@ export type Database = {
         }
         Insert: {
           api_key_id?: string | null
+          cache_read_tokens?: number
+          cache_write_tokens?: number
           completion_tokens?: number
           cost_usd?: number | null
           created_at?: string
@@ -1530,6 +1540,8 @@ export type Database = {
         }
         Update: {
           api_key_id?: string | null
+          cache_read_tokens?: number
+          cache_write_tokens?: number
           completion_tokens?: number
           cost_usd?: number | null
           created_at?: string

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -2210,6 +2210,31 @@ export type Database = {
         }
         Returns: number
       }
+      get_user_analytics: {
+        Args: {
+          p_org_id: string
+          p_project_id: string | null
+          p_search: string | null
+          p_from: string | null
+          p_to: string | null
+          p_sort_by: string
+          p_sort_dir: string
+          p_limit: number
+          p_offset: number
+        }
+        Returns: {
+          user_id: string
+          total_requests: number
+          total_tokens: number
+          total_cost_usd: number | null
+          avg_latency_ms: number | null
+          first_seen: string
+          last_seen: string
+          error_requests: number
+          distinct_models: number
+          total_count: number
+        }[]
+      }
       get_prompts_quality_sparklines: {
         Args: {
           p_buckets?: number


### PR DESCRIPTION
## Replaces PR #9

PR #9 had merge conflicts because the demo branch `demo/evals-datasets-experiments-annotation` carries the **original** commits of work that was already squash-merged into main as PRs #5/#6/#7/#8. Same code, different SHAs → git can't auto-merge.

This branch is a clean cherry-pick of just the 7 new commits onto current `main`, with zero conflicts.

## Summary

| # | feature | commit |
|---|---------|--------|
| #4 | **Prompt-cache cost** — Anthropic / OpenAI cache 토큰을 별도 가격으로 청구. 이전엔 input rate로 2-10x 과다 계상 | f1adc77 (cherry-picked) |
| #8 | **Gemini streaming + 본문 캡처** — `:streamGenerateContent` true pass-through + 3-provider regression tests | 915e9f8 (cherry-picked) |
| #1 | **/users analytics** — `x-spanlens-user` 태깅된 요청 유저별 집계, /users + /users/[id] | 7f0105d (cherry-picked) |

Follow-ups: SQL paren fix, types.ts sync, launch doc, competitive parity roadmap.

## DB migrations (이미 PROD 적용 완료)

- `20260514120000_cache_pricing.sql`
- `20260514130000_user_analytics_fn.sql`

Both pushed to PROD via `supabase db push` after `migration repair` reconciled the divergent timestamps. Schema verified — `requests.cache_*_tokens` columns + `get_user_analytics()` RPC exist in PROD. Cache pricing seed (21 rows) also applied.

## Test plan (after merge)

- [ ] Anthropic prompt-caching request → `/requests/<id>` cache breakdown card
- [ ] OpenAI / Anthropic / Gemini stream requests → response_body non-null
- [ ] `withUser('smoke-test')` → /users row + drill-through

PostHog dashboard 4-card setup (separate task by user) — see `docs/launch/2026-05-14_cache-stream-users.md` \xa73.

## Verification

- 262 server tests pass (+ 23 new: cost 9 / parsers 3 / stream-body 11)
- pnpm typecheck / lint / web build all green
- RPC verified end-to-end on local Postgres with 8 scenarios (sort / search / pagination / cross-org isolation / SQL injection / error count / distinct models)