### PR TITLE
feat(server): P3.3 — DB-backed model recommendation rules

### DIFF
--- a/apps/server/src/api/admin/modelRecommendations.ts
+++ b/apps/server/src/api/admin/modelRecommendations.ts
@@ -1,0 +1,184 @@
+import { Hono } from 'hono'
+import { authJwt, type JwtContext } from '../../middleware/authJwt.js'
+import { requireSystemAdmin } from '../../middleware/requireSystemAdmin.js'
+import { supabaseAdmin } from '../../lib/db.js'
+import { refreshRulesNow } from '../../lib/model-recommendations-cache.js'
+import { parsePositiveInt } from '../../lib/params.js'
+
+/**
+ * Admin-only CRUD for `model_recommendations` substitute rules (P3.3).
+ *
+ *   GET    /api/v1/admin/model-recommendations         list all
+ *   POST   /api/v1/admin/model-recommendations         upsert (current_provider+current_model)
+ *   DELETE /api/v1/admin/model-recommendations/:id     remove
+ *
+ * After every mutation the in-memory cache is refreshed so the next request
+ * sees the new rule on THIS function instance. Other Vercel instances pick
+ * up the change within their own 5-min TTL.
+ *
+ * Authorization: SPANLENS_ADMIN_EMAILS env var (see requireSystemAdmin).
+ * Same pattern as `/api/v1/admin/model-prices` from P2.1.
+ */
+export const adminModelRecommendationsRouter = new Hono<JwtContext>()
+
+adminModelRecommendationsRouter.use('*', authJwt)
+adminModelRecommendationsRouter.use('*', requireSystemAdmin)
+
+const ALLOWED_PROVIDERS = new Set(['openai', 'anthropic', 'gemini'])
+
+interface UpsertInput {
+  current_provider: 'openai' | 'anthropic' | 'gemini'
+  current_model: string
+  suggested_provider: 'openai' | 'anthropic' | 'gemini'
+  suggested_model: string
+  cost_ratio: number
+  max_avg_prompt_tokens: number
+  max_avg_completion_tokens: number
+  reason: string
+}
+
+function parseUpsert(body: unknown): { ok: true; data: UpsertInput } | { ok: false; error: string } {
+  if (!body || typeof body !== 'object') return { ok: false, error: 'Body must be an object' }
+  const b = body as Record<string, unknown>
+
+  const stringFields: Array<{ key: keyof UpsertInput; max?: number }> = [
+    { key: 'current_model', max: 200 },
+    { key: 'suggested_model', max: 200 },
+    { key: 'reason', max: 2000 },
+  ]
+  for (const { key, max = 500 } of stringFields) {
+    const v = b[key]
+    if (typeof v !== 'string' || v.length === 0 || v.length > max) {
+      return { ok: false, error: `${key} must be a non-empty string ≤ ${max} chars` }
+    }
+  }
+
+  for (const k of ['current_provider', 'suggested_provider'] as const) {
+    if (typeof b[k] !== 'string' || !ALLOWED_PROVIDERS.has(b[k] as string)) {
+      return { ok: false, error: `${k} must be one of openai|anthropic|gemini` }
+    }
+  }
+
+  const numFields: Array<{ key: keyof UpsertInput; positive?: boolean; integer?: boolean }> = [
+    { key: 'cost_ratio', positive: true },
+    { key: 'max_avg_prompt_tokens', positive: true, integer: true },
+    { key: 'max_avg_completion_tokens', positive: true, integer: true },
+  ]
+  for (const { key, positive, integer } of numFields) {
+    const v = b[key]
+    if (typeof v !== 'number' || !Number.isFinite(v)) {
+      return { ok: false, error: `${key} must be a finite number` }
+    }
+    if (positive && v <= 0) return { ok: false, error: `${key} must be > 0` }
+    if (integer && !Number.isInteger(v)) return { ok: false, error: `${key} must be an integer` }
+  }
+
+  return {
+    ok: true,
+    data: {
+      current_provider: b['current_provider'] as UpsertInput['current_provider'],
+      current_model: b['current_model'] as string,
+      suggested_provider: b['suggested_provider'] as UpsertInput['suggested_provider'],
+      suggested_model: b['suggested_model'] as string,
+      cost_ratio: b['cost_ratio'] as number,
+      max_avg_prompt_tokens: b['max_avg_prompt_tokens'] as number,
+      max_avg_completion_tokens: b['max_avg_completion_tokens'] as number,
+      reason: b['reason'] as string,
+    },
+  }
+}
+
+adminModelRecommendationsRouter.get('/', async (c) => {
+  // Allow paging in case the rule set grows (unlikely > 50 for a long time).
+  const limit = Math.min(parsePositiveInt(c.req.query('limit'), 200), 500)
+  const offset = parsePositiveInt(c.req.query('offset'), 0)
+
+  const { data, error, count } = await supabaseAdmin
+    .from('model_recommendations')
+    .select(
+      'id, current_provider, current_model, suggested_provider, suggested_model, ' +
+      'cost_ratio, max_avg_prompt_tokens, max_avg_completion_tokens, reason, ' +
+      'effective_from, created_at, updated_at',
+      { count: 'exact' },
+    )
+    .order('current_provider', { ascending: true })
+    .order('current_model', { ascending: true })
+    .range(offset, offset + limit - 1)
+
+  if (error) return c.json({ error: 'Failed to fetch recommendations' }, 500)
+
+  return c.json({
+    success: true,
+    data: data ?? [],
+    meta: { total: count ?? 0, limit, offset },
+  })
+})
+
+adminModelRecommendationsRouter.post('/', async (c) => {
+  const userId = c.get('userId')
+  const body = await c.req.json().catch(() => null)
+  const parsed = parseUpsert(body)
+  if (!parsed.ok) return c.json({ error: parsed.error }, 400)
+
+  const row = {
+    ...parsed.data,
+    effective_from: new Date().toISOString(),
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('model_recommendations')
+    .upsert(row, { onConflict: 'current_provider,current_model' })
+    .select()
+    .single()
+
+  if (error) return c.json({ error: `Upsert failed: ${error.message}` }, 500)
+
+  // Make the new rule visible on this instance immediately. Others pick it up
+  // within TTL (≤5 min).
+  await refreshRulesNow()
+
+  const orgId = c.get('orgId')
+  if (orgId && data) {
+    await supabaseAdmin.from('audit_logs').insert({
+      organization_id: orgId,
+      user_id: userId,
+      action: 'model_recommendation.upsert',
+      resource_type: 'model_recommendation',
+      resource_id: (data as { id: string }).id,
+      metadata: {
+        current: `${parsed.data.current_provider}:${parsed.data.current_model}`,
+        suggested: `${parsed.data.suggested_provider}:${parsed.data.suggested_model}`,
+        cost_ratio: parsed.data.cost_ratio,
+      },
+    })
+  }
+
+  return c.json({ success: true, data })
+})
+
+adminModelRecommendationsRouter.delete('/:id', async (c) => {
+  const id = c.req.param('id')
+  const userId = c.get('userId')
+
+  const { error } = await supabaseAdmin
+    .from('model_recommendations')
+    .delete()
+    .eq('id', id)
+
+  if (error) return c.json({ error: `Delete failed: ${error.message}` }, 500)
+
+  await refreshRulesNow()
+
+  const orgId = c.get('orgId')
+  if (orgId) {
+    await supabaseAdmin.from('audit_logs').insert({
+      organization_id: orgId,
+      user_id: userId,
+      action: 'model_recommendation.delete',
+      resource_type: 'model_recommendation',
+      resource_id: id,
+    })
+  }
+
+  return c.json({ success: true })
+})

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -45,6 +45,7 @@ import { providerKeysRouter }  from './api/providerKeys.js'
 import { meRouter }            from './api/me.js'
 import { systemRouter }       from './api/system.js'
 import { adminModelPricesRouter } from './api/admin/modelPrices.js'
+import { adminModelRecommendationsRouter } from './api/admin/modelRecommendations.js'
 
 export const app = new Hono()
 
@@ -172,5 +173,6 @@ app.route('/api/v1/system',         systemRouter)
 
 // ── Admin routes (authJwt + requireSystemAdmin via SPANLENS_ADMIN_EMAILS) ──
 app.route('/api/v1/admin/model-prices', adminModelPricesRouter)
+app.route('/api/v1/admin/model-recommendations', adminModelRecommendationsRouter)
 
 export default app

--- a/apps/server/src/lib/model-recommend-rules.ts
+++ b/apps/server/src/lib/model-recommend-rules.ts
@@ -141,7 +141,14 @@ export const SUBSTITUTES: Record<string, Substitute> = {
 }
 
 /**
- * Match a bucket key like 'openai:gpt-4o-mini-2024-07-18' against SUBSTITUTES.
+ * Match a bucket key like 'openai:gpt-4o-mini-2024-07-18' against the active
+ * substitute rules. The rules come from the DB-backed cache by default;
+ * callers may pass a precomputed `rules` map for tests / batch contexts.
+ *
+ * P3.3: rules are sourced from the `model_recommendations` table via
+ * `getCachedRules()` (stale-while-revalidate, 5-min TTL). The SUBSTITUTES
+ * constant above is the cold-start fallback — keep in sync with the seed
+ * at `supabase/seeds/model_recommendations.sql`.
  *
  * Order:
  *   1. Exact match.
@@ -153,16 +160,35 @@ export const SUBSTITUTES: Record<string, Substitute> = {
  * variant of the SUGGESTED model (e.g. gpt-4o-mini-2024-07-18) can match the
  * gpt-4o rule and would otherwise suggest switching to gpt-4o-mini, which is
  * a no-op. See model-recommend.ts for the suggestedKey guard.
+ *
+ * The `rules` parameter is optional: when omitted we resolve from the
+ * cache module via a dynamic import to avoid a circular static import
+ * (cache imports SUBSTITUTES from this file as its FALLBACK).
  */
-export function matchSubstitute(key: string): Substitute | null {
-  const exact = SUBSTITUTES[key]
+export function matchSubstituteIn(
+  key: string,
+  rules: Record<string, Substitute>,
+): Substitute | null {
+  const exact = rules[key]
   if (exact) return exact
 
   let bestKey = ''
-  for (const k of Object.keys(SUBSTITUTES)) {
+  for (const k of Object.keys(rules)) {
     if (key.startsWith(k + '-') && k.length > bestKey.length) {
       bestKey = k
     }
   }
-  return bestKey ? (SUBSTITUTES[bestKey] ?? null) : null
+  return bestKey ? (rules[bestKey] ?? null) : null
 }
+
+/**
+ * Production matcher — resolves rules from the DB-backed cache.
+ * For backward compat with callers that import from this file. The actual
+ * logic lives in `model-recommendations-cache.ts` so this module stays
+ * free of the cache implementation (which depends on supabaseAdmin).
+ *
+ * Tests that want to exercise the rule MATCHING logic against a known
+ * rule set should call `matchSubstituteIn(key, FALLBACK_RULES)` directly
+ * — it's pure and free of any side effects.
+ */
+export { matchSubstitute } from './model-recommendations-cache.js'

--- a/apps/server/src/lib/model-recommendations-cache.test.ts
+++ b/apps/server/src/lib/model-recommendations-cache.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+// Mock `./db.js` BEFORE importing the module under test so `supabaseAdmin.from()`
+// returns a programmable stub. Mirror of model-prices-cache.test.ts.
+const fromMock = vi.fn()
+vi.mock('./db.js', () => ({
+  supabaseAdmin: {
+    from: (...args: unknown[]) => fromMock(...args),
+  },
+}))
+
+let cache: typeof import('./model-recommendations-cache.js')
+let rulesMod: typeof import('./model-recommend-rules.js')
+
+beforeEach(async () => {
+  vi.resetModules()
+  fromMock.mockReset()
+  cache = await import('./model-recommendations-cache.js')
+  rulesMod = await import('./model-recommend-rules.js')
+  cache._resetCacheForTests()
+})
+
+afterEach(() => vi.useRealTimers())
+
+describe('model-recommendations-cache', () => {
+  test('cold start returns FALLBACK_RULES synchronously', () => {
+    const rules = cache.getCachedRules()
+    expect(rules['openai:gpt-4o']).toBeDefined()
+    expect(rules['openai:gpt-4o']?.suggestedModel).toBe('gpt-4o-mini')
+    expect(rules['anthropic:claude-opus-4-7']?.suggestedModel).toBe('claude-haiku-4.5')
+  })
+
+  test('refreshRulesNow loads from DB and overrides fallback', async () => {
+    fromMock.mockReturnValue({
+      select: vi.fn().mockResolvedValue({
+        data: [
+          {
+            current_provider: 'openai',
+            current_model: 'gpt-4o',
+            suggested_provider: 'openai',
+            suggested_model: 'gpt-4.1-nano',
+            cost_ratio: '0.01',
+            max_avg_prompt_tokens: 100,
+            max_avg_completion_tokens: 50,
+            reason: 'admin-tuned',
+          },
+        ],
+        error: null,
+      }),
+    })
+
+    const ok = await cache.refreshRulesNow()
+    expect(ok).toBe(true)
+
+    const rules = cache.getCachedRules()
+    expect(rules['openai:gpt-4o']?.suggestedModel).toBe('gpt-4.1-nano')
+    expect(rules['openai:gpt-4o']?.costRatio).toBe(0.01)
+    expect(rules['openai:gpt-4o']?.reason).toBe('admin-tuned')
+    // Other rules still come from fallback (e.g. anthropic family)
+    expect(rules['anthropic:claude-opus-4-7']?.suggestedModel).toBe('claude-haiku-4.5')
+  })
+
+  test('numeric string columns are coerced to Number (Postgres decimal)', async () => {
+    fromMock.mockReturnValue({
+      select: vi.fn().mockResolvedValue({
+        data: [
+          {
+            current_provider: 'openai',
+            current_model: 'gpt-4o',
+            suggested_provider: 'openai',
+            suggested_model: 'gpt-4o-mini',
+            cost_ratio: '0.123456',
+            max_avg_prompt_tokens: 500,
+            max_avg_completion_tokens: 150,
+            reason: 'numeric coercion check',
+          },
+        ],
+        error: null,
+      }),
+    })
+    await cache.refreshRulesNow()
+    const rule = cache.getCachedRules()['openai:gpt-4o']
+    expect(rule).toBeDefined()
+    expect(typeof rule?.costRatio).toBe('number')
+    expect(rule?.costRatio).toBe(0.123456)
+  })
+
+  test('DB error → returns false, falls back to existing cache', async () => {
+    fromMock.mockReturnValue({
+      select: vi.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'connection refused' },
+      }),
+    })
+
+    // Suppress the intentional console.warn from the error path
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const ok = await cache.refreshRulesNow()
+    expect(ok).toBe(false)
+    expect(warnSpy).toHaveBeenCalledOnce()
+
+    // Fallback rules still available
+    expect(cache.getCachedRules()['openai:gpt-4o']).toBeDefined()
+    warnSpy.mockRestore()
+  })
+
+  test('empty table preserves fallback rules', async () => {
+    fromMock.mockReturnValue({
+      select: vi.fn().mockResolvedValue({ data: [], error: null }),
+    })
+
+    await cache.refreshRulesNow()
+    expect(cache.getCachedRules()['openai:gpt-4o']).toBeDefined()
+  })
+
+  test('FALLBACK_RULES contains all the canonical models in seed', () => {
+    const required = [
+      'openai:gpt-4o', 'openai:gpt-4.1', 'openai:gpt-4-turbo', 'openai:gpt-4',
+      'anthropic:claude-opus-4-7', 'anthropic:claude-3-opus-20240229',
+      'anthropic:claude-sonnet-4-6', 'anthropic:claude-sonnet-4-5',
+      'anthropic:claude-3-5-sonnet-20241022',
+      'gemini:gemini-2.5-pro', 'gemini:gemini-1.5-pro', 'gemini:gemini-2.0-pro',
+    ]
+    for (const key of required) {
+      expect(cache.FALLBACK_RULES[key], `missing fallback for ${key}`).toBeDefined()
+    }
+  })
+})
+
+// ── matchSubstitute regression — DB rules MUST produce identical matches to
+//    FALLBACK_RULES on the inputs covered by existing model-recommend tests. ──
+describe('matchSubstitute regression vs FALLBACK_RULES', () => {
+  test('exact match returns the same substitute as the legacy hardcoded path', () => {
+    const fromFallback = rulesMod.matchSubstituteIn('openai:gpt-4o', rulesMod.SUBSTITUTES)
+    const fromCache = cache.matchSubstitute('openai:gpt-4o')
+    expect(fromCache).toEqual(fromFallback)
+  })
+
+  test('dated suffix prefix-matches like before', () => {
+    const fromFallback = rulesMod.matchSubstituteIn('openai:gpt-4o-mini-2024-07-18', rulesMod.SUBSTITUTES)
+    const fromCache = cache.matchSubstitute('openai:gpt-4o-mini-2024-07-18')
+    // Note: gpt-4o-mini is the SUGGESTED side, not the current side, so no
+    // substitute rule exists for it — both paths should agree on "null".
+    expect(fromCache).toBe(fromFallback)
+  })
+
+  test('boundary-aware prefix: openai:gpt-4 does not match gpt-4o', () => {
+    // Sanity that we did NOT regress the gpt-4 vs gpt-4o boundary trick.
+    const fromCache = cache.matchSubstitute('openai:gpt-4o')
+    expect(fromCache?.suggestedModel).toBe('gpt-4o-mini') // matches gpt-4o exact
+  })
+
+  test('unknown key returns null', () => {
+    expect(cache.matchSubstitute('openai:no-such-model')).toBeNull()
+  })
+})

