### PR TITLE
feat(legal): persist signup ToS / Privacy acceptance to user_consents table

### DIFF
--- a/apps/server/src/api/userConsent.ts
+++ b/apps/server/src/api/userConsent.ts
@@ -1,0 +1,133 @@
+import { Hono } from 'hono'
+import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { supabaseAdmin } from '../lib/db.js'
+
+/**
+ * /api/v1/me/consent — append-only record of the user's acceptance
+ * of the Terms of Service and Privacy Policy at signup (and any
+ * subsequent re-acceptance prompts when those documents are revised).
+ *
+ *   POST /me/consent  body: { documents: [{ document, version }, ...] }
+ *   GET  /me/consent              — return this user's accepted versions
+ *
+ * Writes capture IP + user-agent server-side from the incoming request,
+ * not from the client body, so the audit row reflects what the server
+ * actually observed.
+ *
+ * Schema reference: supabase/migrations/20260518100000_user_consents.sql
+ */
+export const userConsentRouter = new Hono<JwtContext>()
+
+userConsentRouter.use('*', authJwt)
+
+type AllowedDocument = 'terms' | 'privacy'
+const ALLOWED_DOCUMENTS: readonly AllowedDocument[] = ['terms', 'privacy'] as const
+
+interface ConsentItem {
+  document: AllowedDocument
+  version: string
+}
+
+interface RecordBody {
+  documents?: unknown
+}
+
+function parseDocuments(input: unknown): ConsentItem[] | null {
+  if (!Array.isArray(input)) return null
+  const out: ConsentItem[] = []
+  for (const item of input) {
+    if (!item || typeof item !== 'object') return null
+    const doc = (item as { document?: unknown }).document
+    const version = (item as { version?: unknown }).version
+    if (typeof doc !== 'string' || !ALLOWED_DOCUMENTS.includes(doc as AllowedDocument)) {
+      return null
+    }
+    if (typeof version !== 'string' || version.trim().length === 0 || version.length > 32) {
+      return null
+    }
+    out.push({ document: doc as AllowedDocument, version: version.trim() })
+  }
+  // Deduplicate (document, version) pairs in case the client sends both
+  // a Terms and a Privacy row that happen to share a version string.
+  const seen = new Set<string>()
+  return out.filter((row) => {
+    const key = `${row.document}:${row.version}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function readClientIp(headerValue: string | undefined): string | null {
+  if (!headerValue) return null
+  // X-Forwarded-For is "ip1, ip2, ip3" — Vercel puts the original client IP first
+  const first = headerValue.split(',')[0]?.trim()
+  if (!first) return null
+  // Postgres INET will reject obviously malformed input — let it do the validation
+  // by passing through. The basic shape check below is just to reject empty / huge strings.
+  if (first.length > 64) return null
+  return first
+}
+
+userConsentRouter.post('/', async (c) => {
+  const userId = c.get('userId')
+
+  let body: RecordBody
+  try {
+    body = (await c.req.json()) as RecordBody
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400)
+  }
+
+  const items = parseDocuments(body.documents)
+  if (!items || items.length === 0) {
+    return c.json(
+      {
+        error:
+          'documents must be a non-empty array of { document: "terms"|"privacy", version: string }',
+      },
+      400,
+    )
+  }
+
+  // Capture IP + UA from the actual request — never trust client-supplied values
+  const ipAddress = readClientIp(c.req.header('x-forwarded-for'))
+  const userAgent = c.req.header('user-agent')?.slice(0, 512) ?? null
+
+  const rows = items.map((row) => ({
+    user_id: userId,
+    document: row.document,
+    version: row.version,
+    ip_address: ipAddress,
+    user_agent: userAgent,
+  }))
+
+  const { data, error } = await supabaseAdmin
+    .from('user_consents')
+    .insert(rows)
+    .select('id, document, version, accepted_at')
+
+  if (error) {
+    console.error('[user-consent] insert failed:', error.message)
+    return c.json({ error: 'Failed to record consent' }, 500)
+  }
+
+  return c.json({ success: true, data })
+})
+
+userConsentRouter.get('/', async (c) => {
+  const userId = c.get('userId')
+
+  const { data, error } = await supabaseAdmin
+    .from('user_consents')
+    .select('id, document, version, accepted_at')
+    .eq('user_id', userId)
+    .order('accepted_at', { ascending: false })
+
+  if (error) {
+    console.error('[user-consent] fetch failed:', error.message)
+    return c.json({ error: 'Failed to fetch consent history' }, 500)
+  }
+
+  return c.json({ success: true, data: data ?? [] })
+})

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -36,6 +36,7 @@ import { membersRouter }       from './api/members.js'
 import { orgInvitationsRouter, invitationsRouter, meInvitationsRouter } from './api/invitations.js'
 import { dismissalsRouter }    from './api/dismissals.js'
 import { userProfilesRouter }  from './api/userProfiles.js'
+import { userConsentRouter }   from './api/userConsent.js'
 import { waitlistRouter }      from './api/waitlist.js'
 import { webhooksRouter }      from './api/webhooks.js'
 import { exportsRouter }       from './api/exports.js'
@@ -126,6 +127,7 @@ app.route('/api/v1/invitations', invitationsRouter)
 app.route('/api/v1/me/pending-invitations', meInvitationsRouter)
 app.route('/api/v1/dismissals',     dismissalsRouter)
 app.route('/api/v1/me/profile',     userProfilesRouter)
+app.route('/api/v1/me/consent',     userConsentRouter)
 app.route('/api/v1/me',             meRouter)        // sl_live_* introspection (CLI), registered AFTER other /me/* prefixes
 app.route('/api/v1/webhooks',       webhooksRouter)
 app.route('/api/v1/exports',        exportsRouter)

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -4,6 +4,37 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
+import { TERMS_VERSION, PRIVACY_VERSION } from '@/lib/legal-versions'
+
+/**
+ * Record the user's acceptance of Terms + Privacy on the new account.
+ * Fire-and-forget — failure to record consent must NOT block the signup
+ * flow (the user already clicked the checkbox; we don't want a transient
+ * server error to lock them out of their own onboarding). The server
+ * captures IP + UA from the request, not from the client body.
+ *
+ * If the call fails the user can still re-accept on a future prompt; we
+ * surface the failure to Sentry via the standard fetch error path.
+ */
+async function recordSignupConsent(accessToken: string): Promise<void> {
+  try {
+    await fetch('/api/v1/me/consent', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        documents: [
+          { document: 'terms', version: TERMS_VERSION },
+          { document: 'privacy', version: PRIVACY_VERSION },
+        ],
+      }),
+    })
+  } catch (err) {
+    console.error('[signup] consent recording failed:', err)
+  }
+}
 
 function LogoMark() {
   return (
@@ -75,6 +106,17 @@ function SignupPageInner() {
       setError(authError.message)
       setLoading(false)
       return
+    }
+
+    // Record consent immediately after signUp succeeds. The session JWT
+    // is only present on local Supabase (auto-confirm) or when email
+    // confirmation is disabled — in the email-confirmation path we lose
+    // the chance to record consent at this exact moment, but the user
+    // clicked the checkbox before we accepted the request, so the
+    // contract is formed at this point regardless of whether we
+    // persisted it server-side.
+    if (signupData.session?.access_token) {
+      await recordSignupConsent(signupData.session.access_token)
     }
 
     // Invitation flow: skip onboarding, auto-accept the invite, go to dashboard.

--- a/apps/web/lib/legal-versions.ts
+++ b/apps/web/lib/legal-versions.ts
@@ -1,0 +1,14 @@
+/**
+ * Effective document versions for the legal pages that users accept at
+ * signup. The string MUST match the `EFFECTIVE_DATE` constant at the top
+ * of each corresponding page — that's what gets persisted in
+ * `user_consents.version` to prove which revision the user accepted.
+ *
+ * Update both this file and the page in the same commit when revising a
+ * document; the user_consents table is append-only so the next user to
+ * sign up will be recorded as accepting the new version.
+ */
+
+export const TERMS_VERSION = '2026-05-17'
+
+export const PRIVACY_VERSION = '2026-05-18'

--- a/supabase/migrations/20260518100000_user_consents.sql
+++ b/supabase/migrations/20260518100000_user_consents.sql
@@ -1,0 +1,56 @@
+-- Migration: user_consents
+-- Immutable audit trail of each user's acceptance of the Terms of Service
+-- and Privacy Policy at signup (and on subsequent re-acceptance prompts
+-- when those documents are revised).
+--
+-- Why a dedicated table rather than auth.users.raw_user_meta_data:
+--   1. user_meta_data is mutable — for legal record-keeping we want
+--      append-only history. A consent dispute hinges on being able to
+--      prove "this user accepted version X at time Y from IP Z".
+--   2. We want IP + user-agent at the moment of acceptance, captured
+--      server-side from the request — neither belongs in auth metadata.
+--   3. Re-acceptance prompts (when Terms or Privacy is revised) need
+--      multiple rows per user; metadata would need a manual journal.
+--
+-- The version column matches the EFFECTIVE_DATE string at the top of
+-- the corresponding legal page (e.g. "2026-05-18" for Privacy Policy
+-- v2026-05-18). Update both at the same time when revising a document.
+
+CREATE TABLE user_consents (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Which document was accepted. New documents (e.g. 'dpa') can be
+  -- added without a schema change.
+  document     TEXT NOT NULL
+                 CHECK (document IN ('terms', 'privacy')),
+
+  -- Version of the document accepted — matches EFFECTIVE_DATE on the page.
+  version      TEXT NOT NULL,
+
+  accepted_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  -- Captured by the server at the moment of acceptance, NOT supplied
+  -- by the client. inet/text rather than jsonb because we want simple
+  -- indexable equality lookups for fraud/dispute investigation.
+  ip_address   INET,
+  user_agent   TEXT
+);
+
+-- Lookup: "what did user X accept and when".
+CREATE INDEX user_consents_user_doc_idx
+  ON user_consents (user_id, document, accepted_at DESC);
+
+-- Append-only invariant — no UPDATE / DELETE policy means no role can
+-- modify a recorded consent. Service-role bypasses RLS for inserts,
+-- which is what the server endpoint uses; users cannot rewrite history.
+ALTER TABLE user_consents ENABLE ROW LEVEL SECURITY;
+
+-- Users may read their own consent history (for a future "show me what
+-- I accepted" UI). They cannot read anyone else's.
+CREATE POLICY "user_consents_select_own" ON user_consents
+  FOR SELECT USING (user_id = auth.uid());
+
+-- Deliberately no INSERT / UPDATE / DELETE policies for the
+-- anon/authenticated roles. All writes go through the server's
+-- service-role client at /api/v1/me/consent.


### PR DESCRIPTION
## Summary

Closes the P1.6 \"회원가입 시 ToS 동의 체크박스 + DB 기록\" checkbox.

The signup page already gates submit on a Terms + Privacy consent checkbox ([apps/web/app/signup/page.tsx:246](apps/web/app/signup/page.tsx:246)), but acceptance was never persisted — clicking the box only flipped a local state variable. For legal record-keeping we now write an append-only audit row per (user, document, version) tuple so a future dispute can answer \"what did this user accept and when\".

## Schema

\`supabase/migrations/20260518100000_user_consents.sql\`

\`\`\`sql
CREATE TABLE user_consents (
  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
  user_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
  document     TEXT NOT NULL CHECK (document IN ('terms', 'privacy')),
  version      TEXT NOT NULL,
  accepted_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
  ip_address   INET,
  user_agent   TEXT
);
\`\`\`

- \`version\` is the \`EFFECTIVE_DATE\` string from the corresponding page (e.g. \`'2026-05-18'\`).
- \`ip_address\` + \`user_agent\` are captured **server-side** from the request, never from the client body.
- RLS: SELECT for the row's owner only; no INSERT / UPDATE / DELETE policies, so all writes go through the service-role server endpoint. **Append-only by construction.**

## Server endpoint

\`POST /api/v1/me/consent\` (authJwt)
- Body: \`{ documents: [{ document, version }, ...] }\`
- Validates document against allowlist, version length, deduplicates pairs.
- Inserts one row per item.

\`GET /api/v1/me/consent\` — returns the user's full acceptance history (for a future \"show me what I accepted\" UI; not yet wired into the dashboard).

## Client wiring

- \`apps/web/lib/legal-versions.ts\` — single source of truth for the EFFECTIVE_DATE strings. Bumping either constant alongside the corresponding page revision is what triggers a new audit row on the next sign-up.
- \`apps/web/app/signup/page.tsx\` — after a successful \`supabase.auth.signUp\` returns a session, fire-and-forget POST the two consent rows before navigating to \`/onboarding\`. Failures are logged but **do not block the user** — they already clicked the checkbox; a transient server hiccup must not lock them out of their own onboarding.

## Why a dedicated table (not auth user_metadata)

1. \`user_metadata\` is mutable — for legal record-keeping we want append-only history.
2. We want IP + user-agent at the moment of acceptance, captured server-side. Neither belongs in auth metadata.
3. Re-acceptance prompts (when Terms or Privacy is revised) need multiple rows per user; metadata would need a manual journal.

## Test plan

- [x] \`pnpm --filter web typecheck && lint\` clean
- [x] \`pnpm --filter server typecheck && lint && test\` (351/351) clean
- [ ] Post-merge: run \`supabase db push\` on production; verify new signup creates 2 rows in \`user_consents\` with the correct IP + UA captured
- [ ] CI green

## Out of scope

- \`POST /me/consent\` is currently called from signup only. A future re-prompt UI (when we revise Terms or Privacy) would call the same endpoint — that flow is not built yet.
- No UI surface to view your own consent history. The GET endpoint exists for the future \"show me what I accepted\" account-settings tab.
- Email-confirmation signup paths (when Supabase requires the user to click a magic link) won't have a session token at \`signUp\` return time. The user clicked the checkbox before the request, so the contract is formed — but server-side recording at that exact moment is impossible. Acceptable for v1; a re-prompt at first dashboard load could close the gap if it ever becomes a compliance ask.