### PR TITLE
feat(sdk): LangChain / Vercel AI SDK / LlamaIndex integrations

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @spanlens/sdk changelog
 
+## 0.3.0
+
+Framework callback integrations — trace LangChain, Vercel AI SDK, and LlamaIndex without touching the proxy URL.
+
+### Added
+
+- **`@spanlens/sdk/langchain`** — `createSpanlensCallbackHandler({ client, trace?, traceName? })`.
+  Returns a LangChain-compatible callback handler (duck-typed, no `@langchain/core` import). Pass to the `callbacks` option of any chain, LLM, or `RunnableConfig`. Captures `promptTokens`, `completionTokens`, `model_name` from `llmOutput`, handles concurrent runs by `runId`, and records error spans on `handleLLMError`.
+
+- **`@spanlens/sdk/vercel-ai`** — `createSpanlensTracker({ client, trace?, traceName?, modelName? })`.
+  Returns `{ onStepFinish, onFinish }` that spread directly into `generateText`, `streamText`, `generateObject`, and `streamObject` options. Auto-computes `totalTokens` when absent, records `finishReason` and multi-step count in span metadata.
+
+- **`@spanlens/sdk/llamaindex`** — `registerSpanlensCallbacks(Settings, { client, trace?, traceName? })`.
+  Hooks into `Settings.callbackManager` `llm-start` / `llm-end` events. Parses `raw.usage.input_tokens` / `output_tokens` from the LlamaIndex response. Returns an `unregister()` cleanup function.
+
+All three integrations:
+- Accept an optional `trace?: TraceHandle` — when provided, spans are attached to it and `trace.end()` is left to the caller. When omitted, a trace is auto-created and closed per LLM call.
+- Are fully duck-typed (no imports from the framework package) — compatible with any version.
+- Follow the SDK's fire-and-forget, silent-by-default contract.
+
+### Backward compatible
+
+All existing exports unchanged. The three new entry points are additive.
+
 ## 0.2.3
 
 Critical fix — long-running traces lost their spans on serverless runtimes.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -194,62 +194,100 @@ const res = await observeAnthropic(trace, 'reason', (headers) =>
 await trace.end()
 ```
 
-### LangChain (JS)
+### LangChain JS (v0.3.0+)
 
-LangChain calls go through the underlying OpenAI/Anthropic client — point that
-client at the Spanlens proxy and wrap the chain invocation in `observe()`:
+`@spanlens/sdk/langchain` ships a drop-in callback handler. Pass it to the
+`callbacks` option of any LangChain chain, LLM, or `RunnableConfig` — no
+proxy URL needed, no imports from `@langchain/core` required:
 
 ```ts
-import { ChatOpenAI } from '@langchain/openai'
-import { SpanlensClient, observe } from '@spanlens/sdk'
+import { SpanlensClient } from '@spanlens/sdk'
+import { createSpanlensCallbackHandler } from '@spanlens/sdk/langchain'
 
-const spanlens = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+const handler = createSpanlensCallbackHandler({ client })
 
-const llm = new ChatOpenAI({
-  apiKey: process.env.SPANLENS_API_KEY!,
-  configuration: {
-    baseURL: 'https://spanlens-server.vercel.app/proxy/openai/v1',
-  },
-})
+// Works with any chain, LLM, or tool
+const result = await chain.invoke({ input: 'Hello' }, { callbacks: [handler] })
+// → prompt/completion tokens, model name, latency automatically recorded
+```
 
-const trace = spanlens.startTrace({ name: 'langchain_qa' })
+Attach to an existing trace to nest spans under your workflow:
 
-// LangChain's internal fetch won't carry our trace headers, so we group
-// the whole chain under one span for dashboard visibility.
-const answer = await observe(trace, { name: 'chain.invoke', spanType: 'llm' }, async () => {
-  return llm.invoke('What is Spanlens?')
-})
+```ts
+const trace = client.startTrace({ name: 'my_workflow' })
+const handler = createSpanlensCallbackHandler({ client, trace })
+
+await chain.invoke({ input: '...' }, { callbacks: [handler] })
+await someOtherStep()
 
 await trace.end()
 ```
 
-### LlamaIndex (TS)
+### Vercel AI SDK (v0.3.0+)
+
+`@spanlens/sdk/vercel-ai` provides `createSpanlensTracker()` whose
+`onStepFinish` and `onFinish` callbacks spread directly into `generateText`,
+`streamText`, `generateObject`, and `streamObject` options:
 
 ```ts
-import { OpenAI, VectorStoreIndex, SimpleDirectoryReader } from 'llamaindex'
-import { SpanlensClient, observe } from '@spanlens/sdk'
+import { generateText } from 'ai'
+import { openai } from '@ai-sdk/openai'
+import { SpanlensClient } from '@spanlens/sdk'
+import { createSpanlensTracker } from '@spanlens/sdk/vercel-ai'
 
-const spanlens = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+const tracker = createSpanlensTracker({ client, modelName: 'gpt-4o' })
 
-const llm = new OpenAI({
-  apiKey: process.env.SPANLENS_API_KEY!,
-  additionalSessionOptions: {
-    baseURL: 'https://spanlens-server.vercel.app/proxy/openai/v1',
-  },
+const result = await generateText({
+  model: openai('gpt-4o'),
+  messages: [{ role: 'user', content: 'Hello!' }],
+  onStepFinish: tracker.onStepFinish,  // optional — captures multi-step tool calls
+  onFinish: tracker.onFinish,          // required  — records final usage
 })
+```
 
-const trace = spanlens.startTrace({ name: 'rag_query' })
+Attach to an existing trace:
 
-const retrieval = await observe(trace, { name: 'retrieve', spanType: 'retrieval' }, async () => {
-  const docs = await new SimpleDirectoryReader().loadData({ directoryPath: './docs' })
-  return VectorStoreIndex.fromDocuments(docs)
-})
+```ts
+const trace = client.startTrace({ name: 'ai_pipeline' })
+const tracker = createSpanlensTracker({ client, trace, modelName: 'gpt-4o' })
 
-const answer = await observe(trace, { name: 'generate', spanType: 'llm' }, async () => {
-  const engine = retrieval.asQueryEngine({ llm })
-  return engine.query({ query: 'What is Spanlens?' })
-})
+await generateText({ ..., onFinish: tracker.onFinish })
+await trace.end()
+```
 
+### LlamaIndex TS (v0.3.0+)
+
+`@spanlens/sdk/llamaindex` hooks directly into LlamaIndex's
+`Settings.callbackManager` — every LLM call is automatically traced:
+
+```ts
+import { Settings } from 'llamaindex'
+import { SpanlensClient } from '@spanlens/sdk'
+import { registerSpanlensCallbacks } from '@spanlens/sdk/llamaindex'
+
+const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+
+// Register once at app startup
+const unregister = registerSpanlensCallbacks(Settings, { client })
+
+// All subsequent LlamaIndex LLM calls are now traced automatically
+const response = await queryEngine.query({ query: 'What is Spanlens?' })
+
+// Clean up when done (e.g. in tests or on process exit)
+unregister()
+```
+
+Attach to an existing trace for RAG pipelines:
+
+```ts
+const trace = client.startTrace({ name: 'rag_query' })
+const unregister = registerSpanlensCallbacks(Settings, { client, trace })
+
+await queryEngine.query({ query: '...' })
+
+unregister()
 await trace.end()
 ```
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -48,18 +48,12 @@
   "peerDependencies": {
     "openai": ">=4.0.0",
     "@anthropic-ai/sdk": ">=0.24.0",
-    "@google/generative-ai": ">=0.20.0",
-    "@langchain/core": ">=0.2.0",
-    "ai": ">=4.0.0",
-    "llamaindex": ">=0.4.0"
+    "@google/generative-ai": ">=0.20.0"
   },
   "peerDependenciesMeta": {
     "openai": { "optional": true },
     "@anthropic-ai/sdk": { "optional": true },
-    "@google/generative-ai": { "optional": true },
-    "@langchain/core": { "optional": true },
-    "ai": { "optional": true },
-    "llamaindex": { "optional": true }
+    "@google/generative-ai": { "optional": true }
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.32.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -22,6 +22,18 @@
     "./gemini": {
       "import": "./dist/integrations/gemini.js",
       "types": "./dist/integrations/gemini.d.ts"
+    },
+    "./langchain": {
+      "import": "./dist/integrations/langchain.js",
+      "types": "./dist/integrations/langchain.d.ts"
+    },
+    "./vercel-ai": {
+      "import": "./dist/integrations/vercel-ai.js",
+      "types": "./dist/integrations/vercel-ai.d.ts"
+    },
+    "./llamaindex": {
+      "import": "./dist/integrations/llamaindex.js",
+      "types": "./dist/integrations/llamaindex.d.ts"
     }
   },
   "files": ["dist", "README.md", "CHANGELOG.md", "LICENSE"],
@@ -36,12 +48,18 @@
   "peerDependencies": {
     "openai": ">=4.0.0",
     "@anthropic-ai/sdk": ">=0.24.0",
-    "@google/generative-ai": ">=0.20.0"
+    "@google/generative-ai": ">=0.20.0",
+    "@langchain/core": ">=0.2.0",
+    "ai": ">=4.0.0",
+    "llamaindex": ">=0.4.0"
   },
   "peerDependenciesMeta": {
     "openai": { "optional": true },
     "@anthropic-ai/sdk": { "optional": true },
-    "@google/generative-ai": { "optional": true }
+    "@google/generative-ai": { "optional": true },
+    "@langchain/core": { "optional": true },
+    "ai": { "optional": true },
+    "llamaindex": { "optional": true }
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.32.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/__tests__/integrations-new.test.ts
+++ b/packages/sdk/src/__tests__/integrations-new.test.ts
@@ -245,7 +245,7 @@ describe('registerSpanlensCallbacks (LlamaIndex)', () => {
           )
         },
         emit(event: string, payload: unknown) {
-          listeners.get(event)?.forEach((h) => h(payload))
+          listeners.get(event)?.forEach((h) => h({ detail: payload }))
         },
         listenerCount(event: string) {
           return listeners.get(event)?.length ?? 0

--- a/packages/sdk/src/__tests__/integrations-new.test.ts
+++ b/packages/sdk/src/__tests__/integrations-new.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Tests for LangChain, Vercel AI, and LlamaIndex integrations.
+ *
+ * Mocks `fetch` at the global level (same pattern as client.test.ts) so we
+ * exercise the real transport and span/trace creation logic.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createSpanlensCallbackHandler } from '../integrations/langchain.js'
+import { createSpanlensTracker } from '../integrations/vercel-ai.js'
+import { registerSpanlensCallbacks } from '../integrations/llamaindex.js'
+import { SpanlensClient } from '../client.js'
+
+// ── Shared fetch mock setup ────────────────────────────────────────────────
+
+type FetchCall = { url: string; method: string; body: Record<string, unknown> }
+
+function stubFetch() {
+  const calls: FetchCall[] = []
+
+  const fetchMock = vi.fn().mockImplementation((url: string, init: RequestInit) => {
+    const body = init.body ? (JSON.parse(init.body as string) as Record<string, unknown>) : {}
+    calls.push({ url, method: init.method ?? 'GET', body })
+    return Promise.resolve(
+      new Response(JSON.stringify({ id: (url as string).split('/').at(-1) }), { status: 200 }),
+    )
+  })
+
+  vi.stubGlobal('fetch', fetchMock)
+
+  return {
+    calls,
+    posts: () => calls.filter((c) => c.method === 'POST'),
+    patches: () => calls.filter((c) => c.method === 'PATCH'),
+    spanPatches: () =>
+      calls.filter((c) => c.method === 'PATCH' && c.url.includes('/spans/')),
+    tracePatches: () =>
+      calls.filter(
+        (c) => c.method === 'PATCH' && c.url.includes('/traces/') && !c.url.includes('/spans'),
+      ),
+  }
+}
+
+function makeClient() {
+  return new SpanlensClient({ apiKey: 'sl_live_test', baseUrl: 'http://test' })
+}
+
+/** Wait for fire-and-forget promise chains to settle (same as client.test.ts pattern). */
+function tick(ms = 20): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+// ── LangChain ──────────────────────────────────────────────────────────────
+
+describe('createSpanlensCallbackHandler (LangChain)', () => {
+  it('creates a span on handleLLMStart and ends it on handleLLMEnd with token usage', async () => {
+    const { spanPatches } = stubFetch()
+    const client = makeClient()
+    const handler = createSpanlensCallbackHandler({ client })
+
+    handler.handleLLMStart({ id: ['ChatOpenAI'], name: 'ChatOpenAI' }, ['Hello'], 'run-1')
+    await handler.handleLLMEnd(
+      {
+        llmOutput: {
+          tokenUsage: { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+          model_name: 'gpt-4o',
+        },
+        generations: [[{ text: 'World' }]],
+      },
+      'run-1',
+    )
+
+    const patches = spanPatches()
+    expect(patches.length).toBeGreaterThanOrEqual(1)
+    const body = patches[0]?.body ?? {}
+    expect(body['prompt_tokens']).toBe(10)
+    expect(body['completion_tokens']).toBe(20)
+    expect(body['total_tokens']).toBe(30)
+    expect(body['status']).toBe('completed')
+    expect(body['output']).toBe('World')
+  })
+
+  it('ends span with error status on handleLLMError', async () => {
+    const { spanPatches } = stubFetch()
+    const client = makeClient()
+    const handler = createSpanlensCallbackHandler({ client })
+
+    handler.handleChatModelStart({ id: ['ChatAnthropic'] }, [['msg']], 'run-err')
+    await handler.handleLLMError(new Error('API timeout'), 'run-err')
+
+    const patches = spanPatches()
+    expect(patches.length).toBeGreaterThanOrEqual(1)
+    const body = patches[0]?.body ?? {}
+    expect(body['status']).toBe('error')
+    expect(String(body['error_message'])).toContain('API timeout')
+  })
+
+  it('ignores handleLLMEnd for unknown runId without throwing', async () => {
+    const { calls } = stubFetch()
+    const client = makeClient()
+    const handler = createSpanlensCallbackHandler({ client })
+
+    await expect(
+      handler.handleLLMEnd({ llmOutput: { tokenUsage: {} } }, 'unknown-run'),
+    ).resolves.toBeUndefined()
+
+    await tick()
+    expect(calls.filter((c) => c.method === 'PATCH')).toHaveLength(0)
+  })
+
+  it('does not end the outer trace when an external trace is provided', async () => {
+    const { tracePatches } = stubFetch()
+    const client = makeClient()
+    const trace = client.startTrace({ name: 'outer' })
+    const handler = createSpanlensCallbackHandler({ client, trace })
+
+    handler.handleLLMStart({ id: ['Model'] }, ['p'], 'run-2')
+    await handler.handleLLMEnd({}, 'run-2')
+
+    // Only 1 trace POST (the outer trace), 0 trace PATCHes (caller owns lifecycle)
+    expect(tracePatches()).toHaveLength(0)
+  })
+
+  it('handles concurrent runs independently by runId', async () => {
+    const { spanPatches } = stubFetch()
+    const client = makeClient()
+    const handler = createSpanlensCallbackHandler({ client })
+
+    handler.handleLLMStart({ id: ['ModelA'] }, ['p1'], 'run-a')
+    handler.handleLLMStart({ id: ['ModelB'] }, ['p2'], 'run-b')
+
+    await handler.handleLLMEnd(
+      { llmOutput: { tokenUsage: { promptTokens: 5, completionTokens: 5, totalTokens: 10 } } },
+      'run-a',
+    )
+    await handler.handleLLMEnd(
+      { llmOutput: { tokenUsage: { promptTokens: 8, completionTokens: 8, totalTokens: 16 } } },
+      'run-b',
+    )
+
+    expect(spanPatches()).toHaveLength(2)
+  })
+})
+
+// ── Vercel AI SDK ──────────────────────────────────────────────────────────
+
+describe('createSpanlensTracker (Vercel AI SDK)', () => {
+  it('creates a span immediately and ends it on onFinish with usage and model', async () => {
+    const { spanPatches, posts } = stubFetch()
+    const client = makeClient()
+    const tracker = createSpanlensTracker({ client, modelName: 'gpt-4o' })
+
+    await tracker.onFinish({
+      usage: { promptTokens: 15, completionTokens: 25, totalTokens: 40 },
+      finishReason: 'stop',
+      text: 'Hello!',
+      response: { modelId: 'gpt-4o-2024-11-20' },
+    })
+
+    // A span POST was made with the correct span name
+    const spanPost = posts().find((c) => c.url.includes('/spans'))
+    expect(spanPost?.body['name']).toBe('llm.gpt-4o')
+
+    const patches = spanPatches()
+    expect(patches.length).toBeGreaterThanOrEqual(1)
+    const body = patches[0]?.body ?? {}
+    expect(body['prompt_tokens']).toBe(15)
+    expect(body['completion_tokens']).toBe(25)
+    expect(body['total_tokens']).toBe(40)
+    expect(body['output']).toBe('Hello!')
+    expect(body['status']).toBe('completed')
+  })
+
+  it('records error status when finishReason is error', async () => {
+    const { spanPatches } = stubFetch()
+    const client = makeClient()
+    const tracker = createSpanlensTracker({ client })
+
+    await tracker.onFinish({ finishReason: 'error', usage: {} })
+
+    const body = spanPatches()[0]?.body ?? {}
+    expect(body['status']).toBe('error')
+  })
+
+  it('onStepFinish resolves without throwing', async () => {
+    stubFetch()
+    const client = makeClient()
+    const tracker = createSpanlensTracker({ client, modelName: 'claude-3-5-sonnet' })
+
+    await expect(tracker.onStepFinish({ stepType: 'initial' })).resolves.toBeUndefined()
+    await expect(tracker.onStepFinish({ stepType: 'tool-result' })).resolves.toBeUndefined()
+  })
+
+  it('does not call trace.end when an external trace is provided', async () => {
+    const { tracePatches } = stubFetch()
+    const client = makeClient()
+    const trace = client.startTrace({ name: 'pipeline' })
+    const tracker = createSpanlensTracker({ client, trace, modelName: 'gpt-4o-mini' })
+
+    await tracker.onFinish({ usage: { promptTokens: 1, completionTokens: 1 } })
+
+    expect(tracePatches()).toHaveLength(0)
+  })
+
+  it('computes totalTokens from promptTokens + completionTokens when missing', async () => {
+    const { spanPatches } = stubFetch()
+    const client = makeClient()
+    const tracker = createSpanlensTracker({ client })
+
+    await tracker.onFinish({
+      usage: { promptTokens: 5, completionTokens: 7 },  // no totalTokens
+    })
+
+    const body = spanPatches()[0]?.body ?? {}
+    expect(body['total_tokens']).toBe(12)
+  })
+})
+
+// ── LlamaIndex ─────────────────────────────────────────────────────────────
+
+describe('registerSpanlensCallbacks (LlamaIndex)', () => {
+  function createMockSettings() {
+    const listeners = new Map<string, Array<(payload: unknown) => void>>()
+    return {
+      callbackManager: {
+        on(event: string, handler: (payload: unknown) => void) {
+          const list = listeners.get(event) ?? []
+          list.push(handler)
+          listeners.set(event, list)
+        },
+        off(event: string, handler: (payload: unknown) => void) {
+          const list = listeners.get(event) ?? []
+          listeners.set(
+            event,
+            list.filter((h) => h !== handler),
+          )
+        },
+        emit(event: string, payload: unknown) {
+          listeners.get(event)?.forEach((h) => h(payload))
+        },
+        listenerCount(event: string) {
+          return listeners.get(event)?.length ?? 0
+        },
+      },
+    }
+  }
+
+  it('registers llm-start/llm-end hooks, records span with token usage', async () => {
+    const { spanPatches } = stubFetch()
+    const client = makeClient()
+    const settings = createMockSettings()
+
+    registerSpanlensCallbacks(settings, { client })
+
+    settings.callbackManager.emit('llm-start', {
+      id: 'call-1',
+      messages: [{ role: 'user', content: 'Hi' }],
+    })
+    settings.callbackManager.emit('llm-end', {
+      id: 'call-1',
+      response: {
+        raw: {
+          usage: { input_tokens: 5, output_tokens: 10 },
+          model: 'gpt-4o',
+        },
+        message: { role: 'assistant', content: 'Hello!' },
+      },
+    })
+
+    // Allow fire-and-forget promise chain to settle
+    await tick()
+
+    const patches = spanPatches()
+    expect(patches.length).toBeGreaterThanOrEqual(1)
+    const body = patches[0]?.body ?? {}
+    expect(body['prompt_tokens']).toBe(5)
+    expect(body['completion_tokens']).toBe(10)
+    expect(body['total_tokens']).toBe(15)
+    expect(body['status']).toBe('completed')
+  })
+
+  it('returns unregister function that removes both hooks', () => {
+    stubFetch()
+    const client = makeClient()
+    const settings = createMockSettings()
+
+    const unregister = registerSpanlensCallbacks(settings, { client })
+    expect(settings.callbackManager.listenerCount('llm-start')).toBe(1)
+    expect(settings.callbackManager.listenerCount('llm-end')).toBe(1)
+
+    unregister()
+    expect(settings.callbackManager.listenerCount('llm-start')).toBe(0)
+    expect(settings.callbackManager.listenerCount('llm-end')).toBe(0)
+  })
+
+  it('ignores llm-end for unknown call id without patching', async () => {
+    const { calls } = stubFetch()
+    const client = makeClient()
+    const settings = createMockSettings()
+
+    registerSpanlensCallbacks(settings, { client })
+    settings.callbackManager.emit('llm-end', {
+      id: 'ghost-id',
+      response: { raw: { usage: { input_tokens: 1 } } },
+    })
+
+    await tick()
+    expect(calls.filter((c) => c.method === 'PATCH')).toHaveLength(0)
+  })
+
+  it('does not end the outer trace when an external trace is provided', async () => {
+    const { tracePatches } = stubFetch()
+    const client = makeClient()
+    const settings = createMockSettings()
+
+    const trace = client.startTrace({ name: 'rag' })
+    registerSpanlensCallbacks(settings, { client, trace })
+
+    settings.callbackManager.emit('llm-start', { id: 'x', messages: [] })
+    settings.callbackManager.emit('llm-end', {
+      id: 'x',
+      response: { raw: { usage: { input_tokens: 3, output_tokens: 7 } } },
+    })
+
+    await tick()
+    expect(tracePatches()).toHaveLength(0)
+  })
+})

--- a/packages/sdk/src/integrations/langchain.ts
+++ b/packages/sdk/src/integrations/langchain.ts
@@ -1,0 +1,134 @@
+/**
+ * LangChain JS callback handler for Spanlens tracing.
+ *
+ * Records LLM spans (model, tokens, latency) from any LangChain chain or LLM.
+ * Designed as a duck-typed integration — no direct import from @langchain/core.
+ *
+ * @example
+ *   import { SpanlensClient } from '@spanlens/sdk'
+ *   import { createSpanlensCallbackHandler } from '@spanlens/sdk/langchain'
+ *
+ *   const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+ *   const handler = createSpanlensCallbackHandler({ client })
+ *
+ *   const result = await chain.invoke({ input }, { callbacks: [handler] })
+ *   // or: const res = await llm.invoke(prompt, { callbacks: [handler] })
+ */
+
+import { SpanlensClient } from '../client.js'
+import type { TraceHandle } from '../trace.js'
+import type { SpanHandle } from '../span.js'
+import type { EndSpanOptions } from '../types.js'
+
+export interface SpanlensLangChainOptions {
+  /** Spanlens client instance. */
+  client: SpanlensClient
+  /**
+   * Optional trace to attach LLM spans to.
+   * When provided, `trace.end()` is NOT called — the caller manages the lifecycle.
+   * When omitted, a new trace is created per LLM run and closed on completion.
+   */
+  trace?: TraceHandle
+  /** Name for auto-created traces. Default: 'langchain_run'. */
+  traceName?: string
+}
+
+/** Minimal LangChain Serialized shape — only fields we use. */
+interface LangChainSerialized {
+  id?: string[]
+  name?: string
+}
+
+interface LangChainTokenUsage {
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
+}
+
+interface LangChainLLMResult {
+  llmOutput?: {
+    tokenUsage?: LangChainTokenUsage
+    model_name?: string
+  }
+  generations?: ReadonlyArray<ReadonlyArray<{ text?: string }>>
+}
+
+function parseLangChainResult(result: LangChainLLMResult): EndSpanOptions {
+  const usage = result.llmOutput?.tokenUsage
+  if (!usage) return {}
+
+  const promptTokens = usage.promptTokens ?? 0
+  const completionTokens = usage.completionTokens ?? 0
+  const totalTokens = usage.totalTokens ?? promptTokens + completionTokens
+
+  const out: EndSpanOptions = { promptTokens, completionTokens, totalTokens }
+  const modelName = result.llmOutput?.model_name
+  if (modelName) out.metadata = { model: modelName }
+  return out
+}
+
+/**
+ * Returns a LangChain-compatible callback handler that records LLM spans to Spanlens.
+ *
+ * Pass the returned object to the `callbacks` option of any LangChain chain, LLM,
+ * or `RunnableConfig`. Concurrent runs are tracked by LangChain's `runId`.
+ */
+export function createSpanlensCallbackHandler(options: SpanlensLangChainOptions) {
+  const { client, traceName = 'langchain_run' } = options
+
+  const runs = new Map<
+    string,
+    { trace: TraceHandle; span: SpanHandle; isLocalTrace: boolean }
+  >()
+
+  function startRun(runId: string, llm: LangChainSerialized, input: unknown): void {
+    const spanName = `llm.${llm.id?.at(-1) ?? llm.name ?? 'call'}`
+    const isLocalTrace = options.trace === undefined
+    const trace = options.trace ?? client.startTrace({ name: traceName })
+    const span = trace.span({ name: spanName, spanType: 'llm', input })
+    runs.set(runId, { trace, span, isLocalTrace })
+  }
+
+  return {
+    name: 'SpanlensCallbackHandler' as const,
+
+    handleLLMStart(llm: LangChainSerialized, prompts: string[], runId: string): void {
+      startRun(runId, llm, prompts)
+    },
+
+    handleChatModelStart(
+      llm: LangChainSerialized,
+      messages: unknown[][],
+      runId: string,
+    ): void {
+      startRun(runId, llm, messages)
+    },
+
+    async handleLLMEnd(output: LangChainLLMResult, runId: string): Promise<void> {
+      const run = runs.get(runId)
+      if (!run) return
+      runs.delete(runId)
+
+      const parsed = parseLangChainResult(output)
+      const outputText = output.generations?.[0]?.[0]?.text
+
+      await run.span.end({
+        status: 'completed',
+        ...(outputText !== undefined ? { output: outputText } : {}),
+        ...parsed,
+      })
+
+      if (run.isLocalTrace) await run.trace.end({ status: 'completed' })
+    },
+
+    async handleLLMError(err: unknown, runId: string): Promise<void> {
+      const run = runs.get(runId)
+      if (!run) return
+      runs.delete(runId)
+
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      await run.span.end({ status: 'error', errorMessage })
+      if (run.isLocalTrace) await run.trace.end({ status: 'error', errorMessage })
+    },
+  }
+}

--- a/packages/sdk/src/integrations/llamaindex.ts
+++ b/packages/sdk/src/integrations/llamaindex.ts
@@ -1,0 +1,148 @@
+/**
+ * LlamaIndex TS integration for Spanlens tracing.
+ *
+ * Hooks into LlamaIndex's `Settings.callbackManager` to record LLM spans
+ * (model, tokens, latency) for every LLM call made through LlamaIndex.
+ * No direct import from 'llamaindex' — works as a duck-typed integration.
+ *
+ * @example
+ *   import { Settings } from 'llamaindex'
+ *   import { SpanlensClient } from '@spanlens/sdk'
+ *   import { registerSpanlensCallbacks } from '@spanlens/sdk/llamaindex'
+ *
+ *   const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+ *   const unregister = registerSpanlensCallbacks(Settings, { client })
+ *
+ *   // ... run your LlamaIndex queries ...
+ *
+ *   unregister() // remove callbacks when done (e.g. on process exit)
+ *
+ * @example Attach to an existing trace
+ *   const trace = client.startTrace({ name: 'rag_pipeline' })
+ *   const unregister = registerSpanlensCallbacks(Settings, { client, trace })
+ *   await queryEngine.query({ query: '...' })
+ *   unregister()
+ *   await trace.end()
+ */
+
+import { SpanlensClient } from '../client.js'
+import type { TraceHandle } from '../trace.js'
+import type { SpanHandle } from '../span.js'
+import type { EndSpanOptions } from '../types.js'
+
+export interface SpanlensLlamaIndexOptions {
+  /** Spanlens client instance. */
+  client: SpanlensClient
+  /**
+   * Optional trace to attach LLM spans to.
+   * When provided, `trace.end()` is NOT called — the caller manages the lifecycle.
+   * When omitted, a new trace is created per LLM call and closed on completion.
+   */
+  trace?: TraceHandle
+  /** Name for auto-created traces. Default: 'llamaindex_run'. */
+  traceName?: string
+}
+
+/** Minimal CallbackManager interface — only methods we use. */
+interface CallbackManager {
+  on(event: string, handler: (payload: unknown) => void): void
+  off(event: string, handler: (payload: unknown) => void): void
+}
+
+/** Minimal Settings shape — only callbackManager is required. */
+export interface LlamaIndexSettings {
+  callbackManager: CallbackManager
+}
+
+/** LlamaIndex `llm-start` event payload. */
+interface LLMStartPayload {
+  id: string
+  messages: unknown[]
+}
+
+/** LlamaIndex `llm-end` event payload. */
+interface LLMEndPayload {
+  id: string
+  response: {
+    raw?: {
+      usage?: {
+        input_tokens?: number
+        output_tokens?: number
+        total_tokens?: number
+      }
+      model?: string
+    }
+    message?: unknown
+  }
+}
+
+function parseLlamaIndexResult(response: LLMEndPayload['response']): EndSpanOptions {
+  const usage = response?.raw?.usage
+  if (!usage) return {}
+
+  const promptTokens = usage.input_tokens ?? 0
+  const completionTokens = usage.output_tokens ?? 0
+  const totalTokens = usage.total_tokens ?? promptTokens + completionTokens
+
+  const out: EndSpanOptions = { promptTokens, completionTokens, totalTokens }
+  const modelName = response?.raw?.model
+  if (modelName) out.metadata = { model: modelName }
+  return out
+}
+
+/**
+ * Registers Spanlens tracing callbacks on a LlamaIndex `CallbackManager`.
+ *
+ * Returns an `unregister` function — call it to remove the callbacks and
+ * release any pending run state (e.g. when cleaning up after a test or
+ * when the LlamaIndex query engine is disposed).
+ */
+export function registerSpanlensCallbacks(
+  settings: LlamaIndexSettings,
+  options: SpanlensLlamaIndexOptions,
+): () => void {
+  const { client, traceName = 'llamaindex_run' } = options
+
+  const runs = new Map<
+    string,
+    { trace: TraceHandle; span: SpanHandle; isLocalTrace: boolean }
+  >()
+
+  function onStart(payload: unknown): void {
+    const { id, messages } = payload as LLMStartPayload
+    const isLocalTrace = options.trace === undefined
+    const trace = options.trace ?? client.startTrace({ name: traceName })
+    const span = trace.span({ name: 'llm.call', spanType: 'llm', input: messages })
+    runs.set(id, { trace, span, isLocalTrace })
+  }
+
+  function onEnd(payload: unknown): void {
+    const { id, response } = payload as LLMEndPayload
+    const run = runs.get(id)
+    if (!run) return
+    runs.delete(id)
+
+    const parsed = parseLlamaIndexResult(response)
+
+    run.span
+      .end({
+        status: 'completed',
+        ...(response?.message !== undefined ? { output: response.message } : {}),
+        ...parsed,
+      })
+      .catch(() => undefined)
+
+    if (run.isLocalTrace) {
+      run.trace.end({ status: 'completed' }).catch(() => undefined)
+    }
+  }
+
+  settings.callbackManager.on('llm-start', onStart)
+  settings.callbackManager.on('llm-end', onEnd)
+
+  return function unregister(): void {
+    settings.callbackManager.off('llm-start', onStart)
+    settings.callbackManager.off('llm-end', onEnd)
+    runs.clear()
+  }
+}

--- a/packages/sdk/src/integrations/llamaindex.ts
+++ b/packages/sdk/src/integrations/llamaindex.ts
@@ -108,16 +108,16 @@ export function registerSpanlensCallbacks(
     { trace: TraceHandle; span: SpanHandle; isLocalTrace: boolean }
   >()
 
-  function onStart(payload: unknown): void {
-    const { id, messages } = payload as LLMStartPayload
+  function onStart(event: unknown): void {
+    const { id, messages } = (event as { detail: LLMStartPayload }).detail
     const isLocalTrace = options.trace === undefined
     const trace = options.trace ?? client.startTrace({ name: traceName })
     const span = trace.span({ name: 'llm.call', spanType: 'llm', input: messages })
     runs.set(id, { trace, span, isLocalTrace })
   }
 
-  function onEnd(payload: unknown): void {
-    const { id, response } = payload as LLMEndPayload
+  function onEnd(event: unknown): void {
+    const { id, response } = (event as { detail: LLMEndPayload }).detail
     const run = runs.get(id)
     if (!run) return
     runs.delete(id)

--- a/packages/sdk/src/integrations/vercel-ai.ts
+++ b/packages/sdk/src/integrations/vercel-ai.ts
@@ -1,0 +1,147 @@
+/**
+ * Vercel AI SDK integration for Spanlens tracing.
+ *
+ * Records LLM spans from `generateText`, `streamText`, `generateObject`, and
+ * `streamObject` via their `onFinish` / `onStepFinish` callbacks.
+ * No direct import from 'ai' — works as a duck-typed integration.
+ *
+ * @example Basic usage with generateText
+ *   import { SpanlensClient } from '@spanlens/sdk'
+ *   import { createSpanlensTracker } from '@spanlens/sdk/vercel-ai'
+ *
+ *   const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+ *   const tracker = createSpanlensTracker({ client, modelName: 'gpt-4o' })
+ *
+ *   const result = await generateText({
+ *     model: openai('gpt-4o'),
+ *     messages: [...],
+ *     onStepFinish: tracker.onStepFinish,
+ *     onFinish: tracker.onFinish,
+ *   })
+ *
+ * @example Attach to an existing trace
+ *   const trace = client.startTrace({ name: 'my_workflow' })
+ *   const tracker = createSpanlensTracker({ client, trace, modelName: 'gpt-4o' })
+ *   await generateText({ ..., onFinish: tracker.onFinish })
+ *   await trace.end()
+ */
+
+import { SpanlensClient } from '../client.js'
+import type { TraceHandle } from '../trace.js'
+
+export interface SpanlensVercelAIOptions {
+  /** Spanlens client instance. */
+  client: SpanlensClient
+  /**
+   * Optional trace to attach LLM spans to.
+   * When provided, `trace.end()` is NOT called — the caller manages the lifecycle.
+   * When omitted, a new trace is created and closed on `onFinish`.
+   */
+  trace?: TraceHandle
+  /** Name for auto-created traces. Default: 'ai.generate'. */
+  traceName?: string
+  /**
+   * Model name label for the span (e.g. 'gpt-4o', 'claude-3-5-sonnet').
+   * Used to name the span; the actual modelId from the response overrides
+   * `metadata.model` if available.
+   */
+  modelName?: string
+}
+
+/** Token usage shape from Vercel AI SDK `onFinish` / `onStepFinish` events. */
+export interface VercelAIUsage {
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
+}
+
+/** Shape of the `onStepFinish` event from `generateText` / `streamText`. */
+export interface VercelAIStepFinishEvent {
+  usage?: VercelAIUsage
+  finishReason?: string
+  text?: string
+  stepType?: string
+  isContinued?: boolean
+  response?: {
+    id?: string
+    modelId?: string
+    model?: string
+  }
+}
+
+/** Shape of the `onFinish` event from `generateText` / `streamText`. */
+export interface VercelAIFinishEvent {
+  usage?: VercelAIUsage
+  finishReason?: string
+  text?: string
+  response?: {
+    id?: string
+    modelId?: string
+    model?: string
+  }
+}
+
+export interface SpanlensVercelAITracker {
+  /** Pass to `onStepFinish` — records intermediate steps for multi-tool runs. */
+  onStepFinish: (event: VercelAIStepFinishEvent) => Promise<void>
+  /** Pass to `onFinish` — closes the span with final total usage. */
+  onFinish: (event: VercelAIFinishEvent) => Promise<void>
+}
+
+/**
+ * Creates a tracker object whose `onStepFinish` and `onFinish` methods can be
+ * spread directly into `generateText` / `streamText` options.
+ *
+ * A new LLM span is started immediately (so latency is measured from the
+ * moment the AI call begins). The span is closed when `onFinish` fires.
+ */
+export function createSpanlensTracker(
+  options: SpanlensVercelAIOptions,
+): SpanlensVercelAITracker {
+  const { client, traceName = 'ai.generate', modelName } = options
+
+  const isLocalTrace = options.trace === undefined
+  const trace = options.trace ?? client.startTrace({ name: traceName })
+  const span = trace.span({
+    name: modelName ? `llm.${modelName}` : 'llm.call',
+    spanType: 'llm',
+  })
+
+  let stepCount = 0
+
+  return {
+    async onStepFinish(_event: VercelAIStepFinishEvent): Promise<void> {
+      stepCount++
+      // Step-level detail is recorded as metadata on the final span.
+      // Individual steps are not broken out into child spans to keep the
+      // trace tree simple for the common case.
+    },
+
+    async onFinish(event: VercelAIFinishEvent): Promise<void> {
+      const { usage, finishReason, text, response } = event
+      const resolvedModel =
+        response?.modelId ?? response?.model ?? modelName ?? 'unknown'
+      const isError = finishReason === 'error'
+
+      const promptTokens = usage?.promptTokens ?? 0
+      const completionTokens = usage?.completionTokens ?? 0
+      const totalTokens =
+        usage?.totalTokens ?? promptTokens + completionTokens
+
+      await span.end({
+        status: isError ? 'error' : 'completed',
+        ...(text !== undefined ? { output: text } : {}),
+        ...(usage ? { promptTokens, completionTokens, totalTokens } : {}),
+        metadata: {
+          model: resolvedModel,
+          ...(finishReason ? { finishReason } : {}),
+          ...(stepCount > 1 ? { steps: stepCount } : {}),
+        },
+      })
+
+      if (isLocalTrace) {
+        await trace.end({ status: isError ? 'error' : 'completed' })
+      }
+    },
+  }
+}

--- a/packages/sdk/src/integrations/vercel-ai.ts
+++ b/packages/sdk/src/integrations/vercel-ai.ts
@@ -48,10 +48,16 @@ export interface SpanlensVercelAIOptions {
   modelName?: string
 }
 
-/** Token usage shape from Vercel AI SDK `onFinish` / `onStepFinish` events. */
+/**
+ * Token usage shape from Vercel AI SDK `onFinish` / `onStepFinish` events.
+ * AI SDK 4.x uses promptTokens/completionTokens; AI SDK 5.x uses inputTokens/outputTokens.
+ * Both are accepted.
+ */
 export interface VercelAIUsage {
-  promptTokens?: number
+  promptTokens?: number    // AI SDK 4.x
   completionTokens?: number
+  inputTokens?: number     // AI SDK 5.x
+  outputTokens?: number
   totalTokens?: number
 }
 
@@ -123,8 +129,8 @@ export function createSpanlensTracker(
         response?.modelId ?? response?.model ?? modelName ?? 'unknown'
       const isError = finishReason === 'error'
 
-      const promptTokens = usage?.promptTokens ?? 0
-      const completionTokens = usage?.completionTokens ?? 0
+      const promptTokens = usage?.promptTokens ?? usage?.inputTokens ?? 0
+      const completionTokens = usage?.completionTokens ?? usage?.outputTokens ?? 0
       const totalTokens =
         usage?.totalTokens ?? promptTokens + completionTokens
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,13 +110,13 @@ importers:
         version: 1.1.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       geist:
         specifier: ^1.7.0
-        version: 1.7.0(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 1.7.0(next@14.2.35(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       lucide-react:
         specifier: ^0.446.0
         version: 0.446.0(react@18.3.1)
       next:
         specifier: 14.2.35
-        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -697,6 +697,10 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@paddle/paddle-js@1.6.2':
     resolution: {integrity: sha512-nx1NXCzwWUWjf0iaRDiXZlfWgFjNZ6996RFcTDk0G0ggzrh514Zsc6jGTPOUGdLB1sYJXVQiKKoNLoKoXhH+sA==}
@@ -3806,6 +3810,9 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@opentelemetry/api@1.9.1':
+    optional: true
+
   '@paddle/paddle-js@1.6.2': {}
 
   '@pkgjs/parseargs@0.11.0':
@@ -5469,9 +5476,9 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  geist@1.7.0(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  geist@1.7.0(next@14.2.35(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
-      next: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.35(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   generator-function@2.0.1: {}
 
@@ -5868,7 +5875,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.35(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -5889,6 +5896,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.33
       '@next/swc-win32-ia32-msvc': 14.2.33
       '@next/swc-win32-x64-msvc': 14.2.33
+      '@opentelemetry/api': 1.9.1
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros


### PR DESCRIPTION
## Summary

- **`@spanlens/sdk/langchain`** — `createSpanlensCallbackHandler()`: duck-typed LangChain callback handler. Captures `handleLLMStart` / `handleChatModelStart` → start span, `handleLLMEnd` → end span with `promptTokens`, `completionTokens`, `model_name`. Tracks concurrent runs by LangChain `runId`.

- **`@spanlens/sdk/vercel-ai`** — `createSpanlensTracker()`: returns `{ onStepFinish, onFinish }` that spreads directly into `generateText` / `streamText` options. Auto-computes `totalTokens` when absent, records `finishReason` + multi-step count in metadata.

- **`@spanlens/sdk/llamaindex`** — `registerSpanlensCallbacks(Settings, opts)`: hooks into LlamaIndex `Settings.callbackManager` `llm-start` / `llm-end` events. Returns `unregister()` cleanup function. Parses `raw.usage.input_tokens` / `output_tokens` from the LlamaIndex response payload.

**All three integrations:**
- Require no import from the framework package (duck-typed interfaces) — zero new hard dependencies
- Listed as optional `peerDependencies` (`@langchain/core >=0.2.0`, `ai >=4.0.0`, `llamaindex >=0.4.0`)
- Accept optional `trace?: TraceHandle` (caller-managed lifecycle) or auto-create/close a trace per LLM call
- Follow the SDK's fire-and-forget + silent-by-default contract
- Exported via new `package.json` entries: `@spanlens/sdk/langchain`, `@spanlens/sdk/vercel-ai`, `@spanlens/sdk/llamaindex`

## Test plan

- [x] 14 new unit tests in `integrations-new.test.ts` (78 total pass, 0 fail)
- [x] Covers: token capture, error status, concurrent runs, external trace lifecycle, unregister
- [x] `pnpm --filter sdk typecheck` passes (strict + exactOptionalPropertyTypes)
- [x] `pnpm --filter sdk build` produces all 6 `.js` + `.d.ts` in `dist/integrations/`
- [x] Full monorepo `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)