--- a/apps/server/src/lib/model-recommendations-cache.ts
+++ b/apps/server/src/lib/model-recommendations-cache.ts
@@ -1,0 +1,162 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Model recommendation rule cache — DB-backed substitute rules with
+// stale-while-revalidate (P3.3). Mirror of model-prices-cache.ts.
+//
+// WHY THIS DESIGN
+// ----------------
+// `matchSubstitute()` is called from `model-recommend.ts` for every bucket
+// considered (one per provider × model surfaced in the savings dashboard).
+// Making it async would force every caller into await and add a DB round-trip
+// per row. Instead we keep `matchSubstitute()` sync, back the rule table
+// with a module-level cache, and refresh in the background every 5 minutes.
+//
+//   • Cold start            → uses FALLBACK_RULES (hard-coded copy of the
+//                              shipped SUBSTITUTES const) and triggers a
+//                              background refresh.
+//   • Subsequent calls      → freshest cached snapshot (DB or fallback).
+//   • Stale (>5 min)        → returns stale + kicks off refresh
+//                              (stale-while-revalidate).
+//   • DB unreachable        → falls back to hard-coded, logs once per minute.
+//
+// Vercel serverless caveat: each function instance has its own module
+// memory, so updates propagate within TTL per instance (~5 min, ≤2× worst
+// case across the fleet). Rules change a few times a month at most so this
+// is fine.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { supabaseAdmin } from './db.js'
+import type { Substitute } from './model-recommend-rules.js'
+import { SUBSTITUTES as FALLBACK_RULES, matchSubstituteIn } from './model-recommend-rules.js'
+
+export { FALLBACK_RULES }
+
+const CACHE_TTL_MS = 5 * 60 * 1000  // 5 minutes
+const ERROR_LOG_THROTTLE_MS = 60 * 1000
+
+let cache: Record<string, Substitute> = { ...FALLBACK_RULES }
+let lastRefreshedAt = 0
+let refreshInFlight: Promise<void> | null = null
+let lastErrorLoggedAt = 0
+
+/** Build the canonical rule key `provider:model` from a row or pair of strings. */
+export function ruleKey(provider: string, model: string): string {
+  return `${provider}:${model}`
+}
+
+/**
+ * Sync rule map for the matcher. Always returns a non-empty record (worst
+ * case: FALLBACK_RULES). Triggers an async refresh if stale.
+ *
+ * Safe to call on every request — never throws, never awaits.
+ */
+export function getCachedRules(): Record<string, Substitute> {
+  maybeTriggerRefresh()
+  return cache
+}
+
+/**
+ * Match a bucket key like 'openai:gpt-4o-mini-2024-07-18' against the
+ * currently cached rule set. Sync wrapper used by model-recommend.ts —
+ * the rule-matching logic itself is in model-recommend-rules.ts so this
+ * file stays free of the matching algorithm.
+ */
+export function matchSubstitute(key: string): Substitute | null {
+  return matchSubstituteIn(key, getCachedRules())
+}
+
+/**
+ * Force a synchronous refresh. Used by:
+ *   - Admin API after mutations (so the response reflects the new rule)
+ *   - Tests
+ */
+export async function refreshRulesNow(): Promise<boolean> {
+  try {
+    await doRefresh()
+    return true
+  } catch (err) {
+    logRefreshError(err)
+    return false
+  }
+}
+
+/** Test helper — production code never needs this. */
+export function _resetCacheForTests(): void {
+  cache = { ...FALLBACK_RULES }
+  lastRefreshedAt = 0
+  refreshInFlight = null
+}
+
+// ── Internals ─────────────────────────────────────────────────────────────────
+
+function maybeTriggerRefresh(): void {
+  // In tests we don't have a real Supabase — skip the network call so test
+  // stderr stays clean. Direct callers (refreshRulesNow) still work, so
+  // tests that want to exercise the refresh path can do so explicitly.
+  if (process.env['VITEST']) return
+
+  const now = Date.now()
+  const stale = now - lastRefreshedAt > CACHE_TTL_MS
+
+  if (!stale) return
+  if (refreshInFlight) return
+
+  refreshInFlight = doRefresh()
+    .catch(logRefreshError)
+    .finally(() => {
+      refreshInFlight = null
+    })
+}
+
+interface RuleRow {
+  current_provider: string
+  current_model: string
+  suggested_provider: string
+  suggested_model: string
+  cost_ratio: string | number
+  max_avg_prompt_tokens: number
+  max_avg_completion_tokens: number
+  reason: string
+}
+
+async function doRefresh(): Promise<void> {
+  const { data, error } = await supabaseAdmin
+    .from('model_recommendations')
+    .select(
+      'current_provider, current_model, suggested_provider, suggested_model, ' +
+      'cost_ratio, max_avg_prompt_tokens, max_avg_completion_tokens, reason',
+    )
+
+  if (error) throw new Error(`model_recommendations fetch failed: ${error.message}`)
+  if (!data || data.length === 0) {
+    // Empty table — keep fallback values, but mark refresh as done so we
+    // don't hammer the DB. Operator action required (seed the table).
+    lastRefreshedAt = Date.now()
+    return
+  }
+
+  const next: Record<string, Substitute> = {}
+  for (const row of data as unknown as RuleRow[]) {
+    const key = ruleKey(row.current_provider, row.current_model)
+    next[key] = {
+      suggestedProvider: row.suggested_provider,
+      suggestedModel: row.suggested_model,
+      // Decimal columns come back as strings in JSONEachRow; coerce.
+      costRatio: Number(row.cost_ratio),
+      maxAvgPromptTokens: row.max_avg_prompt_tokens,
+      maxAvgCompletionTokens: row.max_avg_completion_tokens,
+      reason: row.reason,
+    }
+  }
+  // Merge fallback under DB rows so a model present in FALLBACK_RULES but
+  // missing from the DB still resolves — protects against an admin
+  // accidentally deleting a row.
+  cache = { ...FALLBACK_RULES, ...next }
+  lastRefreshedAt = Date.now()
+}
+
+function logRefreshError(err: unknown): void {
+  const now = Date.now()
+  if (now - lastErrorLoggedAt < ERROR_LOG_THROTTLE_MS) return
+  lastErrorLoggedAt = now
+  console.warn('[model-recommendations-cache] refresh failed, using stale/fallback rules:', err)
+}

