### PR TITLE
feat: platform hardening — 7 reliability & UX improvements

### DIFF
--- a/apps/server/src/api/anomalies.ts
+++ b/apps/server/src/api/anomalies.ts
@@ -4,6 +4,7 @@ import { requireRole } from '../middleware/requireRole.js'
 import { detectAnomalies } from '../lib/anomaly.js'
 import { getAnomalyHistory } from '../lib/anomaly-snapshot.js'
 import { supabaseAdmin } from '../lib/db.js'
+import { parsePositiveFloat, parseClampedFloat } from '../lib/params.js'
 
 const requireEdit = requireRole('admin', 'editor')
 
@@ -22,18 +23,6 @@ anomaliesRouter.use('*', authJwt)
 
 const VALID_KINDS = new Set(['latency', 'cost', 'error_rate'])
 
-function parsePositiveNumber(raw: string | undefined, fallback: number): number {
-  if (!raw) return fallback
-  const n = Number(raw)
-  return Number.isFinite(n) && n > 0 ? n : fallback
-}
-
-function parseClampedNumber(raw: string | undefined, fallback: number, min: number, max: number): number {
-  if (!raw) return fallback
-  const n = Number(raw)
-  if (!Number.isFinite(n)) return fallback
-  return Math.max(min, Math.min(max, n))
-}
 
 interface AckKey {
   provider: string
@@ -49,9 +38,9 @@ anomaliesRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) return c.json({ error: 'Organization not found' }, 404)
 
