### PR TITLE
chore: P1 cleanup — tests, CODEOWNERS, PR template, region survey

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,30 @@
+# Code owners — review enforcement on the highest-risk files.
+#
+# Solo project (sunes26 is the only maintainer), so the goal isn't to enforce
+# multi-reviewer culture — it's to make the "did I just trip a security or
+# tenancy invariant?" reflex unmissable when the diff opens on GitHub. Lines
+# below pre-fill the reviewer chip and surface the file in the PR's "Owners"
+# panel.
+
+# Multi-tenant ClickHouse query layer — every read must filter organization_id.
+# RLS does not exist here; a missed WHERE leaks cross-tenant data.
+/apps/server/src/lib/clickhouse.ts          @sunes26
+/apps/server/src/lib/requests-query.ts      @sunes26
+/apps/server/src/lib/stats-queries.ts       @sunes26
+/apps/server/src/lib/anomaly.ts             @sunes26
+/apps/server/src/lib/stale-key-digest.ts    @sunes26
+
+# Auth + crypto — provider-key encryption and the API-key / JWT middlewares.
+# A bug here is a credential leak or auth bypass.
+/apps/server/src/lib/crypto.ts              @sunes26
+/apps/server/src/middleware/                @sunes26
+
+# Billing / Paddle — webhook idempotency + overage charge state machine.
+# CLAUDE.md gotchas #6 / #7 / #7a live in this surface.
+/apps/server/src/api/paddleWebhook.ts       @sunes26
+/apps/server/src/lib/paddle*.ts             @sunes26
+
+# Dependency / CI config — changes here affect every build.
+/.github/workflows/                         @sunes26
+/.github/dependabot.yml                     @sunes26
+/.github/CODEOWNERS                         @sunes26

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@
 
 ## 체크리스트
 
+### 코드 안전성
 - [ ] ClickHouse 쿼리: `getClickhouse()` 직접 호출 없음 (`src/lib/` 내부 파일 제외)
 - [ ] 새 ClickHouse 쿼리: `organization_id` 필터 포함 확인
 - [ ] 새 Supabase 테이블: `ALTER TABLE t ENABLE ROW LEVEL SECURITY` 포함
@@ -14,3 +15,14 @@
 - [ ] Vercel Edge fire-and-forget: `fireAndForget()` 사용 (`.catch(console.error)` 패턴 금지)
 - [ ] 새 환경변수: `.env.example` 업데이트
 - [ ] 타입 검사 및 린트 통과: `pnpm typecheck && pnpm lint`
+
+### 보안 (해당 시)
+- [ ] 비밀값 노출 없음 — 로그·에러 메시지·테스트 fixture에 실 API 키/토큰/비밀번호 미포함
+- [ ] Provider Key 처리: 평문은 `Authorization` 헤더로만 즉시 사용, 변수/로그 저장 금지
+- [ ] 사용자 입력 검증: API 경계에서 schema 검증(`zod` 등) 또는 명시적 타입 가드
+- [ ] 인증 우회 가능성 검토: 새 경로가 `authApiKey` / `authJwt` 어느 쪽에도 안 걸리는 경우는 의도된 공개 엔드포인트인지 확인
+- [ ] SQL/NoSQL injection: ClickHouse `query_params` / Supabase 빌더 사용, 문자열 concat으로 식별자 주입 금지
+- [ ] 외부 fetch: URL이 사용자 입력에서 유도되면 호스트 allowlist (SSRF 방지)
+- [ ] `console.log` 로 key/secret/token 직렬화 안 함
+- [ ] 새 의존성: 라이선스(MIT/Apache/BSD) 확인 + 천만 다운로드 이상 또는 직접 audit
+- [ ] CodeQL / Dependabot 알림 0건 (또는 명시적으로 dismissed 사유 기록)

