### PR TITLE
feat(server): ESLint no-restricted-imports for getClickhouse() + PR template (P1.2)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## 설명
+
+<!-- 변경 사항과 그 이유를 간략히 설명해 주세요 -->
+
+## 체크리스트
+
+- [ ] ClickHouse 쿼리: `getClickhouse()` 직접 호출 없음 (`src/lib/` 내부 파일 제외)
+- [ ] 새 ClickHouse 쿼리: `organization_id` 필터 포함 확인
+- [ ] 새 Supabase 테이블: `ALTER TABLE t ENABLE ROW LEVEL SECURITY` 포함
+- [ ] 새 `/proxy/*` 엔드포인트: `authApiKey` 미들웨어 사용
+- [ ] 새 `/api/*` 엔드포인트: `authJwt` 미들웨어 사용
+- [ ] 새 ClickHouse INSERT: `toClickhouseTimestamp()` 사용 (`.toISOString()` 직접 사용 금지)
+- [ ] 새 `lib/crypto.ts` 호출: `await` 빠뜨리지 않음 확인
+- [ ] Vercel Edge fire-and-forget: `fireAndForget()` 사용 (`.catch(console.error)` 패턴 금지)
+- [ ] 새 환경변수: `.env.example` 업데이트
+- [ ] 타입 검사 및 린트 통과: `pnpm typecheck && pnpm lint`

--- a/apps/server/.eslintrc.json
+++ b/apps/server/.eslintrc.json
@@ -12,8 +12,39 @@
   "rules": {
     "no-console": ["warn", { "allow": ["warn", "error"] }],
     "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
-    "@typescript-eslint/no-explicit-any": "warn"
+    "@typescript-eslint/no-explicit-any": "warn",
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "../lib/clickhouse.js",
+            "importNames": ["getClickhouse"],
+            "message": "Use getOrgClickhouse(orgId) from lib/clickhouse.ts or the helpers in lib/requests-query.ts instead of getClickhouse() directly."
+          },
+          {
+            "name": "../../lib/clickhouse.js",
+            "importNames": ["getClickhouse"],
+            "message": "Use getOrgClickhouse(orgId) from lib/clickhouse.ts or the helpers in lib/requests-query.ts instead of getClickhouse() directly."
+          }
+        ]
+      }
+    ]
   },