--- a/supabase/migrations/20260519130000_model_recommendations.sql
+++ b/supabase/migrations/20260519130000_model_recommendations.sql
@@ -1,0 +1,50 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- model_recommendations — substitute-matching rules for the model swap
+-- recommendation engine. Migrates the hand-maintained SUBSTITUTES constant
+-- in `apps/server/src/lib/model-recommend-rules.ts` into a real table so
+-- operators can tune the engine without redeploying.
+--
+-- WHY: Before P3.3 every rule change required a code change + deploy. After
+-- this migration the server reads rules from this table via an in-memory
+-- cache (5-min stale-while-revalidate, FALLBACK_RULES for cold start), and
+-- admins manage them through `/api/v1/admin/model-recommendations`.
+--
+-- DESIGN MIRRORS P2.1 (model_prices):
+--   • UNIQUE (current_provider, current_model) — one rule per source model.
+--   • effective_from for future "what was the rule on date X" analytics
+--     (not yet read by the engine; reserved for parity with model_prices).
+--   • Public SELECT, service-role-only mutations — admin API runs under
+--     supabaseAdmin so RLS bypass is intentional.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS model_recommendations (
+  id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  current_provider            TEXT NOT NULL,
+  current_model               TEXT NOT NULL,
+  suggested_provider          TEXT NOT NULL,
+  suggested_model             TEXT NOT NULL,
+  -- Multiplier applied to current spend to estimate spend on the substitute.
+  -- e.g. 0.06 means the substitute costs 6% of the current spend.
+  cost_ratio                  NUMERIC(10, 6) NOT NULL CHECK (cost_ratio > 0),
+  max_avg_prompt_tokens       INTEGER NOT NULL CHECK (max_avg_prompt_tokens > 0),
+  max_avg_completion_tokens   INTEGER NOT NULL CHECK (max_avg_completion_tokens > 0),
+  reason                      TEXT NOT NULL,
+  effective_from              TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at                  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at                  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (current_provider, current_model)
+);
+
+ALTER TABLE model_recommendations ENABLE ROW LEVEL SECURITY;
+
+-- Public read so the dashboard can render the cost-savings explanation without
+-- a server round-trip. Writes happen via service_role from the admin API only.
+CREATE POLICY "model_recommendations_public_select" ON model_recommendations
+  FOR SELECT USING (true);
+
+CREATE TRIGGER model_recommendations_updated_at
+  BEFORE UPDATE ON model_recommendations
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+COMMENT ON TABLE model_recommendations IS
+  'Substitute-matching rules for the model swap recommendation engine. DB-driven so operators can tune without redeploying. See lib/model-recommendations-cache.ts (P3.3).';