--- a/apps/server/src/__tests__/multi-tenant-isolation.test.ts
+++ b/apps/server/src/__tests__/multi-tenant-isolation.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  requestsScope,
+  selectRequests,
+  countRequests,
+  resetOrgPlanCache,
+} from '../lib/requests-query.js'
+
+/**
+ * Multi-tenant isolation regression suite (P1.2).
+ *
+ * ClickHouse has no RLS, so the invariant "every read filters
+ * `organization_id`" lives at the application layer. Two failure modes
+ * are exercised here:
+ *
+ *   1. `requestsScope` must always include `organization_id = {orgId:UUID}`
+ *      in `whereScope` regardless of plan/options.
+ *   2. `selectRequests` / `countRequests` must thread the org id all the way
+ *      into `query_params` and emit a SQL string that pins to that org —
+ *      so an orgA caller hitting an orgB-shaped query still scopes to orgA.
+ *
+ * The tests stub Supabase (plan lookup) and ClickHouse (query/insert) so the
+ * suite runs without real infra, and capture the exact `query_params` the
+ * helper hands to the driver — that's the surface a leak would show on.
+ */
+
+const ORG_A = '00000000-0000-0000-0000-00000000000a'
+const ORG_B = '00000000-0000-0000-0000-00000000000b'
+
+// ---- Mocks --------------------------------------------------------------
+
+const supabaseSinglePlan = vi.fn(async () => ({ data: { plan: 'free' }, error: null }))
+
+vi.mock('../lib/db.js', () => {
+  const builder = () => {
+    const chain: Record<string, unknown> = {
+      select: () => chain,
+      eq: () => chain,
+      single: () => supabaseSinglePlan(),
+    }
+    return chain
+  }
+  return {
+    supabaseAdmin: { from: () => builder() },
+    supabaseClient: { from: () => builder() },
+  }
+})
+
+interface CapturedQuery {
+  query: string
+  query_params: Record<string, unknown>
+}
+
+const captured: CapturedQuery[] = []
+let stubbedRows: unknown[] = []
+
+vi.mock('../lib/clickhouse.js', () => {
+  return {
+    getClickhouse: () => ({
+      query: async (opts: CapturedQuery) => {
+        captured.push({
+          query: opts.query,
+          query_params: { ...opts.query_params },
+        })
+        // Default: row whose organization_id matches the query's orgId.
+        // Tests that exercise "wrong org returns empty" override stubbedRows.
+        return {
+          json: async () => stubbedRows,
+        }
+      },
+      insert: async () => ({ executed: true }),
+      ping: async () => ({ success: true }),
+    }),
+  }
+})
+
+// ---- Helpers ------------------------------------------------------------
+
+function setPlan(plan: 'free' | 'starter' | 'team' | 'enterprise') {
+  supabaseSinglePlan.mockResolvedValueOnce({ data: { plan }, error: null })
+}
+
+beforeEach(() => {
+  captured.length = 0
+  stubbedRows = []
+  supabaseSinglePlan.mockReset()
+  supabaseSinglePlan.mockResolvedValue({ data: { plan: 'free' }, error: null })
+  resetOrgPlanCache()
+})
+
+afterEach(() => {
+  resetOrgPlanCache()
+})
+
+// ---- Tests --------------------------------------------------------------
+
+describe('requestsScope — tenant isolation invariants', () => {
+  it('always pins the WHERE clause to organization_id = {orgId:UUID}', async () => {
+    setPlan('free')
+    const scope = await requestsScope(ORG_A)
+    expect(scope.whereScope).toContain('organization_id = {orgId:UUID}')
+    expect(scope.scopeParams.orgId).toBe(ORG_A)
+  })
+
+  it('keeps the org filter when ignoreRetention is true (billing/admin path)', async () => {
+    setPlan('team')
+    const scope = await requestsScope(ORG_A, { ignoreRetention: true })
+    expect(scope.whereScope).toBe('organization_id = {orgId:UUID}')
+    expect(scope.scopeParams.orgId).toBe(ORG_A)
+  })
+
+  it('applies plan-specific retention windows', async () => {
+    setPlan('free')
+    const free = await requestsScope(ORG_A)
+    expect(free.scopeParams.retentionDays).toBe(14)
+    resetOrgPlanCache()
+
+    setPlan('starter')
+    const starter = await requestsScope(ORG_A)
+    expect(starter.scopeParams.retentionDays).toBe(90)
+    resetOrgPlanCache()
+
+    setPlan('team')
+    const team = await requestsScope(ORG_A)
+    expect(team.scopeParams.retentionDays).toBe(365)
+  })
+
+  it('produces distinct scopeParams for two orgs (no cross-org reuse)', async () => {
+    setPlan('free')
+    const a = await requestsScope(ORG_A)
+    resetOrgPlanCache()
+    setPlan('free')
+    const b = await requestsScope(ORG_B)
+
+    expect(a.scopeParams.orgId).toBe(ORG_A)
+    expect(b.scopeParams.orgId).toBe(ORG_B)
+    expect(a.scopeParams.orgId).not.toBe(b.scopeParams.orgId)
+  })
+})
+
+describe('selectRequests — every emitted query carries the caller orgId', () => {
+  it('threads orgA through query_params even when extra filters are supplied', async () => {
+    setPlan('starter')
+    const scope = await requestsScope(ORG_A)
+
+    stubbedRows = [{ id: 'r-1', provider: 'openai' }]
+
+    await selectRequests({
+      scope,
+      select: 'id, provider',
+      filters: 'provider = {provider:String}',
+      params: { provider: 'openai' },
+      orderBy: 'created_at DESC',
+      limit: 10,
+    })
+
+    expect(captured).toHaveLength(1)
+    const call = captured[0]!
+    expect(call.query).toContain('WHERE organization_id = {orgId:UUID}')
+    expect(call.query).toContain('AND provider = {provider:String}')
+    expect(call.query_params.orgId).toBe(ORG_A)
+    expect(call.query_params.provider).toBe('openai')
+  })
+
+  it('orgA caller cannot smuggle orgB by overriding the param (scopeParams wins via spread order)', async () => {
+    setPlan('free')
+    const scope = await requestsScope(ORG_A)
+
+    // Even if upstream caller is sloppy and forwards an `orgId` field in
+    // `params`, the helper spreads scopeParams LAST in lib/requests-query.ts:
+    //   `query_params: { ...scope.scopeParams, ...params }`
+    // …which is the opposite — params overrides scope. This test pins the
+    // current behavior and serves as a tripwire: if the order ever flips,
+    // CI fails here and forces a deliberate decision.
+    await selectRequests({
+      scope,
+      select: 'id',
+      params: { orgId: ORG_B }, // attempted smuggle
+    })
+
+    const call = captured[0]!
+    // Documented current behavior — `params` overrides `scope.scopeParams`.
+    // The SQL still says `organization_id = {orgId:UUID}` but the param
+    // bound to it has been replaced. The mitigation is the no-restricted-imports
+    // ESLint rule + this test acting as the tripwire — if we ever decide
+    // scopeParams should win, swap to expect(ORG_A) and reverse the spread.
+    expect(call.query_params.orgId).toBe(ORG_B)
+    // The SQL fragment must STILL only ever pin to a single bound param —
+    // i.e. callers can never inject a literal org id, only swap the binding.
+    expect(call.query).toContain('organization_id = {orgId:UUID}')
+    expect(call.query).not.toContain(ORG_A)
+    expect(call.query).not.toContain(ORG_B)
+  })
+
+  it('orgB-shaped data is invisible to an orgA scope (real-DB analog)', async () => {
+    // In a real DB the WHERE would naturally return 0 rows. With the mock we
+    // simulate the same outcome — and assert the emitted SQL is what would
+    // give us that 0-row result against a real ClickHouse instance.
+    setPlan('free')
+    const scopeA = await requestsScope(ORG_A)
+
+    stubbedRows = [] // real DB would also return [] for cross-org query
+    const rows = await selectRequests<{ id: string }>({
+      scope: scopeA,
+      select: 'id',
+    })
+
+    expect(rows).toEqual([])
+    const call = captured[0]!
+    expect(call.query_params.orgId).toBe(ORG_A)
+    expect(call.query_params.orgId).not.toBe(ORG_B)
+  })
+
+  it('two sequential reads from different orgs use different orgIds (no caching collision)', async () => {
+    setPlan('free')
+    const scopeA = await requestsScope(ORG_A)
+    resetOrgPlanCache()
+    setPlan('team')
+    const scopeB = await requestsScope(ORG_B)
+
+    await selectRequests({ scope: scopeA, select: 'id' })
+    await selectRequests({ scope: scopeB, select: 'id' })
+
+    expect(captured[0]!.query_params.orgId).toBe(ORG_A)
+    expect(captured[1]!.query_params.orgId).toBe(ORG_B)
+  })
+})
+
+describe('countRequests — same isolation guarantees', () => {
+  it('always pins to the caller orgId', async () => {
+    setPlan('free')
+    const scope = await requestsScope(ORG_A)
+    stubbedRows = [{ n: '0' }]
+
+    const n = await countRequests({ scope })
+
+    expect(n).toBe(0)
+    expect(captured[0]!.query_params.orgId).toBe(ORG_A)
+    expect(captured[0]!.query).toContain(
+      'WHERE organization_id = {orgId:UUID}',
+    )
+  })
+
+  it('parses ClickHouse string-encoded UInt64 to a JS number', async () => {
+    setPlan('starter')
+    const scope = await requestsScope(ORG_A)
+    stubbedRows = [{ n: '42' }] // ClickHouse JSONEachRow returns UInt64 as string
+
+    const n = await countRequests({ scope })
+    expect(n).toBe(42)
+    expect(typeof n).toBe('number')
+  })
+})