+  "overrides": [
+    {
+      "files": ["src/lib/**/*.ts"],
+      "rules": {
+        "no-restricted-imports": "off"
+      }
+    },
+    {
+      "files": ["src/__tests__/**/*.ts"],
+      "rules": {
+        "no-restricted-imports": "off"
+      }
+    }
+  ],
   "env": {
     "node": true,
     "es2022": true

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { supabaseAdmin } from '../lib/db.js'
-import { getClickhouse } from '../lib/clickhouse.js'
+import { getOrgClickhouse } from '../lib/clickhouse.js'
 import { deliverToChannel, type AlertNotification } from '../lib/notifiers.js'
 import { retryFailedWebhooks } from '../lib/webhook-dispatch.js'
 import { computeAndReportOverages } from '../lib/paddle-usage.js'
@@ -108,12 +108,13 @@ async function computeMetric(alert: AlertRow): Promise<number | null> {
     'AND created_at >= parseDateTime64BestEffort({windowStart:String})' +
     projectClause
 
+  const { client: ch } = getOrgClickhouse(alert.organization_id)
   try {
     if (alert.type === 'budget') {
       // sum(cost_usd) — no row limit needed, ClickHouse aggregates over the
       // whole window in-DB. Earlier Supabase implementation capped at 10k rows
       // which silently under-reported large alert windows.
-      const result = await getClickhouse().query({
+      const result = await ch.query({
         query: `SELECT sum(cost_usd) AS total FROM requests WHERE ${where}`,
         query_params: params,
         format: 'JSONEachRow',
@@ -124,7 +125,7 @@ async function computeMetric(alert: AlertRow): Promise<number | null> {
 
     if (alert.type === 'error_rate') {
       // Single GROUP-less aggregation returns both numerator and denominator.
-      const result = await getClickhouse().query({
+      const result = await ch.query({
         query: `
           SELECT count() AS total, countIf(status_code >= 400) AS errors
           FROM requests WHERE ${where}`,
@@ -140,7 +141,7 @@ async function computeMetric(alert: AlertRow): Promise<number | null> {
     // latency_p95 — ClickHouse's quantile() computes in-DB. Replaces the old
     // "pull 10k sorted rows, index into array" pattern (also subject to the
     // 10k cap which silently under-estimated p95 at scale).
-    const result = await getClickhouse().query({
+    const result = await ch.query({
       query: `SELECT quantileIf(0.95)(latency_ms, latency_ms > 0) AS p95 FROM requests WHERE ${where}`,
       query_params: params,
       format: 'JSONEachRow',

--- a/apps/server/src/api/providerKeys.ts
+++ b/apps/server/src/api/providerKeys.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { requireRole } from '../middleware/requireRole.js'
 import { supabaseAdmin } from '../lib/db.js'
-import { getClickhouse } from '../lib/clickhouse.js'
+import { getOrgClickhouse } from '../lib/clickhouse.js'
 import { aes256Encrypt } from '../lib/crypto.js'
 
 /**
@@ -72,8 +72,9 @@ providerKeysRouter.get('/', async (c) => {
   // pattern as lib/stale-key-digest.ts.
   const keyIds = rows.map((k) => k.id as string)
   const lastUsedMap = new Map<string, string>()
+  const { client: ch } = getOrgClickhouse(orgId)
   try {
-    const result = await getClickhouse().query({
+    const result = await ch.query({
       query:
         'SELECT provider_key_id AS id, max(created_at) AS last_used_at ' +
         'FROM requests ' +

--- a/apps/server/src/lib/clickhouse.ts
+++ b/apps/server/src/lib/clickhouse.ts
@@ -80,6 +80,31 @@ export async function pingClickhouse(): Promise<boolean> {
 }
 
 /**
+ * Returns the raw ClickHouse client scoped to a specific organization.
+ *
+ * This is a thin helper that pairs `getClickhouse()` with the caller's
+ * `organizationId` so API/middleware code must explicitly declare the org
+ * rather than calling the bare singleton. It does NOT automatically inject
+ * the WHERE clause — callers still write `organization_id = {orgId:UUID}` —
+ * but it makes the required scoping explicit at the call site.
+ *
+ * For higher-level helpers that fully handle scoping, prefer
+ * `requestsScope` / `selectRequests` / `countRequests` from
+ * `lib/requests-query.ts`.
+ *
+ * Usage:
+ *   const { client, orgId } = getOrgClickhouse(organizationId)
+ *   const result = await client.query({
+ *     query: 'SELECT id FROM requests WHERE organization_id = {orgId:UUID} AND ...',
+ *     query_params: { orgId, ... },
+ *     format: 'JSONEachRow',
+ *   })
+ */
+export function getOrgClickhouse(organizationId: string): { client: ClickHouseClient; orgId: string } {
+  return { client: getClickhouse(), orgId: organizationId }
+}
+
+/**
  * Formats a Date for a ClickHouse `DateTime64(3, 'UTC')` column.
  *
  * `Date.toISOString()` produces `2026-05-16T11:49:23.749Z`, but ClickHouse's


### PR DESCRIPTION
## Summary

- **`getOrgClickhouse(organizationId)`** helper added to `lib/clickhouse.ts` — makes the org scoping requirement explicit at the call site rather than invisible.
- **ESLint `no-restricted-imports` rule** added to `apps/server/.eslintrc.json` — blocks any future `getClickhouse` imports from `src/api/**`, `src/middleware/**`, etc., with an actionable error message. `src/lib/**` and `src/__tests__/**` are exempt (internal implementation files).
- **Two existing violations fixed**: `api/cron.ts` and `api/providerKeys.ts` migrated to `getOrgClickhouse` — same queries, no functional change.
- **`.github/pull_request_template.md`** created with a ClickHouse safety checklist.

## Test plan

- [ ] `pnpm --filter server typecheck` passes (no new TS errors)
- [ ] `pnpm --filter server lint` passes (no ESLint violations)
- [ ] Add a test import of `getClickhouse` in `src/api/` and confirm ESLint fires with the guidance message
- [ ] Confirm `src/lib/` files can still import `getClickhouse` without ESLint error

🤖 Generated with [Claude Code](https://claude.com/claude-code)