### PR TITLE
chore(ci): extend Dependabot ignores to root + sdk entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ version: 2
 
 updates:
   # Root workspace (pnpm-lock.yaml)
+  # NOTE: this entry's grouped PRs include bumps for any workspace package
+  # (cli, sdk, server, web) because the lockfile is shared. So the ignore
+  # set must cover every package's incompatibility, not just root deps.
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -27,6 +30,10 @@ updates:
       - dependencies
     ignore:
       - dependency-name: eslint
+        update-types: ["version-update:semver-major"]
+      - dependency-name: vitest
+        update-types: ["version-update:semver-major"]
+      - dependency-name: globals
         update-types: ["version-update:semver-major"]
     groups:
       all-deps:
@@ -43,6 +50,10 @@ updates:
       - dependencies
     ignore:
       - dependency-name: eslint
+        update-types: ["version-update:semver-major"]
+      - dependency-name: vitest
+        update-types: ["version-update:semver-major"]
+      - dependency-name: globals
         update-types: ["version-update:semver-major"]
     groups:
       all-deps:
@@ -78,7 +89,11 @@ updates:
     labels:
       - dependencies
     ignore:
+      - dependency-name: eslint
+        update-types: ["version-update:semver-major"]
       - dependency-name: vitest
+        update-types: ["version-update:semver-major"]
+      - dependency-name: globals
         update-types: ["version-update:semver-major"]
     groups:
       all-deps:


### PR DESCRIPTION
## Summary

Follow-up to #63. The vitest 4 / globals 17 ignore was added to the server-only entry, but the root all-deps group re-opened the same bump in PR #64 (now closed) because the root group's diff scans the whole pnpm-lock.yaml — not just root deps.

This PR extends `vitest` + `globals` semver-major ignores to the root entry, and adds the same set to the sdk entry for symmetry (root vs sdk is a coin flip for who triggers the rebump first).

## Test plan

- [x] dependabot.yml YAML syntax valid
- [x] Main verified locally: `pnpm install --frozen-lockfile` + `pnpm --filter server test` both pass (289/289)
- [ ] No new rebump PRs for vitest 4 / globals 17 next week