--- a/supabase/seeds/model_recommendations.sql
+++ b/supabase/seeds/model_recommendations.sql
@@ -1,0 +1,35 @@
+-- Seed: model substitute-matching rules (P3.3). Idempotent — ON CONFLICT
+-- on (current_provider, current_model) updates each row in place so re-running
+-- this seed safely refreshes the production rules.
+--
+-- Source: apps/server/src/lib/model-recommend-rules.ts FALLBACK_RULES.
+-- Keep these two in sync — FALLBACK_RULES is the cold-start safety net used
+-- when the DB is unreachable.
+INSERT INTO model_recommendations (
+  current_provider, current_model,
+  suggested_provider, suggested_model,
+  cost_ratio, max_avg_prompt_tokens, max_avg_completion_tokens, reason
+) VALUES
+  -- ── OpenAI ─────────────────────────────────────────────────────────
+  ('openai', 'gpt-4o',       'openai', 'gpt-4o-mini',  0.06,  500,  150, 'Short inputs/outputs fit the gpt-4o-mini envelope — ~17x cheaper with comparable accuracy on classification, extraction, and short-form generation.'),
+  ('openai', 'gpt-4.1',      'openai', 'gpt-4.1-mini', 0.20,  500,  150, 'Short inputs fit the gpt-4.1-mini envelope — 5x cheaper with comparable accuracy on classification and short-form generation.'),
+  ('openai', 'gpt-4-turbo',  'openai', 'gpt-4o',       0.25, 2000,  500, 'gpt-4o delivers equivalent reasoning at ~4x lower cost than gpt-4-turbo for most workloads.'),
+  ('openai', 'gpt-4',        'openai', 'gpt-4o',       0.083,4000, 1000, 'Legacy gpt-4 (8k) is ~12x more expensive than gpt-4o with no quality advantage on modern workloads.'),
+  -- ── Anthropic ──────────────────────────────────────────────────────
+  ('anthropic', 'claude-opus-4-7',            'anthropic', 'claude-haiku-4.5', 0.20,  500,  200, 'Low token volume per call fits Haiku 4.5 — 5x cheaper with sub-second latency for short-context tasks.'),
+  ('anthropic', 'claude-3-opus-20240229',     'anthropic', 'claude-haiku-4.5', 0.067, 500,  200, 'Low token volume per call fits Haiku 4.5 — ~15x cheaper with sub-second latency for short-context tasks.'),
+  ('anthropic', 'claude-sonnet-4-6',          'anthropic', 'claude-haiku-4.5', 0.333, 800,  250, 'Sonnet 4.6 is overkill for short-context classification — Haiku 4.5 is ~3x cheaper with comparable accuracy at this token range.'),
+  ('anthropic', 'claude-sonnet-4-5',          'anthropic', 'claude-haiku-4.5', 0.333, 800,  250, 'Short-context workloads that fit Haiku 4.5''s envelope are ~3x cheaper without measurable quality loss.'),
+  ('anthropic', 'claude-3-5-sonnet-20241022', 'anthropic', 'claude-haiku-4.5', 0.333, 800,  250, 'Sonnet 3.5 is overkill for short-context classification — Haiku 4.5 is ~3x cheaper with comparable accuracy at this token range.'),
+  -- ── Gemini ─────────────────────────────────────────────────────────
+  ('gemini', 'gemini-2.5-pro', 'gemini', 'gemini-2.5-flash', 0.25, 1000, 300, 'Gemini 2.5 Flash is ~4x cheaper than 2.5 Pro on short requests with comparable accuracy on structured tasks.'),
+  ('gemini', 'gemini-1.5-pro', 'gemini', 'gemini-1.5-flash', 0.06, 1000, 300, 'Gemini 1.5 Flash is ~17x cheaper than Pro on short requests and typically within 5% accuracy on structured tasks.'),
+  ('gemini', 'gemini-2.0-pro', 'gemini', 'gemini-2.0-flash', 0.10, 1000, 300, 'Gemini 2.0 Flash delivers similar output quality at ~10x lower cost for short-context tasks.')
+ON CONFLICT (current_provider, current_model) DO UPDATE
+  SET suggested_provider        = EXCLUDED.suggested_provider,
+      suggested_model           = EXCLUDED.suggested_model,
+      cost_ratio                = EXCLUDED.cost_ratio,
+      max_avg_prompt_tokens     = EXCLUDED.max_avg_prompt_tokens,
+      max_avg_completion_tokens = EXCLUDED.max_avg_completion_tokens,
+      reason                    = EXCLUDED.reason,
+      updated_at                = now();


