### PR TITLE
fix(web): pin formatDate locale to en-US — stops React #418 on billing page

### DIFF
--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -5,7 +5,17 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+// Locale is pinned to en-US to keep server SSR and client renders identical.
+// `toLocaleDateString()` without an explicit locale follows the runtime default
+// — Node defaults to en-US, but a Korean browser defaults to ko-KR, which
+// produces a different string ("5/18/2026" vs "2026. 5. 18.") and trips
+// React #418 hydration mismatch. The dashboard UI is English, so en-US is
+// consistent with the surrounding copy ("Renews on May 18, 2026").
 export function formatDate(iso: string | null): string {
   if (!iso) return '—'
-  return new Date(iso).toLocaleDateString()
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
 }


### PR DESCRIPTION
## Summary

Fixes the React #418 hydration mismatch ([https://react.dev/errors/418?args[]=text&args[]=](https://react.dev/errors/418?args[]=text&args[]=)) that started appearing on /billing and /settings the moment the first production Paddle subscription landed.

## Root cause

[apps/web/lib/utils.ts:8-11](apps/web/lib/utils.ts:8) called \`toLocaleDateString()\` with no explicit locale. Result:

| Runtime | Locale | Output |
|---------|--------|--------|
| Vercel iad1 SSR (Node) | en-US default | \`"5/18/2026"\` |
| Korean browser (client) | ko-KR | \`"2026. 5. 18."\` |

Same input ISO string → different render → React text hydration mismatch on first paint.

Only triggered when \`subscription.current_period_end\` is non-null, so it stayed dormant until the first successful production checkout populated the column. Free-plan free users hit the \`'—'\` fallback path and never saw it.

## Fix

Pin locale to \`en-US\` with an explicit \`{ year, month: 'short', day }\` shape. Output is now \`"May 18, 2026"\`, which:
- Is deterministic across Node / browser / any locale
- Matches the surrounding English UI copy (\`"Renews on"\`, \`"Access until"\`)

Two pages benefit automatically (both call \`formatDate\` from the same util):
- [apps/web/app/(dashboard)/billing/billing-client.tsx:164-165](apps/web/app/(dashboard)/billing/billing-client.tsx:164)
- [apps/web/app/(dashboard)/settings/settings-client.tsx:713-714](apps/web/app/(dashboard)/settings/settings-client.tsx:713)

## Test plan

- [x] \`pnpm --filter web typecheck\` clean
- [x] \`pnpm --filter web lint\` clean
- [ ] After merge, reload \`https://www.spanlens.io/billing\` on a KR-locale browser with an active subscription — Console should be silent (no #418), and \`"Renews on May 18, 2026"\` text renders cleanly