### PR TITLE
chore(ci): ignore eslint/vitest/globals major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,20 @@
 version: 2
 
+# Notes on the `ignore` rules below — these are workarounds, not preferences.
+# Re-evaluate each when the linked compatibility blocker resolves.
+#
+# - eslint 10: blocked by eslint-plugin-react 7.37 (transitive of
+#   eslint-config-next) using the removed context.getFilename() API. Re-enable
+#   when eslint-plugin-react ships an ESLint 10-compatible release.
+#
+# - vitest 4: requires vite ^6 || ^7 || ^8 as peer, but the workspace
+#   transitively resolves vite 5 (from other deps). Causes
+#   ERR_PACKAGE_PATH_NOT_EXPORTED on 'vite/module-runner' at vitest startup.
+#   Re-enable after upgrading vite to >=6 across the workspace.
+#
+# - globals 17: paired with the vitest 4 bump; safe on its own but Dependabot
+#   keeps grouping them. Drop this once vitest 4 is unblocked.
+
 updates:
   # Root workspace (pnpm-lock.yaml)
   - package-ecosystem: npm
@@ -10,6 +25,9 @@ updates:
     open-pull-requests-limit: 1
     labels:
       - dependencies
+    ignore:
+      - dependency-name: eslint
+        update-types: ["version-update:semver-major"]
     groups:
       all-deps:
         patterns: ["*"]
@@ -23,6 +41,9 @@ updates:
     open-pull-requests-limit: 1
     labels:
       - dependencies
+    ignore:
+      - dependency-name: eslint
+        update-types: ["version-update:semver-major"]
     groups:
       all-deps:
         patterns: ["*"]
@@ -36,6 +57,13 @@ updates:
     open-pull-requests-limit: 1
     labels:
       - dependencies
+    ignore:
+      - dependency-name: eslint
+        update-types: ["version-update:semver-major"]
+      - dependency-name: vitest
+        update-types: ["version-update:semver-major"]
+      - dependency-name: globals
+        update-types: ["version-update:semver-major"]
     groups:
       all-deps:
         patterns: ["*"]
@@ -49,6 +77,9 @@ updates:
     open-pull-requests-limit: 1
     labels:
       - dependencies
+    ignore:
+      - dependency-name: vitest
+        update-types: ["version-update:semver-major"]
     groups:
       all-deps:
         patterns: ["*"]


### PR DESCRIPTION
## Summary

Adds Dependabot `ignore` rules for three packages whose major bumps repeatedly broke grouped PRs this past cycle. Each rule has a documented unblock condition.

## Why

The recent grouped Dependabot PRs (#54-#58) needed manual intervention because three packages have known compatibility blockers that we resolved by **downgrading**. Without ignore rules, Dependabot will keep re-opening the same PRs every week, each requiring the same fix-up.

| Package | Blocker | Unblock |
|---|---|---|
| `eslint` 10 | `eslint-plugin-react@7.37` (transitive of `eslint-config-next`) uses removed `context.getFilename()` API → throws on load | When `eslint-plugin-react` ships ESLint 10 support |
| `vitest` 4 | Peer requires `vite >=6`, but workspace transitively resolves `vite 5` → `ERR_PACKAGE_PATH_NOT_EXPORTED` on `vite/module-runner` at test startup | After vite upgrade across workspace |
| `globals` 17 | Grouped with vitest 4 each week even though safe alone | Drop once vitest 4 unblocked |

## Scope per directory

- `/` (root): eslint
- `/apps/web`: eslint
- `/apps/server`: eslint, vitest, globals
- `/packages/sdk`: vitest

Patches (`update-types: ["version-update:semver-major"]` only) — Dependabot still picks up minor/patch updates for these packages.

## Test plan

- [x] dependabot.yml syntax valid (YAML parses)
- [ ] Wait for next Dependabot run to confirm no rebumps of vitest 4 / eslint 10 / globals 17