### PR TITLE
fix: align retention policy across server, web, marketing and Privacy Policy

### DIFF
--- a/apps/server/src/lib/quota.ts
+++ b/apps/server/src/lib/quota.ts
@@ -35,7 +35,11 @@ export const LOG_RETENTION_DAYS: Record<Plan, number> = {
   free: 14,
   starter: 90,
   team: 365,
-  enterprise: 36_500,
+  // Enterprise default — extendable by separate contract. Previously 36500
+  // (100 years, effectively unlimited), but that conflicted with the
+  // published Privacy Policy and made GDPR data-minimization harder to
+  // justify. 365d aligns with the longest standard tier.
+  enterprise: 365,
 }
 
 // Team seat limits per plan. enforced when inviting members.

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -810,7 +810,7 @@ function PlanLimitsTab() {
   const seatLimit = PLAN_SEAT_LIMITS[currentPlan]
   const seatLimitLabel = seatLimit == null ? 'unlimited' : String(seatLimit)
   const retentionDays = PLAN_RETENTION_DAYS[currentPlan] ?? 14
-  const retentionLabel = retentionDays >= 36_500 ? 'unlimited' : `${retentionDays} days`
+  const retentionLabel = `${retentionDays} days`
 
   return (
     <div className="max-w-[1040px]">

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -53,7 +53,7 @@ const PLANS = [
   },
   {
     name: 'Enterprise', price: 'Custom', unit: '',
-    bullets: ['Custom volume & rate limits', 'Unlimited retention', 'SSO (SAML / Okta)', 'Unlimited seats', 'Dedicated support + SLA'],
+    bullets: ['Custom volume & rate limits', '365 day retention (extendable)', 'SSO (SAML / Okta)', 'Unlimited seats', 'Dedicated support + SLA'],
     cta: 'Contact us', href: 'mailto:hi@spanlens.io', primary: false,
   },
 ]

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -76,7 +76,7 @@ const PLANS = [
       'Custom rate limit',
       'Unlimited seats',
       'Unlimited projects',
-      'Unlimited log retention',
+      '365-day log retention (extendable by contract)',
       'Unlimited alerts',
       'Email + Slack + Discord',
       'Webhooks',

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -224,7 +224,7 @@ export default function PrivacyPage() {
             </tr>
             <tr>
               <td>LLM request logs</td>
-              <td>Per your plan: 7 days (Free) / 30 days (Starter) / 90 days (Team) / 365 days (Enterprise)</td>
+              <td>Per your plan: 14 days (Free) / 90 days (Pro) / 365 days (Team) / 365 days (Enterprise; extendable by contract)</td>
             </tr>
             <tr>
               <td>Encrypted provider keys</td>

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -269,7 +269,7 @@ function SignupPageInner() {
               </form>
 
               <div className="mt-[18px] font-mono text-[10.5px] text-text-faint leading-[1.6]">
-                Included · 50k requests / mo · 7d retention · unlimited projects
+                Included · 50k requests / mo · 14d retention · unlimited projects
               </div>
             </>
           )}

--- a/apps/web/lib/billing-plans.ts
+++ b/apps/web/lib/billing-plans.ts
@@ -66,7 +66,7 @@ export const PLANS: PlanCardConfig[] = [
     description: 'SSO, on-prem, custom SLAs.',
     features: [
       'Custom request volume',
-      'Unlimited log retention',
+      '365-day log retention (extendable by contract)',
       'Unlimited seats',
       'SSO / SAML',
       'Dedicated Slack channel',
@@ -92,7 +92,10 @@ export const PLAN_RETENTION_DAYS: Record<string, number> = {
   free: 14,
   starter: 90,
   team: 365,
-  enterprise: 36_500,
+  // Default Enterprise retention — extendable per contract. Must match
+  // apps/server/src/lib/quota.ts LOG_RETENTION_DAYS to keep dashboard
+  // display consistent with server-enforced ClickHouse filtering.
+  enterprise: 365,
 }
 
 /**


### PR DESCRIPTION
## Summary

Option C of the retention reconciliation discussion. Server-enforced ClickHouse filtering (\`LOG_RETENTION_DAYS\`), dashboard display (\`PLAN_RETENTION_DAYS\`), landing/pricing marketing claims, signup blurb, and the Privacy Policy table now all agree on **14 / 90 / 365 / 365** days.

## Why

Inconsistencies found while auditing during the production Paddle smoke test:

| Surface | Free | Pro/Starter | Team | Enterprise |
|---|---|---|---|---|
| Server \`LOG_RETENTION_DAYS\` (actual ClickHouse filter) | 14 | 90 | 365 | **36,500** |
| Privacy Policy table | 7 | 30 | 90 | 365 |
| Signup page blurb | **7** | — | — | — |
| Landing Enterprise card | — | — | — | "Unlimited" |
| Pricing page Enterprise | — | — | — | "Unlimited" |

Three problems:

1. **Privacy Policy promised SHORTER retention than reality on every plan.** Probably from an older policy draft. Not a GDPR violation (over-retention is the issue), but breaks customer trust if they ever notice.
2. **Enterprise default of 36,500 days (100 years)** is hard to justify under GDPR data minimization, expensive on ClickHouse Cloud as volume grows, and clashes with the published policy's "365 days".
3. **Signup page \"7d retention\" for Free** was a pre-existing bug — Free has been 14 days since launch.

## Decision (per discussion with maintainer)

- Keep Free / Pro / Team at **14 / 90 / 365** (current code is correct, just need to fix Privacy Policy text).
- Reduce **Enterprise default to 365 days**, with marketing copy noting it's "extendable by contract" — covers the rare customer who actually needs longer.
- Fix Privacy Policy to **14 / 90 / 365 / 365** to match.
- Fix signup page **7d → 14d**.

## Files touched

- \`apps/server/src/lib/quota.ts\` — \`LOG_RETENTION_DAYS.enterprise\` 36500 → 365
- \`apps/web/lib/billing-plans.ts\` — \`PLAN_RETENTION_DAYS.enterprise\` 36500 → 365 + Enterprise feature copy
- \`apps/web/app/page.tsx\` — Landing Enterprise card bullet
- \`apps/web/app/pricing/page.tsx\` — Pricing Enterprise bullet
- \`apps/web/app/signup/page.tsx\` — Free retention 7d → 14d
- \`apps/web/app/(dashboard)/settings/settings-client.tsx\` — drop dead \`>= 36500 ? 'unlimited'\` branch
- \`apps/web/app/privacy/page.tsx\` — Privacy Policy table row

## Test plan

- [x] \`pnpm --filter web typecheck && lint\` clean
- [x] \`pnpm --filter server typecheck && lint && test\` clean (308/308)
- [ ] Post-merge: production /privacy shows new table row; /settings?tab=billing shows \"365 days\" for Enterprise (when viewed as Enterprise org); landing/pricing pages show extendable retention copy

## Migration risk

**Zero existing Enterprise customers** — Spanlens has 0 paying customers today (this user is the only test account, on Pro). So reducing Enterprise from 100 years to 365 days has no immediate data impact. ClickHouse TTL is currently 365 days for the table (longest non-Enterprise tier), so even if there were Enterprise data older than 365 days it's already been TTL'd at the storage layer — the server filter is the only enforcer of plan retention windows.

## Out of scope

- \`docs/plans/clickhouse-migration.md\` and \`ROADMAP.md\` reference older retention numbers — kept as historical artifacts of the migration plan.
- \`CLAUDE.md\` line 137 already accurately says \"free=14d / pro=90d / team=365d\" — no Enterprise mention to fix.