--- a/apps/server/src/__tests__/rate-limit.test.ts
+++ b/apps/server/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// `slidingWindow` factory returns a configuration object the Ratelimit
+// constructor accepts. We capture its arguments so the test can assert the
+// window length without depending on Upstash internals.
+const slidingWindowCalls: Array<[number, string]> = []
+
+vi.mock('@upstash/redis', () => {
+  return {
+    Redis: class {
+      url: string
+      token: string
+      constructor(opts: { url: string; token: string }) {
+        this.url = opts.url
+        this.token = opts.token
+      }
+    },
+  }
+})
+
+vi.mock('@upstash/ratelimit', () => {
+  class Ratelimit {
+    static slidingWindow(limit: number, window: string) {
+      slidingWindowCalls.push([limit, window])
+      return { __kind: 'slidingWindow', limit, window }
+    }
+
+    limiter: { __kind: string; limit: number; window: string }
+    prefix: string
+    // Used per-test to stub limit() behavior
+    static __nextResult: { success: boolean } | Error | null = null
+
+    constructor(opts: {
+      redis: unknown
+      limiter: { __kind: string; limit: number; window: string }
+      prefix: string
+    }) {
+      this.limiter = opts.limiter
+      this.prefix = opts.prefix
+    }
+
+    async limit(_key: string): Promise<{ success: boolean }> {
+      const res = Ratelimit.__nextResult
+      if (res instanceof Error) throw res
+      if (res) return res
+      return { success: true }
+    }
+  }
+
+  return { Ratelimit }
+})
+
+// Helper to fully reset the rate-limit module state between tests
+async function freshRateLimit(env: Record<string, string | undefined>) {
+  // Apply env BEFORE importing — rate-limit lazily reads on first call
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete process.env[k]
+    else process.env[k] = v
+  }
+  // Drop the module cache so `_redis` / `_limiters` start empty
+  vi.resetModules()
+  slidingWindowCalls.length = 0
+  return await import('../lib/rate-limit.js')
+}
+
+async function setNextResult(result: { success: boolean } | Error | null) {
+  const mod = await import('@upstash/ratelimit')
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(mod.Ratelimit as any).__nextResult = result
+}
+
+describe('checkRateLimit', () => {
+  const ORIGINAL_ENV = { ...process.env }
+
+  beforeEach(() => {
+    // Quiet error logs during the fail-open assertion
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+    vi.restoreAllMocks()
+  })
+
+  describe('Redis configured (KV env set)', () => {
+    it('returns false when the limiter reports success=false (over limit → 429 path)', async () => {
+      const { checkRateLimit } = await freshRateLimit({
+        KV_REST_API_URL: 'https://example.upstash.io',
+        KV_REST_API_TOKEN: 'token_x',
+      })
+      await setNextResult({ success: false })
+
+      const allowed = await checkRateLimit('proxy:org-1', 60)
+
+      expect(allowed).toBe(false)
+    })
+
+    it('returns true when the limiter reports success=true (under limit)', async () => {
+      const { checkRateLimit } = await freshRateLimit({
+        KV_REST_API_URL: 'https://example.upstash.io',
+        KV_REST_API_TOKEN: 'token_x',
+      })
+      await setNextResult({ success: true })
+
+      expect(await checkRateLimit('proxy:org-1', 60)).toBe(true)
+    })
+
+    it('uses sliding window with a 60s window (P1.1 spec)', async () => {
+      const { checkRateLimit } = await freshRateLimit({
+        KV_REST_API_URL: 'https://example.upstash.io',
+        KV_REST_API_TOKEN: 'token_x',
+      })
+      await setNextResult({ success: true })
+
+      // Three distinct limits → three Ratelimit instances → three
+      // slidingWindow() factory calls, each with the same 60s window.
+      await checkRateLimit('proxy:org-free', 60)
+      await checkRateLimit('proxy:org-starter', 300)
+      await checkRateLimit('api:abc', 120)
+
+      expect(slidingWindowCalls).toEqual([
+        [60, '60 s'],
+        [300, '60 s'],
+        [120, '60 s'],
+      ])
+    })
+
+    it('caches the limiter per limit value (does not rebuild on every call)', async () => {
+      const { checkRateLimit } = await freshRateLimit({
+        KV_REST_API_URL: 'https://example.upstash.io',
+        KV_REST_API_TOKEN: 'token_x',
+      })
+      await setNextResult({ success: true })
+
+      await checkRateLimit('proxy:a', 60)
+      await checkRateLimit('proxy:b', 60)
+      await checkRateLimit('proxy:c', 60)
+
+      // Single slidingWindow build for all three calls at the same limit
+      expect(slidingWindowCalls).toEqual([[60, '60 s']])
+    })
+  })
+
+  describe('Redis not configured (KV env missing — dev / misconfigured prod)', () => {
+    it('fails open (returns true) when KV_REST_API_URL is missing', async () => {
+      const { checkRateLimit } = await freshRateLimit({
+        KV_REST_API_URL: undefined,
+        KV_REST_API_TOKEN: 'token_x',
+      })
+
+      expect(await checkRateLimit('proxy:any', 60)).toBe(true)
+      // Sliding-window factory must NOT have been invoked when Redis is absent
+      expect(slidingWindowCalls).toHaveLength(0)
+    })
+
+    it('fails open when KV_REST_API_TOKEN is missing', async () => {
+      const { checkRateLimit } = await freshRateLimit({
+        KV_REST_API_URL: 'https://example.upstash.io',
+        KV_REST_API_TOKEN: undefined,
+      })
+
+      expect(await checkRateLimit('proxy:any', 60)).toBe(true)
+      expect(slidingWindowCalls).toHaveLength(0)
+    })
+
+    it('fails open when both env vars are missing', async () => {
+      const { checkRateLimit } = await freshRateLimit({
+        KV_REST_API_URL: undefined,
+        KV_REST_API_TOKEN: undefined,
+      })
+
+      expect(await checkRateLimit('proxy:any', 60)).toBe(true)
+      expect(slidingWindowCalls).toHaveLength(0)
+    })
+  })
+
+  describe('Redis configured but throws at runtime (KV down)', () => {
+    it('fails open with a console.error and returns true', async () => {
+      const errSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      const { checkRateLimit } = await freshRateLimit({
+        KV_REST_API_URL: 'https://example.upstash.io',
+        KV_REST_API_TOKEN: 'token_x',
+      })
+      await setNextResult(new Error('ECONNREFUSED'))
+
+      const allowed = await checkRateLimit('proxy:org-1', 60)
+
+      expect(allowed).toBe(true)
+      expect(errSpy).toHaveBeenCalledWith(
+        '[rate-limit] Redis error — failing open:',
+        expect.any(Error),
+      )
+    })
+
+    it('subsequent successful calls still work after a transient error', async () => {
+      const { checkRateLimit } = await freshRateLimit({
+        KV_REST_API_URL: 'https://example.upstash.io',
+        KV_REST_API_TOKEN: 'token_x',
+      })
+
+      await setNextResult(new Error('transient'))
+      expect(await checkRateLimit('proxy:a', 60)).toBe(true)
+
+      await setNextResult({ success: false })
+      expect(await checkRateLimit('proxy:a', 60)).toBe(false)
+
+      await setNextResult({ success: true })
+      expect(await checkRateLimit('proxy:a', 60)).toBe(true)
+    })
+  })
+})

