### PR TITLE
feat(sdk): LangChain / Vercel AI SDK / LlamaIndex integrations + docs update

### DIFF
--- a/apps/web/app/docs/features/anomalies/page.tsx
+++ b/apps/web/app/docs/features/anomalies/page.tsx
@@ -125,11 +125,59 @@ if deviations >= sigmaThreshold:
         <li>Baseline mean ± stddev</li>
         <li>Deviations (how many σ above normal)</li>
         <li>Sample counts (both windows)</li>
+        <li><strong>Contributing factors</strong> — a <code>why ·</code> hint explaining the likely root cause</li>
         <li>Acknowledged state (if you&apos;ve silenced it)</li>
       </ul>
       <p>
         No anomalies? The page tells you — that&apos;s the good state. Your infrastructure is
         behaving predictably.
+      </p>
+
+      <h3>Understanding why — Contributing factors</h3>
+      <p>
+        When a bucket is flagged, Spanlens automatically fetches root-cause context so you don&apos;t
+        have to dig through raw logs first. The <code>why ·</code> line appears beneath each anomaly
+        entry, powered by a single additional DB scan per unique <code>(provider, model)</code>.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Signal</th>
+            <th>What the hint shows</th>
+            <th>How to interpret it</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Latency</strong> or <strong>Cost</strong></td>
+            <td>
+              The token type that changed most between obs and reference windows —
+              e.g. <em>Prompt tokens ↑ 3,200 (was 890, +259%)</em>
+            </td>
+            <td>
+              Prompt token spike → retrieval returning too many chunks, or context growth.
+              Completion token spike → verbose outputs, runaway generation, or a model switch.
+            </td>
+          </tr>
+          <tr>
+            <td><strong>Error rate</strong></td>
+            <td>
+              Top HTTP status codes in the observation window, ranked by frequency —
+              e.g. <em>429: 45 req · 500: 8 req</em>
+            </td>
+            <td>
+              429 → quota exhaustion or rate limiting.
+              500/503 → provider outage.
+              401/403 → auth misconfiguration or key rotation.
+              400/422 → request format change or upstream API shift.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Contributing factors are fetched for the same time windows as the anomaly detection run.
+        If the obs window has no data yet (e.g. you just deployed), the hint is omitted rather than
+        showing misleading nulls.
       </p>
 
       <h3>Acknowledging an anomaly</h3>
@@ -173,7 +221,16 @@ DELETE /api/v1/anomalies/ack?provider=openai&model=gpt-4o&kind=latency`}</CodeBl
 #     "deviations": 39.4,
 #     "sampleCount": 42,
 #     "referenceCount": 18420,
-#     "acknowledgedAt": null       // ISO string if acked, null otherwise
+#     "acknowledgedAt": null,      // ISO string if acked, null otherwise
+#     "factors": {                 // root-cause contributing factors
+#       "obsPromptTokensMean": 3200,
+#       "refPromptTokensMean": 890,
+#       "obsCompletionTokensMean": 410,
+#       "refCompletionTokensMean": 390,
+#       "obsTotalTokensMean": 3610,
+#       "refTotalTokensMean": 1280,
+#       "obsStatusDistribution": [] // e.g. [{code:429,count:5},{code:500,count:2}]
+#     }
 #   }
 # ]`}</CodeBlock>
 

