### PR TITLE
ci: native ARM runner matrix for Docker image publishes

### DIFF
--- a/.github/workflows/docker-publish-web.yml
+++ b/.github/workflows/docker-publish-web.yml
@@ -11,6 +11,9 @@ name: Publish spanlens-web Docker image
 # Note: NEXT_PUBLIC_* vars are compiled with placeholder strings at build time.
 # The docker-entrypoint.sh script replaces them at container startup using
 # the NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env vars.
+#
+# Multi-arch strategy: same matrix + manifest-merge pattern as
+# docker-publish.yml — see that file for the rationale.
 
 on:
   push:
@@ -31,8 +34,16 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/spanlens-web
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -40,6 +51,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Prepare platform pair
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
+      - name: Extract labels (manifest tags come from the merge job)
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.title=spanlens-web
+            org.opencontainers.image.description=Spanlens LLM observability dashboard (Next.js)
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.licenses=MIT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -51,7 +78,58 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./apps/web/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=web-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=web-${{ env.PLATFORM_PAIR }}
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-web-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-24.04
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-web-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags)
         id: meta
         uses: docker/metadata-action@v6
         with:
@@ -61,22 +139,14 @@ jobs:
             type=ref,event=tag
             type=sha,format=short
             type=raw,value=latest,enable={{is_default_branch}}
-          labels: |
-            org.opencontainers.image.title=spanlens-web
-            org.opencontainers.image.description=Spanlens LLM observability dashboard (Next.js)
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.licenses=MIT
 
-      - name: Build and push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./apps/web/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          # NEXT_PUBLIC_* are compiled with placeholder strings at build time.
-          # docker-entrypoint.sh replaces them at runtime — no build args needed here.
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,17 @@ name: Publish spanlens-server Docker image
 #
 # Registry: ghcr.io/<owner>/spanlens-server
 # Requires: built-in GITHUB_TOKEN (has packages:write via permissions block)
+#
+# Multi-arch strategy (2026-05-18, see PR ci/docker-native-arm-runner):
+#   We build amd64 and arm64 on their NATIVE GitHub-hosted runners
+#   (`ubuntu-24.04` and `ubuntu-24.04-arm`), push each to GHCR by digest,
+#   and the `merge` job stitches the two digests into a single tag list
+#   with `docker buildx imagetools create`. We previously used a single
+#   amd64 runner with qemu user-mode emulation for arm64, but Node 22-alpine
+#   + pnpm under qemu hit SIGILL on every other build (workflow run #125
+#   ran 3h before being cancelled). Native ARM runners are 5–10× faster
+#   AND don't crash. Reference: docker/build-push-action docs
+#   "Distribute build across multiple runners".
 
 on:
   push:
@@ -27,15 +38,39 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/spanlens-server
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
-      id-token: write  # for sigstore cosign (future)
+      id-token: write
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Prepare platform pair
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
+      - name: Extract labels (manifest tags come from the merge job)
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.title=spanlens-server
+            org.opencontainers.image.description=Spanlens LLM observability proxy + API server
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.licenses=MIT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -47,7 +82,62 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./apps/server/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Push the image by digest only (no tag). The merge job adds the
+          # human-readable tags as a manifest list referencing both digests.
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          # Scope the GHA cache per-platform so amd64 and arm64 don't
+          # invalidate each other on every run.
+          cache-from: type=gha,scope=server-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=server-${{ env.PLATFORM_PAIR }}
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-server-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-24.04
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-server-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags)
         id: meta
         uses: docker/metadata-action@v6
         with:
@@ -57,20 +147,14 @@ jobs:
             type=ref,event=tag
             type=sha,format=short
             type=raw,value=latest,enable={{is_default_branch}}
-          labels: |
-            org.opencontainers.image.title=spanlens-server
-            org.opencontainers.image.description=Spanlens LLM observability proxy + API server
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.licenses=MIT
 
-      - name: Build and push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./apps/server/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Summary

Fixes the recurring 3-hour hang in [Publish spanlens-server Docker image #125](https://github.com/spanlens/Spanlens/actions/runs/26015993097) and replaces qemu-emulated multi-arch with native ARM runners.

**Root cause** of the hang (workflow run #125, log line 435):
```
#22 20.53 qemu: uncaught target signal 4 (Illegal instruction) - core dumped
```
The previous setup used a single `ubuntu-latest` runner with `--platform linux/amd64,linux/arm64`. ARM64 was emulated via qemu user-mode, and Node 22-alpine + pnpm under that emulator hits SIGILL — not a one-off, this is a known recurring failure mode on JIT-heavy binaries. GitHub Actions doesn't detect qemu hangs, so the job just sat there until manually cancelled.

## Change

Both `docker-publish.yml` (server) and `docker-publish-web.yml` (web) move to the canonical [docker/build-push-action "Distribute build across multiple runners"](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners) pattern:

1. **`build` job** — matrix over `[linux/amd64 on ubuntu-24.04, linux/arm64 on ubuntu-24.04-arm]`. Each leg builds for its own native arch (no emulation), pushes to GHCR **by digest only** (no human tag), and uploads the digest as an artifact.
2. **`merge` job** — downloads both digest artifacts and calls `docker buildx imagetools create` to assemble a multi-arch manifest with the metadata-action tags (`:main`, `:<sha>`, `:latest`).

GHA cache is scoped per platform (`scope=server-linux-amd64` / `scope=server-linux-arm64` and the same for web) so the two legs don't fight over the same cache slot on every push.

## Expected effects

- **Build time:** 40–90 min (qemu) → 5–10 min (native), both legs run in parallel.
- **Reliability:** qemu SIGILL class of failures is gone for good.
- **Cost:** \$0 — `ubuntu-24.04-arm` runners are free on public repos (Jan 2025 GA).

## Test plan

- [ ] CI green on this PR (matrix build runs without `qemu` lines in logs)
- [ ] After merge, the next push that touches `apps/server/**` triggers a successful multi-arch publish — verify by `docker buildx imagetools inspect ghcr.io/spanlens/spanlens-server:main` shows both `linux/amd64` and `linux/arm64` entries
- [ ] arm64 build leg finishes in < 15 min (vs ~3h previously)

## Notes

- The hung run #125 is being cancelled manually by the maintainer in parallel.
- After this PR merges, the `chore(deps): bump the all-deps group with 32 updates (#58)` ARM image will retroactively get re-published on the next qualifying push (or `workflow_dispatch`).