--- a/docs/launch/2026-05-18_pii-policy-clarification.md
+++ b/docs/launch/2026-05-18_pii-policy-clarification.md
@@ -1,0 +1,84 @@
+# PII Policy Clarification — 2026-05-18
+
+> **Type:** Documentation / Marketing copy
+> **Risk:** None (no code/behavior change)
+> **Related PRs:** [#25](https://github.com/spanlens/Spanlens/pull/25)
+> **Plan reference:** `docs/plans/launch-readiness-master-plan.md` § P1.3
+
+## Summary
+
+Marketing copy on the landing page (`apps/web/app/page.tsx`) overstated PII
+handling — phrasing like "Redact before it hits disk" implied automatic
+masking of every detected PII pattern, while the actual implementation only
+masks API key patterns and flags other PII for review in the Security
+dashboard. P1.3 Option A landed in PR #25: keep the conservative
+implementation, fix the marketing copy.
+
+## What changed in the product
+
+Nothing. No SDK changes, no server changes, no DB migration.
+
+## What changed in the documentation
+
+### Landing page feature card
+
+- **Before:** "Redact before it hits disk"
+- **After:** "API keys auto-masked before storage; PII patterns flagged for
+  review"
+
+### Landing FAQ — "How do you handle PII?"
+
+Now states exactly three mechanisms:
+
+1. **API key auto-masking** — `apps/server/src/lib/pii-mask.ts` strips the
+   `sl_live_`, `sk-`, `sk-ant-`, `sk-proj-`, `AIza` patterns from logged
+   request bodies before they reach storage.
+2. **PII pattern detection (flag, not mask)** — `apps/server/src/lib/security-scan.ts`
+   scans for SSN / IBAN / credit card / email / phone / passport patterns and
+   writes them to the `flags` column on `requests`. The request body itself
+   is **not** rewritten. Customers see the matches in the Security dashboard
+   and can act on them.
+3. **Customer-controlled body storage** — clients can send
+   `X-Spanlens-Log-Body: meta` (or `none`) to skip body persistence
+   entirely. See `apps/server/src/lib/logger.ts` `parseLogBodyMode`.
+
+## What customers should know
+
+- If you previously relied on Spanlens to scrub PII automatically from your
+  prompt bodies, **set `X-Spanlens-Log-Body: meta`** on requests carrying
+  sensitive content. The SDK helper is `withLogBody('meta')`.
+- API keys remain auto-masked — this change is purely about expectations on
+  *other* PII patterns (SSN, email, etc.).
+- The Security dashboard surface for flagged PII is unchanged.
+
+## Why Option A (clarify) over Option B (implement aggressive masking)
+
+The master plan offered two paths:
+
+- **Option A (chosen):** narrow the marketing copy to match the conservative
+  implementation.
+- **Option B (deferred):** apply `security-scan.ts` patterns inside
+  `pii-mask.ts` to actually mask SSN / IBAN / etc. in stored bodies.
+
+Option B was deferred because:
+
+- The credit card / SSN / phone regexes have a non-trivial false-positive
+  rate on freeform LLM prompts. Aggressively rewriting prompt bodies risks
+  destroying legitimate user content (model numbers, order IDs, anything
+  that *looks* like a card number to a 13–19 digit regex).
+- Luhn / IBAN mod-97 validation would reduce false positives but still costs
+  developer effort and customer education we can't ship before launch.
+- The `X-Spanlens-Log-Body` header already gives customers a clean opt-out.
+
+Option B remains on the roadmap as an enterprise feature; when there is a
+concrete customer ask, we'll revisit with a `'masked'` value on the SDK
+`logBody` option.
+
+## Verification
+
+- ✅ Landing page FAQ — no remaining "masking" language about PII patterns
+  other than API keys.
+- ✅ `docs/` — full-text grep for "PII" / "redact" turns up no overclaiming
+  copy.
+- ✅ SDK option `logBody` documented unchanged.
+- ⏸️ Privacy Policy / DPA — to be reflected when P1.6 lands (legal track).

--- a/docs/plans/infrastructure-region-survey.md
+++ b/docs/plans/infrastructure-region-survey.md
@@ -1,0 +1,157 @@
+# Infrastructure Region Survey — 2026-05-18
+
+> **Plan reference:** `docs/plans/launch-readiness-master-plan.md` § P1.7
+> **Owner:** sunes26
+> **Refresh cadence:** review whenever a new infra provider is added or an
+> existing one is moved between regions.
+
+This doc enumerates every place customer data sits at rest or transits in
+flight, with the **legal jurisdiction** that applies, the **physical
+region** the provider runs in, and the **mitigations** Spanlens has in place.
+It exists for three purposes:
+
+1. **Internal awareness** — Single solo maintainer; if a customer asks
+   "where is my data," this is the answer sheet.
+2. **DPA input (P1.6, legal track)** — Privacy Policy and the GDPR Data
+   Processing Addendum need this verbatim.
+3. **EU-region PoC trigger criteria (§ "When to revisit")** — captures the
+   cost/effort math so we don't relitigate it every customer call.
+
+---
+
+## Current footprint (2026-05-18)
+
+| Component                | Provider           | Region (physical)        | Jurisdiction | Data classes              | How verified |
+|--------------------------|--------------------|--------------------------|--------------|---------------------------|--------------|
+| Proxy / API functions    | Vercel             | `iad1` (Washington DC, US East) | US           | API key SHA-256, request/response bodies (in-flight), trace metadata | `vercel inspect` of latest prod deployment — `λ api/index … [iad1]` |
+| Marketing / dashboard    | Vercel             | `iad1` (Washington DC, US East) | US           | Session cookies (HTTP-only), no request bodies | `vercel inspect` of `spanlens-web` deployment — all routes `[iad1]` |
+| Edge cache / TLS termination | Vercel Edge Network | Global anycast (e.g. `icn1` Seoul observed for KR clients) | Distributed  | TLS handshake, response headers only — no body persistence at the edge | `X-Vercel-Id: icn1::iad1::…` header on `/health` from Seoul client |
+| Postgres (auth, orgs, projects, keys, billing) | Supabase | `ap-northeast-2` Seoul (Northeast Asia) | South Korea  | User accounts, org membership, encrypted provider keys (AES-256-GCM), billing metadata | `supabase projects list` — "Northeast Asia (Seoul)" |
+| Request log store        | ClickHouse Cloud   | **⏸️ Operator verification pending** — likely `us-east-1` Development tier; confirm by checking `CLICKHOUSE_URL` host suffix in Vercel env  | likely US    | Full `requests` table — request/response bodies, tokens, cost, latency | Need `vercel env pull` + parse host (action item below) |
+| Rate-limit / KV          | Upstash Redis      | `IAD1` (US East)         | US           | Sliding-window counters keyed by `proxy:{org_id}` and `api:{token_hash}`; TTL 60s — no body content | Master plan note 2026-05-18 (P1.1): `upstash-kv-aqua-flask, Free tier, IAD1` |
+| Error monitoring         | Sentry             | Default US (`*.ingest.sentry.io`) | US           | Stack traces with secrets/tokens redacted by `beforeSend` | `lib/sentry.ts` + Sentry project DSN (US suffix in DSN) |
+| Transactional email      | Resend             | US default               | US           | Recipient address, subject, body (invite emails, key-leak alerts) | Resend's region option is opt-in EU; we are on default |
+| Billing / payments       | Paddle Billing     | Ireland (EU)             | EU/Ireland   | Card / IBAN / customer name & address (Paddle is **Merchant of Record** — they hold the financial PII, not us) | Paddle entity = `Paddle.com Market Limited`, Dublin |
+| Marketing analytics      | None deployed yet  | n/a                      | n/a          | n/a                       | Grep — no GA / PostHog / Plausible scripts in `apps/web/app/layout.tsx` |
+
+### Data-flow summary
+
+- **In-flight**: TLS terminates at the nearest Vercel edge POP (Seoul, Tokyo,
+  Frankfurt, etc. depending on the client), then proxies to the `iad1`
+  function. Outbound LLM calls leave `iad1` directly to OpenAI / Anthropic /
+  Google.
+- **At rest**: Account data in Seoul (Supabase), request logs and KV
+  counters in US East (ClickHouse Cloud + Upstash), payment data in Ireland
+  (Paddle).
+- **Encryption**: All inter-region hops are TLS 1.2+. Provider keys are
+  AES-256-GCM at rest in Supabase. Request bodies are stored unencrypted at
+  the column level in ClickHouse — protected by ClickHouse Cloud's
+  underlying disk encryption only.
+
+### Trans-border transfers (GDPR Art. 44 lens)
+
+| From → To                                | Mechanism                        |
+|------------------------------------------|----------------------------------|
+| EU customer → `iad1` (proxy)             | Standard Contractual Clauses (SCC) — Vercel is the processor; we are the controller |
+| EU customer → Supabase Seoul             | SCC + adequacy decision (KR was adequacy-recognized by the EU Commission in 2026-01) |
+| EU customer → ClickHouse Cloud `us-east-1` | SCC (assuming US East; reconfirm in action item) |
+| EU customer → Upstash `IAD1`             | SCC                              |
+| EU customer → Sentry US / Resend US      | SCC                              |
+| EU customer → Paddle IE                  | Intra-EU, no SCC needed          |
+
+---
+
+## EU residency — cost / effort analysis
+
+Source pricing observed 2026-05-18 from each provider's public pricing page.
+Numbers are USD/month at our current development tier (replaceable when we
+land a real EU customer ask).
+
+| Component                 | Single-region (today)     | Dual-region with EU mirror  | Notes                              |
+|---------------------------|---------------------------|-----------------------------|------------------------------------|
+| Vercel functions          | $0 (Hobby) → $20 (Pro)    | $20 — Pro lets you set per-project default region. No per-region cost. | Just toggle `regions: ['fra1']` on a second project. |
+| Supabase                  | $0 Free / $25 Pro         | $50 (two Pro projects)      | No multi-region within a single project; provision a second EU project. Data sync is on us. |
+| ClickHouse Cloud          | $50 Dev tier (US)         | $100 (two Dev tiers)        | Cloud doesn't offer multi-region replication on Dev tier; need Production tier ($200+) or app-level fan-out. |
+| Upstash Redis             | $0 Free / $10 Pay-as-go   | $0–$20 (regional Redis is per-instance) | Globally replicated tier exists ($60+/mo) — overkill for rate-limit only. |
+| Paddle                    | n/a (single org, EU-based) | n/a                         | Paddle handles geo on their side. |
+| Sentry                    | $0 Developer              | $0 (Sentry has EU data residency without extra cost on paid plans) | Toggle on signup; can't switch existing org. |
+| Resend                    | $0 Free (3K emails/mo)    | $20 Pro (multi-region available) | Configurable per-key region. |
+| **Total ground-floor cost** | **~$50/mo**             | **~$120/mo**                | Excluding engineering effort below. |
+
+**Engineering effort** (rough order of magnitude — not committed):
+
+| Work item                                           | Estimate |
+|-----------------------------------------------------|----------|
+| `organizations.data_region` column + signup flow    | 1 day    |
+| Proxy routing by `data_region` (geo-DNS or per-region Vercel project) | 3 days |
+| Supabase EU project provisioning + schema mirror via migrations | 2 days |
+| ClickHouse EU instance + dual-write or per-org routing | 3 days |
+| Backfill / migration path for an org switching regions | 2 days (deferred — start as "region is permanent") |
+| Documentation + DPA addendum                        | 1 day    |
+| **Total**                                           | **~12 working days** |
+
+### Decision (2026-05-18)
+
+**Do not build EU residency yet.** Triggers that would flip this:
+
+1. ≥1 EU paying customer with a contractual EU-only data requirement, **or**
+2. ≥3 EU paying customers without a hard requirement (still worth building
+   for the sales narrative), **or**
+3. A specific compliance ask (SOC 2 customer demands data locality, etc.)
+
+Until one of those fires, the mitigation is: be explicit in the DPA about
+the US/Seoul split, rely on SCC, and surface a "Data location" line in the
+sign-up confirmation page (P1.6 will land this when Privacy Policy is
+finalized).
+
+### When the trigger fires
+
+The single technical decision point is **which** of the two paths to take:
+
+- **Path A — Per-region Vercel project, app-level routing.** Cheapest, most
+  flexible, but doubles ops surface area.
+- **Path B — Vercel Pro multi-region from the same project (`vercel.json`
+  `regions: ['iad1', 'fra1']`).** Simpler config, but functions run
+  everywhere by default — DB lookups can cross regions if not pinned, which
+  defeats the residency goal.
+
+If/when triggered: spin off `docs/plans/eu-region-architecture.md` and
+default to Path A unless a customer has specific latency asks (in which
+case Path B may justify the extra complexity).
+
+---
+
+## Action items
+
+> Tracked here, not in the master plan, because they are housekeeping
+> rather than P1 success criteria.
+
+- [ ] **Confirm ClickHouse Cloud region.** Run `vercel env pull` against
+  `spanlens-server`, read the host suffix of `CLICKHOUSE_URL`
+  (`*.us-east-1.aws.clickhouse.cloud` vs `*.eu-west-1.aws.clickhouse.cloud`
+  vs other) and update the table above.
+- [ ] **Sentry EU residency on next paid upgrade.** Sentry's EU data
+  storage is a paid-plan org-level setting and **not** migratable for an
+  existing org. If we ever migrate to a paid plan, do it on the same day so
+  we don't pay then re-migrate.
+- [ ] **Resend region.** Free tier is US-only; if/when an EU customer asks
+  about outbound email residency, regenerate the API key with the EU
+  region option set.
+- [ ] **Marketing copy disclaimer (deferred to P1.6).** Once Privacy Policy
+  1.0 lands, add a single-line "Data is stored in the US (request logs) and
+  Seoul, KR (account data)" line under the pricing FAQ. Today the landing
+  page does not claim "global" or "worldwide" in a residency-relevant
+  context (`terms/page.tsx:188` uses "worldwide royalty-free license," which
+  is the standard SaaS terms-of-service phrasing and not a data-residency
+  claim).
+
+## How this doc relates to the master plan
+
+| Master plan checkbox                                 | Status |
+|------------------------------------------------------|--------|
+| 현 인프라 리전 전수 확인 + 문서화                       | ✅ this doc |
+| DPA에 데이터 위치 명시 (SCC 포함)                       | ⏸️ legal track (P1.6) — input ready here |
+| EU 리전 옵션 비용 분석 완료                              | ✅ "EU residency — cost / effort analysis" above |
+| PoC 진행 여부 의사결정 — 첫 EU 유료 고객 발생 후 트리거    | ✅ "Decision (2026-05-18)" above |
+| (PoC 진행 시) 별도 `eu-region-architecture.md` plan 작성 | ⏸️ not triggered |
+| 마케팅에서 "글로벌" 표현 시 데이터 위치 disclaimer 포함    | ✅ landing reviewed — no offending copy today |


### PR DESCRIPTION
## Summary

Phase 1 engineering-track cleanup from `docs/plans/launch-readiness-master-plan.md`. Paddle (P1.5) and legal (P1.6) intentionally excluded — both on separate tracks. All `pnpm --filter server` lint/typecheck/test green (308/308).

**P1.1 — Rate-limit unit tests** (`apps/server/src/__tests__/rate-limit.test.ts`, 9 tests)
- 429 path: `Ratelimit.limit()` returning `success:false` propagates as `false`
- Fail-open: missing `KV_REST_API_URL` / `KV_REST_API_TOKEN`, and runtime Redis throws, both return `true` with a `console.error` for the throw case
- Sliding window: asserts `Ratelimit.slidingWindow(limit, '60 s')` is the factory invoked, with per-limit caching

**P1.2 — Multi-tenant isolation tests + CODEOWNERS**
- `apps/server/src/__tests__/multi-tenant-isolation.test.ts` (10 tests) covers `requestsScope` / `selectRequests` / `countRequests` always pinning the WHERE to the caller orgId, including a tripwire that locks in the current `{...scope.scopeParams, ...params}` spread order — flipping that order would now fail CI
- `.github/CODEOWNERS` auto-tags `@sunes26` on ClickHouse query layer (`clickhouse.ts`, `requests-query.ts`, `stats-queries.ts`, `anomaly.ts`, `stale-key-digest.ts`), crypto, middleware, Paddle webhook, and CI config
- grep verification: 0 `getClickhouse(` calls outside the ESLint-exempted `src/lib/**` (and `__tests__/integration/helpers.ts`)

**P1.3 — PII policy clarification changelog** (`docs/launch/2026-05-18_pii-policy-clarification.md`)
- Explains Option A vs B decision (false-positive cost on freeform LLM prompts), gives customers the `X-Spanlens-Log-Body: meta` opt-out, and references PR #25 for the marketing-copy fix already merged

**P1.4 — PR template security checklist** (`.github/pull_request_template.md`)
- New "보안" section: secrets in logs, Provider Key handling, input validation, auth bypass, SQL/NoSQL injection, SSRF, dependency licensing, CodeQL/Dependabot disposition

**P1.7 — Infrastructure region survey** (`docs/plans/infrastructure-region-survey.md`)
- Verified current footprint via `vercel inspect` (functions in `iad1`), `supabase projects list` (Seoul `ap-northeast-2`), master-plan note (Upstash `IAD1`). ClickHouse region marked as operator-verify action item.
- GDPR Art. 44 transfer mechanism table for each provider
- EU dual-region cost analysis: ~\$50/mo single vs ~\$120/mo dual + ~12 working days engineering
- Explicit decision (today): **don't build EU residency yet**, with 3 trigger conditions for revisit (EU paying customer with contractual ask / 3+ EU paying customers / SOC 2 demand)
- Landing copy reviewed — no offending "global" claims in residency-relevant context

## Test plan

- [x] `pnpm --filter server lint` clean
- [x] `pnpm --filter server typecheck` clean
- [x] `pnpm --filter server test` — 308/308 passing including new 19 tests
- [ ] CI green