### PR TITLE
feat(billing): P2.7 — auto-downgrade past-due subscriptions after 7 days

### DIFF
--- a/apps/server/src/__tests__/billing-downgrade.test.ts
+++ b/apps/server/src/__tests__/billing-downgrade.test.ts
@@ -1,0 +1,304 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests for P2.7 auto-downgrade orchestration. The cron flips paying orgs
+// to Free after 7 days of payment failure and emails warnings at D-3 / D-1.
+// A regression here either downgrades too aggressively (revenue + trust
+// damage) or never (we eat free LLM traffic indefinitely). Both bad.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const supabaseFromMock = vi.fn()
+const getUserByIdMock = vi.fn()
+const sendEmailMock = vi.fn()
+const renderPastDueEmailMock = vi.fn()
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: (...args: unknown[]) => supabaseFromMock(...args),
+    auth: { admin: { getUserById: (...args: unknown[]) => getUserByIdMock(...args) } },
+  },
+}))
+
+vi.mock('../lib/resend.js', () => ({
+  sendEmail: (...args: unknown[]) => sendEmailMock(...args),
+  renderPastDueEmail: (...args: unknown[]) => renderPastDueEmailMock(...args),
+}))
+
+let runDowngradeCheck: typeof import('../lib/billing-downgrade.js').runDowngradeCheck
+
+beforeEach(async () => {
+  vi.resetModules()
+  supabaseFromMock.mockReset()
+  getUserByIdMock.mockReset()
+  sendEmailMock.mockReset().mockResolvedValue({ sent: true })
+  renderPastDueEmailMock
+    .mockReset()
+    .mockReturnValue({ subject: 'mock', html: '<p>mock</p>' })
+  ;({ runDowngradeCheck } = await import('../lib/billing-downgrade.js'))
+})
+
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+}
+
+/**
+ * Builds the chained Supabase mock used in every test. We compose smaller
+ * sub-mocks per table so each test can express exactly the subscriptions
+ * shape it wants.
+ */
+function setupSupabaseMocks(opts: {
+  pastDueRows: Array<{ id: string; organization_id: string; past_due_since: string; paddle_subscription_id?: string | null }>
+  dedupeInsertResult?: { error: { code?: string; message: string } | null }
+  ownerEmail?: string | null
+  orgName?: string
+}) {
+  // Capture every UPDATE/INSERT for assertions
+  const mutations: Array<{ table: string; op: string; values: unknown }> = []
+
+  supabaseFromMock.mockImplementation((table: string) => {
+    if (table === 'subscriptions') {
+      return {
+        select: vi.fn().mockReturnValue({
+          not: vi.fn().mockResolvedValue({ data: opts.pastDueRows, error: null }),
+        }),
+        update: (values: unknown) => {
+          mutations.push({ table, op: 'update', values })
+          return { eq: vi.fn().mockResolvedValue({ data: null, error: null }) }
+        },
+      }
+    }
+
+    if (table === 'billing_downgrade_notifications') {
+      return {
+        insert: (values: unknown) => {
+          mutations.push({ table, op: 'insert', values })
+          // Default to success unless test overrode dedupeInsertResult
+          return Promise.resolve(
+            opts.dedupeInsertResult ?? { error: null },
+          )
+        },
+      }
+    }
+
+    if (table === 'organizations') {
+      return {
+        update: (values: unknown) => {
+          mutations.push({ table, op: 'update', values })
+          return { eq: vi.fn().mockResolvedValue({ data: null, error: null }) }
+        },
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: { name: opts.orgName ?? 'Acme' },
+              error: null,
+            }),
+          }),
+        }),
+      }
+    }
+
+    if (table === 'org_members') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue({
+                data: opts.ownerEmail ? [{ user_id: 'usr_owner' }] : [],
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      }
+    }
+
+    if (table === 'audit_logs') {
+      return {
+        insert: (values: unknown) => {
+          mutations.push({ table, op: 'insert', values })
+          return Promise.resolve({ data: null, error: null })
+        },
+      }
+    }
+
+    throw new Error(`unmocked Supabase table: ${table}`)
+  })
+
+  getUserByIdMock.mockResolvedValue({
+    data: { user: opts.ownerEmail ? { email: opts.ownerEmail } : null },
+  })
+
+  return { mutations }
+}
+
+describe('runDowngradeCheck — staging', () => {
+  test('no past_due rows → all counters zero, no email', async () => {
+    setupSupabaseMocks({ pastDueRows: [] })
+
+    const result = await runDowngradeCheck()
+    expect(result).toEqual({
+      scanned: 0,
+      warningsD3: 0,
+      warningsD1: 0,
+      downgraded: 0,
+      emailsSkipped: 0,
+      errors: [],
+    })
+    expect(sendEmailMock).not.toHaveBeenCalled()
+  })
+
+  test('past_due_since < 4 days → no email sent yet', async () => {
+    setupSupabaseMocks({
+      pastDueRows: [
+        { id: 's_fresh', organization_id: 'org_1', past_due_since: daysAgo(2) },
+      ],
+      ownerEmail: 'owner@example.com',
+    })
+
+    const result = await runDowngradeCheck()
+    expect(result.scanned).toBe(1)
+    expect(result.warningsD3).toBe(0)
+    expect(result.warningsD1).toBe(0)
+    expect(result.downgraded).toBe(0)
+    expect(sendEmailMock).not.toHaveBeenCalled()
+  })
+
+  test('past_due_since exactly 4 days → D-3 warning sent', async () => {
+    setupSupabaseMocks({
+      pastDueRows: [
+        { id: 's_d3', organization_id: 'org_1', past_due_since: daysAgo(4) },
+      ],
+      ownerEmail: 'owner@example.com',
+    })
+
+    const result = await runDowngradeCheck()
+    expect(result.warningsD3).toBe(1)
+    expect(sendEmailMock).toHaveBeenCalledOnce()
+    expect(renderPastDueEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'warning-d3' }),
+    )
+  })
+
+  test('past_due_since exactly 6 days → D-1 warning sent', async () => {
+    setupSupabaseMocks({
+      pastDueRows: [
+        { id: 's_d1', organization_id: 'org_1', past_due_since: daysAgo(6) },
+      ],
+      ownerEmail: 'owner@example.com',
+    })
+
+    const result = await runDowngradeCheck()
+    expect(result.warningsD1).toBe(1)
+    expect(renderPastDueEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'warning-d1' }),
+    )
+  })
+
+  test('past_due_since >= 7 days → org downgraded + plan flipped + audit log', async () => {
+    const { mutations } = setupSupabaseMocks({
+      pastDueRows: [
+        {
+          id: 's_old',
+          organization_id: 'org_1',
+          past_due_since: daysAgo(8),
+          paddle_subscription_id: 'sub_paddle_1',
+        },
+      ],
+      ownerEmail: 'owner@example.com',
+    })
+
+    const result = await runDowngradeCheck()
+    expect(result.downgraded).toBe(1)
+
+    // Plan flipped
+    const orgUpdate = mutations.find((m) => m.table === 'organizations' && m.op === 'update')
+    expect(orgUpdate?.values).toEqual({ plan: 'free' })
+
+    // past_due_since cleared so a re-upgrade starts fresh
+    const subUpdate = mutations.find((m) => m.table === 'subscriptions' && m.op === 'update')
+    expect(subUpdate?.values).toEqual({ past_due_since: null })
+
+    // Audit log written
+    const audit = mutations.find((m) => m.table === 'audit_logs' && m.op === 'insert')
+    expect(audit?.values).toMatchObject({
+      action: 'billing.plan.auto_downgrade',
+      organization_id: 'org_1',
+      metadata: expect.objectContaining({
+        reason: 'past_due_7_days',
+        paddle_subscription_id: 'sub_paddle_1',
+      }),
+    })
+
+    // Downgrade email sent
+    expect(renderPastDueEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'downgraded' }),
+    )
+  })
+})
+
+describe('runDowngradeCheck — idempotency', () => {
+  test('dedupe table returns 23505 unique_violation → no email, emailsSkipped++', async () => {
+    setupSupabaseMocks({
+      pastDueRows: [
+        { id: 's_d3', organization_id: 'org_1', past_due_since: daysAgo(4) },
+      ],
+      ownerEmail: 'owner@example.com',
+      dedupeInsertResult: {
+        error: { code: '23505', message: 'duplicate key' },
+      },
+    })
+
+    const result = await runDowngradeCheck()
+    expect(result.warningsD3).toBe(0)
+    expect(result.emailsSkipped).toBe(1)
+    expect(sendEmailMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('runDowngradeCheck — failure modes', () => {
+  test('Supabase SELECT failure → error captured, no rows processed', async () => {
+    supabaseFromMock.mockImplementation((table: string) => {
+      if (table === 'subscriptions') {
+        return {
+          select: vi.fn().mockReturnValue({
+            not: vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: 'connection refused' },
+            }),
+          }),
+        }
+      }
+      throw new Error(`unmocked: ${table}`)
+    })
+
+    const result = await runDowngradeCheck()
+    expect(result.errors[0]).toMatch(/select past_due rows failed.*connection refused/)
+  })
+
+  test('per-row exception is collected and does not abort other rows', async () => {
+    // Two rows: first one due for D-3, second for downgrade. We make the
+    // first throw during email rendering. The second still has to process.
+    let renderCalls = 0
+    renderPastDueEmailMock.mockImplementation(() => {
+      renderCalls += 1
+      if (renderCalls === 1) throw new Error('template render failed')
+      return { subject: 'ok', html: '<p>ok</p>' }
+    })
+
+    setupSupabaseMocks({
+      pastDueRows: [
+        { id: 's_d3', organization_id: 'org_1', past_due_since: daysAgo(4) },
+        { id: 's_old', organization_id: 'org_2', past_due_since: daysAgo(9) },
+      ],
+      ownerEmail: 'owner@example.com',
+    })
+
+    const result = await runDowngradeCheck()
+    expect(result.scanned).toBe(2)
+    expect(result.errors.length).toBe(1)
+    expect(result.errors[0]).toContain('org_1')
+    expect(result.errors[0]).toContain('template render failed')
+    // The second row still went through
+    expect(result.downgraded).toBe(1)
+  })
+})

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -11,6 +11,7 @@ import { runLeakDetectionJob } from '../lib/leak-detection.js'
 import { sendHighConfidenceRecommendationAlerts } from '../lib/recommendation-notify.js'
 import { logCronRun } from '../lib/cron-logger.js'
 import { replayFallbackQueue } from '../lib/fallback-replay.js'
+import { runDowngradeCheck } from '../lib/billing-downgrade.js'
 
 /**
  * Vercel cron endpoints. Invoked hourly via `crons` entry in `vercel.json`.
@@ -457,6 +458,28 @@ cronRouter.get('/replay-fallback', async (c) => {
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
     logCronRun('replay-fallback', 'error', Date.now() - start, msg).catch(console.error)
+    return c.json({ error: msg }, 500)
+  }
+})
+
+// ── Past-due downgrade check (daily, 10 UTC ≈ 19 KST) ───────────
+// Sends D-3 / D-1 warning emails and flips orgs to free after 7 days of
+// failed payments. Idempotent via the billing_downgrade_notifications
+// table. See lib/billing-downgrade.ts for the policy + state machine.
+cronRouter.get('/check-past-due-downgrades', async (c) => {
+  const authFail = assertCronAuth(c.req.header('Authorization'))
+  if (authFail) return c.json({ error: authFail }, 401)
+
+  const start = Date.now()
+  try {
+    const result = await runDowngradeCheck()
+    const status = result.errors.length > 0 ? 'error' : 'ok'
+    const errSummary = result.errors.length > 0 ? result.errors.join('; ').slice(0, 500) : undefined
+    logCronRun('check-past-due-downgrades', status, Date.now() - start, errSummary).catch(console.error)
+    return c.json({ success: result.errors.length === 0, ...result })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'unknown'
+    logCronRun('check-past-due-downgrades', 'error', Date.now() - start, msg).catch(console.error)
     return c.json({ error: msg }, 500)
   }
 })

--- a/apps/server/src/api/paddleWebhook.ts
+++ b/apps/server/src/api/paddleWebhook.ts
@@ -101,6 +101,30 @@ async function upsertSubscription(
   plan: PlanTier,
   priceId: string,
 ): Promise<void> {
+  // ── past_due_since lifecycle (P2.7) ────────────────────────────────────
+  // The auto-downgrade cron uses this column to age out delinquent subs
+  // after 7 days. Three cases:
+  //   1. Entering past_due:    if `past_due_since` is already set keep it
+  //                            (idempotent — duplicate webhooks don't reset
+  //                            the clock); otherwise stamp now().
+  //   2. Recovered to active:  clear the field so a future failure starts
+  //                            its own 7-day window from scratch.
+  //   3. Any other status:     leave untouched (carry through canceled
+  //                            for analytics).
+  let pastDueSinceUpdate: { past_due_since: string | null } | Record<string, never> = {}
+  if (sub.status === 'past_due') {
+    const { data: existing } = await supabaseAdmin
+      .from('subscriptions')
+      .select('past_due_since')
+      .eq('paddle_subscription_id', sub.id)
+      .maybeSingle()
+    if (!(existing as { past_due_since?: string | null } | null)?.past_due_since) {
+      pastDueSinceUpdate = { past_due_since: new Date().toISOString() }
+    }
+  } else if (sub.status === 'active' || sub.status === 'trialing') {
+    pastDueSinceUpdate = { past_due_since: null }
+  }
+
   const updates = {
     organization_id: organizationId,
     paddle_subscription_id: sub.id,
@@ -116,6 +140,7 @@ async function upsertSubscription(
       last_event_type: event.event_type,
       occurred_at: event.occurred_at,
     },
+    ...pastDueSinceUpdate,
   }
 
   const { error } = await supabaseAdmin

--- a/apps/server/src/lib/billing-downgrade.ts
+++ b/apps/server/src/lib/billing-downgrade.ts
@@ -1,0 +1,235 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Auto-downgrade orchestration for past-due subscriptions (P2.7).
+//
+// Lifecycle (driven by /cron/check-past-due-downgrades daily):
+//
+//   t = 0  →  Paddle webhook flips subscriptions.status to past_due.
+//             paddleWebhook stamps `past_due_since = now()`.
+//
+//   t = 4d →  Cron sends D-3 warning email (3 days before downgrade).
+//   t = 6d →  Cron sends D-1 warning email (1 day before downgrade).
+//   t = 7d →  Cron flips organizations.plan to 'free', writes audit_logs,
+//             emails the owner that the downgrade happened, and clears
+//             past_due_since so a re-upgrade starts fresh.
+//
+// Retention impact: `quota.ts` already enforces 14-day retention for the
+// Free plan via `requestsScope`, so the dashboard tightens automatically
+// the moment the plan flips — no extra wiring needed.
+//
+// Idempotency: every email send writes to `billing_downgrade_notifications`
+// with a unique (subscription_id, stage) constraint. If the cron retries
+// (Vercel cron at-least-once delivery), we no-op on the second send.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { supabaseAdmin } from './db.js'
+import { sendEmail, renderPastDueEmail } from './resend.js'
+
+const DOWNGRADE_AFTER_DAYS = 7
+const WARNING_D3_DAY = 4 // 7 - 3
+const WARNING_D1_DAY = 6 // 7 - 1
+
+export type DowngradeStage = 'warning-d3' | 'warning-d1' | 'downgraded'
+
+export interface DowngradeRunResult {
+  scanned: number
+  warningsD3: number
+  warningsD1: number
+  downgraded: number
+  emailsSkipped: number   // already-sent dedupe
+  errors: string[]
+}
+
+interface PastDueRow {
+  id: string
+  organization_id: string
+  past_due_since: string
+  paddle_subscription_id: string | null
+}
+
+/**
+ * Top-level entry point called by the cron. Scans all past_due
+ * subscriptions and applies the appropriate stage to each. Per-row errors
+ * don't abort the run — they're collected for logging.
+ */
+export async function runDowngradeCheck(): Promise<DowngradeRunResult> {
+  const result: DowngradeRunResult = {
+    scanned: 0,
+    warningsD3: 0,
+    warningsD1: 0,
+    downgraded: 0,
+    emailsSkipped: 0,
+    errors: [],
+  }
+
+  const { data: rows, error } = await supabaseAdmin
+    .from('subscriptions')
+    .select('id, organization_id, past_due_since, paddle_subscription_id')
+    .not('past_due_since', 'is', null)
+
+  if (error) {
+    result.errors.push(`select past_due rows failed: ${error.message}`)
+    return result
+  }
+
+  const pastDueRows = (rows ?? []) as PastDueRow[]
+  result.scanned = pastDueRows.length
+
+  for (const row of pastDueRows) {
+    try {
+      const daysOverdue = daysSince(row.past_due_since)
+
+      if (daysOverdue >= DOWNGRADE_AFTER_DAYS) {
+        const did = await applyDowngrade(row)
+        if (did) result.downgraded += 1
+        else result.emailsSkipped += 1
+      } else if (daysOverdue >= WARNING_D1_DAY) {
+        const sent = await sendStageEmail(row, 'warning-d1')
+        if (sent) result.warningsD1 += 1
+        else result.emailsSkipped += 1
+      } else if (daysOverdue >= WARNING_D3_DAY) {
+        const sent = await sendStageEmail(row, 'warning-d3')
+        if (sent) result.warningsD3 += 1
+        else result.emailsSkipped += 1
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      result.errors.push(`org ${row.organization_id}: ${message}`)
+    }
+  }
+
+  return result
+}
+
+// ── Internals ─────────────────────────────────────────────────────────────────
+
+function daysSince(iso: string): number {
+  const start = new Date(iso).getTime()
+  const now = Date.now()
+  return Math.floor((now - start) / (24 * 60 * 60 * 1000))
+}
+
+/**
+ * Send a stage email, deduped against `billing_downgrade_notifications`.
+ * Returns true if a new email was actually sent (or attempted), false if
+ * a row already existed for (subscription, stage) — i.e. cron retry.
+ */
+async function sendStageEmail(row: PastDueRow, stage: DowngradeStage): Promise<boolean> {
+  // De-dupe via a unique constraint on (paddle_subscription_id, stage).
+  // We INSERT first; on conflict (row exists), the INSERT no-ops and we
+  // skip the send. This makes the cron safely re-runnable.
+  const { error: dedupeErr } = await supabaseAdmin
+    .from('billing_downgrade_notifications')
+    .insert({
+      subscription_id: row.id,
+      stage,
+    })
+  if (dedupeErr) {
+    // 23505 = unique_violation. Anything else is unexpected and we should
+    // still try to send — losing dedup is better than missing a warning.
+    if ((dedupeErr as { code?: string }).code === '23505') {
+      return false
+    }
+  }
+
+  const { owner, orgName } = await fetchOwner(row.organization_id)
+  if (!owner) return false
+
+  const webUrl = process.env['WEB_URL'] ?? 'https://www.spanlens.io'
+  const { subject, html } = renderPastDueEmail({
+    orgName,
+    stage,
+    pastDueSince: row.past_due_since,
+    billingUrl: `${webUrl}/billing`,
+  })
+  const sendResult = await sendEmail({ to: owner, subject, html })
+  if (!sendResult.sent && sendResult.error) {
+    console.error('[downgrade] email send failed:', sendResult.error)
+  }
+  return true
+}
+
+/**
+ * Move the org to the Free plan, audit-log it, email the owner, and clear
+ * past_due_since so future failures restart the clock.
+ *
+ * Idempotent via the same `billing_downgrade_notifications` dedupe — if a
+ * row for stage='downgraded' already exists, we treat it as already done.
+ */
+async function applyDowngrade(row: PastDueRow): Promise<boolean> {
+  const { error: dedupeErr } = await supabaseAdmin
+    .from('billing_downgrade_notifications')
+    .insert({ subscription_id: row.id, stage: 'downgraded' })
+  if (dedupeErr && (dedupeErr as { code?: string }).code === '23505') {
+    return false
+  }
+
+  // 1. Flip the plan
+  await supabaseAdmin
+    .from('organizations')
+    .update({ plan: 'free' })
+    .eq('id', row.organization_id)
+
+  // 2. Clear past_due_since on the subscription (so a re-upgrade starts fresh).
+  await supabaseAdmin
+    .from('subscriptions')
+    .update({ past_due_since: null })
+    .eq('id', row.id)
+
+  // 3. Audit log
+  await supabaseAdmin.from('audit_logs').insert({
+    organization_id: row.organization_id,
+    user_id: null, // system action
+    action: 'billing.plan.auto_downgrade',
+    resource_type: 'organization',
+    resource_id: row.organization_id,
+    metadata: {
+      reason: 'past_due_7_days',
+      past_due_since: row.past_due_since,
+      paddle_subscription_id: row.paddle_subscription_id,
+    },
+  })
+
+  // 4. Email the owner
+  const { owner, orgName } = await fetchOwner(row.organization_id)
+  if (owner) {
+    const webUrl = process.env['WEB_URL'] ?? 'https://www.spanlens.io'
+    const { subject, html } = renderPastDueEmail({
+      orgName,
+      stage: 'downgraded',
+      pastDueSince: row.past_due_since,
+      billingUrl: `${webUrl}/billing`,
+    })
+    await sendEmail({ to: owner, subject, html }).catch((err: unknown) => {
+      console.error('[downgrade] post-downgrade email failed:', err)
+    })
+  }
+
+  return true
+}
+
+async function fetchOwner(organizationId: string): Promise<{
+  owner: string | null
+  orgName: string
+}> {
+  const { data: org } = await supabaseAdmin
+    .from('organizations')
+    .select('name')
+    .eq('id', organizationId)
+    .single()
+
+  const { data: members } = await supabaseAdmin
+    .from('org_members')
+    .select('user_id')
+    .eq('organization_id', organizationId)
+    .eq('role', 'owner')
+    .limit(1)
+
+  const ownerId = members?.[0]?.user_id
+  if (!ownerId) return { owner: null, orgName: (org?.name as string | undefined) ?? organizationId }
+
+  const { data: { user } } = await supabaseAdmin.auth.admin.getUserById(ownerId)
+  return {
+    owner: user?.email ?? null,
+    orgName: (org?.name as string | undefined) ?? organizationId,
+  }
+}

--- a/apps/server/src/lib/resend.ts
+++ b/apps/server/src/lib/resend.ts
@@ -289,3 +289,106 @@ export function renderLeakAlertEmail(params: {
 
   return { subject, html }
 }
+
+/**
+ * P2.7 — past_due warning + auto-downgrade notification.
+ *
+ * Three flavours, picked by `params.stage`:
+ *   • 'warning-d3' — payment failed 4 days ago, 3 days until auto-downgrade
+ *   • 'warning-d1' — 6 days ago, 1 day until auto-downgrade
+ *   • 'downgraded' — sent immediately after the cron flips the org to free
+ *
+ * Tone: calm reminder, not dunning. Most past_due is an expired card.
+ */
+export function renderPastDueEmail(params: {
+  orgName: string
+  stage: 'warning-d3' | 'warning-d1' | 'downgraded'
+  pastDueSince: string
+  billingUrl: string
+}): { subject: string; html: string } {
+  const { orgName, stage, pastDueSince, billingUrl } = params
+  const sinceLabel = new Date(pastDueSince).toLocaleDateString('en-US', {
+    year: 'numeric', month: 'short', day: 'numeric',
+  })
+
+  let subject: string
+  let headerBg: string
+  let headerBorder: string
+  let headerColor: string
+  let headerTitle: string
+  let body: string
+  let ctaLabel: string
+
+  if (stage === 'warning-d3') {
+    subject = `[Spanlens] Payment failed — update your card to keep your plan`
+    headerBg = '#fff7ed'
+    headerBorder = '#fed7aa'
+    headerColor = '#9a3412'
+    headerTitle = 'Payment failed'
+    body = `
+      Hi ${escapeHtml(orgName)} team,
+      <br><br>
+      Your most recent Spanlens invoice didn&apos;t go through — usually an expired
+      or replaced card. We&apos;ll keep your plan active for <strong>3 more days</strong>;
+      after that the workspace automatically drops to the Free plan and log
+      retention shortens to 14 days.
+      <br><br>
+      Updating the card on file takes about 30 seconds and avoids any service
+      change.
+    `
+    ctaLabel = 'Update payment method'
+  } else if (stage === 'warning-d1') {
+    subject = `[Spanlens] Last reminder — auto-downgrade in 24 hours`
+    headerBg = '#fef2f2'
+    headerBorder = '#fecaca'
+    headerColor = '#991b1b'
+    headerTitle = 'Auto-downgrade in 24 hours'
+    body = `
+      Hi ${escapeHtml(orgName)} team,
+      <br><br>
+      We still haven&apos;t been able to charge the card on file (first failure on
+      ${escapeHtml(sinceLabel)}). If we don&apos;t recover by tomorrow, the workspace
+      drops to the Free plan and log retention shortens to 14 days.
+      <br><br>
+      You can re-upgrade at any time — this is just a heads-up so it&apos;s not a
+      surprise.
+    `
+    ctaLabel = 'Update payment method'
+  } else {
+    subject = `[Spanlens] Your workspace has been moved to the Free plan`
+    headerBg = '#f1f5f9'
+    headerBorder = '#e2e8f0'
+    headerColor = '#0f172a'
+    headerTitle = 'Plan changed to Free'
+    body = `
+      Hi ${escapeHtml(orgName)} team,
+      <br><br>
+      After 7 days without a successful payment (first failure
+      ${escapeHtml(sinceLabel)}), we&apos;ve moved this workspace to the Free plan.
+      Existing logs older than 14 days are no longer visible in the dashboard,
+      but they remain in our database for a 7-day grace window — re-upgrade in
+      that time and they reappear automatically.
+      <br><br>
+      Nothing has been deleted yet. Your data, projects, API keys, and integrations
+      are all intact — only the plan tier changed.
+    `
+    ctaLabel = 'Re-upgrade'
+  }
+
+  const html = `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 580px; margin: 0 auto; padding: 24px; color: #111;">
+      <div style="background: ${headerBg}; border: 1px solid ${headerBorder}; border-radius: 8px; padding: 14px 16px; margin-bottom: 18px;">
+        <div style="font-weight: 600; font-size: 14px; color: ${headerColor};">${headerTitle}</div>
+      </div>
+      <p style="margin: 0 0 14px; color: #333; font-size: 13.5px; line-height: 1.55;">${body.trim()}</p>
+      <p style="margin: 22px 0;">
+        <a href="${billingUrl}" style="display: inline-block; padding: 10px 18px; background: #111; color: #fff; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 13px;">${ctaLabel}</a>
+      </p>
+      <p style="margin: 18px 0 0; color: #aaa; font-size: 11.5px;">
+        Questions? Reply to this email — it goes straight to the team.
+      </p>
+    </div>
+  `.trim()
+
+  return { subject, html }
+}

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -15,6 +15,7 @@
     { "path": "/cron/stale-key-reminders",  "schedule": "0 9 * * 1" },
     { "path": "/cron/leak-detect-keys",          "schedule": "0 4 * * *" },
     { "path": "/cron/recommend-savings-alerts",  "schedule": "0 9 * * *" },
-    { "path": "/cron/replay-fallback",            "schedule": "*/5 * * * *" }
+    { "path": "/cron/replay-fallback",            "schedule": "*/5 * * * *" },
+    { "path": "/cron/check-past-due-downgrades",  "schedule": "0 10 * * *" }
   ]
 }

--- a/supabase/migrations/20260519110000_subscriptions_past_due_since.sql
+++ b/supabase/migrations/20260519110000_subscriptions_past_due_since.sql
@@ -1,0 +1,27 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- subscriptions.past_due_since — tracks when a subscription first entered
+-- the `past_due` status so the auto-downgrade cron knows how long the
+-- customer has been delinquent.
+--
+-- WHY: Paddle reports `subscription.status = 'past_due'` indefinitely after
+-- payment failure. Without recording the FIRST transition we couldn't tell
+-- "failed yesterday" from "failed 30 days ago". The downgrade cron uses
+-- `now() - past_due_since >= 7d` to trigger free fallback.
+--
+-- BEHAVIOR:
+--   • Set to now() in the webhook ONLY on the transition into past_due
+--     (idempotent — re-receiving the same past_due event doesn't reset it)
+--   • Cleared (set NULL) when status returns to active/trialing
+--   • Carries through canceled status so we keep history for analytics
+-- ─────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE subscriptions
+  ADD COLUMN IF NOT EXISTS past_due_since TIMESTAMPTZ;
+
+COMMENT ON COLUMN subscriptions.past_due_since IS
+  'Timestamp of the FIRST transition into past_due. Used by cron /check-past-due-downgrades. NULL = subscription has not been delinquent (or has recovered).';
+
+-- Partial index for the daily cron — only past_due rows are scanned.
+CREATE INDEX IF NOT EXISTS idx_subscriptions_past_due_since
+  ON subscriptions (past_due_since)
+  WHERE past_due_since IS NOT NULL;

--- a/supabase/migrations/20260519110001_billing_downgrade_notifications.sql
+++ b/supabase/migrations/20260519110001_billing_downgrade_notifications.sql
@@ -1,0 +1,26 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- billing_downgrade_notifications — idempotency table for the P2.7 cron.
+--
+-- The cron sends D-3, D-1, and final downgrade emails. Vercel cron is
+-- at-least-once, so we need a way to dedupe a re-run. UNIQUE on
+-- (subscription_id, stage) lets the cron INSERT-first and treat a
+-- 23505 (unique_violation) as "already done — skip this row".
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS billing_downgrade_notifications (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  subscription_id   UUID NOT NULL REFERENCES subscriptions(id) ON DELETE CASCADE,
+  -- 'warning-d3' | 'warning-d1' | 'downgraded'
+  stage             TEXT NOT NULL CHECK (stage IN ('warning-d3', 'warning-d1', 'downgraded')),
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (subscription_id, stage)
+);
+
+CREATE INDEX IF NOT EXISTS idx_billing_downgrade_notifications_subscription
+  ON billing_downgrade_notifications (subscription_id);
+
+ALTER TABLE billing_downgrade_notifications ENABLE ROW LEVEL SECURITY;
+-- No policies: clients can't read this. Useful only to the server-side cron.
+
+COMMENT ON TABLE billing_downgrade_notifications IS
+  'Idempotency table for P2.7 past-due downgrade cron. (subscription_id, stage) UNIQUE prevents duplicate emails on cron retry.';


### PR DESCRIPTION
## Summary

Closes the last piece of Phase 2's billing safety net. When a customer's card fails, we now warn them at D-3 / D-1 and auto-downgrade the workspace to Free after 7 days — instead of accruing free LLM traffic indefinitely.

## Policy

| t | Action |
|---|--------|
| **0** | Paddle webhook flips status to `past_due` → `paddleWebhook` stamps `subscriptions.past_due_since = now()` (idempotent — duplicate webhooks don't reset the clock) |
| **4d** | D-3 warning email ("3 days until auto-downgrade") |
| **6d** | D-1 warning email ("24 hours") |
| **7d** | Org plan flipped to `'free'`, `audit_logs` row written, confirmation email sent, `past_due_since` cleared so a future failure starts its own window |

If the subscription recovers (status → active/trialing) at any point, the webhook clears `past_due_since` and no further warnings or downgrade fire.

**Retention impact**: `quota.ts` already enforces 14-day Free-plan retention via `requestsScope`, so the dashboard tightens automatically the moment the plan flips — no extra wiring needed.

## Idempotency

`billing_downgrade_notifications` has `UNIQUE (subscription_id, stage)`. The cron INSERTs first and treats Postgres 23505 (unique_violation) as "already done, skip." Vercel cron is at-least-once, so this is mandatory.

## Changes

| File | Role |
|------|------|
| `supabase/migrations/20260519110000_subscriptions_past_due_since.sql` | New column + partial index |
| `supabase/migrations/20260519110001_billing_downgrade_notifications.sql` | Dedup table |
| `apps/server/src/api/paddleWebhook.ts` | `past_due_since` lifecycle inside `upsertSubscription` |
| `apps/server/src/lib/billing-downgrade.ts` (new) | `runDowngradeCheck()` state machine, per-row error isolation |
| `apps/server/src/lib/resend.ts` | `renderPastDueEmail({stage})` 3 templates (calm tone, not dunning) |
| `apps/server/src/api/cron.ts` | `/cron/check-past-due-downgrades` endpoint |
| `apps/server/vercel.json` | Daily 10 UTC schedule (~19 KST) |

## Verification

- `pnpm --filter server typecheck` — clean
- `pnpm --filter server lint` — clean
- `pnpm --filter server test` — **428/428 pass** (420 → 428, +8)

| Test scenario |
|---------------|
| No past_due rows → all zero |
| `<4 days` → no email |
| Exactly 4 days → D-3 warning |
| Exactly 6 days → D-1 warning |
| 8 days → plan flipped + audit log + email |
| Dedup `23505` → email skipped, counter incremented |
| Supabase SELECT failure → error captured, no rows processed |
| Per-row exception isolation — bad row doesn't abort others |

## Post-merge ops

- Apply both Supabase migrations via Studio or `supabase db push`
- Vercel picks up the new cron entry on first deploy
- Live Paddle sandbox smoke (manual) — flip a test sub to `past_due`, advance clock or wait, confirm cron fires
- Monitor: `audit_logs.action = 'billing.plan.auto_downgrade'` rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)