### PR TITLE
docs: fill in launch followups (proxy headers, OpenAPI users, overview, README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ Same proxy, same dashboard. For agent tracing in Python (multi-step, async, tool
 
 | Feature | Description |
 |---|---|
-| **Request log** | Every LLM call — model, tokens, cost, latency, request/response body |
+| **Request log** | Every LLM call — model, tokens, cost, latency, request/response body (streaming responses reconstructed too) |
 | **Agent tracing** | Multi-step workflows as Gantt/waterfall span trees |
-| **Cost tracking** | Per-request cost breakdown, daily rollups, budget alerts |
+| **Cost tracking** | Per-request cost breakdown with prompt-cache pricing (Anthropic / OpenAI cache hits billed at their reduced rate), daily rollups, budget alerts |
+| **Per-end-user analytics** | Tag calls with `x-spanlens-user` (SDK: `withUser()` / `with_user()`) → /users page shows per-user cost, tokens, errors, models, last seen |
 | **Anomaly detection** | 3σ deviations in latency or cost vs. your 7-day baseline |
 | **PII + prompt-injection scan** | Regex-based detection on request **and response** bodies; optional per-project blocking (422) for injections; instant alert emails to workspace owner |
 | **Model recommendations** | "Your gpt-4o calls look like classification — try gpt-4o-mini" |

--- a/apps/server/src/api/openapi.ts
+++ b/apps/server/src/api/openapi.ts
@@ -126,16 +126,35 @@ const SPEC = {
           id: { type: 'string', format: 'uuid' },
           provider: { type: 'string', enum: ['openai', 'anthropic', 'gemini'] },
           model: { type: 'string', example: 'gpt-4o-mini' },
-          prompt_tokens: { type: 'integer' },
+          prompt_tokens: { type: 'integer', description: 'Gross input tokens (cache portions included).' },
           completion_tokens: { type: 'integer' },
           total_tokens: { type: 'integer' },
+          cache_read_tokens: { type: 'integer', description: 'Subset of prompt_tokens that hit a prompt cache (Anthropic cache_read_input_tokens / OpenAI cached_tokens). 0 if not applicable.' },
+          cache_write_tokens: { type: 'integer', description: 'Subset of prompt_tokens that wrote a cache entry (Anthropic cache_creation_input_tokens). 0 if not applicable.' },
           cost_usd: { type: 'number', format: 'float', nullable: true },
           latency_ms: { type: 'integer' },
           proxy_overhead_ms: { type: 'integer', nullable: true },
           status_code: { type: 'integer' },
+          user_id: { type: 'string', nullable: true, description: 'Customer-supplied end-user ID via x-spanlens-user header.' },
+          session_id: { type: 'string', nullable: true, description: 'Customer-supplied session ID via x-spanlens-session header.' },
           flags: { type: 'array', items: { $ref: '#/components/schemas/SecurityFlag' }, description: 'Request-body security flags' },
           response_flags: { type: 'array', items: { $ref: '#/components/schemas/SecurityFlag' }, description: 'Response-body security flags' },
           created_at: { type: 'string', format: 'date-time' },
+        },
+      },
+      UserAnalytics: {
+        type: 'object',
+        description: 'Per-end-user aggregate stats. Sourced from requests grouped by user_id (x-spanlens-user header).',
+        properties: {
+          user_id: { type: 'string' },
+          total_requests: { type: 'integer' },
+          total_tokens: { type: 'integer' },
+          total_cost_usd: { type: 'number', format: 'float' },
+          avg_latency_ms: { type: 'number', format: 'float', nullable: true },
+          first_seen: { type: 'string', format: 'date-time' },
+          last_seen: { type: 'string', format: 'date-time' },
+          error_requests: { type: 'integer', description: 'Count of requests with status_code >= 400' },
+          distinct_models: { type: 'integer', description: 'Number of distinct models used by this user' },
         },
       },
       Trace: {
@@ -473,6 +492,83 @@ const SPEC = {
         responses: {
           200: { description: 'Request detail', content: { 'application/json': { schema: { $ref: '#/components/schemas/Request' } } } },
           404: { description: 'Not found' },
+        },
+      },
+    },
+    '/api/v1/users': {
+      get: {
+        tags: ['Users'],
+        summary: 'List per-end-user analytics',
+        description: 'Returns one aggregate row per distinct `x-spanlens-user` value within the org — totals (requests / tokens / cost), behaviour (avg latency, error count, distinct models), lifetime markers (first_seen / last_seen).',
+        operationId: 'listUsers',
+        security: [{ BearerJWT: [] }],
+        parameters: [
+          { name: 'projectId', in: 'query', schema: { type: 'string', format: 'uuid' } },
+          { name: 'search', in: 'query', schema: { type: 'string' }, description: 'Substring match on user_id' },
+          { name: 'from', in: 'query', schema: { type: 'string', format: 'date-time' } },
+          { name: 'to', in: 'query', schema: { type: 'string', format: 'date-time' } },
+          { name: 'sortBy', in: 'query', schema: { type: 'string', enum: ['cost', 'requests', 'tokens', 'last_seen'], default: 'cost' } },
+          { name: 'sortDir', in: 'query', schema: { type: 'string', enum: ['asc', 'desc'], default: 'desc' } },
+          { name: 'page', in: 'query', schema: { type: 'integer', default: 1 } },
+          { name: 'limit', in: 'query', schema: { type: 'integer', default: 50, maximum: 100 } },
+        ],
+        responses: {
+          200: {
+            description: 'User analytics list',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    success: { type: 'boolean' },
+                    data: { type: 'array', items: { $ref: '#/components/schemas/UserAnalytics' } },
+                    meta: { type: 'object', properties: { total: { type: 'integer' }, page: { type: 'integer' }, limit: { type: 'integer' } } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/v1/users/{userId}': {
+      get: {
+        tags: ['Users'],
+        summary: 'Get end-user detail with recent requests',
+        description: 'Aggregate stats + most recent 50 requests for a single user_id. Mirrors the list endpoint filters.',
+        operationId: 'getUser',
+        security: [{ BearerJWT: [] }],
+        parameters: [
+          { name: 'userId', in: 'path', required: true, schema: { type: 'string' } },
+          { name: 'projectId', in: 'query', schema: { type: 'string', format: 'uuid' } },
+          { name: 'from', in: 'query', schema: { type: 'string', format: 'date-time' } },
+          { name: 'to', in: 'query', schema: { type: 'string', format: 'date-time' } },
+        ],
+        responses: {
+          200: {
+            description: 'User detail',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    success: { type: 'boolean' },
+                    data: {
+                      allOf: [
+                        { $ref: '#/components/schemas/UserAnalytics' },
+                        {
+                          type: 'object',
+                          properties: {
+                            recent_requests: { type: 'array', items: { $ref: '#/components/schemas/Request' } },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
         },
       },
     },

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -12,7 +12,7 @@ export default function DocsIndex() {
     <div className="not-prose">
       <h1 className="text-4xl font-bold tracking-tight mb-3">Spanlens Docs</h1>
       <p className="text-lg text-muted-foreground mb-10">
-        LLM observability — cost tracking, agent tracing, PII + prompt-injection detection, and model recommendations for OpenAI / Anthropic / Gemini calls.
+        LLM observability — cost tracking (with prompt-cache breakdown), per-end-user analytics, agent tracing, PII + prompt-injection detection, and model recommendations for OpenAI / Anthropic / Gemini calls.
       </p>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-12">
@@ -71,6 +71,29 @@ export default function DocsIndex() {
           </summary>
           <p className="mt-2 text-muted-foreground">
             OpenAI, Anthropic, and Google Gemini — including streaming responses. We match the upstream API 1:1, so any SDK that talks to those providers works.
+          </p>
+        </details>
+
+        <details className="rounded border p-4">
+          <summary className="cursor-pointer font-medium">
+            Can I see which of my end-users is spending the most on LLM calls?
+          </summary>
+          <p className="mt-2 text-muted-foreground">
+            Yes. Tag each call with the <code className="text-xs bg-bg-elev rounded px-1">x-spanlens-user</code> header (SDK helper{' '}
+            <code className="text-xs bg-bg-elev rounded px-1">withUser()</code>) and the{' '}
+            <Link href="/users" className="text-accent hover:underline">/users</Link> page shows a sortable per-end-user breakdown — cost, requests, tokens, error rate, models used. Drill into any user for their full request history. See{' '}
+            <Link href="/docs/features/users" className="text-accent hover:underline">users docs</Link>.
+          </p>
+        </details>
+
+        <details className="rounded border p-4">
+          <summary className="cursor-pointer font-medium">
+            Does Spanlens charge Anthropic prompt-cache hits correctly?
+          </summary>
+          <p className="mt-2 text-muted-foreground">
+            Yes. Both Anthropic <code className="text-xs bg-bg-elev rounded px-1">cache_read_input_tokens</code> /{' '}
+            <code className="text-xs bg-bg-elev rounded px-1">cache_creation_input_tokens</code> and OpenAI{' '}
+            <code className="text-xs bg-bg-elev rounded px-1">prompt_tokens_details.cached_tokens</code> are parsed automatically and billed at each provider&apos;s reduced cache rate (≈ 0.1× input on Anthropic, ≈ 0.5× on OpenAI). The breakdown shows on every request detail page. Other tools that lump everything into prompt tokens overcount cache-heavy workloads by 2–10×.
           </p>
         </details>
       </div>

--- a/apps/web/app/docs/proxy/page.tsx
+++ b/apps/web/app/docs/proxy/page.tsx
@@ -183,6 +183,31 @@ res, _ := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
         prompt tag is stale. The request just isn&apos;t linked to a version.
       </p>
 
+      <p>
+        Add <code>X-Spanlens-User</code> and <code>X-Spanlens-Session</code> headers to tag the
+        request with an end-user or session ID. The values are opaque strings of your choosing
+        (Spanlens never interprets them):
+      </p>
+      <CodeBlock>{`-H "X-Spanlens-User: user_abc123"
+-H "X-Spanlens-Session: sess_xyz789"`}</CodeBlock>
+      <p>
+        Tagged requests roll up at <a href="/users">/users</a> (per-end-user cost / token / latency
+        analytics) and can be filtered at <a href="/requests">/requests</a> via{' '}
+        <code>?userId=…</code> / <code>?sessionId=…</code>. See{' '}
+        <a href="/docs/features/users">Users docs</a> for tagging strategy and SDK helpers.
+      </p>
+
+      <h3>About prompt-cache breakdown</h3>
+      <p>
+        When Anthropic returns <code>cache_read_input_tokens</code> /{' '}
+        <code>cache_creation_input_tokens</code> or OpenAI returns{' '}
+        <code>prompt_tokens_details.cached_tokens</code>, Spanlens parses them out of the response
+        automatically and stores the breakdown in <code>requests.cache_read_tokens</code> /{' '}
+        <code>cache_write_tokens</code>. <em>No header from you is required.</em> Cost is billed at
+        each provider&apos;s reduced cache rate (≈ 0.1× input on Anthropic, ≈ 0.5× input on OpenAI).
+        See <a href="/docs/features/cost-tracking">cost tracking</a> for the full formula.
+      </p>
+
       <h2>Self-hosting</h2>
       <p>
         If you&apos;re running Spanlens on your own infra, replace the base URL:


### PR DESCRIPTION
4 small doc gaps surfaced by post-launch audit. Zero runtime code changes.

## Changes

1. **Direct-proxy docs** (`apps/web/app/docs/proxy/page.tsx`) — added \`X-Spanlens-User\` / \`X-Spanlens-Session\` header section (was missing entirely) + brief note on cache-token breakdown being automatic.

2. **OpenAPI spec** (`apps/server/src/api/openapi.ts`) — registered \`GET /api/v1/users\` (list) + \`GET /api/v1/users/{userId}\` (detail) with full param/response schemas. Added new \`UserAnalytics\` schema. Extended existing \`Request\` schema with cache_*_tokens, user_id, session_id.

3. **Docs overview** (`apps/web/app/docs/page.tsx`) — hero paragraph mentions cache pricing + users. Added two demo-friendly FAQ entries: 'which user is spending the most' and 'is cache billed correctly'.

4. **README** — Features table now includes per-end-user analytics row + extended cost tracking / request log rows to mention cache and reconstructed streams.

## Test plan

- [x] `pnpm --filter web typecheck` ✅
- [x] `pnpm --filter server typecheck` ✅
- [ ] Vercel preview build green
- [ ] Smoke check that \`/api/v1/openapi.json\` includes the new \`/api/v1/users\` paths after merge

Safe to squash-merge.