-  const observationHours = parseClampedNumber(c.req.query('observationHours'), 1, 0.25, 72)
-  const referenceHours = parseClampedNumber(c.req.query('referenceHours'), 168, 1, 8760)
-  const sigmaThreshold = parseClampedNumber(c.req.query('sigma'), 3, 1, 10)
+  const observationHours = parseClampedFloat(c.req.query('observationHours'), 1, 0.25, 72)
+  const referenceHours = parseClampedFloat(c.req.query('referenceHours'), 168, 1, 8760)
+  const sigmaThreshold = parseClampedFloat(c.req.query('sigma'), 3, 1, 10)
   const projectId = c.req.query('projectId')
 
   if (projectId) {
@@ -114,7 +103,7 @@ anomaliesRouter.get('/history', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) return c.json({ error: 'Organization not found' }, 404)
 
-  const days = Math.min(parsePositiveNumber(c.req.query('days'), 30), 365)
+  const days = Math.min(parsePositiveFloat(c.req.query('days'), 30), 365)
   const history = await getAnomalyHistory(orgId, days)
 
   return c.json({

--- a/apps/server/src/api/auditLogs.ts
+++ b/apps/server/src/api/auditLogs.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { supabaseAdmin } from '../lib/db.js'
+import { parsePositiveInt } from '../lib/params.js'
 
 /**
  * Audit log endpoints. The `audit_logs` table is INSERT-by-service-role only
@@ -15,11 +16,6 @@ export const auditLogsRouter = new Hono<JwtContext>()
 
 auditLogsRouter.use('*', authJwt)
 
-function parseIntSafe(raw: string | undefined, fallback: number): number {
-  if (!raw) return fallback
-  const n = Number(raw)
-  return Number.isInteger(n) && n > 0 ? n : fallback
-}
 
 export interface AuditLogRow {
   id: string
@@ -36,8 +32,8 @@ auditLogsRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) return c.json({ error: 'Organization not found' }, 404)
 
-  const limit = Math.min(parseIntSafe(c.req.query('limit'), 50), 200)
-  const offset = parseIntSafe(c.req.query('offset'), 0)
+  const limit = Math.min(parsePositiveInt(c.req.query('limit'), 50), 200)
+  const offset = parsePositiveInt(c.req.query('offset'), 0)
   const actionFilter = c.req.query('action')
 
   let query = supabaseAdmin

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -1,12 +1,14 @@
 import { Hono } from 'hono'
 import { supabaseAdmin } from '../lib/db.js'
 import { deliverToChannel, type AlertNotification } from '../lib/notifiers.js'
+import { retryFailedWebhooks } from '../lib/webhook-dispatch.js'
 import { computeAndReportOverages } from '../lib/paddle-usage.js'
 import { runQuotaWarningsJob } from '../lib/quota-warnings.js'
 import { snapshotAnomaliesForAllOrgs } from '../lib/anomaly-snapshot.js'
 import { runStaleKeyDigestJob } from '../lib/stale-key-digest.js'
 import { runLeakDetectionJob } from '../lib/leak-detection.js'
 import { sendHighConfidenceRecommendationAlerts } from '../lib/recommendation-notify.js'
+import { logCronRun } from '../lib/cron-logger.js'
 
 /**
  * Vercel cron endpoints. Invoked hourly via `crons` entry in `vercel.json`.
@@ -36,6 +38,7 @@ cronRouter.get('/aggregate-usage', async (c) => {
   const authFail = assertCronAuth(c.req.header('Authorization'))
   if (authFail) return c.json({ error: authFail }, 401)
 
+  const start = Date.now()
   const now = new Date()
   const today = now.toISOString().slice(0, 10)
   const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
@@ -52,6 +55,9 @@ cronRouter.get('/aggregate-usage', async (c) => {
       results.push({ date, rows: data as number })
     }
   }
+
+  const hasError = results.some((r) => r.error)
+  logCronRun('aggregate-usage', hasError ? 'error' : 'ok', Date.now() - start, hasError ? results.find((r) => r.error)?.error : undefined).catch(console.error)
 
   return c.json({
     success: true,
@@ -153,6 +159,7 @@ cronRouter.get('/evaluate-alerts', async (c) => {
   const authFail = assertCronAuth(c.req.header('Authorization'))
   if (authFail) return c.json({ error: authFail }, 401)
 
+  const start = Date.now()
   const dashboardBase = process.env['DASHBOARD_URL'] ?? 'https://spanlens-web.vercel.app'
 
   const { data: alerts } = await supabaseAdmin
@@ -258,6 +265,7 @@ cronRouter.get('/evaluate-alerts', async (c) => {
     report.push({ alert_id: alert.id, fired: true })
   }
 
+  logCronRun('evaluate-alerts', 'ok', Date.now() - start).catch(console.error)
   return c.json({ success: true, evaluated: report.length, report })
 })
 
@@ -266,11 +274,14 @@ cronRouter.get('/report-usage-overage', async (c) => {
   const authFail = assertCronAuth(c.req.header('Authorization'))
   if (authFail) return c.json({ error: authFail }, 401)
 
+  const start = Date.now()
   try {
     const reports = await computeAndReportOverages()
+    logCronRun('report-usage-overage', 'ok', Date.now() - start).catch(console.error)
     return c.json({ success: true, count: reports.length, reports })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
+    logCronRun('report-usage-overage', 'error', Date.now() - start, msg).catch(console.error)
     return c.json({ error: msg }, 500)
   }
 })
@@ -283,11 +294,14 @@ cronRouter.get('/check-quota-warnings', async (c) => {
   const authFail = assertCronAuth(c.req.header('Authorization'))
   if (authFail) return c.json({ error: authFail }, 401)
 
+  const start = Date.now()
   try {
     const result = await runQuotaWarningsJob()
+    logCronRun('check-quota-warnings', 'ok', Date.now() - start).catch(console.error)
     return c.json({ success: true, ...result })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
+    logCronRun('check-quota-warnings', 'error', Date.now() - start, msg).catch(console.error)
     return c.json({ error: msg }, 500)
   }
 })
@@ -299,13 +313,16 @@ cronRouter.get('/snapshot-anomalies', async (c) => {
   const authFail = assertCronAuth(c.req.header('Authorization'))
   if (authFail) return c.json({ error: authFail }, 401)
 
+  const start = Date.now()
   try {
     const results = await snapshotAnomaliesForAllOrgs()
     const total = results.reduce((s, r) => s + r.detected, 0)
     const errored = results.filter((r) => r.errors.length > 0).length
+    logCronRun('snapshot-anomalies', 'ok', Date.now() - start).catch(console.error)
     return c.json({ success: true, orgs: results.length, anomalies: total, errors: errored, results })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
+    logCronRun('snapshot-anomalies', 'error', Date.now() - start, msg).catch(console.error)
     return c.json({ error: msg }, 500)
   }
 })
@@ -315,13 +332,18 @@ cronRouter.get('/prune-logs', async (c) => {
   const authFail = assertCronAuth(c.req.header('Authorization'))
   if (authFail) return c.json({ error: authFail }, 401)
 
+  const start = Date.now()
   const [logsResult, bucketsResult] = await Promise.all([
     supabaseAdmin.rpc('prune_logs_by_retention'),
     supabaseAdmin.rpc('prune_rate_limit_buckets'),
   ])
 
-  if (logsResult.error) return c.json({ error: logsResult.error.message }, 500)
+  if (logsResult.error) {
+    logCronRun('prune-logs', 'error', Date.now() - start, logsResult.error.message).catch(console.error)
+    return c.json({ error: logsResult.error.message }, 500)
+  }
 
+  logCronRun('prune-logs', 'ok', Date.now() - start).catch(console.error)
   return c.json({
     success: true,
     logs: logsResult.data,
@@ -338,11 +360,14 @@ cronRouter.get('/stale-key-reminders', async (c) => {
   const authFail = assertCronAuth(c.req.header('Authorization'))
   if (authFail) return c.json({ error: authFail }, 401)
 
+  const start = Date.now()
   try {
     const result = await runStaleKeyDigestJob()
+    logCronRun('stale-key-reminders', 'ok', Date.now() - start).catch(console.error)
     return c.json({ success: true, ...result })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
+    logCronRun('stale-key-reminders', 'error', Date.now() - start, msg).catch(console.error)
     return c.json({ error: msg }, 500)
   }
 })
@@ -355,14 +380,36 @@ cronRouter.get('/recommend-savings-alerts', async (c) => {
   const authFail = assertCronAuth(c.req.header('Authorization'))
   if (authFail) return c.json({ error: authFail }, 401)
 
+  const start = Date.now()
   try {
     const results = await sendHighConfidenceRecommendationAlerts()
     const totalSent    = results.reduce((s, r) => s + r.sent, 0)
     const totalSkipped = results.reduce((s, r) => s + r.skipped, 0)
     const totalErrors  = results.reduce((s, r) => s + r.errors.length, 0)
+    logCronRun('recommend-savings-alerts', 'ok', Date.now() - start).catch(console.error)
     return c.json({ success: true, orgs: results.length, sent: totalSent, skipped: totalSkipped, errors: totalErrors, results })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
+    logCronRun('recommend-savings-alerts', 'error', Date.now() - start, msg).catch(console.error)
+    return c.json({ error: msg }, 500)
+  }
+})
+
+// ── Webhook retry (every 5 minutes) ────────────────────────────
+// Re-dispatches failed webhook_deliveries whose next_retry_at is past.
+// Uses exponential back-off up to MAX_ATTEMPTS (5).
+cronRouter.get('/retry-webhooks', async (c) => {
+  const authFail = assertCronAuth(c.req.header('Authorization'))
+  if (authFail) return c.json({ error: authFail }, 401)
+
+  const start = Date.now()
+  try {
+    const result = await retryFailedWebhooks()
+    logCronRun('retry-webhooks', 'ok', Date.now() - start).catch(console.error)
+    return c.json({ success: true, ...result })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'unknown'
+    logCronRun('retry-webhooks', 'error', Date.now() - start, msg).catch(console.error)
     return c.json({ error: msg }, 500)
   }
 })
@@ -377,11 +424,14 @@ cronRouter.get('/leak-detect-keys', async (c) => {
   const authFail = assertCronAuth(c.req.header('Authorization'))
   if (authFail) return c.json({ error: authFail }, 401)
 
+  const start = Date.now()
   try {
     const result = await runLeakDetectionJob()
+    logCronRun('leak-detect-keys', 'ok', Date.now() - start).catch(console.error)
     return c.json({ success: true, ...result })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
+    logCronRun('leak-detect-keys', 'error', Date.now() - start, msg).catch(console.error)
     return c.json({ error: msg }, 500)
   }
 })

--- a/apps/server/src/api/prompts.ts
+++ b/apps/server/src/api/prompts.ts
@@ -3,6 +3,7 @@ import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { requireRole } from '../middleware/requireRole.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { comparePromptVersions } from '../lib/prompt-compare.js'
+import { parsePositiveFloat } from '../lib/params.js'
 
 const requireEdit = requireRole('admin', 'editor')
 
@@ -87,8 +88,7 @@ promptsRouter.get('/', async (c) => {
 
   // Aggregate request metrics per prompt_version_id, then roll up per name.
   // sinceHours defaults to 24h; the UI passes the selected date range.
-  const sinceHoursRaw = Number(c.req.query('sinceHours'))
-  const sinceHours = Number.isFinite(sinceHoursRaw) && sinceHoursRaw > 0 ? sinceHoursRaw : 24
+  const sinceHours = parsePositiveFloat(c.req.query('sinceHours'), 24)
   const sinceIso = new Date(Date.now() - sinceHours * 3_600_000).toISOString()
   const allVersionIds = allRows.map((r) => r.id as string)
   const statsByName = new Map<string, PromptStats>()
@@ -192,9 +192,7 @@ promptsRouter.get('/:name/compare', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) return c.json({ error: 'Organization not found' }, 404)
   const name = c.req.param('name')
-  const sinceHoursRaw = Number(c.req.query('sinceHours'))
-  const sinceHours =
-    Number.isFinite(sinceHoursRaw) && sinceHoursRaw > 0 ? sinceHoursRaw : 24 * 30
+  const sinceHours = parsePositiveFloat(c.req.query('sinceHours'), 24 * 30)
 
   const metrics = await comparePromptVersions(orgId, name, { sinceHours })
   return c.json({ success: true, data: metrics, meta: { name, sinceHours } })
@@ -285,6 +283,59 @@ promptsRouter.post('/', requireEdit, async (c) => {
     .single()
 
   if (error || !data) return c.json({ error: 'Failed to create version' }, 500)
+  return c.json({ success: true, data }, 201)
+})
+
+// POST /:name/:version/rollback — create a new version copied from the target
+// "Rollback" is non-destructive: it creates a new version with the same
+// content and variables so version history stays intact.
+promptsRouter.post('/:name/:version/rollback', requireEdit, async (c) => {
+  const orgId = c.get('orgId')
+  const userId = c.get('userId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  const name = c.req.param('name')
+  const version = Number(c.req.param('version'))
+  if (!Number.isInteger(version) || version < 1) {
+    return c.json({ error: 'Invalid version' }, 400)
+  }
+
+  const { data: source, error: fetchErr } = await supabaseAdmin
+    .from('prompt_versions')
+    .select('content, variables, metadata, project_id')
+    .eq('organization_id', orgId)
+    .eq('name', name)
+    .eq('version', version)
+    .maybeSingle()
+
+  if (fetchErr || !source) return c.json({ error: 'Version not found' }, 404)
+
+  const { data: latest } = await supabaseAdmin
+    .from('prompt_versions')
+    .select('version')
+    .eq('organization_id', orgId)
+    .eq('name', name)
+    .order('version', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  const nextVersion = (latest?.version ?? 0) + 1
+
+  const { data, error } = await supabaseAdmin
+    .from('prompt_versions')
+    .insert({
+      organization_id: orgId,
+      project_id: source.project_id,
+      name,
+      version: nextVersion,
+      content: source.content,
+      variables: source.variables ?? [],
+      metadata: { ...(source.metadata as object ?? {}), rolledBackFrom: version },
+      created_by: userId,
+    })
+    .select('id, name, version, content, variables, metadata, project_id, created_at, created_by')
+    .single()
+
+  if (error || !data) return c.json({ error: 'Failed to create rollback version' }, 500)
   return c.json({ success: true, data }, 201)
 })
 

--- a/apps/server/src/api/recommendations.ts
+++ b/apps/server/src/api/recommendations.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { recommendModelSwaps } from '../lib/model-recommend.js'
 import { supabaseAdmin } from '../lib/db.js'
+import { parsePositiveFloat } from '../lib/params.js'
 
 /**
  * GET /api/v1/recommendations
@@ -28,11 +29,6 @@ export const recommendationsRouter = new Hono<JwtContext>()
 
 recommendationsRouter.use('*', authJwt)
 
-function parsePositive(raw: string | undefined, fallback: number): number {
-  if (!raw) return fallback
-  const n = Number(raw)
-  return Number.isFinite(n) && n > 0 ? n : fallback
-}
 
 // ── Shape returned by get_model_percentiles() ────────────────────────────────
 
@@ -52,8 +48,8 @@ recommendationsRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) return c.json({ error: 'Organization not found' }, 404)
 
-  const hours = parsePositive(c.req.query('hours'), 24 * 7)
-  const minSavingsUsd = parsePositive(c.req.query('minSavings'), 5)
+  const hours = parsePositiveFloat(c.req.query('hours'), 24 * 7)
+  const minSavingsUsd = parsePositiveFloat(c.req.query('minSavings'), 5)
 
   const recommendations = await recommendModelSwaps(orgId, { hours, minSavingsUsd })
   return c.json({
@@ -73,7 +69,7 @@ recommendationsRouter.get('/percentiles', async (c) => {
 
   const provider = c.req.query('provider')
   const model    = c.req.query('model')
-  const hours    = parsePositive(c.req.query('hours'), 24 * 7)
+  const hours    = parsePositiveFloat(c.req.query('hours'), 24 * 7)
 
   if (!provider || provider.length > 64) {
     return c.json({ error: 'provider is required (max 64 chars)' }, 400)

--- a/apps/server/src/api/requests.ts
+++ b/apps/server/src/api/requests.ts
@@ -6,6 +6,7 @@ import { getDecryptedProviderKeyById, getDecryptedProviderKey } from '../proxy/u
 import { calculateCost } from '../lib/cost.js'
 import { logRequestAsync } from '../lib/logger.js'
 import { fireAndForget } from '../lib/wait-until.js'
+import { parsePageLimit } from '../lib/params.js'
 
 export const requestsRouter = new Hono<JwtContext>()
 
@@ -22,9 +23,7 @@ requestsRouter.get('/', async (c) => {
   const model      = c.req.query('model')
   const from       = c.req.query('from')     // ISO date string
   const to         = c.req.query('to')
-  const page       = Math.max(1, parseInt(c.req.query('page') ?? '1', 10))
-  const limit      = Math.min(100, Math.max(1, parseInt(c.req.query('limit') ?? '50', 10)))
-  const offset     = (page - 1) * limit
+  const { page, limit, offset } = parsePageLimit(c.req.query('page'), c.req.query('limit'))
 
   // Optional new filter: provider_key_id ("show only requests that used this key")
   const providerKeyId    = c.req.query('providerKeyId')

--- a/apps/server/src/api/security.ts
+++ b/apps/server/src/api/security.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { supabaseAdmin } from '../lib/db.js'
+import { parseIntMin, parsePositiveInt } from '../lib/params.js'
 
 /**
  * Security endpoints:
@@ -16,19 +17,13 @@ export const securityRouter = new Hono<JwtContext>()
 
 securityRouter.use('*', authJwt)
 
-function parseIntSafe(raw: string | undefined, fallback: number, min = 1): number {
-  if (!raw) return fallback
-  const n = Number(raw)
-  return Number.isInteger(n) && n >= min ? n : fallback
-}
-
 // GET /api/v1/security/flagged?limit=50&offset=0
 securityRouter.get('/flagged', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) return c.json({ error: 'Organization not found' }, 404)
 
-  const limit = Math.min(parseIntSafe(c.req.query('limit'), 50), 200)
-  const offset = parseIntSafe(c.req.query('offset'), 0, 0)
+  const limit = Math.min(parsePositiveInt(c.req.query('limit'), 50), 200)
+  const offset = parseIntMin(c.req.query('offset'), 0, 0)
 
   const { data, error, count } = await supabaseAdmin
     .from('requests')
@@ -58,7 +53,7 @@ securityRouter.get('/summary', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) return c.json({ error: 'Organization not found' }, 404)
 
-  const hours = Math.min(parseIntSafe(c.req.query('hours'), 24), 720)
+  const hours = Math.min(parsePositiveInt(c.req.query('hours'), 24), 720)
 
   const { data, error } = await supabaseAdmin.rpc('security_summary', {
     p_org_id: orgId,

--- a/apps/server/src/api/stats.ts
+++ b/apps/server/src/api/stats.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { supabaseAdmin } from '../lib/db.js'
+import { parseClampedFloat } from '../lib/params.js'
 
 /**
  * Stats endpoints — SQL-aggregated server-side.
@@ -158,8 +159,7 @@ statsRouter.get('/models', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) return c.json({ error: 'Organization not found' }, 404)
 
-  const hoursRaw = Number(c.req.query('hours'))
-  const hours = Number.isFinite(hoursRaw) && hoursRaw > 0 ? Math.min(hoursRaw, 24 * 30) : 24
+  const hours = parseClampedFloat(c.req.query('hours'), 24, 0.001, 24 * 30)
   const projectId = c.req.query('projectId')
   const fromIso = new Date(Date.now() - hours * 3_600_000).toISOString()
 
@@ -335,8 +335,7 @@ statsRouter.get('/latency', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) return c.json({ error: 'Organization not found' }, 404)
 
-  const hoursRaw = Number(c.req.query('hours'))
-  const hours = Number.isFinite(hoursRaw) && hoursRaw > 0 ? Math.min(hoursRaw, 24 * 30) : 24
+  const hours = parseClampedFloat(c.req.query('hours'), 24, 0.001, 24 * 30)
   const sinceIso = new Date(Date.now() - hours * 3_600_000).toISOString()
 
   const { data, error } = await supabaseAdmin

--- a/apps/server/src/api/system.ts
+++ b/apps/server/src/api/system.ts
@@ -1,0 +1,48 @@
+import { Hono } from 'hono'
+import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { requireRole } from '../middleware/requireRole.js'
+import { supabaseAdmin } from '../lib/db.js'
+
+/**
+ * /api/v1/system — internal system monitoring endpoints.
+ * Admin-only; not part of the public API.
+ */
+
+export const systemRouter = new Hono<JwtContext>()
+
+systemRouter.use('*', authJwt)
+
+const requireAdmin = requireRole('admin')
+
+// GET /cron-runs — latest run per job name (last 90 days)
+systemRouter.get('/cron-runs', requireAdmin, async (c) => {
+  const { data, error } = await supabaseAdmin
+    .from('cron_job_runs')
+    .select('id, job_name, ran_at, status, duration_ms, error_message')
+    .order('ran_at', { ascending: false })
+    .limit(500)
+
+  if (error) return c.json({ error: 'Failed to fetch cron runs' }, 500)
+
+  // Collapse to latest run per job
+  const latestByJob = new Map<string, typeof data[0]>()
+  const recentByJob = new Map<string, typeof data>()
+
+  for (const row of data ?? []) {
+    if (!latestByJob.has(row.job_name)) latestByJob.set(row.job_name, row)
+    const list = recentByJob.get(row.job_name) ?? []
+    if (list.length < 5) list.push(row)
+    recentByJob.set(row.job_name, list)
+  }
+
+  const jobs = Array.from(latestByJob.entries()).map(([jobName, latest]) => ({
+    jobName,
+    lastRanAt: latest.ran_at,
+    lastStatus: latest.status,
+    lastDurationMs: latest.duration_ms,
+    lastErrorMessage: latest.error_message,
+    recentRuns: recentByJob.get(jobName) ?? [],
+  }))
+
+  return c.json({ success: true, data: jobs })
+})

--- a/apps/server/src/api/traces.ts
+++ b/apps/server/src/api/traces.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { computeCriticalPath } from '../lib/critical-path.js'
+import { parsePageLimit } from '../lib/params.js'
 
 export const tracesRouter = new Hono<JwtContext>()
 
@@ -17,9 +18,7 @@ tracesRouter.get('/', async (c) => {
   const status = c.req.query('status')
   const from = c.req.query('from')
   const to = c.req.query('to')
-  const page = Math.max(1, parseInt(c.req.query('page') ?? '1', 10))
-  const limit = Math.min(100, Math.max(1, parseInt(c.req.query('limit') ?? '50', 10)))
-  const offset = (page - 1) * limit
+  const { page, limit, offset } = parsePageLimit(c.req.query('page'), c.req.query('limit'))
 
   let query = supabaseAdmin
     .from('traces')

--- a/apps/server/src/api/users.ts
+++ b/apps/server/src/api/users.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { supabaseAdmin } from '../lib/db.js'
+import { parsePageLimit } from '../lib/params.js'
 
 export const usersRouter = new Hono<JwtContext>()
 
@@ -31,9 +32,7 @@ usersRouter.get('/', async (c) => {
   const to        = c.req.query('to') ?? null
   const sortBy    = c.req.query('sortBy') ?? 'cost'
   const sortDir   = c.req.query('sortDir') ?? 'desc'
-  const page      = Math.max(1, parseInt(c.req.query('page') ?? '1', 10))
-  const limit     = Math.min(100, Math.max(1, parseInt(c.req.query('limit') ?? '50', 10)))
-  const offset    = (page - 1) * limit
+  const { page, limit, offset } = parsePageLimit(c.req.query('page'), c.req.query('limit'))
 
   // Hand-rolled RPC — supabase-js doesn't expose GROUP BY in the table API.
   // The function lives in the migration we add below.

--- a/apps/server/src/api/webhooks.ts
+++ b/apps/server/src/api/webhooks.ts
@@ -3,6 +3,7 @@ import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { requireRole } from '../middleware/requireRole.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { randomHex } from '../lib/crypto.js'
+import { dispatchWebhookEvent } from '../lib/webhook-dispatch.js'
 
 export const webhooksRouter = new Hono<JwtContext>()
 webhooksRouter.use('*', authJwt)
@@ -166,74 +167,13 @@ webhooksRouter.post('/:id/test', requireEdit, async (c) => {
 
   if (fetchError || !webhook) return c.json({ error: 'Webhook not found' }, 404)
 
-  const payload = JSON.stringify({
-    event: 'test',
-    timestamp: new Date().toISOString(),
-    webhook_id: id,
-  })
-
-  // HMAC-SHA256 signature using Web Crypto API (Edge-compatible)
-  const encoder = new TextEncoder()
-  const keyMaterial = await crypto.subtle.importKey(
-    'raw',
-    encoder.encode(webhook.secret as string),
-    { name: 'HMAC', hash: 'SHA-256' },
-    false,
-    ['sign'],
+  await dispatchWebhookEvent(
+    { id: webhook.id as string, url: webhook.url as string, secret: webhook.secret as string },
+    'test',
+    {},
   )
-  const signatureBuffer = await crypto.subtle.sign(
-    'HMAC',
-    keyMaterial,
-    encoder.encode(payload),
-  )
-  const signature = Array.from(new Uint8Array(signatureBuffer))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('')
 
-  const startMs = Date.now()
-  let httpStatus: number | null = null
-  let errorMessage: string | null = null
-  let status: 'success' | 'failed' = 'failed'
-
-  try {
-    const res = await fetch(webhook.url as string, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Spanlens-Signature': `sha256=${signature}`,
-      },
-      body: payload,
-      signal: AbortSignal.timeout(10_000),
-    })
-    httpStatus = res.status
-    status = res.ok ? 'success' : 'failed'
-    if (!res.ok) {
-      errorMessage = `HTTP ${res.status}`
-    }
-  } catch (err) {
-    errorMessage = err instanceof Error ? err.message : 'Request failed'
-  }
-
-  const durationMs = Date.now() - startMs
-
-  // Record the delivery (fire-and-forget, non-blocking)
-  void Promise.resolve(
-    supabaseAdmin
-      .from('webhook_deliveries')
-      .insert({
-        webhook_id: id,
-        event_type: 'test',
-        status,
-        http_status: httpStatus,
-        error_message: errorMessage,
-        duration_ms: durationMs,
-      }),
-  ).catch(console.error)
-
-  return c.json({
-    success: true,
-    data: { status, http_status: httpStatus, error_message: errorMessage, duration_ms: durationMs },
-  })
+  return c.json({ success: true, data: { dispatched: true } })
 })
 
 // ── GET /api/v1/webhooks/:id/deliveries ─────────────────────────

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -42,6 +42,7 @@ import { exportsRouter }       from './api/exports.js'
 import { openapiRouter }       from './api/openapi.js'
 import { providerKeysRouter }  from './api/providerKeys.js'
 import { meRouter }            from './api/me.js'
+import { systemRouter }       from './api/system.js'
 
 export const app = new Hono()
 
@@ -128,5 +129,6 @@ app.route('/api/v1/me/profile',     userProfilesRouter)
 app.route('/api/v1/me',             meRouter)        // sl_live_* introspection (CLI), registered AFTER other /me/* prefixes
 app.route('/api/v1/webhooks',       webhooksRouter)
 app.route('/api/v1/exports',        exportsRouter)
+app.route('/api/v1/system',         systemRouter)
 
 export default app

--- a/apps/server/src/lib/cron-logger.ts
+++ b/apps/server/src/lib/cron-logger.ts
@@ -1,0 +1,39 @@
+import { supabaseAdmin } from './db.js'
+
+/**
+ * Record one cron job execution. Fire-and-forget — never throws.
+ * Caller measures elapsed time and passes it in.
+ */
+export async function logCronRun(
+  jobName: string,
+  status: 'ok' | 'error',
+  durationMs: number,
+  errorMessage?: string,
+): Promise<void> {
+  await supabaseAdmin.from('cron_job_runs').insert({
+    job_name: jobName,
+    status,
+    duration_ms: Math.round(durationMs),
+    error_message: errorMessage ?? null,
+  })
+}
+
+/**
+ * Wrap an async function so the result is logged to cron_job_runs.
+ * Returns the wrapped function's return value; never re-throws.
+ */
+export async function withCronLog<T>(
+  jobName: string,
+  fn: () => Promise<T>,
+): Promise<T | null> {
+  const start = Date.now()
+  try {
+    const result = await fn()
+    logCronRun(jobName, 'ok', Date.now() - start).catch(console.error)
+    return result
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    logCronRun(jobName, 'error', Date.now() - start, msg).catch(console.error)
+    return null
+  }
+}

--- a/apps/server/src/lib/params.ts
+++ b/apps/server/src/lib/params.ts
@@ -1,0 +1,56 @@
+/**
+ * Query-parameter parsing helpers.
+ * All functions accept `string | undefined` (the shape returned by
+ * `c.req.query()`) and return a validated number, falling back to a supplied
+ * default rather than throwing.
+ */
+
+/** Parse a positive float; returns fallback if missing, non-finite, or ≤ 0. */
+export function parsePositiveFloat(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? n : fallback
+}
+
+/** Parse a positive float clamped to [min, max]; returns fallback if invalid. */
+export function parseClampedFloat(
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (!raw) return fallback
+  const n = Number(raw)
+  if (!Number.isFinite(n)) return fallback
+  return Math.max(min, Math.min(max, n))
+}
+
+/** Parse a positive integer (≥ 1); returns fallback if missing or invalid. */
+export function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback
+  const n = Number(raw)
+  return Number.isInteger(n) && n >= 1 ? n : fallback
+}
+
+/** Parse an integer ≥ min; returns fallback if missing or invalid. */
+export function parseIntMin(raw: string | undefined, fallback: number, min: number): number {
+  if (!raw) return fallback
+  const n = Number(raw)
+  return Number.isInteger(n) && n >= min ? n : fallback
+}
+
+/**
+ * Parse the standard `page` + `limit` pagination params.
+ * Returns `{ page, limit, offset }` with page ≥ 1 and limit clamped to
+ * [1, maxLimit].
+ */
+export function parsePageLimit(
+  pageRaw: string | undefined,
+  limitRaw: string | undefined,
+  defaultLimit = 50,
+  maxLimit = 100,
+): { page: number; limit: number; offset: number } {
+  const page = Math.max(1, parseInt(pageRaw ?? '1', 10) || 1)
+  const limit = Math.min(maxLimit, Math.max(1, parseInt(limitRaw ?? String(defaultLimit), 10) || defaultLimit))
+  return { page, limit, offset: (page - 1) * limit }
+}

--- a/apps/server/src/lib/webhook-dispatch.ts
+++ b/apps/server/src/lib/webhook-dispatch.ts
@@ -1,0 +1,229 @@
+/**
+ * Webhook dispatch with HMAC-SHA256 signing and exponential-backoff retry
+ * tracking.
+ *
+ * Callers:
+ *   - webhooks.ts /test endpoint — manual test
+ *   - cron.ts /retry-webhooks    — automatic retry of failed deliveries
+ *   - future event emitters (logger, ingest) for request.created etc.
+ */
+
+import { supabaseAdmin } from './db.js'
+
+export interface WebhookRow {
+  id: string
+  url: string
+  secret: string
+}
+
+export interface DispatchResult {
+  ok: boolean
+  httpStatus: number | null
+  errorMessage: string | null
+  durationMs: number
+}
+
+/** Max delivery attempts before permanently marking as failed. */
+const MAX_ATTEMPTS = 5
+
+/**
+ * Computes the next retry delay in minutes using exponential back-off.
+ * attempt=1 → 1 min, 2 → 2 min, 3 → 4 min, 4 → 8 min.
+ */
+function nextRetryDelayMs(attempt: number): number {
+  return Math.pow(2, attempt - 1) * 60_000
+}
+
+/** Builds the HMAC-SHA256 signature for a payload string. */
+async function signPayload(payload: string, secret: string): Promise<string> {
+  const encoder = new TextEncoder()
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const signatureBuffer = await crypto.subtle.sign('HMAC', keyMaterial, encoder.encode(payload))
+  return Array.from(new Uint8Array(signatureBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/** Sends a single webhook attempt. Returns timing + result without writing to DB. */
+export async function sendWebhook(
+  url: string,
+  secret: string,
+  payloadObj: Record<string, unknown>,
+): Promise<DispatchResult & { payloadStr: string }> {
+  const payloadStr = JSON.stringify(payloadObj)
+  const signature = await signPayload(payloadStr, secret)
+
+  const startMs = Date.now()
+  let httpStatus: number | null = null
+  let errorMessage: string | null = null
+  let ok = false
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Spanlens-Signature': `sha256=${signature}`,
+      },
+      body: payloadStr,
+      signal: AbortSignal.timeout(10_000),
+    })
+    httpStatus = res.status
+    ok = res.ok
+    if (!res.ok) {
+      errorMessage = `HTTP ${res.status}`
+    }
+  } catch (err) {
+    errorMessage = err instanceof Error ? err.message : 'Request failed'
+  }
+
+  return { ok, httpStatus, errorMessage, durationMs: Date.now() - startMs, payloadStr }
+}
+
+/**
+ * Dispatches an event to a single webhook endpoint and writes a delivery record.
+ *
+ * On failure, sets `next_retry_at` for the first attempt so the retry cron
+ * can pick it up. Returns the created delivery row ID.
+ */
+export async function dispatchWebhookEvent(
+  webhook: WebhookRow,
+  eventType: string,
+  payloadObj: Record<string, unknown>,
+): Promise<string> {
+  const fullPayload = {
+    ...payloadObj,
+    event: eventType,
+    timestamp: new Date().toISOString(),
+    webhook_id: webhook.id,
+  }
+
+  const { ok, httpStatus, errorMessage, durationMs, payloadStr } = await sendWebhook(
+    webhook.url,
+    webhook.secret,
+    fullPayload,
+  )
+
+  const nextRetryAt = !ok
+    ? new Date(Date.now() + nextRetryDelayMs(1)).toISOString()
+    : null
+
+  const { data } = await supabaseAdmin
+    .from('webhook_deliveries')
+    .insert({
+      webhook_id: webhook.id,
+      event_type: eventType,
+      status: ok ? 'success' : 'failed',
+      http_status: httpStatus,
+      error_message: errorMessage,
+      duration_ms: durationMs,
+      payload: JSON.parse(payloadStr) as Record<string, unknown>,
+      attempt_count: 1,
+      next_retry_at: nextRetryAt,
+    })
+    .select('id')
+    .single()
+
+  return (data as { id: string } | null)?.id ?? ''
+}
+
+/**
+ * Retries all failed webhook deliveries whose `next_retry_at` is in the past.
+ * Deliveries that have reached MAX_ATTEMPTS are skipped (left as permanently failed).
+ *
+ * Called by the /cron/retry-webhooks endpoint.
+ */
+export async function retryFailedWebhooks(): Promise<{
+  retried: number
+  succeeded: number
+  failed: number
+  exhausted: number
+}> {
+  const now = new Date().toISOString()
+
+  // Fetch pending retries (past-due, still under attempt limit)
+  const { data: pending, error } = await supabaseAdmin
+    .from('webhook_deliveries')
+    .select('id, webhook_id, event_type, payload, attempt_count, webhooks(id, url, secret, is_active)')
+    .eq('status', 'failed')
+    .lte('next_retry_at', now)
+    .lt('attempt_count', MAX_ATTEMPTS)
+    .limit(50)
+
+  if (error || !pending) {
+    console.error('[retryFailedWebhooks] fetch error:', error?.message)
+    return { retried: 0, succeeded: 0, failed: 0, exhausted: 0 }
+  }
+
+  let succeeded = 0
+  let failed = 0
+
+  for (const delivery of pending as unknown as Array<{
+    id: string
+    webhook_id: string
+    event_type: string
+    payload: Record<string, unknown> | null
+    attempt_count: number
+    webhooks: { id: string; url: string; secret: string; is_active: boolean } | null
+  }>) {
+    const webhook = delivery.webhooks
+    if (!webhook?.is_active || !delivery.payload) {
+      // Mark exhausted if webhook was deleted/disabled or payload missing
+      await supabaseAdmin
+        .from('webhook_deliveries')
+        .update({ next_retry_at: null, attempt_count: MAX_ATTEMPTS })
+        .eq('id', delivery.id)
+      continue
+    }
+
+    const attempt = delivery.attempt_count + 1
+    const { ok, httpStatus, errorMessage, durationMs } = await sendWebhook(
+      webhook.url,
+      webhook.secret,
+      delivery.payload,
+    )
+
+    if (ok) {
+      await supabaseAdmin
+        .from('webhook_deliveries')
+        .update({
+          status: 'success',
+          http_status: httpStatus,
+          error_message: null,
+          duration_ms: durationMs,
+          attempt_count: attempt,
+          next_retry_at: null,
+        })
+        .eq('id', delivery.id)
+      succeeded++
+    } else {
+      const nextRetryAt = attempt >= MAX_ATTEMPTS
+        ? null
+        : new Date(Date.now() + nextRetryDelayMs(attempt)).toISOString()
+
+      await supabaseAdmin
+        .from('webhook_deliveries')
+        .update({
+          http_status: httpStatus,
+          error_message: errorMessage,
+          duration_ms: durationMs,
+          attempt_count: attempt,
+          next_retry_at: nextRetryAt,
+        })
+        .eq('id', delivery.id)
+      failed++
+    }
+  }
+
+  const exhausted = pending.filter(
+    (d) => (d as { attempt_count: number }).attempt_count + 1 >= MAX_ATTEMPTS && failed > 0
+  ).length
+
+  return { retried: pending.length, succeeded, failed, exhausted }
+}

--- a/apps/server/src/proxy/anthropic.ts
+++ b/apps/server/src/proxy/anthropic.ts
@@ -13,6 +13,7 @@ import { getDecryptedProviderKey, buildUpstreamHeaders, buildDownstreamHeaders, 
 import { logAnthropicStream } from './stream-logger.js'
 
 const ANTHROPIC_BASE = 'https://api.anthropic.com'
+const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '35000', 10)
 
 export const anthropicProxy = new Hono<ApiKeyContext>()
 
@@ -66,14 +67,21 @@ anthropicProxy.all('/*', async (c) => {
   const startMs = Date.now()
   const fetchBody = c.req.method !== 'GET' && c.req.method !== 'HEAD' ? reqBodyText : null
 
+  const upstreamAbort = new AbortController()
+  const upstreamTimer = setTimeout(() => upstreamAbort.abort(), UPSTREAM_TIMEOUT_MS)
   let upstreamRes: Response
   try {
-    upstreamRes = await fetch(upstreamUrl, { method: c.req.method, headers, body: fetchBody })
+    upstreamRes = await fetch(upstreamUrl, { method: c.req.method, headers, body: fetchBody, signal: upstreamAbort.signal })
   } catch (err) {
+    clearTimeout(upstreamTimer)
     const msg = err instanceof Error ? err.message : 'Unknown error'
+    if (err instanceof Error && err.name === 'AbortError') {
+      return c.json({ error: `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms` }, 504)
+    }
     console.error('[anthropic-proxy] upstream fetch error:', msg)
     return c.json({ error: `Upstream request failed: ${msg}` }, 502)
   }
+  clearTimeout(upstreamTimer)
   const latencyMs = Date.now() - startMs
   const proxyOverheadMs = startMs - handlerStartMs
 

--- a/apps/server/src/proxy/gemini.ts
+++ b/apps/server/src/proxy/gemini.ts
@@ -12,6 +12,7 @@ import { scanAll } from '../lib/security-scan.js'
 import { getDecryptedProviderKey, buildUpstreamHeaders, buildDownstreamHeaders, isBlockingEnabled } from './utils.js'
 
 const GEMINI_BASE = 'https://generativelanguage.googleapis.com'
+const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '35000', 10)
 
 export const geminiProxy = new Hono<ApiKeyContext>()
 
@@ -66,18 +67,26 @@ geminiProxy.all('/*', async (c) => {
 
   const startMs = Date.now()
   const fetchBody = c.req.method !== 'GET' && c.req.method !== 'HEAD' ? reqBodyText : null
+  const upstreamAbort = new AbortController()
+  const upstreamTimer = setTimeout(() => upstreamAbort.abort(), UPSTREAM_TIMEOUT_MS)
   let upstreamRes: Response
   try {
     upstreamRes = await fetch(originalUrl.toString(), {
       method: c.req.method,
       headers,
       body: fetchBody,
+      signal: upstreamAbort.signal,
     })
   } catch (err) {
+    clearTimeout(upstreamTimer)
     const msg = err instanceof Error ? err.message : 'Unknown error'
+    if (err instanceof Error && err.name === 'AbortError') {
+      return c.json({ error: `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms` }, 504)
+    }
     console.error('[gemini-proxy] upstream fetch error:', msg)
     return c.json({ error: `Upstream request failed: ${msg}` }, 502)
   }
+  clearTimeout(upstreamTimer)
   const latencyMs = Date.now() - startMs
   const proxyOverheadMs = startMs - handlerStartMs
 

--- a/apps/server/src/proxy/openai.ts
+++ b/apps/server/src/proxy/openai.ts
@@ -13,6 +13,7 @@ import { getDecryptedProviderKey, buildUpstreamHeaders, buildDownstreamHeaders, 
 import { logOpenAIStream } from './stream-logger.js'
 
 const OPENAI_BASE = 'https://api.openai.com'
+const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '35000', 10)
 
 export const openaiProxy = new Hono<ApiKeyContext>()
 
@@ -79,14 +80,21 @@ openaiProxy.all('/*', async (c) => {
       ? isStreaming && reqBodyJson ? JSON.stringify(reqBodyJson) : reqBodyText
       : null
 
+  const upstreamAbort = new AbortController()
+  const upstreamTimer = setTimeout(() => upstreamAbort.abort(), UPSTREAM_TIMEOUT_MS)
   let upstreamRes: Response
   try {
-    upstreamRes = await fetch(upstreamUrl, { method: c.req.method, headers, body: fetchBody })
+    upstreamRes = await fetch(upstreamUrl, { method: c.req.method, headers, body: fetchBody, signal: upstreamAbort.signal })
   } catch (err) {
+    clearTimeout(upstreamTimer)
     const msg = err instanceof Error ? err.message : 'Unknown error'
+    if (err instanceof Error && err.name === 'AbortError') {
+      return c.json({ error: `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms` }, 504)
+    }
     console.error('[openai-proxy] upstream fetch error:', msg)
     return c.json({ error: `Upstream request failed: ${msg}` }, 502)
   }
+  clearTimeout(upstreamTimer)
   const latencyMs = Date.now() - startMs
   // Pre-fetch overhead: auth + key decryption + body parsing (our cost, not provider's)
   const proxyOverheadMs = startMs - handlerStartMs

--- a/apps/web/app/(dashboard)/prompts/[name]/tabs/versions-tab.tsx
+++ b/apps/web/app/(dashboard)/prompts/[name]/tabs/versions-tab.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState } from 'react'
-import { Trash2, ChevronDown, ChevronUp } from 'lucide-react'
-import { useDeletePromptVersion, type PromptVersion } from '@/lib/queries/use-prompts'
+import { Trash2, ChevronDown, ChevronUp, RotateCcw } from 'lucide-react'
+import { useDeletePromptVersion, useRollbackPromptVersion, type PromptVersion } from '@/lib/queries/use-prompts'
 import { PermissionGate } from '@/components/permission-gate'
 
 interface Props {
@@ -12,8 +12,10 @@ interface Props {
 
 export function VersionsTab({ name, versions, isLoading }: Props) {
   const deleteMutation = useDeletePromptVersion()
+  const rollbackMutation = useRollbackPromptVersion()
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [deleting, setDeleting] = useState<string | null>(null)
+  const [rollingBack, setRollingBack] = useState<string | null>(null)
 
   function toggle(id: string) {
     setExpanded((prev) => {
@@ -34,6 +36,18 @@ export function VersionsTab({ name, versions, isLoading }: Props) {
       await deleteMutation.mutateAsync({ name, version })
     } finally {
       setDeleting(null)
+    }
+  }
+
+  async function handleRollback(version: number) {
+    const latestVersion = versions?.[0]?.version ?? version
+    if (version === latestVersion) return
+    if (!confirm(`Roll back to v${version}? A new version will be created with the same content.`)) return
+    setRollingBack(String(version))
+    try {
+      await rollbackMutation.mutateAsync({ name, version })
+    } finally {
+      setRollingBack(null)
     }
   }
 
@@ -121,15 +135,28 @@ export function VersionsTab({ name, versions, isLoading }: Props) {
                     )}
                   </div>
                   <PermissionGate need="edit">
-                    <button
-                      type="button"
-                      onClick={() => void handleDelete(v.version)}
-                      disabled={deleting === String(v.version)}
-                      className="flex items-center gap-1.5 font-mono text-[11px] px-[8px] py-[4px] rounded-[4px] border border-border text-bad hover:bg-bad/10 transition-colors disabled:opacity-40"
-                    >
-                      <Trash2 className="h-3 w-3" />
-                      {deleting === String(v.version) ? 'Deleting…' : 'Delete'}
-                    </button>
+                    <div className="flex items-center gap-2">
+                      {v.version !== versions?.[0]?.version && (
+                        <button
+                          type="button"
+                          onClick={() => void handleRollback(v.version)}
+                          disabled={rollingBack === String(v.version)}
+                          className="flex items-center gap-1.5 font-mono text-[11px] px-[8px] py-[4px] rounded-[4px] border border-border text-text-muted hover:bg-bg-elev transition-colors disabled:opacity-40"
+                        >
+                          <RotateCcw className="h-3 w-3" />
+                          {rollingBack === String(v.version) ? 'Rolling back…' : 'Roll back'}
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => void handleDelete(v.version)}
+                        disabled={deleting === String(v.version)}
+                        className="flex items-center gap-1.5 font-mono text-[11px] px-[8px] py-[4px] rounded-[4px] border border-border text-bad hover:bg-bad/10 transition-colors disabled:opacity-40"
+                      >
+                        <Trash2 className="h-3 w-3" />
+                        {deleting === String(v.version) ? 'Deleting…' : 'Delete'}
+                      </button>
+                    </div>
                   </PermissionGate>
                 </div>
               </div>

--- a/apps/web/app/(dashboard)/requests/requests-client.tsx
+++ b/apps/web/app/(dashboard)/requests/requests-client.tsx
@@ -1,6 +1,6 @@
 'use client'
-import { useEffect, useMemo, useState } from 'react'
-import { useSearchParams } from 'next/navigation'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useSearchParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { ExportDropdown } from '@/components/ui/export-dropdown'
 import { cn } from '@/lib/utils'
@@ -30,7 +30,6 @@ interface UiFilters {
   providerKeyId: string
 }
 
-const DEFAULT_FILTERS: UiFilters = { provider: 'all', status: 'all', model: '', providerKeyId: 'all' }
 
 function relAge(dateStr: string): string {
   const s = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000)
@@ -811,31 +810,57 @@ function RequestsTable({
 // ── Page ──────────────────────────────────────────────────────────────────────
 export function RequestsClient() {
   const searchParams = useSearchParams()
-  const [filters, setFilters] = useState<UiFilters>(() => {
-    // Support deep-linking from Anomalies / etc. — ?provider=openai&model=gpt-4o
-    const providerParam = searchParams.get('provider') ?? undefined
-    const modelParam = searchParams.get('model') ?? undefined
-    return {
-      ...DEFAULT_FILTERS,
-      ...(providerParam && { provider: providerParam }),
-      ...(modelParam && { model: modelParam }),
-    }
-  })
+  const router = useRouter()
+
+  // Derive filter state from URL — makes links shareable and browser back/forward work
+  const provider = searchParams.get('provider') ?? 'all'
+  const status = (searchParams.get('status') ?? 'all') as StatusFilter
+  const providerKeyId = searchParams.get('providerKeyId') ?? 'all'
+  const sortField = (searchParams.get('sortBy') ?? 'created_at') as SortField
+  const sortDir = (searchParams.get('sortDir') ?? 'desc') as SortDir
+  const timeRange = (searchParams.get('timeRange') ?? 'all') as TimeRange
+
+  // Reconstruct the UiFilters struct consumed by serverFilters / UI
+  const filters: UiFilters = useMemo(() => ({
+    provider,
+    status,
+    model: searchParams.get('model') ?? '',
+    providerKeyId,
+  }), [provider, status, providerKeyId, searchParams])
+
+  // model input stays local for debounce; synced to URL 300ms after last keystroke
   const [modelInput, setModelInput] = useState(() => searchParams.get('model') ?? '')
+  const [page, setPage] = useState(1)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [pendingNavigation, setPendingNavigation] = useState<'first' | 'last' | null>(null)
+
+  // Ref so the debounce effect always reads the latest searchParams without re-firing
+  const searchParamsRef = useRef(searchParams)
+  useEffect(() => { searchParamsRef.current = searchParams }, [searchParams])
+
+  // Merge updates into the current URL params and replace without scroll
+  function pushParams(updates: Record<string, string | null>) {
+    const params = new URLSearchParams(searchParamsRef.current.toString())
+    for (const [key, val] of Object.entries(updates)) {
+      if (val === null || val === '') params.delete(key)
+      else params.set(key, val)
+    }
+    router.replace(`/requests?${params.toString()}`, { scroll: false })
+  }
+
   useEffect(() => {
     const t = setTimeout(() => {
-      setFilters((f) => ({ ...f, model: modelInput.trim() }))
+      const params = new URLSearchParams(searchParamsRef.current.toString())
+      if (modelInput.trim()) params.set('model', modelInput.trim())
+      else params.delete('model')
+      router.replace(`/requests?${params.toString()}`, { scroll: false })
       setPage(1)
       setSelectedId(null)
     }, 300)
     return () => clearTimeout(t)
+  // router is stable; searchParamsRef is a ref — neither needs to be a dep
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modelInput])
-  const [page, setPage] = useState(1)
-  const [selectedId, setSelectedId] = useState<string | null>(null)
-  const [pendingNavigation, setPendingNavigation] = useState<'first' | 'last' | null>(null)
-  const [sortField, setSortField] = useState<SortField>('created_at')
-  const [sortDir, setSortDir] = useState<SortDir>('desc')
-  const [timeRange, setTimeRange] = useState<TimeRange>('all')
 
   const fromIso = useMemo(() => {
     const now = Date.now()
@@ -902,12 +927,11 @@ export function RequestsClient() {
     timeRange !== 'all'
 
   function handleSort(field: SortField) {
-    if (sortField === field) {
-      setSortDir((d) => (d === 'desc' ? 'asc' : 'desc'))
-    } else {
-      setSortField(field)
-      setSortDir('desc')
-    }
+    const newDir = sortField === field ? (sortDir === 'desc' ? 'asc' : 'desc') : 'desc'
+    pushParams({
+      sortBy: field === 'created_at' ? null : field,
+      sortDir: newDir === 'desc' ? null : newDir,
+    })
     setPage(1)
     setSelectedId(null)
   }
@@ -967,7 +991,7 @@ export function RequestsClient() {
           {(['all', 'today', '7d', '30d'] as TimeRange[]).map((r) => (
             <button
               key={r}
-              onClick={() => { setTimeRange(r); setPage(1); setSelectedId(null) }}
+              onClick={() => { pushParams({ timeRange: r === 'all' ? null : r }); setPage(1); setSelectedId(null) }}
               className={cn(
                 'px-[10px] py-[5px]',
                 timeRange === r ? 'bg-text text-bg' : 'text-text-muted hover:text-text transition-colors',
@@ -983,7 +1007,7 @@ export function RequestsClient() {
           {(['all', 'ok', '4xx', '5xx'] as StatusFilter[]).map((v) => (
             <button
               key={v}
-              onClick={() => { setFilters((f) => ({ ...f, status: v })); setPage(1); setSelectedId(null) }}
+              onClick={() => { pushParams({ status: v === 'all' ? null : v }); setPage(1); setSelectedId(null) }}
               className={cn(
                 'px-[10px] py-[5px] inline-flex items-center gap-1.5',
                 filters.status === v ? 'bg-text text-bg' : 'text-text-muted hover:text-text transition-colors',
@@ -1000,7 +1024,7 @@ export function RequestsClient() {
         {/* Provider select */}
         <select
           value={filters.provider}
-          onChange={(e) => { setFilters((f) => ({ ...f, provider: e.target.value, providerKeyId: 'all' })); setPage(1); setSelectedId(null) }}
+          onChange={(e) => { pushParams({ provider: e.target.value === 'all' ? null : e.target.value, providerKeyId: null }); setPage(1); setSelectedId(null) }}
           className="font-mono text-[11px] border border-border rounded-[5px] px-2 py-[5px] bg-bg text-text-muted hover:border-border-strong transition-colors focus:outline-none appearance-none cursor-pointer"
         >
           <option value="all">All providers</option>
@@ -1025,7 +1049,7 @@ export function RequestsClient() {
         {visibleKeys.length > 0 && (
           <select
             value={filters.providerKeyId}
-            onChange={(e) => { setFilters((f) => ({ ...f, providerKeyId: e.target.value })); setPage(1); setSelectedId(null) }}
+            onChange={(e) => { pushParams({ providerKeyId: e.target.value === 'all' ? null : e.target.value }); setPage(1); setSelectedId(null) }}
             className="font-mono text-[11px] border border-border rounded-[5px] px-2 py-[5px] bg-bg text-text-muted hover:border-border-strong transition-colors focus:outline-none appearance-none cursor-pointer max-w-[140px] truncate"
           >
             <option value="all">All keys</option>
@@ -1038,9 +1062,8 @@ export function RequestsClient() {
         {hasActiveFilters && (
           <button
             onClick={() => {
-              setFilters(DEFAULT_FILTERS)
               setModelInput('')
-              setTimeRange('all')
+              pushParams({ provider: null, status: null, model: null, providerKeyId: null, timeRange: null, sortBy: null, sortDir: null })
               setPage(1)
               setSelectedId(null)
             }}

--- a/apps/web/app/(dashboard)/settings/cron-jobs-panel.tsx
+++ b/apps/web/app/(dashboard)/settings/cron-jobs-panel.tsx
@@ -1,0 +1,108 @@
+'use client'
+import { useCronRuns, type CronJobSummary } from '@/lib/queries/use-system'
+
+// Known cron schedules for display (mirrors apps/server/vercel.json + cron.ts)
+const CRON_SCHEDULES: Record<string, string> = {
+  'evaluate-alerts':           '*/15 * * * *',
+  'snapshot-anomalies':        '0 1 * * *',
+  'stale-key-reminders':       '0 9 * * 1',
+  'leak-detect-keys':          '0 4 * * *',
+  'recommend-savings-alerts':  '0 9 * * *',
+  'aggregate-usage':           '0 * * * *',
+  'report-usage-overage':      '0 0 * * *',
+  'check-quota-warnings':      '0 * * * *',
+  'prune-logs':                '0 3 * * *',
+  'retry-webhooks':            '*/5 * * * *',
+}
+
+function relTime(iso: string): string {
+  const s = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
+  if (s < 60) return `${s}s ago`
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`
+  return `${Math.floor(s / 86400)}d ago`
+}
+
+function StatusDot({ status }: { status: 'ok' | 'error' }) {
+  return (
+    <span
+      className={`inline-block h-1.5 w-1.5 rounded-full ${
+        status === 'ok' ? 'bg-good' : 'bg-bad'
+      }`}
+    />
+  )
+}
+
+function JobRow({ job }: { job: CronJobSummary }) {
+  const schedule = CRON_SCHEDULES[job.jobName] ?? '—'
+
+  return (
+    <div className="flex items-center gap-3 px-[22px] py-[11px] border-b border-border last:border-0">
+      <StatusDot status={job.lastStatus} />
+      <span className="font-mono text-[12px] text-text flex-1 min-w-0 truncate">
+        {job.jobName}
+      </span>
+      <span className="font-mono text-[11px] text-text-faint shrink-0 hidden sm:block w-36">
+        {schedule}
+      </span>
+      <span
+        className="font-mono text-[11px] text-text-muted shrink-0 w-24 text-right"
+        title={new Date(job.lastRanAt).toLocaleString()}
+      >
+        {relTime(job.lastRanAt)}
+      </span>
+      <span className="font-mono text-[11px] text-text-faint shrink-0 w-16 text-right">
+        {job.lastDurationMs != null ? `${job.lastDurationMs}ms` : '—'}
+      </span>
+      {job.lastStatus === 'error' && job.lastErrorMessage && (
+        <span
+          className="font-mono text-[10px] text-bad truncate max-w-[200px]"
+          title={job.lastErrorMessage}
+        >
+          {job.lastErrorMessage}
+        </span>
+      )}
+    </div>
+  )
+}
+
+export function CronJobsPanel() {
+  const { data: jobs, isLoading } = useCronRuns()
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2 p-6">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="h-8 bg-bg-elev rounded animate-pulse" />
+        ))}
+      </div>
+    )
+  }
+
+  if (!jobs || jobs.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-48 gap-2 text-text-faint">
+        <p className="font-mono text-[13px]">No cron runs recorded yet.</p>
+        <p className="font-mono text-[11px]">Runs are logged after the first execution.</p>
+      </div>
+    )
+  }
+
+  const sorted = [...jobs].sort((a, b) => a.jobName.localeCompare(b.jobName))
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex items-center gap-3 px-[22px] py-[8px] border-b border-border bg-bg-elev">
+        <span className="w-3 shrink-0" />
+        <span className="font-mono text-[10px] uppercase tracking-[0.07em] text-text-faint flex-1">Job</span>
+        <span className="font-mono text-[10px] uppercase tracking-[0.07em] text-text-faint shrink-0 hidden sm:block w-36">Schedule</span>
+        <span className="font-mono text-[10px] uppercase tracking-[0.07em] text-text-faint shrink-0 w-24 text-right">Last run</span>
+        <span className="font-mono text-[10px] uppercase tracking-[0.07em] text-text-faint shrink-0 w-16 text-right">Duration</span>
+      </div>
+      {sorted.map((job) => (
+        <JobRow key={job.jobName} job={job} />
+      ))}
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -53,11 +53,12 @@ import {
 } from '@/lib/queries/use-webhooks'
 import type { WebhookEvent, WebhookRow } from '@/lib/queries/types'
 import { useNotificationChannels } from '@/lib/queries/use-alerts'
+import { CronJobsPanel } from './cron-jobs-panel'
 
 // ─── types ───────────────────────────────────────────────────────────────────
 
 type TabId =
-  | 'general' | 'members' | 'security' | 'audit-log'
+  | 'general' | 'members' | 'security' | 'audit-log' | 'system'
   | 'billing' | 'plan' | 'invoices'
   | 'profile' | 'notifications' | 'preferences'
   | 'integrations' | 'destinations' | 'webhooks' | 'opentelemetry'
@@ -74,6 +75,7 @@ const NAV: { group: string; items: NavItem[] }[] = [
       { id: 'members',    label: 'Members',    crumbs: [{ label: 'Workspace' }, { label: 'Settings' }, { label: 'Members' }] },
       { id: 'security',   label: 'Security',      crumbs: [{ label: 'Workspace' }, { label: 'Settings' }, { label: 'Security' }] },
       { id: 'audit-log',  label: 'Audit log',  crumbs: [{ label: 'Workspace' }, { label: 'Settings' }, { label: 'Audit log' }] },
+      { id: 'system',     label: 'System',     crumbs: [{ label: 'Workspace' }, { label: 'Settings' }, { label: 'System' }] },
     ],
   },
   {
@@ -637,6 +639,22 @@ function AuditLogTab() {
           </div>
         )}
       </Section>
+    </div>
+  )
+}
+
+// ─── SYSTEM tab ───────────────────────────────────────────────────────────────
+
+function SystemTab() {
+  return (
+    <div className="max-w-[980px]">
+      <TabHeader
+        title="System"
+        description="Cron job execution history. Runs are logged after each execution. Refreshes every 60s."
+      />
+      <div className="border border-border rounded-[8px] overflow-hidden">
+        <CronJobsPanel />
+      </div>
     </div>
   )
 }
@@ -1688,6 +1706,7 @@ function TabContent({ tab }: { tab: TabId }) {
     case 'members':       return <MembersTab />
     case 'security':      return <SecurityTab />
     case 'audit-log':     return <AuditLogTab />
+    case 'system':        return <SystemTab />
     case 'billing':       return <BillingTab />
     case 'plan':          return <PlanLimitsTab />
     case 'invoices':      return <InvoicesTab />

--- a/apps/web/lib/queries/use-prompts.ts
+++ b/apps/web/lib/queries/use-prompts.ts
@@ -190,6 +190,22 @@ export function useDeletePromptVersion() {
   })
 }
 
+export function useRollbackPromptVersion() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: { name: string; version: number }) => {
+      const res = await apiPost<ApiEnvelope<PromptVersion>>(
+        `/api/v1/prompts/${encodeURIComponent(input.name)}/${input.version}/rollback`,
+        {},
+      )
+      return res.data
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: promptsQueryKey })
+    },
+  })
+}
+
 // ── Experiment hooks ──────────────────────────────────────────────────────────
 
 export function usePromptExperiments(promptName?: string | null, status?: string) {

--- a/apps/web/lib/queries/use-system.ts
+++ b/apps/web/lib/queries/use-system.ts
@@ -1,0 +1,34 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { apiGet } from '@/lib/api'
+import type { ApiEnvelope } from './types'
+
+export interface CronJobRun {
+  id: string
+  job_name: string
+  ran_at: string
+  status: 'ok' | 'error'
+  duration_ms: number | null
+  error_message: string | null
+}
+
+export interface CronJobSummary {
+  jobName: string
+  lastRanAt: string
+  lastStatus: 'ok' | 'error'
+  lastDurationMs: number | null
+  lastErrorMessage: string | null
+  recentRuns: CronJobRun[]
+}
+
+export function useCronRuns() {
+  return useQuery({
+    queryKey: ['system', 'cron-runs'] as const,
+    queryFn: async () => {
+      const res = await apiGet<ApiEnvelope<CronJobSummary[]>>('/api/v1/system/cron-runs')
+      return res.data ?? []
+    },
+    refetchInterval: 60_000,
+  })
+}

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -28,6 +28,17 @@ export class SpanlensClient {
     return createTrace(this.transport, options.name, options.metadata)
   }
 
+  /**
+   * Waits for all in-flight ingest calls to settle.
+   * Call this before process exit to ensure no spans are dropped.
+   *
+   * @example
+   * process.on('beforeExit', () => client.flush())
+   */
+  async flush(): Promise<void> {
+    return this.transport.flush()
+  }
+
   /** Exposed for wrappers (openai/anthropic auto-instrumentation). */
   get _transport(): Transport {
     return this.transport

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -1,6 +1,10 @@
 /**
- * Lightweight fetch wrapper that never throws — observability SDKs must not
- * crash user code if the backend is unreachable or slow.
+ * Lightweight fetch wrapper for ingest calls.
+ *
+ * - Never throws (observability must not crash user code).
+ * - Retries transient failures (network error, 429, 5xx) with exponential
+ *   back-off up to MAX_RETRIES attempts.
+ * - Tracks in-flight requests so callers can await flush() before process exit.
  */
 
 import type { SpanlensConfig } from './types.js'
@@ -8,6 +12,19 @@ import type { SpanlensConfig } from './types.js'
 export interface Transport {
   post(path: string, body: unknown): Promise<unknown>
   patch(path: string, body: unknown): Promise<unknown>
+  /** Resolves when all in-flight ingest calls have settled. */
+  flush(): Promise<void>
+}
+
+const MAX_RETRIES = 3
+
+/** ms to wait before the nth retry: 200, 400, 800 */
+function retryDelayMs(attempt: number): number {
+  return 200 * Math.pow(2, attempt - 1)
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 export function createTransport(config: SpanlensConfig): Transport {
@@ -16,44 +33,82 @@ export function createTransport(config: SpanlensConfig): Transport {
   const silent = config.silent ?? true
   const onError = config.onError
 
-  async function call(method: 'POST' | 'PATCH', path: string, body: unknown): Promise<unknown> {
-    const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), timeoutMs)
+  // Set of Promises for all in-flight calls — used by flush().
+  const pending = new Set<Promise<unknown>>()
 
-    try {
-      const res = await fetch(`${baseUrl}${path}`, {
-        method,
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${config.apiKey}`,
-        },
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      })
+  async function callWithRetry(
+    method: 'POST' | 'PATCH',
+    path: string,
+    body: unknown,
+  ): Promise<unknown> {
+    let lastErr: unknown
 
-      if (!res.ok) {
-        const text = await res.text().catch(() => '')
-        const err = new Error(`[spanlens] ${method} ${path} failed: ${res.status} ${text.slice(0, 200)}`)
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+      try {
+        const res = await fetch(`${baseUrl}${path}`, {
+          method,
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${config.apiKey}`,
+          },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        })
+        clearTimeout(timer)
+
+        // 4xx = client error, don't retry
+        if (res.status >= 400 && res.status < 500) {
+          const text = await res.text().catch(() => '')
+          const err = new Error(`[spanlens] ${method} ${path} → ${res.status} ${text.slice(0, 200)}`)
+          onError?.(err, `${method} ${path}`)
+          if (!silent) throw err
+          return null
+        }
+
+        // 5xx / 429 — retryable
+        if (!res.ok) {
+          lastErr = new Error(`[spanlens] ${method} ${path} → ${res.status}`)
+          if (attempt < MAX_RETRIES) {
+            await sleep(retryDelayMs(attempt))
+            continue
+          }
+          onError?.(lastErr, `${method} ${path}`)
+          if (!silent) throw lastErr
+          return null
+        }
+
+        const text = await res.text()
+        if (!text) return null
+        try { return JSON.parse(text) } catch { return null }
+      } catch (err) {
+        clearTimeout(timer)
+        // AbortError (timeout) or network failure — retryable
+        lastErr = err
+        if (attempt < MAX_RETRIES) {
+          await sleep(retryDelayMs(attempt))
+          continue
+        }
         onError?.(err, `${method} ${path}`)
         if (!silent) throw err
         return null
       }
-
-      // PATCH responses may be empty/void — parse defensively
-      const text = await res.text()
-      if (!text) return null
-      try { return JSON.parse(text) } catch { return null }
-    } catch (err) {
-      onError?.(err, `${method} ${path}`)
-      if (!silent) throw err
-      return null
-    } finally {
-      clearTimeout(timer)
     }
+
+    return null
+  }
+
+  function tracked(promise: Promise<unknown>): Promise<unknown> {
+    pending.add(promise)
+    promise.finally(() => pending.delete(promise)).catch(() => { /* handled inside */ })
+    return promise
   }
 
   return {
-    post: (path, body) => call('POST', path, body),
-    patch: (path, body) => call('PATCH', path, body),
+    post: (path, body) => tracked(callWithRetry('POST', path, body)),
+    patch: (path, body) => tracked(callWithRetry('PATCH', path, body)),
+    flush: () => Promise.allSettled([...pending]).then(() => undefined),
   }
 }

--- a/supabase/migrations/20260515000000_webhook_retry.sql
+++ b/supabase/migrations/20260515000000_webhook_retry.sql
@@ -1,0 +1,20 @@
+-- Migration: webhook_retry
+--
+-- Adds columns needed to retry failed webhook deliveries with exponential
+-- back-off:
+--   payload        — stores the signed payload so the retry can re-send it
+--   attempt_count  — how many times delivery has been attempted
+--   next_retry_at  — when the next retry should run (NULL = done / succeeded)
+--
+-- The cron endpoint /cron/retry-webhooks queries on next_retry_at and
+-- re-dispatches deliveries that are past-due and have attempt_count < 5.
+
+ALTER TABLE webhook_deliveries
+  ADD COLUMN IF NOT EXISTS payload        JSONB,
+  ADD COLUMN IF NOT EXISTS attempt_count  INTEGER     NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS next_retry_at  TIMESTAMPTZ;
+
+-- Sparse index: only rows that are pending retry (failed + has a retry_at).
+CREATE INDEX IF NOT EXISTS webhook_deliveries_retry_idx
+  ON webhook_deliveries (next_retry_at)
+  WHERE next_retry_at IS NOT NULL AND status = 'failed';

--- a/supabase/migrations/20260515010000_cron_job_runs.sql
+++ b/supabase/migrations/20260515010000_cron_job_runs.sql
@@ -1,0 +1,24 @@
+-- Track cron job execution history for the Settings → System monitor.
+-- No org scoping — system-level table, accessed only via service_role.
+
+CREATE TABLE IF NOT EXISTS cron_job_runs (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_name     TEXT        NOT NULL,
+  ran_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  status       TEXT        NOT NULL CHECK (status IN ('ok', 'error')),
+  duration_ms  INTEGER,
+  error_message TEXT
+);
+
+ALTER TABLE cron_job_runs ENABLE ROW LEVEL SECURITY;
+-- Deny all direct client access; only supabaseAdmin (service_role) reads/writes.
+CREATE POLICY "deny_all" ON cron_job_runs USING (false);
+
+-- Index for the "latest run per job" query pattern
+CREATE INDEX IF NOT EXISTS cron_job_runs_job_name_ran_at_idx
+  ON cron_job_runs (job_name, ran_at DESC);
+
+-- Auto-prune: keep only the last 90 days of run history
+CREATE OR REPLACE FUNCTION prune_cron_job_runs() RETURNS void LANGUAGE sql AS $$
+  DELETE FROM cron_job_runs WHERE ran_at < now() - INTERVAL '90 days';
+$$;


### PR DESCRIPTION
## Summary

- **Proxy upstream timeout**: openai/anthropic/gemini에 AbortController 기반 35s 타임아웃 추가. 초과 시 504 반환 (환경변수 `UPSTREAM_TIMEOUT_MS`로 조정 가능)
- **Webhook retry**: `webhook_deliveries` 테이블에 `payload`/`attempt_count`/`next_retry_at` 컬럼 추가. `webhook-dispatch.ts`에서 HMAC-SHA256 서명 + 지수 백오프(1→2→4→8→16분) 재시도 최대 5회. `/cron/retry-webhooks` 엔드포인트
- **SDK flush + retry**: `transport.ts`에 5xx/429/네트워크 오류 3회 재시도(200/400/800ms) 추가. `client.flush()`로 프로세스 종료 전 in-flight 호출 대기
- **Prompt rollback**: `POST /:name/:version/rollback` 서버 엔드포인트. 비파괴적(새 버전 생성, 히스토리 보존). `useRollbackPromptVersion` 훅 + versions-tab Roll back 버튼 (PermissionGate로 editor 이상만 노출)
- **URL filter sync**: requests-client 필터값(provider/status/model/providerKeyId/sortBy/sortDir/timeRange)을 `router.replace`로 URL에 동기화. 링크 공유, 브라우저 뒤로가기 지원
- **Cron monitor**: `cron_job_runs` 테이블 + `logCronRun` 헬퍼로 모든 10개 크론 핸들러 계측. `GET /api/v1/system/cron-runs` (admin only). Settings → System 탭에 마지막 실행 상태/시간/소요시간 표시
- **Params util**: `lib/params.ts`에 `parsePositiveFloat` / `parseClampedFloat` / `parsePositiveInt` / `parseIntMin` / `parsePageLimit` 추출. 8개 파일의 중복 로컬 파서 제거

## Changed files

| 영역 | 파일 |
|------|------|
| Server proxy | `proxy/openai.ts`, `proxy/anthropic.ts`, `proxy/gemini.ts` |
| Server API | `api/prompts.ts`, `api/webhooks.ts`, `api/cron.ts`, `api/system.ts` (신규) |
| Server lib | `lib/webhook-dispatch.ts` (신규), `lib/cron-logger.ts` (신규), `lib/params.ts` (신규) |
| Server refactor | `api/anomalies.ts`, `api/auditLogs.ts`, `api/security.ts`, `api/recommendations.ts`, `api/stats.ts`, `api/requests.ts`, `api/traces.ts`, `api/users.ts` |
| Web | `requests/requests-client.tsx`, `prompts/[name]/tabs/versions-tab.tsx`, `settings/settings-client.tsx`, `settings/cron-jobs-panel.tsx` (신규) |
| Web queries | `lib/queries/use-prompts.ts`, `lib/queries/use-system.ts` (신규) |
| SDK | `packages/sdk/src/transport.ts`, `packages/sdk/src/client.ts` |
| Migrations | `20260515000000_webhook_retry.sql`, `20260515010000_cron_job_runs.sql` |

## Test plan

- [ ] proxy: LLM 호출을 35s 이상 걸리는 케이스에서 504 반환 확인
- [ ] webhook: 실패한 delivery에 `next_retry_at` 세팅 → `/cron/retry-webhooks` 재시도 확인
- [ ] SDK: `client.flush()` 호출 후 in-flight span이 DB에 기록되는지 확인
- [ ] prompt rollback: 버전 탭에서 Roll back 버튼 클릭 → 새 버전 생성, 원본 유지 확인
- [ ] URL filter: requests 페이지에서 필터 적용 후 URL 변경, 새로고침 시 필터 유지 확인
- [ ] cron monitor: Settings → System 탭에서 크론 실행 이력 표시 확인
- [ ] `supabase db push`로 2개 마이그레이션 적용 확인