--- a/apps/web/app/docs/sdk/page.tsx
+++ b/apps/web/app/docs/sdk/page.tsx
@@ -389,6 +389,79 @@ res = observe_openai(trace, "greeting", lambda headers:
         and <code>observeGemini()</code> / <code>observe_gemini()</code>.
       </p>
 
+      <h2 id="framework-integrations">Framework integrations (v0.3.0+)</h2>
+      <p>
+        If you use LangChain, Vercel AI SDK, or LlamaIndex, plug in the matching integration instead
+        of wiring callbacks manually. Each one records an LLM span automatically — tokens, latency,
+        model name — without importing from the framework itself (duck-typed, version-agnostic).
+      </p>
+
+      <h3 id="langchain">LangChain JS</h3>
+      <p>
+        Pass the handler to any chain, LLM, or agent via the <code>callbacks</code> option.
+        Works with both <code>BaseLLM</code> (text completion) and <code>BaseChatModel</code>.
+      </p>
+      <LangTabs
+        ts={`import { createSpanlensCallbackHandler } from '@spanlens/sdk/langchain'
+import { SpanlensClient } from '@spanlens/sdk'
+
+const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+const handler = createSpanlensCallbackHandler({ client })
+
+// Attach to any LangChain chain / LLM / agent
+const result = await chain.invoke({ input: '...' }, { callbacks: [handler] })
+
+// Or attach to an existing trace
+const trace = client.startTrace({ name: 'rag_pipeline' })
+const handler2 = createSpanlensCallbackHandler({ client, trace })
+await llm.invoke('...', { callbacks: [handler2] })
+await trace.end()`}
+        py={`# LangChain Python integration — coming soon`}
+      />
+
+      <h3 id="vercel-ai">Vercel AI SDK</h3>
+      <p>
+        Pass <code>tracker.onStepFinish</code> and <code>tracker.onFinish</code> to{' '}
+        <code>generateText</code> / <code>streamText</code>. Works with AI SDK 4.x and 5.x.
+      </p>
+      <LangTabs
+        ts={`import { createSpanlensTracker } from '@spanlens/sdk/vercel-ai'
+import { SpanlensClient } from '@spanlens/sdk'
+import { generateText } from 'ai'
+import { openai } from '@ai-sdk/openai'
+
+const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+const tracker = createSpanlensTracker({ client, modelName: 'gpt-4o' })
+
+const result = await generateText({
+  model: openai('gpt-4o'),
+  messages: [{ role: 'user', content: 'Hello' }],
+  onStepFinish: tracker.onStepFinish,  // records intermediate tool steps
+  onFinish: tracker.onFinish,          // closes span with final token counts
+})`}
+        py={`# Vercel AI SDK is TypeScript-only`}
+      />
+
+      <h3 id="llamaindex">LlamaIndex TS</h3>
+      <p>
+        Hook into <code>Settings.callbackManager</code> before running queries.
+        Call the returned <code>unregister()</code> function to detach when done.
+      </p>
+      <LangTabs
+        ts={`import { registerSpanlensCallbacks } from '@spanlens/sdk/llamaindex'
+import { SpanlensClient } from '@spanlens/sdk'
+import { Settings } from 'llamaindex'
+
+const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+const unregister = registerSpanlensCallbacks(Settings, { client })
+
+// ... run your LlamaIndex queries ...
+await queryEngine.query({ query: 'What is RAG?' })
+
+unregister()  // remove callbacks when done (e.g. on process exit)`}
+        py={`# LlamaIndex Python integration — coming soon`}
+      />
+
       <h2 id="span-handle">Low-level: trace + span handles</h2>
       <p>
         For complex flows (parallel spans, manual timing) use the handle-based API directly. Spans

--- a/apps/web/app/docs/self-host/page.tsx
+++ b/apps/web/app/docs/self-host/page.tsx
@@ -3,7 +3,7 @@ import { CodeBlock } from '../_components/code-block'
 export const metadata = {
   title: 'Self-hosting · Spanlens Docs',
   description:
-    'Run the Spanlens proxy on your own infra with a Supabase project. Honest walkthrough with current gaps clearly marked.',
+    'Run the full Spanlens stack (dashboard + proxy) on your own infra with a Supabase project.',
 }
 
 export default function SelfHostDocs() {
@@ -11,22 +11,9 @@ export default function SelfHostDocs() {
     <div>
       <h1>Self-hosting</h1>
       <p className="lead">
-        Run the Spanlens proxy + API on your own infra. Keeps all request bodies, traces, and
-        encrypted provider keys inside your network. The hosted dashboard at{' '}
-        <a href="https://spanlens.io">spanlens.io</a> can then read from your self-hosted
-        backend.
+        Run the Spanlens proxy, API, and dashboard on your own infra. Keeps all request bodies,
+        traces, and encrypted provider keys inside your network.
       </p>
-
-      <div className="rounded-lg border-2 border-accent bg-accent-bg p-4 my-6 not-prose">
-        <p className="text-sm font-semibold text-accent mb-1">⚠️ Early access</p>
-        <p className="text-sm text-accent">
-          Both the proxy server and dashboard images boot end-to-end (verified 2026-05-15).
-          Rough edges: Supabase is required (plain Postgres isn&apos;t supported yet), and
-          migrations aren&apos;t bundled in the image — a manual <code>supabase db push</code>{' '}
-          step is required. Walk through the steps below; if you hit friction, file a GitHub
-          issue and we&apos;ll smooth it.
-        </p>
-      </div>
 
       <h2>Who should self-host</h2>
       <ul>
@@ -42,20 +29,8 @@ export default function SelfHostDocs() {
           <a href="https://supabase.com" target="_blank" rel="noopener noreferrer">
             supabase.com
           </a>{' '}
-          is enough to start; power users can also self-host the full Supabase Docker stack on
-          their own Postgres. <strong>Plain Postgres is not supported</strong> — the server
+          is enough to start. <strong>Plain Postgres is not supported</strong> — the server
           uses <code>@supabase/supabase-js</code> directly.
-        </li>
-        <li>
-          <strong>The Supabase CLI</strong> locally, to push the schema migrations to your
-          Supabase project. Install:{' '}
-          <a
-            href="https://supabase.com/docs/guides/local-development/cli/getting-started"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            supabase.com/docs/guides/local-development/cli
-          </a>
         </li>
         <li>
           <strong>A 32-byte encryption key.</strong> Used for AES-256-GCM encryption of provider
@@ -68,7 +43,7 @@ export default function SelfHostDocs() {
         </li>
         <li>
           <strong>A reverse proxy with HTTPS</strong> in front (Caddy, nginx, Cloudflare Tunnel).
-          The container speaks HTTP on port 3001.
+          The containers speak HTTP on ports 3000 (web) and 3001 (server).
         </li>
       </ol>
 
@@ -76,14 +51,32 @@ export default function SelfHostDocs() {
 
       <h3>Option A — docker-compose (recommended)</h3>
       <p>
-        The easiest way to self-host. Runs both the <strong>dashboard (web)</strong> and the{' '}
-        <strong>proxy / API server</strong> together from a single compose file.
+        The easiest way to self-host. Pulls pre-built images from GHCR and runs both the{' '}
+        <strong>dashboard (web)</strong> and the <strong>proxy / API server</strong> together.
+        No source code needed.
       </p>
 
-      <h4>1. Clone the repo and create a <code>.env</code> file</h4>
-      <CodeBlock language="bash">{`git clone https://github.com/sunes26/Spanlens.git
-cd Spanlens`}</CodeBlock>
-      <CodeBlock language="bash">{`# .env — required variables
+      <h4>1. Apply the database schema</h4>
+      <p>
+        Open your Supabase project → <strong>SQL Editor → New query</strong>, paste the contents
+        of{' '}
+        <a
+          href="https://raw.githubusercontent.com/spanlens/Spanlens/main/supabase/init.sql"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          supabase/init.sql
+        </a>
+        , and click <strong>Run</strong>. No CLI needed.
+      </p>
+      <p className="text-sm text-muted-foreground">
+        Prefer the terminal? Use psql instead:
+      </p>
+      <CodeBlock language="bash">{`curl -o init.sql https://raw.githubusercontent.com/spanlens/Spanlens/main/supabase/init.sql
+psql "postgresql://postgres:<password>@db.<ref>.supabase.co:5432/postgres" -f init.sql`}</CodeBlock>
+
+      <h4>2. Create a <code>.env</code> file</h4>
+      <CodeBlock language="bash">{`# Required
 NEXT_PUBLIC_SUPABASE_URL=https://<ref>.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
 SUPABASE_URL=https://<ref>.supabase.co
@@ -97,84 +90,63 @@ CRON_SECRET=$(openssl rand -hex 16)
 # RESEND_API_KEY=re_...
 # RESEND_FROM=Spanlens <no-reply@your-domain.com>`}</CodeBlock>
 
-      <h4>2. Apply the schema migrations</h4>
-      <CodeBlock language="bash">{`supabase login
-supabase link --project-ref <your-ref>
-supabase db push`}</CodeBlock>
-
-      <h4>3. Build and start</h4>
-      <CodeBlock language="bash">{`docker compose up -d --build`}</CodeBlock>
+      <h4>3. Start</h4>
+      <CodeBlock language="bash">{`curl -o docker-compose.yml https://raw.githubusercontent.com/spanlens/Spanlens/main/docker-compose.yml
+docker compose up -d`}</CodeBlock>
       <ul>
         <li>Dashboard: <code>http://localhost:3000</code></li>
         <li>API / proxy: <code>http://localhost:3001</code></li>
       </ul>
       <p className="text-sm text-muted-foreground">
-        ⚠️ <code>NEXT_PUBLIC_*</code> vars are baked into the Next.js client bundle at build time.
-        They must be present in <code>.env</code> before running <code>docker compose build</code>.
+        The web container reads <code>NEXT_PUBLIC_*</code> from env at startup and patches them
+        into the pre-built bundle automatically — no rebuild needed.
       </p>
 
       <h3>Option B — server only</h3>
       <p>
-        If you run the dashboard separately (hosted at{' '}
+        If you run the dashboard separately (at{' '}
         <a href="https://spanlens.io">spanlens.io</a> or your own Next.js deployment), you can
-        run just the API server:
+        run just the API server.
       </p>
 
-      <h3>1. Create a Supabase project</h3>
+      <h4>1. Create a Supabase project</h4>
       <p>
-        Sign in at <a href="https://supabase.com" target="_blank" rel="noopener noreferrer">supabase.com</a>, create a project, wait for it to provision (~1 minute).
-      </p>
-      <p>
-        From <code>Project Settings → API</code>, copy:
+        Sign in at <a href="https://supabase.com" target="_blank" rel="noopener noreferrer">supabase.com</a>,
+        create a project, wait for it to provision (~1 minute).
+        From <strong>Project Settings → API</strong>, copy:
       </p>
       <ul>
-        <li><strong>Project URL</strong> → will be your <code>SUPABASE_URL</code></li>
+        <li><strong>Project URL</strong> → <code>SUPABASE_URL</code></li>
         <li><strong>anon public key</strong> → <code>SUPABASE_ANON_KEY</code></li>
-        <li><strong>service_role secret key</strong> → <code>SUPABASE_SERVICE_ROLE_KEY</code> (keep this server-side only)</li>
+        <li><strong>service_role secret key</strong> → <code>SUPABASE_SERVICE_ROLE_KEY</code> (server-side only)</li>
       </ul>
 
-      <h3>2. Apply the schema migrations</h3>
+      <h4>2. Apply the schema</h4>
       <p>
-        Clone the repo to get the migration SQL files, then link your Supabase project and push:
-      </p>
-      <CodeBlock language="bash">{`git clone https://github.com/sunes26/Spanlens.git
-cd Spanlens
-
-# One-time: log in and link to your Supabase project
-supabase login
-supabase link --project-ref <your-ref>   # "ref" is the <ref>.supabase.co subdomain
-
-# Apply all migrations
-supabase db push`}</CodeBlock>
-      <p className="text-sm text-muted-foreground">
-        ⚠️ <em>Known gap:</em> migrations aren&apos;t bundled in the Docker image yet, so this
-        manual step is required. Roadmap: ship a separate <code>spanlens-migrate</code> image
-        that applies them for you.
+        Same as Option A step 1 — open <strong>SQL Editor → New query</strong>, paste{' '}
+        <a
+          href="https://raw.githubusercontent.com/spanlens/Spanlens/main/supabase/init.sql"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          init.sql
+        </a>
+        , run.
       </p>
 
-      <h3>3. Run the server</h3>
-      <CodeBlock language="bash">{`docker run -d --name spanlens \\
+      <h4>3. Run the server</h4>
+      <CodeBlock language="bash">{`docker run -d --name spanlens-server \\
   -p 3001:3001 \\
-  -e SUPABASE_URL="https://<your-ref>.supabase.co" \\
-  -e SUPABASE_ANON_KEY="eyJhbGciOi..." \\
-  -e SUPABASE_SERVICE_ROLE_KEY="eyJhbGciOi..." \\
+  -e SUPABASE_URL="https://<ref>.supabase.co" \\
+  -e SUPABASE_ANON_KEY="eyJ..." \\
+  -e SUPABASE_SERVICE_ROLE_KEY="eyJ..." \\
   -e ENCRYPTION_KEY="$(openssl rand -base64 32)" \\
-  ghcr.io/sunes26/spanlens-server:latest`}</CodeBlock>
-      <p>
-        Health check: <code>curl http://localhost:3001/health</code> should return <code>{`{"status":"ok"}`}</code>.
-      </p>
-      <p className="text-sm text-muted-foreground">
-        Verified 2026-04-22: the image pulls without auth and boots against fake env vars past
-        the DB init check. If you prefer building from source,{' '}
-        <code>docker build -f apps/server/Dockerfile -t spanlens-server .</code> from the repo
-        root works too.
-      </p>
+  -e CRON_SECRET="$(openssl rand -hex 16)" \\
+  ghcr.io/spanlens/spanlens-server:latest`}</CodeBlock>
+      <CodeBlock language="bash">{`curl http://localhost:3001/health
+# {"status":"ok"}`}</CodeBlock>
 
-      <h3>4. Point your application at the self-hosted proxy</h3>
-      <p>
-        Any <a href="/docs/sdk">SDK</a> or <a href="/docs/proxy">direct proxy</a> pattern works —
-        replace the default base URL with your self-hosted domain:
-      </p>
+      <h4>4. Point your SDK at the self-hosted proxy</h4>
       <CodeBlock language="ts">{`import { createOpenAI } from '@spanlens/sdk/openai'
 
 const openai = createOpenAI({
@@ -212,11 +184,21 @@ const openai = createOpenAI({
             <td>32-byte base64 key for AES-256-GCM provider-key encryption at rest</td>
           </tr>
           <tr>
+            <td><code>NEXT_PUBLIC_SUPABASE_URL</code></td>
+            <td>Yes (web only)</td>
+            <td>Same as <code>SUPABASE_URL</code> — exposed to the browser for Supabase Auth</td>
+          </tr>
+          <tr>
+            <td><code>NEXT_PUBLIC_SUPABASE_ANON_KEY</code></td>
+            <td>Yes (web only)</td>
+            <td>Same as <code>SUPABASE_ANON_KEY</code> — exposed to the browser for Supabase Auth</td>
+          </tr>
+          <tr>
             <td><code>WEB_URL</code></td>
             <td>Yes (multi-user)</td>
             <td>
               Base URL of your dashboard (e.g. <code>https://spanlens.example.com</code>).
-              Used to build the accept link in invitation emails. Falls back to
+              Used to build the accept link in invitation emails. Falls back to{' '}
               <code>http://localhost:3000</code> if unset — fine for local dev,
               broken in production.
             </td>
@@ -225,60 +207,54 @@ const openai = createOpenAI({
             <td><code>RESEND_API_KEY</code></td>
             <td>No</td>
             <td>
-              Resend (<a href="https://resend.com">resend.com</a>) API token for outbound
-              email (currently invitations). When unset, emails are skipped silently
-              and the invite endpoint returns the accept link as <code>devAcceptUrl</code>
-              in its JSON response so an admin can hand-deliver it.
+              Resend API token for outbound email (invitations). When unset, emails are skipped
+              silently and the invite endpoint returns the accept link as{' '}
+              <code>devAcceptUrl</code> so an admin can hand-deliver it.
             </td>
           </tr>
           <tr>
             <td><code>RESEND_FROM</code></td>
             <td>No</td>
             <td>
-              Sender header for outbound email. Default
-              <code>Spanlens &lt;notifications@spanlens.io&gt;</code>. Override with a
-              verified sender on your own domain (e.g.
-              <code>Spanlens &lt;notifications@mail.example.com&gt;</code>) — unverified
-              senders land in spam folders.
+              Sender header. Default <code>Spanlens &lt;notifications@spanlens.io&gt;</code>.
+              Override with a verified sender on your own domain to avoid spam filters.
             </td>
           </tr>
           <tr>
             <td><code>PORT</code></td>
             <td>No</td>
-            <td>HTTP port (default 3001)</td>
+            <td>HTTP port for the server (default 3001)</td>
           </tr>
         </tbody>
       </table>
 
       <h2 id="upgrading">Upgrading</h2>
-      <CodeBlock language="bash">{`docker pull ghcr.io/sunes26/spanlens-server:latest
-docker restart spanlens
+      <CodeBlock language="bash">{`# Pull the latest images and restart
+docker compose pull && docker compose up -d
 
-# If new migrations shipped, re-pull the repo and push:
-cd Spanlens && git pull && supabase db push`}</CodeBlock>
+# If a new release added migrations, re-run init.sql in SQL Editor
+# (all statements use CREATE IF NOT EXISTS / ALTER IF NOT EXISTS — safe to re-run)`}</CodeBlock>
       <p>
-        We ship semver tags (<code>ghcr.io/sunes26/spanlens-server:0.3.0</code>). Pin a tag in
-        production and upgrade deliberately.
+        We ship semver tags (<code>ghcr.io/spanlens/spanlens-server:0.3.0</code>,{' '}
+        <code>ghcr.io/spanlens/spanlens-web:0.3.0</code>). Pin a tag in production and upgrade
+        deliberately.
       </p>
 
-      <h2 id="dashboard">Dashboard access</h2>
-      <p>
-        Three options:
-      </p>
+      <h2 id="dashboard">Dashboard options</h2>
       <ul>
         <li>
-          <strong>docker-compose</strong> — builds and runs the web dashboard alongside the server.
-          Recommended for full self-hosting. See <a href="#quickstart">Option A</a> above.
+          <strong>docker-compose (recommended)</strong> — pulls{' '}
+          <code>ghcr.io/spanlens/spanlens-web:latest</code> alongside the server. Full
+          self-hosting with no source required. See <a href="#quickstart">Option A</a> above.
         </li>
         <li>
           <strong>Use the hosted dashboard at <a href="https://spanlens.io">spanlens.io</a></strong>{' '}
-          pointed at your self-hosted backend. Log in, then override the API base URL in your
-          browser via <a href="/settings">/settings</a>.
+          pointed at your self-hosted backend. Log in, then override the API base URL in{' '}
+          <a href="/settings">Settings</a>.
         </li>
         <li>
-          <strong>Run the web app locally yourself</strong> — clone the repo and{' '}
-          <code>pnpm --filter web dev</code> with <code>NEXT_PUBLIC_API_URL</code> pointed at
-          your backend.
+          <strong>Build from source</strong> — clone the repo and{' '}
+          <code>docker compose up -d --build</code> to build both images locally.
         </li>
       </ul>
 
@@ -288,26 +264,15 @@ cd Spanlens && git pull && supabase db push`}</CodeBlock>
         covers you. The critical thing to back up outside the DB is{' '}
         <code>ENCRYPTION_KEY</code> — without it, encrypted provider keys are unrecoverable.
         Store it in your secret manager (AWS Secrets Manager, GCP Secret Manager, HashiCorp
-        Vault) with a rotation schedule you can follow.
+        Vault) with a rotation schedule.
       </p>
 
-      <h2>Known gaps & roadmap</h2>
-      <p>Honest current state of self-host:</p>
+      <h2>Known limitations</h2>
       <ul>
         <li>
           <strong>Plain Postgres isn&apos;t supported.</strong> The server imports{' '}
-          <code>@supabase/supabase-js</code> directly. Moving to a thin Postgres abstraction is
-          on the roadmap but not a launch blocker.
-        </li>
-        <li>
-          <strong>Migrations ship separately</strong> (via Supabase CLI + repo clone). A bundled{' '}
-          <code>spanlens-migrate</code> tool is a post-launch priority.
-        </li>
-        <li>
-          <strong>No published <code>ghcr.io/sunes26/spanlens-web</code> image yet.</strong> The
-          dashboard Dockerfile is in the repo — build it yourself via{' '}
-          <code>docker compose build</code> from the repo root. A pre-built image is on the
-          roadmap.
+          <code>@supabase/supabase-js</code> directly. Moving to a thin abstraction layer is on
+          the roadmap but not a launch blocker.
         </li>
         <li>
           <strong>Operational tooling is minimal.</strong> No built-in monitoring, no migration
@@ -319,7 +284,7 @@ cd Spanlens && git pull && supabase db push`}</CodeBlock>
       <p className="text-sm text-muted-foreground">
         Found a problem?{' '}
         <a
-          href="https://github.com/sunes26/Spanlens/issues"
+          href="https://github.com/spanlens/Spanlens/issues"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -31,7 +31,8 @@ const COMPAT = [
   ['TypeScript SDK', '@spanlens/sdk'],
   ['Python SDK', 'pip · 3.9+'],
   ['LangChain', 'js · py'],
-  ['LlamaIndex', 'py'],
+  ['LlamaIndex', 'js · py'],
+  ['Vercel AI SDK', 'js'],
 ]
 
 const PLANS = [
@@ -96,8 +97,8 @@ export default function LandingPage() {
         {/* Version badge */}
         <div className="inline-flex flex-wrap items-center gap-x-2 gap-y-1 px-2 py-[5px] rounded-full border border-accent-border bg-accent-bg text-accent font-mono text-[12px] tracking-[0.03em] mb-7 max-w-full">
           <span className="bg-accent text-bg px-[7px] py-[2px] rounded-full text-[10px] font-semibold tracking-[0.05em] shrink-0">NEW</span>
-          <span>Python SDK is here</span>
-          <code className="font-mono hidden sm:inline">· pip install spanlens</code>
+          <span>SDK v0.3.0 — LangChain, Vercel AI SDK, LlamaIndex integrations</span>
+          <code className="font-mono hidden sm:inline">· npm install @spanlens/sdk</code>
         </div>
 
         <h1 className="text-[44px] sm:text-[64px] lg:text-[88px] leading-[0.96] tracking-[-2px] sm:tracking-[-2.8px] font-medium max-w-[980px] mb-7 [text-wrap:balance]">

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @spanlens/sdk changelog
 
+## 0.3.0
+
+Framework callback integrations — trace LangChain, Vercel AI SDK, and LlamaIndex without touching the proxy URL.
+
+### Added
+
+- **`@spanlens/sdk/langchain`** — `createSpanlensCallbackHandler({ client, trace?, traceName? })`.
+  Returns a LangChain-compatible callback handler (duck-typed, no `@langchain/core` import). Pass to the `callbacks` option of any chain, LLM, or `RunnableConfig`. Captures `promptTokens`, `completionTokens`, `model_name` from `llmOutput`, handles concurrent runs by `runId`, and records error spans on `handleLLMError`.
+
+- **`@spanlens/sdk/vercel-ai`** — `createSpanlensTracker({ client, trace?, traceName?, modelName? })`.
+  Returns `{ onStepFinish, onFinish }` that spread directly into `generateText`, `streamText`, `generateObject`, and `streamObject` options. Auto-computes `totalTokens` when absent, records `finishReason` and multi-step count in span metadata.
+
+- **`@spanlens/sdk/llamaindex`** — `registerSpanlensCallbacks(Settings, { client, trace?, traceName? })`.
+  Hooks into `Settings.callbackManager` `llm-start` / `llm-end` events. Parses `raw.usage.input_tokens` / `output_tokens` from the LlamaIndex response. Returns an `unregister()` cleanup function.
+
+All three integrations:
+- Accept an optional `trace?: TraceHandle` — when provided, spans are attached to it and `trace.end()` is left to the caller. When omitted, a trace is auto-created and closed per LLM call.
+- Are fully duck-typed (no imports from the framework package) — compatible with any version.
+- Follow the SDK's fire-and-forget, silent-by-default contract.
+
+### Backward compatible
+
+All existing exports unchanged. The three new entry points are additive.
+
 ## 0.2.3
 
 Critical fix — long-running traces lost their spans on serverless runtimes.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -194,62 +194,100 @@ const res = await observeAnthropic(trace, 'reason', (headers) =>
 await trace.end()
 ```
 
-### LangChain (JS)
+### LangChain JS (v0.3.0+)
 
-LangChain calls go through the underlying OpenAI/Anthropic client — point that
-client at the Spanlens proxy and wrap the chain invocation in `observe()`:
+`@spanlens/sdk/langchain` ships a drop-in callback handler. Pass it to the
+`callbacks` option of any LangChain chain, LLM, or `RunnableConfig` — no
+proxy URL needed, no imports from `@langchain/core` required:
 
 ```ts
-import { ChatOpenAI } from '@langchain/openai'
-import { SpanlensClient, observe } from '@spanlens/sdk'
+import { SpanlensClient } from '@spanlens/sdk'
+import { createSpanlensCallbackHandler } from '@spanlens/sdk/langchain'
 
-const spanlens = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+const handler = createSpanlensCallbackHandler({ client })
 
-const llm = new ChatOpenAI({
-  apiKey: process.env.SPANLENS_API_KEY!,
-  configuration: {
-    baseURL: 'https://spanlens-server.vercel.app/proxy/openai/v1',
-  },
-})
+// Works with any chain, LLM, or tool
+const result = await chain.invoke({ input: 'Hello' }, { callbacks: [handler] })
+// → prompt/completion tokens, model name, latency automatically recorded
+```
 
-const trace = spanlens.startTrace({ name: 'langchain_qa' })
+Attach to an existing trace to nest spans under your workflow:
 
-// LangChain's internal fetch won't carry our trace headers, so we group
-// the whole chain under one span for dashboard visibility.
-const answer = await observe(trace, { name: 'chain.invoke', spanType: 'llm' }, async () => {
-  return llm.invoke('What is Spanlens?')
-})
+```ts
+const trace = client.startTrace({ name: 'my_workflow' })
+const handler = createSpanlensCallbackHandler({ client, trace })
+
+await chain.invoke({ input: '...' }, { callbacks: [handler] })
+await someOtherStep()
 
 await trace.end()
 ```
 
-### LlamaIndex (TS)
+### Vercel AI SDK (v0.3.0+)
+
+`@spanlens/sdk/vercel-ai` provides `createSpanlensTracker()` whose
+`onStepFinish` and `onFinish` callbacks spread directly into `generateText`,
+`streamText`, `generateObject`, and `streamObject` options:
 
 ```ts
-import { OpenAI, VectorStoreIndex, SimpleDirectoryReader } from 'llamaindex'
-import { SpanlensClient, observe } from '@spanlens/sdk'
+import { generateText } from 'ai'
+import { openai } from '@ai-sdk/openai'
+import { SpanlensClient } from '@spanlens/sdk'
+import { createSpanlensTracker } from '@spanlens/sdk/vercel-ai'
 
-const spanlens = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+const tracker = createSpanlensTracker({ client, modelName: 'gpt-4o' })
 
-const llm = new OpenAI({
-  apiKey: process.env.SPANLENS_API_KEY!,
-  additionalSessionOptions: {
-    baseURL: 'https://spanlens-server.vercel.app/proxy/openai/v1',
-  },
+const result = await generateText({
+  model: openai('gpt-4o'),
+  messages: [{ role: 'user', content: 'Hello!' }],
+  onStepFinish: tracker.onStepFinish,  // optional — captures multi-step tool calls
+  onFinish: tracker.onFinish,          // required  — records final usage
 })
+```
 
-const trace = spanlens.startTrace({ name: 'rag_query' })
+Attach to an existing trace:
 
-const retrieval = await observe(trace, { name: 'retrieve', spanType: 'retrieval' }, async () => {
-  const docs = await new SimpleDirectoryReader().loadData({ directoryPath: './docs' })
-  return VectorStoreIndex.fromDocuments(docs)
-})
+```ts
+const trace = client.startTrace({ name: 'ai_pipeline' })
+const tracker = createSpanlensTracker({ client, trace, modelName: 'gpt-4o' })
 
-const answer = await observe(trace, { name: 'generate', spanType: 'llm' }, async () => {
-  const engine = retrieval.asQueryEngine({ llm })
-  return engine.query({ query: 'What is Spanlens?' })
-})
+await generateText({ ..., onFinish: tracker.onFinish })
+await trace.end()
+```
 
+### LlamaIndex TS (v0.3.0+)
+
+`@spanlens/sdk/llamaindex` hooks directly into LlamaIndex's
+`Settings.callbackManager` — every LLM call is automatically traced:
+
+```ts
+import { Settings } from 'llamaindex'
+import { SpanlensClient } from '@spanlens/sdk'
+import { registerSpanlensCallbacks } from '@spanlens/sdk/llamaindex'
+
+const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+
+// Register once at app startup
+const unregister = registerSpanlensCallbacks(Settings, { client })
+
+// All subsequent LlamaIndex LLM calls are now traced automatically
+const response = await queryEngine.query({ query: 'What is Spanlens?' })
+
+// Clean up when done (e.g. in tests or on process exit)
+unregister()
+```
+
+Attach to an existing trace for RAG pipelines:
+
+```ts
+const trace = client.startTrace({ name: 'rag_query' })
+const unregister = registerSpanlensCallbacks(Settings, { client, trace })
+
+await queryEngine.query({ query: '...' })
+
+unregister()
 await trace.end()
 ```
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -48,18 +48,12 @@
   "peerDependencies": {
     "openai": ">=4.0.0",
     "@anthropic-ai/sdk": ">=0.24.0",
-    "@google/generative-ai": ">=0.20.0",
-    "@langchain/core": ">=0.2.0",
-    "ai": ">=4.0.0",
-    "llamaindex": ">=0.4.0"
+    "@google/generative-ai": ">=0.20.0"
   },
   "peerDependenciesMeta": {
     "openai": { "optional": true },
     "@anthropic-ai/sdk": { "optional": true },
-    "@google/generative-ai": { "optional": true },
-    "@langchain/core": { "optional": true },
-    "ai": { "optional": true },
-    "llamaindex": { "optional": true }
+    "@google/generative-ai": { "optional": true }
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.32.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -22,6 +22,18 @@
     "./gemini": {
       "import": "./dist/integrations/gemini.js",
       "types": "./dist/integrations/gemini.d.ts"
+    },
+    "./langchain": {
+      "import": "./dist/integrations/langchain.js",
+      "types": "./dist/integrations/langchain.d.ts"
+    },
+    "./vercel-ai": {
+      "import": "./dist/integrations/vercel-ai.js",
+      "types": "./dist/integrations/vercel-ai.d.ts"
+    },
+    "./llamaindex": {
+      "import": "./dist/integrations/llamaindex.js",
+      "types": "./dist/integrations/llamaindex.d.ts"
     }
   },
   "files": ["dist", "README.md", "CHANGELOG.md", "LICENSE"],
@@ -36,12 +48,18 @@
   "peerDependencies": {
     "openai": ">=4.0.0",
     "@anthropic-ai/sdk": ">=0.24.0",
-    "@google/generative-ai": ">=0.20.0"
+    "@google/generative-ai": ">=0.20.0",
+    "@langchain/core": ">=0.2.0",
+    "ai": ">=4.0.0",
+    "llamaindex": ">=0.4.0"
   },
   "peerDependenciesMeta": {
     "openai": { "optional": true },
     "@anthropic-ai/sdk": { "optional": true },
-    "@google/generative-ai": { "optional": true }
+    "@google/generative-ai": { "optional": true },
+    "@langchain/core": { "optional": true },
+    "ai": { "optional": true },
+    "llamaindex": { "optional": true }
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.32.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/__tests__/integrations-new.test.ts
+++ b/packages/sdk/src/__tests__/integrations-new.test.ts
@@ -245,7 +245,7 @@ describe('registerSpanlensCallbacks (LlamaIndex)', () => {
           )
         },
         emit(event: string, payload: unknown) {
-          listeners.get(event)?.forEach((h) => h(payload))
+          listeners.get(event)?.forEach((h) => h({ detail: payload }))
         },
         listenerCount(event: string) {
           return listeners.get(event)?.length ?? 0

--- a/packages/sdk/src/__tests__/integrations-new.test.ts
+++ b/packages/sdk/src/__tests__/integrations-new.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Tests for LangChain, Vercel AI, and LlamaIndex integrations.
+ *
+ * Mocks `fetch` at the global level (same pattern as client.test.ts) so we
+ * exercise the real transport and span/trace creation logic.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createSpanlensCallbackHandler } from '../integrations/langchain.js'
+import { createSpanlensTracker } from '../integrations/vercel-ai.js'
+import { registerSpanlensCallbacks } from '../integrations/llamaindex.js'
+import { SpanlensClient } from '../client.js'
+
+// ── Shared fetch mock setup ────────────────────────────────────────────────
+
+type FetchCall = { url: string; method: string; body: Record<string, unknown> }
+
+function stubFetch() {
+  const calls: FetchCall[] = []
+
+  const fetchMock = vi.fn().mockImplementation((url: string, init: RequestInit) => {
+    const body = init.body ? (JSON.parse(init.body as string) as Record<string, unknown>) : {}
+    calls.push({ url, method: init.method ?? 'GET', body })
+    return Promise.resolve(
+      new Response(JSON.stringify({ id: (url as string).split('/').at(-1) }), { status: 200 }),
+    )
+  })
+
+  vi.stubGlobal('fetch', fetchMock)
+
+  return {
+    calls,
+    posts: () => calls.filter((c) => c.method === 'POST'),
+    patches: () => calls.filter((c) => c.method === 'PATCH'),
+    spanPatches: () =>
+      calls.filter((c) => c.method === 'PATCH' && c.url.includes('/spans/')),
+    tracePatches: () =>
+      calls.filter(
+        (c) => c.method === 'PATCH' && c.url.includes('/traces/') && !c.url.includes('/spans'),
+      ),
+  }
+}
+
+function makeClient() {
+  return new SpanlensClient({ apiKey: 'sl_live_test', baseUrl: 'http://test' })
+}
+
+/** Wait for fire-and-forget promise chains to settle (same as client.test.ts pattern). */
+function tick(ms = 20): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+// ── LangChain ──────────────────────────────────────────────────────────────
+
+describe('createSpanlensCallbackHandler (LangChain)', () => {
+  it('creates a span on handleLLMStart and ends it on handleLLMEnd with token usage', async () => {
+    const { spanPatches } = stubFetch()
+    const client = makeClient()
+    const handler = createSpanlensCallbackHandler({ client })
+
+    handler.handleLLMStart({ id: ['ChatOpenAI'], name: 'ChatOpenAI' }, ['Hello'], 'run-1')
+    await handler.handleLLMEnd(
+      {
+        llmOutput: {
+          tokenUsage: { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+          model_name: 'gpt-4o',
+        },
+        generations: [[{ text: 'World' }]],
+      },
+      'run-1',
+    )
+
+    const patches = spanPatches()
+    expect(patches.length).toBeGreaterThanOrEqual(1)
+    const body = patches[0]?.body ?? {}
+    expect(body['prompt_tokens']).toBe(10)
+    expect(body['completion_tokens']).toBe(20)
+    expect(body['total_tokens']).toBe(30)
+    expect(body['status']).toBe('completed')
+    expect(body['output']).toBe('World')
+  })
+
+  it('ends span with error status on handleLLMError', async () => {
+    const { spanPatches } = stubFetch()
+    const client = makeClient()
+    const handler = createSpanlensCallbackHandler({ client })
+
+    handler.handleChatModelStart({ id: ['ChatAnthropic'] }, [['msg']], 'run-err')
+    await handler.handleLLMError(new Error('API timeout'), 'run-err')
+
+    const patches = spanPatches()
+    expect(patches.length).toBeGreaterThanOrEqual(1)
+    const body = patches[0]?.body ?? {}
+    expect(body['status']).toBe('error')
+    expect(String(body['error_message'])).toContain('API timeout')
+  })
+
+  it('ignores handleLLMEnd for unknown runId without throwing', async () => {
+    const { calls } = stubFetch()
+    const client = makeClient()
+    const handler = createSpanlensCallbackHandler({ client })
+
+    await expect(
+      handler.handleLLMEnd({ llmOutput: { tokenUsage: {} } }, 'unknown-run'),
+    ).resolves.toBeUndefined()
+
+    await tick()
+    expect(calls.filter((c) => c.method === 'PATCH')).toHaveLength(0)
+  })
+
+  it('does not end the outer trace when an external trace is provided', async () => {
+    const { tracePatches } = stubFetch()
+    const client = makeClient()
+    const trace = client.startTrace({ name: 'outer' })
+    const handler = createSpanlensCallbackHandler({ client, trace })
+
+    handler.handleLLMStart({ id: ['Model'] }, ['p'], 'run-2')
+    await handler.handleLLMEnd({}, 'run-2')
+
+    // Only 1 trace POST (the outer trace), 0 trace PATCHes (caller owns lifecycle)
+    expect(tracePatches()).toHaveLength(0)
+  })
+
+  it('handles concurrent runs independently by runId', async () => {
+    const { spanPatches } = stubFetch()
+    const client = makeClient()
+    const handler = createSpanlensCallbackHandler({ client })
+
+    handler.handleLLMStart({ id: ['ModelA'] }, ['p1'], 'run-a')
+    handler.handleLLMStart({ id: ['ModelB'] }, ['p2'], 'run-b')
+
+    await handler.handleLLMEnd(
+      { llmOutput: { tokenUsage: { promptTokens: 5, completionTokens: 5, totalTokens: 10 } } },
+      'run-a',
+    )
+    await handler.handleLLMEnd(
+      { llmOutput: { tokenUsage: { promptTokens: 8, completionTokens: 8, totalTokens: 16 } } },
+      'run-b',
+    )
+
+    expect(spanPatches()).toHaveLength(2)
+  })
+})
+
+// ── Vercel AI SDK ──────────────────────────────────────────────────────────
+
+describe('createSpanlensTracker (Vercel AI SDK)', () => {
+  it('creates a span immediately and ends it on onFinish with usage and model', async () => {
+    const { spanPatches, posts } = stubFetch()
+    const client = makeClient()
+    const tracker = createSpanlensTracker({ client, modelName: 'gpt-4o' })
+
+    await tracker.onFinish({
+      usage: { promptTokens: 15, completionTokens: 25, totalTokens: 40 },
+      finishReason: 'stop',
+      text: 'Hello!',
+      response: { modelId: 'gpt-4o-2024-11-20' },
+    })
+
+    // A span POST was made with the correct span name
+    const spanPost = posts().find((c) => c.url.includes('/spans'))
+    expect(spanPost?.body['name']).toBe('llm.gpt-4o')
+
+    const patches = spanPatches()
+    expect(patches.length).toBeGreaterThanOrEqual(1)
+    const body = patches[0]?.body ?? {}
+    expect(body['prompt_tokens']).toBe(15)
+    expect(body['completion_tokens']).toBe(25)
+    expect(body['total_tokens']).toBe(40)
+    expect(body['output']).toBe('Hello!')
+    expect(body['status']).toBe('completed')
+  })
+
+  it('records error status when finishReason is error', async () => {
+    const { spanPatches } = stubFetch()
+    const client = makeClient()
+    const tracker = createSpanlensTracker({ client })
+
+    await tracker.onFinish({ finishReason: 'error', usage: {} })
+
+    const body = spanPatches()[0]?.body ?? {}
+    expect(body['status']).toBe('error')
+  })
+
+  it('onStepFinish resolves without throwing', async () => {
+    stubFetch()
+    const client = makeClient()
+    const tracker = createSpanlensTracker({ client, modelName: 'claude-3-5-sonnet' })
+
+    await expect(tracker.onStepFinish({ stepType: 'initial' })).resolves.toBeUndefined()
+    await expect(tracker.onStepFinish({ stepType: 'tool-result' })).resolves.toBeUndefined()
+  })
+
+  it('does not call trace.end when an external trace is provided', async () => {
+    const { tracePatches } = stubFetch()
+    const client = makeClient()
+    const trace = client.startTrace({ name: 'pipeline' })
+    const tracker = createSpanlensTracker({ client, trace, modelName: 'gpt-4o-mini' })
+
+    await tracker.onFinish({ usage: { promptTokens: 1, completionTokens: 1 } })
+
+    expect(tracePatches()).toHaveLength(0)
+  })
+
+  it('computes totalTokens from promptTokens + completionTokens when missing', async () => {
+    const { spanPatches } = stubFetch()
+    const client = makeClient()
+    const tracker = createSpanlensTracker({ client })
+
+    await tracker.onFinish({
+      usage: { promptTokens: 5, completionTokens: 7 },  // no totalTokens
+    })
+
+    const body = spanPatches()[0]?.body ?? {}
+    expect(body['total_tokens']).toBe(12)
+  })
+})
+
+// ── LlamaIndex ─────────────────────────────────────────────────────────────
+
+describe('registerSpanlensCallbacks (LlamaIndex)', () => {
+  function createMockSettings() {
+    const listeners = new Map<string, Array<(payload: unknown) => void>>()
+    return {
+      callbackManager: {
+        on(event: string, handler: (payload: unknown) => void) {
+          const list = listeners.get(event) ?? []
+          list.push(handler)
+          listeners.set(event, list)
+        },
+        off(event: string, handler: (payload: unknown) => void) {
+          const list = listeners.get(event) ?? []
+          listeners.set(
+            event,
+            list.filter((h) => h !== handler),
+          )
+        },
+        emit(event: string, payload: unknown) {
+          listeners.get(event)?.forEach((h) => h(payload))
+        },
+        listenerCount(event: string) {
+          return listeners.get(event)?.length ?? 0
+        },
+      },
+    }
+  }
+
+  it('registers llm-start/llm-end hooks, records span with token usage', async () => {
+    const { spanPatches } = stubFetch()
+    const client = makeClient()
+    const settings = createMockSettings()
+
+    registerSpanlensCallbacks(settings, { client })
+
+    settings.callbackManager.emit('llm-start', {
+      id: 'call-1',
+      messages: [{ role: 'user', content: 'Hi' }],
+    })
+    settings.callbackManager.emit('llm-end', {
+      id: 'call-1',
+      response: {
+        raw: {
+          usage: { input_tokens: 5, output_tokens: 10 },
+          model: 'gpt-4o',
+        },
+        message: { role: 'assistant', content: 'Hello!' },
+      },
+    })
+
+    // Allow fire-and-forget promise chain to settle
+    await tick()
+
+    const patches = spanPatches()
+    expect(patches.length).toBeGreaterThanOrEqual(1)
+    const body = patches[0]?.body ?? {}
+    expect(body['prompt_tokens']).toBe(5)
+    expect(body['completion_tokens']).toBe(10)
+    expect(body['total_tokens']).toBe(15)
+    expect(body['status']).toBe('completed')
+  })
+
+  it('returns unregister function that removes both hooks', () => {
+    stubFetch()
+    const client = makeClient()
+    const settings = createMockSettings()
+
+    const unregister = registerSpanlensCallbacks(settings, { client })
+    expect(settings.callbackManager.listenerCount('llm-start')).toBe(1)
+    expect(settings.callbackManager.listenerCount('llm-end')).toBe(1)
+
+    unregister()
+    expect(settings.callbackManager.listenerCount('llm-start')).toBe(0)
+    expect(settings.callbackManager.listenerCount('llm-end')).toBe(0)
+  })
+
+  it('ignores llm-end for unknown call id without patching', async () => {
+    const { calls } = stubFetch()
+    const client = makeClient()
+    const settings = createMockSettings()
+
+    registerSpanlensCallbacks(settings, { client })
+    settings.callbackManager.emit('llm-end', {
+      id: 'ghost-id',
+      response: { raw: { usage: { input_tokens: 1 } } },
+    })
+
+    await tick()
+    expect(calls.filter((c) => c.method === 'PATCH')).toHaveLength(0)
+  })
+
+  it('does not end the outer trace when an external trace is provided', async () => {
+    const { tracePatches } = stubFetch()
+    const client = makeClient()
+    const settings = createMockSettings()
+
+    const trace = client.startTrace({ name: 'rag' })
+    registerSpanlensCallbacks(settings, { client, trace })
+
+    settings.callbackManager.emit('llm-start', { id: 'x', messages: [] })
+    settings.callbackManager.emit('llm-end', {
+      id: 'x',
+      response: { raw: { usage: { input_tokens: 3, output_tokens: 7 } } },
+    })
+
+    await tick()
+    expect(tracePatches()).toHaveLength(0)
+  })
+})

--- a/packages/sdk/src/integrations/langchain.ts
+++ b/packages/sdk/src/integrations/langchain.ts
@@ -1,0 +1,134 @@
+/**
+ * LangChain JS callback handler for Spanlens tracing.
+ *
+ * Records LLM spans (model, tokens, latency) from any LangChain chain or LLM.
+ * Designed as a duck-typed integration — no direct import from @langchain/core.
+ *
+ * @example
+ *   import { SpanlensClient } from '@spanlens/sdk'
+ *   import { createSpanlensCallbackHandler } from '@spanlens/sdk/langchain'
+ *
+ *   const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+ *   const handler = createSpanlensCallbackHandler({ client })
+ *
+ *   const result = await chain.invoke({ input }, { callbacks: [handler] })
+ *   // or: const res = await llm.invoke(prompt, { callbacks: [handler] })
+ */
+
+import { SpanlensClient } from '../client.js'
+import type { TraceHandle } from '../trace.js'
+import type { SpanHandle } from '../span.js'
+import type { EndSpanOptions } from '../types.js'
+
+export interface SpanlensLangChainOptions {
+  /** Spanlens client instance. */
+  client: SpanlensClient
+  /**
+   * Optional trace to attach LLM spans to.
+   * When provided, `trace.end()` is NOT called — the caller manages the lifecycle.
+   * When omitted, a new trace is created per LLM run and closed on completion.
+   */
+  trace?: TraceHandle
+  /** Name for auto-created traces. Default: 'langchain_run'. */
+  traceName?: string
+}
+
+/** Minimal LangChain Serialized shape — only fields we use. */
+interface LangChainSerialized {
+  id?: string[]
+  name?: string
+}
+
+interface LangChainTokenUsage {
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
+}
+
+interface LangChainLLMResult {
+  llmOutput?: {
+    tokenUsage?: LangChainTokenUsage
+    model_name?: string
+  }
+  generations?: ReadonlyArray<ReadonlyArray<{ text?: string }>>
+}
+
+function parseLangChainResult(result: LangChainLLMResult): EndSpanOptions {
+  const usage = result.llmOutput?.tokenUsage
+  if (!usage) return {}
+
+  const promptTokens = usage.promptTokens ?? 0
+  const completionTokens = usage.completionTokens ?? 0
+  const totalTokens = usage.totalTokens ?? promptTokens + completionTokens
+
+  const out: EndSpanOptions = { promptTokens, completionTokens, totalTokens }
+  const modelName = result.llmOutput?.model_name
+  if (modelName) out.metadata = { model: modelName }
+  return out
+}
+
+/**
+ * Returns a LangChain-compatible callback handler that records LLM spans to Spanlens.
+ *
+ * Pass the returned object to the `callbacks` option of any LangChain chain, LLM,
+ * or `RunnableConfig`. Concurrent runs are tracked by LangChain's `runId`.
+ */
+export function createSpanlensCallbackHandler(options: SpanlensLangChainOptions) {
+  const { client, traceName = 'langchain_run' } = options
+
+  const runs = new Map<
+    string,
+    { trace: TraceHandle; span: SpanHandle; isLocalTrace: boolean }
+  >()
+
+  function startRun(runId: string, llm: LangChainSerialized, input: unknown): void {
+    const spanName = `llm.${llm.id?.at(-1) ?? llm.name ?? 'call'}`
+    const isLocalTrace = options.trace === undefined
+    const trace = options.trace ?? client.startTrace({ name: traceName })
+    const span = trace.span({ name: spanName, spanType: 'llm', input })
+    runs.set(runId, { trace, span, isLocalTrace })
+  }
+
+  return {
+    name: 'SpanlensCallbackHandler' as const,
+
+    handleLLMStart(llm: LangChainSerialized, prompts: string[], runId: string): void {
+      startRun(runId, llm, prompts)
+    },
+
+    handleChatModelStart(
+      llm: LangChainSerialized,
+      messages: unknown[][],
+      runId: string,
+    ): void {
+      startRun(runId, llm, messages)
+    },
+
+    async handleLLMEnd(output: LangChainLLMResult, runId: string): Promise<void> {
+      const run = runs.get(runId)
+      if (!run) return
+      runs.delete(runId)
+
+      const parsed = parseLangChainResult(output)
+      const outputText = output.generations?.[0]?.[0]?.text
+
+      await run.span.end({
+        status: 'completed',
+        ...(outputText !== undefined ? { output: outputText } : {}),
+        ...parsed,
+      })
+
+      if (run.isLocalTrace) await run.trace.end({ status: 'completed' })
+    },
+
+    async handleLLMError(err: unknown, runId: string): Promise<void> {
+      const run = runs.get(runId)
+      if (!run) return
+      runs.delete(runId)
+
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      await run.span.end({ status: 'error', errorMessage })
+      if (run.isLocalTrace) await run.trace.end({ status: 'error', errorMessage })
+    },
+  }
+}

--- a/packages/sdk/src/integrations/llamaindex.ts
+++ b/packages/sdk/src/integrations/llamaindex.ts
@@ -1,0 +1,148 @@
+/**
+ * LlamaIndex TS integration for Spanlens tracing.
+ *
+ * Hooks into LlamaIndex's `Settings.callbackManager` to record LLM spans
+ * (model, tokens, latency) for every LLM call made through LlamaIndex.
+ * No direct import from 'llamaindex' — works as a duck-typed integration.
+ *
+ * @example
+ *   import { Settings } from 'llamaindex'
+ *   import { SpanlensClient } from '@spanlens/sdk'
+ *   import { registerSpanlensCallbacks } from '@spanlens/sdk/llamaindex'
+ *
+ *   const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+ *   const unregister = registerSpanlensCallbacks(Settings, { client })
+ *
+ *   // ... run your LlamaIndex queries ...
+ *
+ *   unregister() // remove callbacks when done (e.g. on process exit)
+ *
+ * @example Attach to an existing trace
+ *   const trace = client.startTrace({ name: 'rag_pipeline' })
+ *   const unregister = registerSpanlensCallbacks(Settings, { client, trace })
+ *   await queryEngine.query({ query: '...' })
+ *   unregister()
+ *   await trace.end()
+ */
+
+import { SpanlensClient } from '../client.js'
+import type { TraceHandle } from '../trace.js'
+import type { SpanHandle } from '../span.js'
+import type { EndSpanOptions } from '../types.js'
+
+export interface SpanlensLlamaIndexOptions {
+  /** Spanlens client instance. */
+  client: SpanlensClient
+  /**
+   * Optional trace to attach LLM spans to.
+   * When provided, `trace.end()` is NOT called — the caller manages the lifecycle.
+   * When omitted, a new trace is created per LLM call and closed on completion.
+   */
+  trace?: TraceHandle
+  /** Name for auto-created traces. Default: 'llamaindex_run'. */
+  traceName?: string
+}
+
+/** Minimal CallbackManager interface — only methods we use. */
+interface CallbackManager {
+  on(event: string, handler: (payload: unknown) => void): void
+  off(event: string, handler: (payload: unknown) => void): void
+}
+
+/** Minimal Settings shape — only callbackManager is required. */
+export interface LlamaIndexSettings {
+  callbackManager: CallbackManager
+}
+
+/** LlamaIndex `llm-start` event payload. */
+interface LLMStartPayload {
+  id: string
+  messages: unknown[]
+}
+
+/** LlamaIndex `llm-end` event payload. */
+interface LLMEndPayload {
+  id: string
+  response: {
+    raw?: {
+      usage?: {
+        input_tokens?: number
+        output_tokens?: number
+        total_tokens?: number
+      }
+      model?: string
+    }
+    message?: unknown
+  }
+}
+
+function parseLlamaIndexResult(response: LLMEndPayload['response']): EndSpanOptions {
+  const usage = response?.raw?.usage
+  if (!usage) return {}
+
+  const promptTokens = usage.input_tokens ?? 0
+  const completionTokens = usage.output_tokens ?? 0
+  const totalTokens = usage.total_tokens ?? promptTokens + completionTokens
+
+  const out: EndSpanOptions = { promptTokens, completionTokens, totalTokens }
+  const modelName = response?.raw?.model
+  if (modelName) out.metadata = { model: modelName }
+  return out
+}
+
+/**
+ * Registers Spanlens tracing callbacks on a LlamaIndex `CallbackManager`.
+ *
+ * Returns an `unregister` function — call it to remove the callbacks and
+ * release any pending run state (e.g. when cleaning up after a test or
+ * when the LlamaIndex query engine is disposed).
+ */
+export function registerSpanlensCallbacks(
+  settings: LlamaIndexSettings,
+  options: SpanlensLlamaIndexOptions,
+): () => void {
+  const { client, traceName = 'llamaindex_run' } = options
+
+  const runs = new Map<
+    string,
+    { trace: TraceHandle; span: SpanHandle; isLocalTrace: boolean }
+  >()
+
+  function onStart(payload: unknown): void {
+    const { id, messages } = payload as LLMStartPayload
+    const isLocalTrace = options.trace === undefined
+    const trace = options.trace ?? client.startTrace({ name: traceName })
+    const span = trace.span({ name: 'llm.call', spanType: 'llm', input: messages })
+    runs.set(id, { trace, span, isLocalTrace })
+  }
+
+  function onEnd(payload: unknown): void {
+    const { id, response } = payload as LLMEndPayload
+    const run = runs.get(id)
+    if (!run) return
+    runs.delete(id)
+
+    const parsed = parseLlamaIndexResult(response)
+
+    run.span
+      .end({
+        status: 'completed',
+        ...(response?.message !== undefined ? { output: response.message } : {}),
+        ...parsed,
+      })
+      .catch(() => undefined)
+
+    if (run.isLocalTrace) {
+      run.trace.end({ status: 'completed' }).catch(() => undefined)
+    }
+  }
+
+  settings.callbackManager.on('llm-start', onStart)
+  settings.callbackManager.on('llm-end', onEnd)
+
+  return function unregister(): void {
+    settings.callbackManager.off('llm-start', onStart)
+    settings.callbackManager.off('llm-end', onEnd)
+    runs.clear()
+  }
+}

--- a/packages/sdk/src/integrations/llamaindex.ts
+++ b/packages/sdk/src/integrations/llamaindex.ts
@@ -108,16 +108,16 @@ export function registerSpanlensCallbacks(
     { trace: TraceHandle; span: SpanHandle; isLocalTrace: boolean }
   >()
 
-  function onStart(payload: unknown): void {
-    const { id, messages } = payload as LLMStartPayload
+  function onStart(event: unknown): void {
+    const { id, messages } = (event as { detail: LLMStartPayload }).detail
     const isLocalTrace = options.trace === undefined
     const trace = options.trace ?? client.startTrace({ name: traceName })
     const span = trace.span({ name: 'llm.call', spanType: 'llm', input: messages })
     runs.set(id, { trace, span, isLocalTrace })
   }
 
-  function onEnd(payload: unknown): void {
-    const { id, response } = payload as LLMEndPayload
+  function onEnd(event: unknown): void {
+    const { id, response } = (event as { detail: LLMEndPayload }).detail
     const run = runs.get(id)
     if (!run) return
     runs.delete(id)

--- a/packages/sdk/src/integrations/vercel-ai.ts
+++ b/packages/sdk/src/integrations/vercel-ai.ts
@@ -1,0 +1,147 @@
+/**
+ * Vercel AI SDK integration for Spanlens tracing.
+ *
+ * Records LLM spans from `generateText`, `streamText`, `generateObject`, and
+ * `streamObject` via their `onFinish` / `onStepFinish` callbacks.
+ * No direct import from 'ai' — works as a duck-typed integration.
+ *
+ * @example Basic usage with generateText
+ *   import { SpanlensClient } from '@spanlens/sdk'
+ *   import { createSpanlensTracker } from '@spanlens/sdk/vercel-ai'
+ *
+ *   const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+ *   const tracker = createSpanlensTracker({ client, modelName: 'gpt-4o' })
+ *
+ *   const result = await generateText({
+ *     model: openai('gpt-4o'),
+ *     messages: [...],
+ *     onStepFinish: tracker.onStepFinish,
+ *     onFinish: tracker.onFinish,
+ *   })
+ *
+ * @example Attach to an existing trace
+ *   const trace = client.startTrace({ name: 'my_workflow' })
+ *   const tracker = createSpanlensTracker({ client, trace, modelName: 'gpt-4o' })
+ *   await generateText({ ..., onFinish: tracker.onFinish })
+ *   await trace.end()
+ */
+
+import { SpanlensClient } from '../client.js'
+import type { TraceHandle } from '../trace.js'
+
+export interface SpanlensVercelAIOptions {
+  /** Spanlens client instance. */
+  client: SpanlensClient
+  /**
+   * Optional trace to attach LLM spans to.
+   * When provided, `trace.end()` is NOT called — the caller manages the lifecycle.
+   * When omitted, a new trace is created and closed on `onFinish`.
+   */
+  trace?: TraceHandle
+  /** Name for auto-created traces. Default: 'ai.generate'. */
+  traceName?: string
+  /**
+   * Model name label for the span (e.g. 'gpt-4o', 'claude-3-5-sonnet').
+   * Used to name the span; the actual modelId from the response overrides
+   * `metadata.model` if available.
+   */
+  modelName?: string
+}
+
+/** Token usage shape from Vercel AI SDK `onFinish` / `onStepFinish` events. */
+export interface VercelAIUsage {
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
+}
+
+/** Shape of the `onStepFinish` event from `generateText` / `streamText`. */
+export interface VercelAIStepFinishEvent {
+  usage?: VercelAIUsage
+  finishReason?: string
+  text?: string
+  stepType?: string
+  isContinued?: boolean
+  response?: {
+    id?: string
+    modelId?: string
+    model?: string
+  }
+}
+
+/** Shape of the `onFinish` event from `generateText` / `streamText`. */
+export interface VercelAIFinishEvent {
+  usage?: VercelAIUsage
+  finishReason?: string
+  text?: string
+  response?: {
+    id?: string
+    modelId?: string
+    model?: string
+  }
+}
+
+export interface SpanlensVercelAITracker {
+  /** Pass to `onStepFinish` — records intermediate steps for multi-tool runs. */
+  onStepFinish: (event: VercelAIStepFinishEvent) => Promise<void>
+  /** Pass to `onFinish` — closes the span with final total usage. */
+  onFinish: (event: VercelAIFinishEvent) => Promise<void>
+}
+
+/**
+ * Creates a tracker object whose `onStepFinish` and `onFinish` methods can be
+ * spread directly into `generateText` / `streamText` options.
+ *
+ * A new LLM span is started immediately (so latency is measured from the
+ * moment the AI call begins). The span is closed when `onFinish` fires.
+ */
+export function createSpanlensTracker(
+  options: SpanlensVercelAIOptions,
+): SpanlensVercelAITracker {
+  const { client, traceName = 'ai.generate', modelName } = options
+
+  const isLocalTrace = options.trace === undefined
+  const trace = options.trace ?? client.startTrace({ name: traceName })
+  const span = trace.span({
+    name: modelName ? `llm.${modelName}` : 'llm.call',
+    spanType: 'llm',
+  })
+
+  let stepCount = 0
+
+  return {
+    async onStepFinish(_event: VercelAIStepFinishEvent): Promise<void> {
+      stepCount++
+      // Step-level detail is recorded as metadata on the final span.
+      // Individual steps are not broken out into child spans to keep the
+      // trace tree simple for the common case.
+    },
+
+    async onFinish(event: VercelAIFinishEvent): Promise<void> {
+      const { usage, finishReason, text, response } = event
+      const resolvedModel =
+        response?.modelId ?? response?.model ?? modelName ?? 'unknown'
+      const isError = finishReason === 'error'
+
+      const promptTokens = usage?.promptTokens ?? 0
+      const completionTokens = usage?.completionTokens ?? 0
+      const totalTokens =
+        usage?.totalTokens ?? promptTokens + completionTokens
+
+      await span.end({
+        status: isError ? 'error' : 'completed',
+        ...(text !== undefined ? { output: text } : {}),
+        ...(usage ? { promptTokens, completionTokens, totalTokens } : {}),
+        metadata: {
+          model: resolvedModel,
+          ...(finishReason ? { finishReason } : {}),
+          ...(stepCount > 1 ? { steps: stepCount } : {}),
+        },
+      })
+
+      if (isLocalTrace) {
+        await trace.end({ status: isError ? 'error' : 'completed' })
+      }
+    },
+  }
+}

--- a/packages/sdk/src/integrations/vercel-ai.ts
+++ b/packages/sdk/src/integrations/vercel-ai.ts
@@ -48,10 +48,16 @@ export interface SpanlensVercelAIOptions {
   modelName?: string
 }
 
-/** Token usage shape from Vercel AI SDK `onFinish` / `onStepFinish` events. */
+/**
+ * Token usage shape from Vercel AI SDK `onFinish` / `onStepFinish` events.
+ * AI SDK 4.x uses promptTokens/completionTokens; AI SDK 5.x uses inputTokens/outputTokens.
+ * Both are accepted.
+ */
 export interface VercelAIUsage {
-  promptTokens?: number
+  promptTokens?: number    // AI SDK 4.x
   completionTokens?: number
+  inputTokens?: number     // AI SDK 5.x
+  outputTokens?: number
   totalTokens?: number
 }
 
@@ -123,8 +129,8 @@ export function createSpanlensTracker(
         response?.modelId ?? response?.model ?? modelName ?? 'unknown'
       const isError = finishReason === 'error'
 
-      const promptTokens = usage?.promptTokens ?? 0
-      const completionTokens = usage?.completionTokens ?? 0
+      const promptTokens = usage?.promptTokens ?? usage?.inputTokens ?? 0
+      const completionTokens = usage?.completionTokens ?? usage?.outputTokens ?? 0
       const totalTokens =
         usage?.totalTokens ?? promptTokens + completionTokens
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,13 +110,13 @@ importers:
         version: 1.1.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       geist:
         specifier: ^1.7.0
-        version: 1.7.0(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 1.7.0(next@14.2.35(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       lucide-react:
         specifier: ^0.446.0
         version: 0.446.0(react@18.3.1)
       next:
         specifier: 14.2.35
-        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -697,6 +697,10 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@paddle/paddle-js@1.6.2':
     resolution: {integrity: sha512-nx1NXCzwWUWjf0iaRDiXZlfWgFjNZ6996RFcTDk0G0ggzrh514Zsc6jGTPOUGdLB1sYJXVQiKKoNLoKoXhH+sA==}
@@ -3806,6 +3810,9 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@opentelemetry/api@1.9.1':
+    optional: true
+
   '@paddle/paddle-js@1.6.2': {}
 
   '@pkgjs/parseargs@0.11.0':
@@ -5469,9 +5476,9 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  geist@1.7.0(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  geist@1.7.0(next@14.2.35(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
-      next: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.35(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   generator-function@2.0.1: {}
 
@@ -5868,7 +5875,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.35(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -5889,6 +5896,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.33
       '@next/swc-win32-ia32-msvc': 14.2.33
       '@next/swc-win32-x64-msvc': 14.2.33
+      '@opentelemetry/api': 1.9.1
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros


### PR DESCRIPTION
## Summary

- **SDK v0.3.0 integrations**: LangChain, Vercel AI SDK, LlamaIndex native integrations with auto-traced callbacks/handlers
- **SDK docs**: new `/docs/sdk` page covering all framework integrations with code examples
- **Anomalies docs**: add "Contributing factors" section explaining root-cause signals (token delta, HTTP status breakdown, latency spikes)
- **Self-host docs**: full rewrite — init.sql SQL Editor flow, pre-built GHCR images, runtime `NEXT_PUBLIC_*` patching via entrypoint sed, env var reference table

## Test plan

- [ ] `pnpm --filter sdk test` — integration tests for LangChain, Vercel AI SDK, LlamaIndex
- [ ] `pnpm typecheck` — full monorepo type check
- [ ] `/docs/sdk` page renders correctly with all framework examples
- [ ] `/docs/features/anomalies` page renders contributing factors section
- [ ] `/docs/self-host` page renders Option A/B, env table, Upgrading section
- [ ] `docker compose up -d` with pre-built images boots successfully