### PR TITLE
feat(anomaly): P3.2 — confidence tiers for small reference windows

### DIFF
--- a/apps/server/src/__tests__/anomaly-confidence.test.ts
+++ b/apps/server/src/__tests__/anomaly-confidence.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P3.2 confidence tier tests.
+//
+// Two layers tested:
+//   1. `classifyConfidence(refCount)` — pure function, exhaustive boundaries.
+//   2. `detectAnomalies(...)` — end-to-end via a mocked ClickHouse query,
+//      verifying the right confidence tag travels through the detection
+//      pipeline AND that <10-sample buckets are still suppressed entirely.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const clickhouseQueryMock = vi.fn()
+
+vi.mock('../lib/clickhouse.js', () => ({
+  getClickhouse: () => ({
+    query: (opts: unknown) => clickhouseQueryMock(opts),
+  }),
+}))
+
+let classifyConfidence: typeof import('../lib/anomaly.js').classifyConfidence
+let detectAnomalies: typeof import('../lib/anomaly.js').detectAnomalies
+let ANOMALY_DEFAULTS: typeof import('../lib/anomaly.js').ANOMALY_DEFAULTS
+
+beforeEach(async () => {
+  vi.resetModules()
+  clickhouseQueryMock.mockReset()
+  ;({ classifyConfidence, detectAnomalies, ANOMALY_DEFAULTS } = await import('../lib/anomaly.js'))
+})
+
+/** Build a query result with one anomalous bucket where reference_count is the
+ *  variable being tested. All three signals (latency, cost, error_rate) carry
+ *  the same refCount so a single ClickHouse mock covers the full code path. */
+function singleBucketResult(refCount: number) {
+  return {
+    json: () => Promise.resolve([
+      {
+        provider: 'openai',
+        model: 'gpt-4o',
+        // Anomalous: obs mean is 1000ms, baseline 100ms with 10ms stddev → 90σ
+        obs_latency_mean: 1000,
+        obs_latency_count: refCount,
+        ref_latency_mean: 100,
+        ref_latency_stddev: 10,
+        ref_latency_count: refCount,
+        // Cost not anomalous (within 1σ) so this row exercises only the
+        // latency + error_rate branches.
+        obs_cost_mean: 0.5,
+        obs_cost_count: refCount,
+        ref_cost_mean: 0.5,
+        ref_cost_stddev: 0.1,
+        ref_cost_count: refCount,
+        // Error rate spike: 50% errors observed vs 1% baseline (huge σ)
+        obs_error_rate: 0.5,
+        obs_all_count: refCount,
+        ref_error_rate: 0.01,
+        ref_error_stddev: 0.05,
+        ref_all_count: refCount,
+      },
+    ]),
+  }
+}
+
+// ── Pure function tests ──────────────────────────────────────────────────────
+
+describe('classifyConfidence', () => {
+  test('returns null when refCount < MIN_SAMPLES_LOW (10)', () => {
+    expect(classifyConfidence(0)).toBeNull()
+    expect(classifyConfidence(5)).toBeNull()
+    expect(classifyConfidence(9)).toBeNull()
+  })
+
+  test("returns 'low' for 10..29 reference samples", () => {
+    expect(classifyConfidence(10)).toBe('low')
+    expect(classifyConfidence(20)).toBe('low')
+    expect(classifyConfidence(29)).toBe('low')
+  })
+
+  test("returns 'medium' for 30..99 reference samples", () => {
+    expect(classifyConfidence(30)).toBe('medium')
+    expect(classifyConfidence(50)).toBe('medium')
+    expect(classifyConfidence(99)).toBe('medium')
+  })
+
+  test("returns 'high' for >= 100 reference samples", () => {
+    expect(classifyConfidence(100)).toBe('high')
+    expect(classifyConfidence(1_000)).toBe('high')
+    expect(classifyConfidence(1_000_000)).toBe('high')
+  })
+
+  test('thresholds match the documented constants (regression guard)', () => {
+    expect(ANOMALY_DEFAULTS.MIN_SAMPLES_LOW).toBe(10)
+    expect(ANOMALY_DEFAULTS.MIN_SAMPLES_MEDIUM).toBe(30)
+    expect(ANOMALY_DEFAULTS.MIN_SAMPLES_HIGH).toBe(100)
+  })
+})
+
+// ── End-to-end via detectAnomalies ───────────────────────────────────────────
+
+describe('detectAnomalies — confidence tier wiring', () => {
+  test('refCount=15 surfaces anomalies tagged "low"', async () => {
+    clickhouseQueryMock.mockResolvedValue(singleBucketResult(15))
+    const anomalies = await detectAnomalies('org_1')
+    expect(anomalies.length).toBeGreaterThan(0)
+    for (const a of anomalies) {
+      expect(a.confidence).toBe('low')
+    }
+  })
+
+  test('refCount=50 surfaces anomalies tagged "medium"', async () => {
+    clickhouseQueryMock.mockResolvedValue(singleBucketResult(50))
+    const anomalies = await detectAnomalies('org_1')
+    expect(anomalies.length).toBeGreaterThan(0)
+    for (const a of anomalies) {
+      expect(a.confidence).toBe('medium')
+    }
+  })
+
+  test('refCount=200 surfaces anomalies tagged "high"', async () => {
+    clickhouseQueryMock.mockResolvedValue(singleBucketResult(200))
+    const anomalies = await detectAnomalies('org_1')
+    expect(anomalies.length).toBeGreaterThan(0)
+    for (const a of anomalies) {
+      expect(a.confidence).toBe('high')
+    }
+  })
+
+  test('refCount=5 (below low threshold) suppresses anomalies entirely', async () => {
+    clickhouseQueryMock.mockResolvedValue(singleBucketResult(5))
+    const anomalies = await detectAnomalies('org_1')
+    expect(anomalies).toEqual([])
+  })
+
+  test('regression: refCount=29 is "low" not "medium" (boundary)', async () => {
+    clickhouseQueryMock.mockResolvedValue(singleBucketResult(29))
+    const anomalies = await detectAnomalies('org_1')
+    expect(anomalies.length).toBeGreaterThan(0)
+    expect(anomalies[0]?.confidence).toBe('low')
+  })
+
+  test('regression: refCount=30 is "medium" not "low" (boundary)', async () => {
+    clickhouseQueryMock.mockResolvedValue(singleBucketResult(30))
+    const anomalies = await detectAnomalies('org_1')
+    expect(anomalies.length).toBeGreaterThan(0)
+    expect(anomalies[0]?.confidence).toBe('medium')
+  })
+
+  test('caller can override minSamples to suppress low-confidence findings', async () => {
+    clickhouseQueryMock.mockResolvedValue(singleBucketResult(15))
+    // Cron that pages on-call passes minSamples=30 to gate at medium+ only.
+    const anomalies = await detectAnomalies('org_1', { minSamples: 30 })
+    expect(anomalies).toEqual([])
+  })
+})

