### PR TITLE
fix(web): plan label says "Pro" instead of "STARTER" in sidebar & settings

### DIFF
--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -41,7 +41,7 @@ import {
   useCurrentMember,
   type OrgRole,
 } from '@/lib/queries/use-members'
-import { PLANS, PLAN_REQUEST_LIMITS, PLAN_SEAT_LIMITS, PLAN_RETENTION_DAYS } from '@/lib/billing-plans'
+import { PLANS, PLAN_REQUEST_LIMITS, PLAN_SEAT_LIMITS, PLAN_RETENTION_DAYS, formatPlanLabel } from '@/lib/billing-plans'
 import type { BillingPlan } from '@/lib/queries/types'
 import {
   useWebhooks,
@@ -674,7 +674,7 @@ function BillingTab() {
   const { data: quota } = useQuota()
 
   const planName = subscription?.plan ?? 'free'
-  const planLabel = planName.charAt(0).toUpperCase() + planName.slice(1)
+  const planLabel = formatPlanLabel(planName)
 
   const usedThisMonth = quota?.usedThisMonth ?? 0
   const limit = quota?.limit ?? 10_000

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils'
 import { createClient } from '@/lib/supabase/client'
 import { useStatsOverview } from '@/lib/queries/use-stats'
 import { useQuota } from '@/lib/queries/use-billing'
+import { formatPlanLabel } from '@/lib/billing-plans'
 import { useSidebar } from '@/lib/sidebar-context'
 import { useAnomalies } from '@/lib/queries/use-anomalies'
 import { useAlerts } from '@/lib/queries/use-alerts'
@@ -403,7 +404,7 @@ export function Sidebar() {
       {/* Usage + upgrade widget */}
       <div className="mx-[18px] mb-[14px] mt-2 p-3 rounded-md border border-border bg-bg-muted">
         <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-1.5">
-          Plan · {quota.data?.plan ?? 'free'}
+          Plan · {formatPlanLabel(quota.data?.plan)}
         </div>
         <div className="text-[13px] text-text mb-1.5">
           {quota.data

--- a/apps/web/lib/billing-plans.ts
+++ b/apps/web/lib/billing-plans.ts
@@ -94,3 +94,19 @@ export const PLAN_RETENTION_DAYS: Record<string, number> = {
   team: 365,
   enterprise: 36_500,
 }
+
+/**
+ * Display label for a plan identifier. Single source of truth for the
+ * marketing name attached to each internal plan id — keeps the rename
+ * `starter` → "Pro" in one place so the sidebar and settings widgets
+ * agree with the billing page's plan cards.
+ *
+ * Falls back to capitalizing the raw id, which keeps unknown future
+ * plans rendering sensibly without a hard failure.
+ */
+export function formatPlanLabel(planId: string | null | undefined): string {
+  if (!planId) return 'Free'
+  const known = PLANS.find((p) => p.id === planId)
+  if (known) return known.name
+  return planId.charAt(0).toUpperCase() + planId.slice(1)
+}


### PR DESCRIPTION
## Summary

Two places were bypassing the \`PLANS\` array and rendering the raw plan id, so the sidebar showed \"STARTER\" and the settings Billing tab showed \"Starter\" — while the billing page's plan cards correctly say \"Pro\" (via \`PLANS[1].name\`).

Marketing renamed the Starter tier to \"Pro\"; this PR makes the dashboard reflect that without churning the internal identifier.

## Why display-only (not full \`starter\` → \`pro\` rename)

| | Display label only (this PR) | Full rename |
|---|---|---|
| Files touched | 3 | ~15+ (DB CHECK migration, env var names, Paddle Dashboard descriptions, every code path filtering on plan id) |
| Risk | None — internal identifiers unchanged | Existing active subscriptions row could break CHECK constraint mid-migration; env var rename forces Vercel redeploy with downtime; Paddle Dashboard descriptions need re-edit |
| Reversible | Trivially | Hard |

Internal id stays \`starter\` everywhere (DB \`organizations.plan\`, \`subscriptions.plan\`, \`PADDLE_PRICE_STARTER\` env var, \`PLAN_REQUEST_LIMITS['starter']\`, etc.). Only the marketing label maps to \"Pro\".

## Change

- \`lib/billing-plans.ts\`: new \`formatPlanLabel(planId)\` — single source of truth, reads \`PLANS[].name\`
- \`components/layout/sidebar.tsx:406\`: \`Plan · STARTER\` → \`Plan · PRO\`
- \`app/(dashboard)/settings/settings-client.tsx:677\`: \`Starter\` → \`Pro\` (BillingTab hero card)

## Follow-up flagged separately

\`apps/web/app/privacy/page.tsx:227\` hardcodes both \"Starter\" AND stale retention numbers (\`7 days (Free) / 30 days (Starter) / 90 days (Team) / 365 days (Enterprise)\`) — actual \`PLAN_RETENTION_DAYS\` is \`14 / 90 / 365 / 36500\`. Legal copy — needs separate review with intent (correct the numbers to match code, or change code to match the published policy?).

## Test plan

- [x] \`pnpm --filter web typecheck\` clean
- [x] \`pnpm --filter web lint\` clean
- [ ] After merge: spanlens.io sidebar shows \`Plan · PRO\` (was STARTER); /settings?tab=billing hero card shows \`Pro\` (was Starter)