### PR TITLE
docs(public): align /docs with Phase 0 / 1 changes (retention, ARM64, compliance)

### DIFF
--- a/apps/web/app/docs/features/audit-logs/page.tsx
+++ b/apps/web/app/docs/features/audit-logs/page.tsx
@@ -241,8 +241,12 @@ curl "https://spanlens-server.vercel.app/api/v1/audit-logs?limit=50&offset=50" \
           order. Sort direction cannot be changed.
         </li>
         <li>
-          <strong>Retention.</strong> Free plan: 30 days. Pro and above: 1 year. For longer
-          retention, export the log periodically via the API and store it externally.
+          <strong>Retention.</strong> Audit logs are retained for the lifetime of your
+          account and are not currently pruned on a fixed schedule. If you need a guaranteed
+          retention window for compliance reasons, export the log periodically via the API
+          and store it in your own system; a future release may introduce per-plan
+          retention windows, at which point this page and the{' '}
+          <a href="/privacy">Privacy Policy</a> will be updated together.
         </li>
         <li>
           <strong>Proxy requests are not recorded here.</strong> LLM request and response history

--- a/apps/web/app/docs/features/billing/page.tsx
+++ b/apps/web/app/docs/features/billing/page.tsx
@@ -54,7 +54,7 @@ export default function BillingDocs() {
             <td>Enterprise</td>
             <td>custom</td>
             <td>unlimited</td>
-            <td>unlimited</td>
+            <td>365 days (extendable by contract)</td>
             <td>unlimited</td>
           </tr>
         </tbody>

--- a/apps/web/app/docs/features/requests/page.tsx
+++ b/apps/web/app/docs/features/requests/page.tsx
@@ -357,9 +357,10 @@ POST /api/v1/requests/:id/replay/run
           <code>session_id</code>. See <a href="/docs/sdk">SDK</a>.
         </li>
         <li>
-          <strong>Retention policy.</strong> Free plan: 14 days. Pro: 90 days. Team: 365 days.
-          Enterprise: configurable up to unlimited. Enforced by the table&apos;s TTL plus a
-          per-plan query-time clip — older rows are dropped by ClickHouse&apos;s background merge.
+          <strong>Retention policy.</strong> Free plan: 14 days. Pro: 90 days. Team and
+          Enterprise: 365 days (Enterprise is extendable by contract). Enforced by the
+          table&apos;s TTL plus a per-plan query-time clip — older rows are dropped by
+          ClickHouse&apos;s background merge.
         </li>
         <li>
           <strong>Tenant isolation.</strong> ClickHouse has no row-level security; every read

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -96,6 +96,29 @@ export default function DocsIndex() {
             <code className="text-xs bg-bg-elev rounded px-1">prompt_tokens_details.cached_tokens</code> are parsed automatically and billed at each provider&apos;s reduced cache rate (≈ 0.1× input on Anthropic, ≈ 0.5× on OpenAI). The breakdown shows on every request detail page. Other tools that lump everything into prompt tokens overcount cache-heavy workloads by 2–10×.
           </p>
         </details>
+
+        <details className="rounded border p-4">
+          <summary className="cursor-pointer font-medium">
+            Where do I find compliance documents (Privacy, Terms, DPA, Subprocessors)?
+          </summary>
+          <p className="mt-2 text-muted-foreground">
+            All four are linked from the footer of every page and are publicly accessible
+            without an account:{' '}
+            <Link href="/privacy" className="text-accent hover:underline">Privacy Policy</Link>{' '}
+            (PIPA + GDPR coverage),{' '}
+            <Link href="/terms" className="text-accent hover:underline">Terms of Service</Link>,{' '}
+            <Link href="/dpa" className="text-accent hover:underline">Data Processing Addendum</Link>{' '}
+            (auto-incorporated on org creation; countersigned PDFs available on request),
+            and the{' '}
+            <Link href="/subprocessors" className="text-accent hover:underline">Subprocessors list</Link>{' '}
+            with per-vendor processing locations and transfer mechanisms. The DPA
+            incorporates EU SCCs Module 2 in Annex A. For security questionnaires or a
+            countersigned DPA, email{' '}
+            <a href="mailto:support@spanlens.io" className="text-accent hover:underline">
+              support@spanlens.io
+            </a>.
+          </p>
+        </details>
       </div>
     </div>
   )

--- a/apps/web/app/docs/self-host/page.tsx
+++ b/apps/web/app/docs/self-host/page.tsx
@@ -328,6 +328,13 @@ docker compose pull && docker compose up -d
         <code>ghcr.io/spanlens/spanlens-web:0.3.0</code>). Pin a tag in production and upgrade
         deliberately.
       </p>
+      <p>
+        <strong>Supported architectures.</strong> Both images are published as
+        multi-arch manifests for <code>linux/amd64</code> and <code>linux/arm64</code>{' '}
+        — Docker pulls the right variant for your host automatically. M1 / M2 / M3
+        Macs and AWS Graviton instances run the native ARM binary; x86 hosts run
+        the amd64 binary. No platform flag needed.
+      </p>
 
       <h2 id="dashboard">Dashboard options</h2>
       <ul>


### PR DESCRIPTION
## Summary

Five drift points between the time the original docs pages shipped and the Phase 0 / 1 work landed. Each is small in isolation; together they were enough that a customer reading the docs could form the wrong mental model.

## What changed

| File | Drift | Fix |
|---|---|---|
| \`/docs/features/billing\` | Plan-quotas table claimed Enterprise log retention was \"unlimited\" | \"365 days (extendable by contract)\" — matches PR #72 + Privacy Policy |
| \`/docs/features/requests\` | Retention paragraph said \"Enterprise: configurable up to unlimited\" | \"Team and Enterprise: 365 days (Enterprise is extendable by contract)\" |
| \`/docs/features/audit-logs\` | Claimed \"Free 30d / Pro+ 1yr\" — but no cron, TTL, or query-time clip actually enforces this | Reworded to the truth: lifetime retention, customer-side export available for compliance windows. Flagged that per-plan windows may be added later, in which case page + Privacy Policy will move together. |
| \`/docs/self-host\` | No mention of architecture support | Added \"Supported architectures\" paragraph confirming \`linux/amd64\` + \`linux/arm64\` are both published (PR #69 native ARM runners). M1/M2/M3 Mac + AWS Graviton evaluators no longer have to guess. |
| \`/docs\` (index) | No way to reach Privacy / Terms / DPA / Subprocessors from the docs surface | New FAQ item linking all four. B2B evaluators shouldn't have to dig through the footer. |

## Why the audit-logs claim mattered most

Promising a retention window in legal-adjacent docs without backing code is the kind of thing that turns into a security incident report. Either we ship enforcement and keep the claim, or we drop the claim and tell customers to export. This PR does the latter — much faster + still honest.

## Test plan

- [x] \`pnpm --filter web typecheck\` clean
- [x] \`pnpm --filter web lint\` clean
- [ ] Vercel preview: all 5 pages render with the updated text + the new compliance FAQ on /docs is expandable
- [ ] CI green

## Out of scope

- Building actual per-plan audit-log retention (would need a cron + a per-plan window decision + Privacy Policy update — separate Phase 2 item if/when prioritized).
- Adding analytics gating to \`/docs\` itself — PR #78 lint guard already blocks any analytics SDK from being imported anywhere in apps/web.