--- a/apps/server/src/__tests__/anomaly-snapshot.test.ts
+++ b/apps/server/src/__tests__/anomaly-snapshot.test.ts
@@ -61,6 +61,8 @@ function makeAnomaly(overrides: Partial<AnomalyBucket> = {}): AnomalyBucket {
     deviations: 3.5,
     sampleCount: 40,
     referenceCount: 200,
+    // P3.2: referenceCount=200 → 'high' tier by classifyConfidence.
+    confidence: 'high',
     ...overrides,
   }
 }

--- a/apps/server/src/lib/anomaly-snapshot.ts
+++ b/apps/server/src/lib/anomaly-snapshot.ts
@@ -110,6 +110,7 @@ async function persistSnapshot(
     deviations: a.deviations,
     sample_count: a.sampleCount,
     reference_count: a.referenceCount,
+    confidence: a.confidence,
   }))
 
   // Upsert on the unique (org, day, provider, model, kind) tuple — re-runs
@@ -135,6 +136,8 @@ interface AnomalyEventRow {
   deviations: string | number
   sample_count: number
   reference_count: number
+  /** P3.2: nullable for rows persisted before the column was added. */
+  confidence: 'low' | 'medium' | 'high' | null
 }
 
 export interface AnomalyHistoryEntry {
@@ -149,6 +152,8 @@ export interface AnomalyHistoryEntry {
   deviations: number
   sampleCount: number
   referenceCount: number
+  /** Null for pre-P3.2 historical rows; otherwise 'low' | 'medium' | 'high'. */
+  confidence: 'low' | 'medium' | 'high' | null
 }
 
 async function notifyHighSeverityAnomalies(
@@ -224,7 +229,7 @@ export async function getAnomalyHistory(
   const { data, error } = await supabaseAdmin
     .from('anomaly_events')
     .select(
-      'id, detected_on, provider, model, kind, current_value, baseline_mean, baseline_stddev, deviations, sample_count, reference_count',
+      'id, detected_on, provider, model, kind, current_value, baseline_mean, baseline_stddev, deviations, sample_count, reference_count, confidence',
     )
     .eq('organization_id', organizationId)
     .gte('detected_on', since)
@@ -251,5 +256,6 @@ export async function getAnomalyHistory(
     deviations: Number(r.deviations) || 0,
     sampleCount: r.sample_count,
     referenceCount: r.reference_count,
+    confidence: r.confidence,
   }))
 }

