### PR TITLE
feat(demo): add /demo/users page (match real sidebar after PR #10)

### DIFF
--- a/apps/web/app/demo/users/[userId]/page.tsx
+++ b/apps/web/app/demo/users/[userId]/page.tsx
@@ -1,0 +1,123 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { DEMO_REQUESTS } from '@/lib/demo-data'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Demo /users/[userId] detail page — same shape as the real
+// apps/web/app/(dashboard)/users/[userId]/user-detail-client.tsx, but static
+// and sourced from DEMO_REQUESTS.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function fmtCost(n: number | null | undefined): string {
+  if (n == null) return '—'
+  return '$' + Number(n).toFixed(6)
+}
+
+function fmtCount(n: number): string {
+  return n.toLocaleString()
+}
+
+export default async function DemoUserDetailPage({ params }: { params: Promise<{ userId: string }> }) {
+  const { userId } = await params
+  const decoded = decodeURIComponent(userId)
+
+  const userRequests = DEMO_REQUESTS.filter((r) => r.user_id === decoded)
+  if (userRequests.length === 0) {
+    notFound()
+  }
+
+  const totalRequests = userRequests.length
+  const totalTokens = userRequests.reduce((s, r) => s + r.total_tokens, 0)
+  const totalCost = userRequests.reduce((s, r) => s + (r.cost_usd ?? 0), 0)
+  const avgLatency = userRequests.reduce((s, r) => s + r.latency_ms, 0) / totalRequests
+  const errorCount = userRequests.filter((r) => r.status_code >= 400).length
+  const distinctModels = new Set(userRequests.map((r) => r.model)).size
+  const sortedByTime = [...userRequests].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+  const firstSeen = sortedByTime[sortedByTime.length - 1]?.created_at ?? null
+  const lastSeen = sortedByTime[0]?.created_at ?? null
+
+  const stats = [
+    { label: 'Requests', value: fmtCount(totalRequests) },
+    { label: 'Total tokens', value: fmtCount(totalTokens) },
+    { label: 'Total cost', value: fmtCost(totalCost) },
+    { label: 'Avg latency', value: `${Math.round(avgLatency)} ms` },
+    { label: 'Error count', value: fmtCount(errorCount), warn: errorCount > 0 },
+    { label: 'Distinct models', value: fmtCount(distinctModels) },
+    { label: 'First seen', value: firstSeen ? new Date(firstSeen).toLocaleDateString() : '—' },
+    { label: 'Last seen', value: lastSeen ? new Date(lastSeen).toLocaleDateString() : '—' },
+  ]
+
+  return (
+    <div className="space-y-6 px-6 py-6 max-w-[1200px] mx-auto">
+      <Link
+        href="/demo/users"
+        className="inline-flex items-center gap-1.5 font-mono text-[12px] text-text-muted hover:text-text transition-colors"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" /> Back to users
+      </Link>
+
+      <div>
+        <h1 className="font-mono text-[18px] tracking-[-0.2px] text-text break-all">{decoded}</h1>
+        <p className="font-mono text-[11px] text-text-faint mt-1.5">
+          End-user analytics · all requests tagged with this{' '}
+          <code className="bg-bg-elev px-1 py-px rounded">x-spanlens-user</code> value
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        {stats.map(({ label, value, warn }) => (
+          <div key={label} className="border border-border rounded-[6px] px-4 py-3 bg-bg-elev">
+            <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-1.5">
+              {label}
+            </div>
+            <div className={cn('font-mono text-[13px] font-medium truncate', warn ? 'text-accent' : 'text-text')}>
+              {value}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div>
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.05em] text-text-faint mb-3">
+          Recent requests
+        </h2>
+        <div className="border border-border rounded-[6px] overflow-hidden">
+          <div className="grid grid-cols-[1fr,1fr,1fr,1fr,1fr] gap-3 px-4 py-2.5 bg-bg-elev border-b border-border font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+            <span>Time</span>
+            <span>Model</span>
+            <span>Tokens</span>
+            <span>Cost</span>
+            <span>Status</span>
+          </div>
+          <div className="divide-y divide-border">
+            {sortedByTime.map((r) => {
+              const isErr = r.status_code >= 400
+              return (
+                <Link
+                  key={r.id}
+                  href={`/demo/requests/${r.id}`}
+                  className="grid grid-cols-[1fr,1fr,1fr,1fr,1fr] gap-3 items-center px-4 py-2.5 font-mono text-[12px] text-text hover:bg-bg-elev transition-colors"
+                >
+                  <span className="text-text-muted">
+                    {new Date(r.created_at).toLocaleString(undefined, {
+                      month: 'short',
+                      day: 'numeric',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </span>
+                  <span className="truncate">{r.model}</span>
+                  <span className="text-text-muted">{r.total_tokens.toLocaleString()}</span>
+                  <span>{fmtCost(r.cost_usd)}</span>
+                  <span className={isErr ? 'text-bad' : 'text-good'}>{r.status_code}</span>
+                </Link>
+              )
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/demo/users/page.tsx
+++ b/apps/web/app/demo/users/page.tsx
@@ -1,0 +1,182 @@
+'use client'
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { ArrowDown, Search, Users as UsersIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { DEMO_REQUESTS } from '@/lib/demo-data'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Demo /users page — static mirror of the real /users surface.
+// Aggregates DEMO_REQUESTS in-memory (group by user_id) and renders the same
+// 6-column table layout as apps/web/app/(dashboard)/users/users-client.tsx.
+// Read-only: no sorting / search / pagination wired (would just be visual
+// noise for a marketing demo). Sales talking point is the row click-through
+// to /demo/users/[userId].
+// ─────────────────────────────────────────────────────────────────────────────
+
+function fmtCost(n: number): string {
+  if (n === 0) return '$0.00'
+  return n < 0.01 ? '< $0.01' : '$' + n.toFixed(2)
+}
+
+function fmtCount(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k'
+  return String(n)
+}
+
+function fmtRelativeTime(iso: string): string {
+  const d = new Date(iso).getTime()
+  const diff = Date.now() - d
+  if (diff < 60_000) return 'just now'
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+  if (diff < 7 * 86_400_000) return `${Math.floor(diff / 86_400_000)}d ago`
+  return new Date(iso).toLocaleDateString()
+}
+
+interface UserAggregate {
+  user_id: string
+  total_requests: number
+  total_tokens: number
+  total_cost_usd: number
+  avg_latency_ms: number
+  error_requests: number
+  distinct_models: number
+  first_seen: string
+  last_seen: string
+}
+
+function aggregate(): UserAggregate[] {
+  const grouped = new Map<string, {
+    requests: number
+    tokens: number
+    cost: number
+    latencies: number[]
+    errors: number
+    models: Set<string>
+    firstSeen: string
+    lastSeen: string
+  }>()
+
+  for (const r of DEMO_REQUESTS) {
+    if (!r.user_id) continue
+    const existing = grouped.get(r.user_id) ?? {
+      requests: 0,
+      tokens: 0,
+      cost: 0,
+      latencies: [] as number[],
+      errors: 0,
+      models: new Set<string>(),
+      firstSeen: r.created_at,
+      lastSeen: r.created_at,
+    }
+    existing.requests += 1
+    existing.tokens += r.total_tokens
+    existing.cost += r.cost_usd ?? 0
+    existing.latencies.push(r.latency_ms)
+    if (r.status_code >= 400) existing.errors += 1
+    existing.models.add(r.model)
+    if (r.created_at < existing.firstSeen) existing.firstSeen = r.created_at
+    if (r.created_at > existing.lastSeen) existing.lastSeen = r.created_at
+    grouped.set(r.user_id, existing)
+  }
+
+  return Array.from(grouped.entries())
+    .map(([user_id, g]) => ({
+      user_id,
+      total_requests: g.requests,
+      total_tokens: g.tokens,
+      total_cost_usd: g.cost,
+      avg_latency_ms: g.latencies.reduce((s, n) => s + n, 0) / g.latencies.length,
+      error_requests: g.errors,
+      distinct_models: g.models.size,
+      first_seen: g.firstSeen,
+      last_seen: g.lastSeen,
+    }))
+    .sort((a, b) => b.total_cost_usd - a.total_cost_usd)
+}
+
+export default function DemoUsersPage() {
+  const rows = useMemo(aggregate, [])
+  const total = rows.length
+
+  return (
+    <div className="space-y-6 px-6 py-6 max-w-[1200px] mx-auto">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="font-medium text-[20px] tracking-[-0.3px] text-text">Users</h1>
+          <p className="font-mono text-[11.5px] text-text-faint mt-1.5">
+            End-user attribution from{' '}
+            <code className="bg-bg-elev px-1 py-px rounded text-text">x-spanlens-user</code> header.
+            Sorted by total cost.
+          </p>
+        </div>
+        <div className="font-mono text-[11px] text-text-faint">
+          {total} user{total === 1 ? '' : 's'}
+        </div>
+      </div>
+
+      {/* Filter bar (read-only on demo) */}
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-text-faint" />
+          <input
+            disabled
+            placeholder="Search user ID…"
+            className="w-full pl-8 pr-3 py-1.5 font-mono text-[12px] bg-bg-elev border border-border rounded-[6px] text-text placeholder:text-text-faint focus:outline-none focus:border-accent"
+          />
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="border border-border rounded-[6px] overflow-hidden">
+        {/* Header row */}
+        <div className="grid grid-cols-[2fr,1fr,1fr,1fr,1fr,1fr] gap-3 px-4 py-2.5 bg-bg-elev border-b border-border font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+          <span>User ID</span>
+          <span>Requests</span>
+          <span>Tokens</span>
+          <span className="inline-flex items-center gap-1 text-text">
+            Cost <ArrowDown className="h-3 w-3" />
+          </span>
+          <span>Avg latency</span>
+          <span className="justify-self-end">Last seen</span>
+        </div>
+
+        {rows.length === 0 ? (
+          <div className="px-4 py-16 text-center">
+            <UsersIcon className="mx-auto h-6 w-6 text-text-faint mb-3" />
+            <p className="font-mono text-[12.5px] text-text mb-1.5">No users yet</p>
+          </div>
+        ) : (
+          <div className="divide-y divide-border">
+            {rows.map((u) => (
+              <Link
+                key={u.user_id}
+                href={`/demo/users/${encodeURIComponent(u.user_id)}`}
+                className="grid grid-cols-[2fr,1fr,1fr,1fr,1fr,1fr] gap-3 items-center px-4 py-3 font-mono text-[12px] text-text hover:bg-bg-elev transition-colors"
+              >
+                <span className="truncate">{u.user_id}</span>
+                <span className="text-text-muted">
+                  {fmtCount(u.total_requests)}
+                  {u.error_requests > 0 && (
+                    <span className="text-bad ml-1.5">· {u.error_requests} err</span>
+                  )}
+                </span>
+                <span className="text-text-muted">{fmtCount(u.total_tokens)}</span>
+                <span>{fmtCost(u.total_cost_usd)}</span>
+                <span className="text-text-muted">{Math.round(u.avg_latency_ms)}ms</span>
+                <span className="text-text-faint text-right">{fmtRelativeTime(u.last_seen)}</span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <p className={cn('font-mono text-[11px] text-text-faint')}>
+        Demo data · in production this view comes from <code className="bg-bg-elev px-1 py-px rounded">GET /api/v1/users</code> (RPC-backed aggregate).
+      </p>
+    </div>
+  )
+}

--- a/apps/web/components/layout/demo-sidebar.tsx
+++ b/apps/web/components/layout/demo-sidebar.tsx
@@ -23,6 +23,7 @@ const DEMO_NAV = [
       { href: '/demo/dashboard', label: 'Dashboard', badge: null },
       { href: '/demo/requests',  label: 'Requests',  badge: '2.4k' },
       { href: '/demo/traces',    label: 'Traces',    badge: null },
+      { href: '/demo/users',     label: 'Users',     badge: '4' },
     ],
   },
   {


### PR DESCRIPTION
## Why

User caught a sidebar inconsistency: the real workspace shows **Users** in the nav (added by PR #10) but the **DEMO workspace doesn't** — because demo uses a separate sidebar file (\`apps/web/components/layout/demo-sidebar.tsx\`) that PR #10 missed.

This matters for sales — \`/users\` is the killer demo (\"which customer is spending the most on LLM?\"). Missing from the marketing demo = silent regression of the sales pitch.

## Changes

1. **\`demo-sidebar.tsx\`** — \`Users\` entry added to the first nav group with badge \"4\" (matches distinct user_ids in DEMO_REQUESTS: u_alice, u_bob, u_charlie, usr-88421).
2. **\`app/demo/users/page.tsx\`** — static aggregator over DEMO_REQUESTS. Groups by user_id in-memory, renders the same 6-column table layout as the real \`/users\` page. Search/sort intentionally disabled (only 4 rows, visual clutter on demo).
3. **\`app/demo/users/[userId]/page.tsx\`** — 8-card stat grid + recent requests, mirrors real \`/users/[id]\`. Each recent-request row links to the existing \`/demo/requests/[id]\`.

ADMIN section (Projects & Keys / Settings / Docs) intentionally stays out of the demo sidebar — demo simulates a viewer, not an admin (existing convention).

## Test plan

- [x] Build green — both \`/demo/users\` and \`/demo/users/[userId]\` show up in Next.js route table
- [ ] After merge — click flow: /demo (any page) sidebar → Users → row → recent request → existing demo request detail. End-to-end consistency between marketing surface and the real product.

Pure demo addition, no production code paths touched.