### PR DESCRIPTION
## Summary

The 12-entry `SUBSTITUTES` constant in `apps/server/src/lib/model-recommend-rules.ts` is now a DB table. Operators can tune the engine (new model rule, price-change update, token threshold) without a deploy.

Mirror of P2.1 (model_prices) — same cache pattern, admin API shape, FALLBACK safety net.

## Architecture

- **Migration** — `model_recommendations` table, `UNIQUE (current_provider, current_model)`, check constraints, public SELECT, service-role mutations.
- **Seed** — 12 rules matching FALLBACK_RULES, `ON CONFLICT DO UPDATE` so re-runs are safe.
- **Cache (`lib/model-recommendations-cache.ts`)** — sync `getCachedRules()` + `matchSubstitute()`, async `refreshRulesNow()`, 5-min TTL, stale-while-revalidate, FALLBACK_RULES cold-start.
- **Admin API (`/api/v1/admin/model-recommendations`)** — GET/POST/DELETE gated by `SPANLENS_ADMIN_EMAILS`, audit_logs writes, immediate cache refresh on mutation.

## Tests added (10)

- Cold start returns FALLBACK_RULES
- DB load overrides fallback per-row
- Decimal column → Number coercion
- DB error → console.warn fires once, fallback intact
- Empty table preserves fallback
- FALLBACK_RULES covers all canonical models in the seed
- **Regression suite**: matchSubstitute via cache returns the same Substitute as `matchSubstituteIn(key, FALLBACK_RULES)` for exact / dated suffix / boundary / unknown keys

## Verification

- `pnpm --filter server typecheck` — clean
- `pnpm --filter server lint` — clean
- `pnpm --filter server test` — **483/483 pass** (473 → 483, +10)

## Post-merge ops

- `supabase db push` to apply migration
- Run seed against prod via Studio or `psql -f supabase/seeds/model_recommendations.sql`
- Cache picks up the rows within 5 min per Vercel function instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)