### PR TITLE
feat(server): Upstash Redis sliding-window rate limiter (P1.1)

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -44,6 +44,12 @@ SENTRY_ORG=
 SENTRY_PROJECT=spanlens-server
 SENTRY_AUTH_TOKEN=
 
+# Upstash for Redis — rate limiting (sliding window)
+# Vercel Storage → "upstash-kv-aqua-flask" 연결 시 자동 주입됨
+# 로컬 dev: 미설정 시 rate limit이 fails-open (항상 허용)
+KV_REST_API_URL=
+KV_REST_API_TOKEN=
+
 # ClickHouse — requests 테이블이 여기 저장됨 (Supabase 아님)
 # 로컬 dev: docker compose up clickhouse 후 아래 default 값 사용
 # 프로덕션: ClickHouse Cloud (https://clickhouse.cloud/) 가입 후 발급받은 값

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -21,6 +21,8 @@
     "@sentry/node": "^10.53.1",
     "@sentry/profiling-node": "^10.53.1",
     "@supabase/supabase-js": "^2.45.4",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "@vercel/functions": "^3.4.4",
     "dotenv": "^16.4.5",
     "hono": "^4.6.3"

--- a/apps/server/src/lib/rate-limit.ts
+++ b/apps/server/src/lib/rate-limit.ts
@@ -1,4 +1,5 @@
-import { supabaseAdmin } from './db.js'
+import { Redis } from '@upstash/redis'
+import { Ratelimit } from '@upstash/ratelimit'
 import type { Plan } from './quota.js'
 
 /**
@@ -22,34 +23,80 @@ export const PROXY_RATE_LIMITS: Record<Plan, number | null> = {
  */
 export const API_RATE_LIMIT = 120
 
-/** Returns the current UTC minute window string: "YYYY-MM-DDTHH:MM" */
-function currentWindow(): string {
-  return new Date().toISOString().slice(0, 16)
+// ---------------------------------------------------------------------------
+// Redis singleton — lazy init so the module is safe to import without env vars
+// ---------------------------------------------------------------------------
+
+let _redis: Redis | null = null
+
+function getRedis(): Redis | null {
+  if (_redis) return _redis
+
+  const url = process.env.KV_REST_API_URL
+  const token = process.env.KV_REST_API_TOKEN
+
+  if (!url || !token) return null
+
+  _redis = new Redis({ url, token })
+  return _redis
 }
 
+// ---------------------------------------------------------------------------
+// Ratelimit instances — one per unique limit value (free/starter/team/api)
+// ---------------------------------------------------------------------------
+
+const _limiters = new Map<number, Ratelimit>()
+
+function getLimiter(limit: number): Ratelimit | null {
+  const redis = getRedis()
+  if (!redis) return null
+
+  if (!_limiters.has(limit)) {
+    _limiters.set(
+      limit,
+      new Ratelimit({
+        redis,
+        limiter: Ratelimit.slidingWindow(limit, '60 s'),
+        // Prefix all keys so they don't collide with other Redis data
+        prefix: 'spanlens:rl',
+      }),
+    )
+  }
+
+  return _limiters.get(limit)!
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
 /**
- * Atomically increments the request count for (key, currentMinute) and
- * returns whether the request is within the given limit.
+ * Checks whether `key` is within the sliding-window rate limit.
  *
- * Fails open (returns true) on any DB error so transient Supabase
- * hiccups never block legitimate traffic.
+ * Returns true (allow) when:
+ *   - the request is within the limit
+ *   - Redis is not configured (fails open — transient misconfiguration
+ *     should never block legitimate traffic)
+ *   - any Redis error occurs (fails open with a console warning)
+ *
+ * Returns false (deny) only when the limit is positively exceeded.
  */
 export async function checkRateLimit(
   key: string,
   limit: number,
 ): Promise<boolean> {
-  const window = currentWindow()
+  const limiter = getLimiter(limit)
 
-  const { data, error } = await supabaseAdmin.rpc('check_rate_limit', {
-    p_key: key,
-    p_window_key: window,
-    p_limit: limit,
-  })
-
-  if (error) {
-    console.error('[rate-limit] rpc error — failing open:', error.message)
+  if (!limiter) {
+    // Redis not configured — fail open (dev / misconfigured prod)
     return true
   }
 
-  return data as boolean
+  try {
+    const { success } = await limiter.limit(key)
+    return success
+  } catch (err) {
+    console.error('[rate-limit] Redis error — failing open:', err)
+    return true
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.45.4
         version: 2.104.0
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.38.0)
+      '@upstash/redis':
+        specifier: ^1.38.0
+        version: 1.38.0
       '@vercel/functions':
         specifier: ^3.4.4
         version: 3.4.4
@@ -2153,6 +2159,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+
+  '@upstash/redis@1.38.0':
+    resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
+
   '@vercel/functions@3.4.4':
     resolution: {integrity: sha512-mdmCTMxAUTT5GMSs/iS4EuovzoofXNbb44/iPFwlgqulnJg3FEf6Sk46kLlZL4zuTTJQPT5YPTdBgZVlYZ5Azg==}
     engines: {node: '>= 20'}
@@ -4246,6 +4264,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
@@ -6259,6 +6280,19 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.38.0
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.38.0)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.38.0
+
+  '@upstash/redis@1.38.0':
+    dependencies:
+      uncrypto: 0.1.3
 
   '@vercel/functions@3.4.4':
     dependencies:
@@ -8626,6 +8660,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  uncrypto@0.1.3: {}
 
   undici-types@5.26.5: {}
 


### PR DESCRIPTION
## Summary

- **Replaces** Supabase RPC `check_rate_limit` with `@upstash/ratelimit` sliding-window algorithm
- **Redis source**: Vercel Storage `upstash-kv-aqua-flask` (Free tier, IAD1 region) — env vars `KV_REST_API_URL` / `KV_REST_API_TOKEN` auto-injected by Vercel
- **Behavior unchanged**: same `checkRateLimit(key, limit)` interface, same plan-based limits in `PROXY_RATE_LIMITS`, same `middleware/rateLimit.ts`
- **Fails open** when Redis is not configured (local dev) or on any Redis error — transient issues never block legitimate proxy traffic
- Ratelimit instances are cached per limit value (4 unique values: 60 / 120 / 300 / 1500)

## Why sliding window?

Fixed window has a burst exploit at the boundary (2× requests in a short interval spanning two windows). Sliding window prevents this by counting requests in a rolling 60-second period.

## New packages

| Package | Version | Purpose |
|---------|---------|---------|
| `@upstash/redis` | ^1.38.0 | Upstash HTTP Redis client |
| `@upstash/ratelimit` | ^2.0.8 | Atomic sliding-window rate limiter |

## Test plan

- [ ] Deploy to preview — confirm `KV_REST_API_URL` / `KV_REST_API_TOKEN` are present in Vercel env
- [ ] Send >60 requests/min with a free-plan API key → verify 429 response with `Retry-After: 60`
- [ ] Send requests with Redis env vars unset locally → verify fails open (200, no 429)
- [ ] Typecheck + lint pass (already verified locally)