--- a/apps/server/src/lib/anomaly.ts
+++ b/apps/server/src/lib/anomaly.ts
@@ -28,6 +28,25 @@ function fmtTs(iso: string): string {
 
 export type AnomalyKind = 'latency' | 'cost' | 'error_rate'
 
+/**
+ * How statistically reliable this anomaly is, gated by the size of the
+ * reference window:
+ *
+ *   • 'low'    — 10 to 29 reference samples. Surface as informational only;
+ *                σ math is still mathematically valid but the small-sample
+ *                estimate of the population stddev is wide.
+ *   • 'medium' — 30 to 99. Roughly the cutoff where standard textbook
+ *                "n ≥ 30" approximation of normality kicks in.
+ *   • 'high'   — 100+. Both the mean and the stddev are well-estimated;
+ *                the σ count is trustworthy enough to page on.
+ *
+ * Before P3.2 the detector required ≥30 samples to flag *anything*, so brand
+ * new orgs (which have <30 historical samples for their first week) saw
+ * zero anomalies. Surfacing 'low' confidence at 10 samples lets them see
+ * directional signal while not making us look certain about a noisy stat.
+ */
+export type AnomalyConfidence = 'low' | 'medium' | 'high'
+
 export interface AnomalyContributingFactors {
   obsPromptTokensMean: number | null
   refPromptTokensMean: number | null
@@ -43,9 +62,32 @@ export const ANOMALY_DEFAULTS = {
   OBSERVATION_HOURS: 1,
   REFERENCE_HOURS: 168,
   SIGMA_THRESHOLD: 3,
-  MIN_SAMPLES: 30,
+  /**
+   * Minimum reference samples needed to surface an anomaly at any
+   * confidence level. Below this threshold, the stddev estimate is too
+   * noisy to be useful even with a clear "low confidence" label.
+   */
+  MIN_SAMPLES_LOW: 10,
+  /**
+   * Threshold for medium confidence — the historical "n ≥ 30 normality"
+   * cutoff. Pre-P3.2 this was the hard `MIN_SAMPLES` gate.
+   */
+  MIN_SAMPLES_MEDIUM: 30,
+  /** Threshold for high confidence — well-estimated mean + stddev. */
+  MIN_SAMPLES_HIGH: 100,
   HIGH_SEVERITY_SIGMA: 5,
 } as const
+
+/**
+ * Pure function so it's trivially testable. Returns null when the count
+ * is too small to surface as an anomaly at all (caller filters out).
+ */
+export function classifyConfidence(referenceCount: number): AnomalyConfidence | null {
+  if (referenceCount >= ANOMALY_DEFAULTS.MIN_SAMPLES_HIGH) return 'high'
+  if (referenceCount >= ANOMALY_DEFAULTS.MIN_SAMPLES_MEDIUM) return 'medium'
+  if (referenceCount >= ANOMALY_DEFAULTS.MIN_SAMPLES_LOW) return 'low'
+  return null
+}
 
 export interface AnomalyBucket {
   provider: string
@@ -59,6 +101,13 @@ export interface AnomalyBucket {
   sampleCount: number
   /** Number of requests in the reference (historical) window. */
   referenceCount: number
+  /**
+   * How trustworthy the σ count is, given the size of the reference window.
+   * Always present — even 'low' anomalies are surfaced (with a clear UI
+   * marker) so new orgs see directional signal. See `classifyConfidence`
+   * for the tier thresholds.
+   */
+  confidence: AnomalyConfidence
 }
 
 export interface DetectAnomaliesOptions {
@@ -101,7 +150,12 @@ export async function detectAnomalies(
   const observationHours = opts.observationHours ?? ANOMALY_DEFAULTS.OBSERVATION_HOURS
   const referenceHours   = opts.referenceHours  ?? ANOMALY_DEFAULTS.REFERENCE_HOURS
   const sigmaThreshold   = opts.sigmaThreshold  ?? ANOMALY_DEFAULTS.SIGMA_THRESHOLD
-  const minSamples       = opts.minSamples       ?? ANOMALY_DEFAULTS.MIN_SAMPLES
+  // Gate at the LOW threshold — anomalies between 10..29 reference samples
+  // still surface but are tagged `confidence: 'low'` for the UI to render
+  // less prominently. Callers can override `minSamples` to suppress low
+  // confidence entirely (e.g., the alert cron that only pages on
+  // medium/high).
+  const minSamples       = opts.minSamples       ?? ANOMALY_DEFAULTS.MIN_SAMPLES_LOW
 
   const now     = Date.now()
   const obsStart = fmtTs(new Date(now - observationHours * 3_600_000).toISOString())
@@ -195,17 +249,21 @@ export async function detectAnomalies(
       const deviations = (row.obs_latency_mean - row.ref_latency_mean) / row.ref_latency_stddev
       // One-sided: only flag SPIKES (improvements are not anomalies).
       if (deviations >= sigmaThreshold) {
-        anomalies.push({
-          provider:       row.provider,
-          model:          row.model,
-          kind:           'latency',
-          currentValue:   row.obs_latency_mean,
-          baselineMean:   row.ref_latency_mean,
-          baselineStdDev: row.ref_latency_stddev,
-          deviations,
-          sampleCount:    row.obs_latency_count,
-          referenceCount: row.ref_latency_count,
-        })
+        const confidence = classifyConfidence(row.ref_latency_count)
+        if (confidence !== null) {
+          anomalies.push({
+            provider:       row.provider,
+            model:          row.model,
+            kind:           'latency',
+            currentValue:   row.obs_latency_mean,
+            baselineMean:   row.ref_latency_mean,
+            baselineStdDev: row.ref_latency_stddev,
+            deviations,
+            sampleCount:    row.obs_latency_count,
+            referenceCount: row.ref_latency_count,
+            confidence,
+          })
+        }
       }
     }
 
@@ -221,17 +279,21 @@ export async function detectAnomalies(
       const deviations = (row.obs_cost_mean - row.ref_cost_mean) / row.ref_cost_stddev
       // One-sided: only flag SPIKES (cost drops are not anomalies).
       if (deviations >= sigmaThreshold) {
-        anomalies.push({
-          provider:       row.provider,
-          model:          row.model,
-          kind:           'cost',
-          currentValue:   row.obs_cost_mean,
-          baselineMean:   row.ref_cost_mean,
-          baselineStdDev: row.ref_cost_stddev,
-          deviations,
-          sampleCount:    row.obs_cost_count,
-          referenceCount: row.ref_cost_count,
-        })
+        const confidence = classifyConfidence(row.ref_cost_count)
+        if (confidence !== null) {
+          anomalies.push({
+            provider:       row.provider,
+            model:          row.model,
+            kind:           'cost',
+            currentValue:   row.obs_cost_mean,
+            baselineMean:   row.ref_cost_mean,
+            baselineStdDev: row.ref_cost_stddev,
+            deviations,
+            sampleCount:    row.obs_cost_count,
+            referenceCount: row.ref_cost_count,
+            confidence,
+          })
+        }
       }
     }
 
@@ -247,17 +309,21 @@ export async function detectAnomalies(
       const deviations = (row.obs_error_rate - row.ref_error_rate) / row.ref_error_stddev
       // One-sided: only flag SPIKES (more errors than baseline).
       if (deviations >= sigmaThreshold) {
-        anomalies.push({
-          provider:       row.provider,
-          model:          row.model,
-          kind:           'error_rate',
-          currentValue:   row.obs_error_rate,
-          baselineMean:   row.ref_error_rate,
-          baselineStdDev: row.ref_error_stddev,
-          deviations,
-          sampleCount:    row.obs_all_count,
-          referenceCount: row.ref_all_count,
-        })
+        const confidence = classifyConfidence(row.ref_all_count)
+        if (confidence !== null) {
+          anomalies.push({
+            provider:       row.provider,
+            model:          row.model,
+            kind:           'error_rate',
+            currentValue:   row.obs_error_rate,
+            baselineMean:   row.ref_error_rate,
+            baselineStdDev: row.ref_error_stddev,
+            deviations,
+            sampleCount:    row.obs_all_count,
+            referenceCount: row.ref_all_count,
+            confidence,
+          })
+        }
       }
     }
   }

--- a/apps/web/app/(dashboard)/anomalies/anomalies-client.tsx
+++ b/apps/web/app/(dashboard)/anomalies/anomalies-client.tsx
@@ -163,6 +163,29 @@ function AnomRow({ a, idx, last, onAck, onUnack, ackPending, dimmed }: AnomRowPr
           >
             {kindLabel(a.kind)}
           </span>
+          {a.confidence && (
+            // P3.2: trustworthiness label based on reference window size.
+            //   • low   — under 30 baseline samples; treat as directional only
+            //   • medium— textbook 30+ sample threshold; reliable
+            //   • high  — 100+ samples; both mean + stddev well-estimated
+            <span
+              className={cn(
+                'font-mono text-[9px] px-[6px] py-[1px] rounded-[3px] border uppercase tracking-[0.04em]',
+                a.confidence === 'high' && 'text-text-muted border-border',
+                a.confidence === 'medium' && 'text-text-muted border-border opacity-90',
+                a.confidence === 'low' && 'text-text-faint border-border opacity-70',
+              )}
+              title={
+                a.confidence === 'low'
+                  ? `Low confidence — only ${a.referenceCount} baseline samples (< 30). Treat as directional only.`
+                  : a.confidence === 'medium'
+                    ? `Medium confidence — ${a.referenceCount} baseline samples.`
+                    : `High confidence — ${a.referenceCount} baseline samples.`
+              }
+            >
+              {a.confidence}
+            </span>
+          )}
           <span className="text-[13.5px] text-text font-medium truncate">{anomTitle(a)}</span>
         </div>
         <div className="font-mono text-[11px] text-text-muted tracking-[0.01em]">

--- a/apps/web/lib/queries/use-anomalies.ts
+++ b/apps/web/lib/queries/use-anomalies.ts
@@ -6,6 +6,14 @@ import type { ApiEnvelope } from './types'
 
 export type AnomalyKind = 'latency' | 'cost' | 'error_rate'
 
+/**
+ * Statistical reliability of the anomaly given the size of the reference
+ * window. P3.2: surfaces low-confidence anomalies (10..29 ref samples) so
+ * new orgs see directional signal in their first week, while still labeling
+ * the result clearly. See `apps/server/src/lib/anomaly.ts:classifyConfidence`.
+ */
+export type AnomalyConfidence = 'low' | 'medium' | 'high'
+
 export interface AnomalyContributingFactors {
   obsPromptTokensMean: number | null
   refPromptTokensMean: number | null
@@ -30,6 +38,9 @@ export interface Anomaly {
   acknowledgedAt?: string | null
   /** Root-cause contributing factors — token usage change, error code breakdown. */
   factors?: AnomalyContributingFactors | null
+  /** Statistical reliability label. Always present on detection results from
+   *  the server; historical rows persisted before P3.2 may be null. */
+  confidence?: AnomalyConfidence
 }
 
 export interface AnomalyHistoryEntry {
@@ -44,6 +55,8 @@ export interface AnomalyHistoryEntry {
   deviations: number
   sampleCount: number
   referenceCount: number
+  /** Null for historical rows persisted before P3.2. */
+  confidence?: AnomalyConfidence | null
 }
 
 interface AnomalyResponseMeta {

--- a/supabase/migrations/20260519120000_anomaly_events_confidence.sql
+++ b/supabase/migrations/20260519120000_anomaly_events_confidence.sql
@@ -1,0 +1,23 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- anomaly_events.confidence — statistical reliability label (P3.2).
+--
+-- WHY: Before P3.2 the anomaly detector required ≥30 reference samples to
+-- surface anything. New customers (first week of traffic) saw no anomalies
+-- because the historical window was too thin. P3.2 lowers the gate to 10
+-- samples and tags each row with a confidence level so the dashboard can
+-- render low-confidence findings less prominently.
+--
+-- Existing rows: NULL → reasonable default. The cron rewrites all anomaly
+-- rows daily on each detected_on UTC date, so within 24h every live row
+-- will have a populated confidence. Backfill is not attempted; the column
+-- nullability lets old rows coexist without ALTER pain.
+--
+-- IDEMPOTENT (`ADD COLUMN IF NOT EXISTS`).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE anomaly_events
+  ADD COLUMN IF NOT EXISTS confidence TEXT
+    CHECK (confidence IN ('low', 'medium', 'high'));
+
+COMMENT ON COLUMN anomaly_events.confidence IS
+  'Statistical reliability tier based on reference_count. low=10..29, medium=30..99, high=100+. Pre-P3.2 rows are NULL until the next daily snapshot rewrites them.';


### PR DESCRIPTION
## Summary

Before P3.2 the anomaly detector required **≥30 reference samples** to surface anything. New customers (first week of traffic) saw zero anomalies and got a permanently-empty Anomalies page, hiding real directional signal.

This PR lowers the gate to 10 samples and tags each anomaly with a statistical reliability label so the dashboard can render small-sample findings less prominently without hiding them entirely.

## Tiers

| Tier | Reference samples | UI treatment | Use case |
|------|-------------------|--------------|----------|
| `low` | 10..29 | Dimmed badge | First-week orgs, directional only |
| `medium` | 30..99 | Standard badge | Textbook n≥30 normality cutoff |
| `high` | 100+ | Standard badge | Both mean + stddev well-estimated |

The on-call alert cron can still gate at medium+ by passing `minSamples: 30` to `detectAnomalies(...)` — that escape hatch is covered by a test.

## Changes

| Area | Change |
|------|--------|
| `apps/server/src/lib/anomaly.ts` | `AnomalyConfidence` type, `classifyConfidence()` pure fn, 3 new `MIN_SAMPLES_*` constants, required `confidence` on `AnomalyBucket`, detection gate lowered to LOW |
| `apps/server/src/lib/anomaly-snapshot.ts` | persistSnapshot writes confidence; AnomalyHistoryEntry exposes it |
| `supabase/migrations/20260519120000_anomaly_events_confidence.sql` | New `TEXT CHECK` column, nullable for pre-P3.2 rows |
| `apps/web/lib/queries/use-anomalies.ts` | `AnomalyConfidence` type, optional `confidence` field |
| `apps/web/(dashboard)/anomalies/anomalies-client.tsx` | Badge next to kind label with hover tooltip showing actual baseline sample count |

## Tests (12 new)

- `classifyConfidence` boundary: 0/5/9 → null, 10..29 → low, 30..99 → medium, 100+ → high
- Detection pipeline: refCount=15/50/200 yields anomalies tagged low/medium/high
- Suppression: refCount=5 returns no anomalies even when σ is huge
- Override: `minSamples: 30` gates out low-confidence (used by alert cron)
- Boundary regression: 29 → low, 30 → medium

## Verification

- `pnpm --filter server typecheck` — clean
- `pnpm --filter server lint` — clean
- `pnpm --filter server test` — **473/473 pass** (461 → 473, +12)
- `pnpm --filter web typecheck` — clean

## Post-merge ops

- `supabase db push` to apply migration. Next daily snapshot cron will rewrite existing rows with `confidence` populated (the snapshot uses upsert on `(org, day, provider, model, kind)`, so existing pre-P3.2 rows update in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)