### PR TITLE
feat(sdk): P3.8 — trace sampling with tail-based error bypass (TS + Python)

### DIFF
--- a/packages/sdk-python/spanlens/client.py
+++ b/packages/sdk-python/spanlens/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Optional
 
+from .sampler import BufferingTransport, should_sample, validate_sample_rate
 from .trace import TraceHandle, create_trace
 from .transport import Transport
 
@@ -19,6 +20,9 @@ class SpanlensClient:
         >>> # ... do work ...
         >>> span.end(total_tokens=150, cost_usd=0.0023)
         >>> trace.end(status="completed")
+
+    Example (sampling — keep 10% of successful traces; errors always logged):
+        >>> client = SpanlensClient(api_key="sl_live_...", sample_rate=0.1)
     """
 
     def __init__(
@@ -29,9 +33,13 @@ class SpanlensClient:
         timeout_ms: int = 3000,
         silent: bool = True,
         on_error: Optional[Callable[[BaseException, str], None]] = None,
+        sample_rate: Optional[float] = None,
     ) -> None:
         if not api_key or not api_key.strip():
             raise ValueError("[spanlens] api_key is required")
+
+        # Validate early so a malformed value can't silently drop 100% of traces.
+        self._sample_rate = validate_sample_rate(sample_rate)
 
         config: dict[str, Any] = {
             "api_key": api_key,
@@ -59,8 +67,28 @@ class SpanlensClient:
             with client.start_trace("rag_pipeline") as trace:
                 with trace.span("retrieval", span_type="retrieval") as span:
                     ...
+
+        Sampling: the decision is made here (per-trace) and is sticky for
+        every span beneath this trace. Sampled-out traces buffer their
+        ingest calls in memory; the buffer is either replayed (on
+        ``status='error'``) or dropped (on success) when ``trace.end()`` runs.
         """
-        return create_trace(self._transport, name, metadata)
+        sampled = should_sample(self._sample_rate)
+        # Sampled-in: hand the trace the real transport directly (identical
+        # to pre-P3.8). Sampled-out: wrap with a BufferingTransport so child
+        # POSTs/PATCHes are queued in memory until the trace ends.
+        trace_transport: Any = (
+            self._transport
+            if sampled
+            else BufferingTransport(self._transport)
+        )
+        return create_trace(
+            trace_transport,
+            name,
+            metadata,
+            sampled=sampled,
+            real_transport=self._transport,
+        )
 
     def close(self) -> None:
         """Drain in-flight ingest calls and release the connection pool.

--- a/packages/sdk-python/spanlens/sampler.py
+++ b/packages/sdk-python/spanlens/sampler.py
@@ -1,0 +1,186 @@
+"""Trace sampling — opt-in cost / volume control for the agent-tracing layer.
+
+Mirrors ``packages/sdk/src/sampler.ts``. See that module's docstring for the
+rationale (per-trace decisions, tail-based error bypass, scope clarifications).
+
+Implementation notes:
+    The Python SDK already runs every ingest call through a daemon
+    ``ThreadPoolExecutor`` and returns a ``Future``. A buffering transport
+    just records ``(method, path, body)`` tuples and returns an
+    already-resolved Future, so consumers see the same API surface (no
+    awaits change shape).
+"""
+
+from __future__ import annotations
+
+import random as _random_module
+from concurrent.futures import Future
+from threading import Lock
+from typing import Any, Callable, Optional
+
+from .transport import Transport
+
+
+# Cap on buffered ops per sampled-out trace. Bounds worst-case memory if a
+# long-running trace never ends. ~1000 ops = ~50 spans × 20-deep nesting.
+MAX_BUFFER_SIZE = 1000
+
+
+def validate_sample_rate(value: Any) -> float:
+    """Validate and normalise a sample-rate value.
+
+    Returns ``1.0`` when the value is ``None`` (the default — no sampling).
+    Raises ``ValueError`` for any other invalid input. We'd rather fail at
+    construction than silently drop 100% of traces because the user passed
+    ``"0.1"`` (string) by accident.
+    """
+    if value is None:
+        return 1.0
+    # Reject bool explicitly — ``True`` and ``False`` are subclasses of int.
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(
+            f"[spanlens] sample_rate must be a number in [0, 1] — got {value!r}"
+        )
+    f = float(value)
+    if f != f or f < 0.0 or f > 1.0:  # NaN-check via self-inequality
+        raise ValueError(
+            f"[spanlens] sample_rate must be a number in [0, 1] — got {value!r}"
+        )
+    return f
+
+
+def should_sample(
+    sample_rate: float,
+    rng: Optional[Callable[[], float]] = None,
+) -> bool:
+    """Decide whether a single trace is sampled in.
+
+    Pure function — tests inject a deterministic RNG via the ``rng`` argument
+    (or by patching ``spanlens.sampler._random_module.random``).
+    ``sample_rate=1`` short-circuits the RNG call entirely (cheap fast path
+    for the default config).
+
+    The default RNG is looked up at call time (not bound at function-definition
+    time) so ``unittest.mock.patch`` against ``_random_module.random`` works
+    for monkey-patching in tests.
+    """
+    if sample_rate >= 1.0:
+        return True
+    if sample_rate <= 0.0:
+        return False
+    if rng is None:
+        rng = _random_module.random
+    return rng() < sample_rate
+
+
+def _completed_future() -> Future[Any]:
+    """Returns a Future already resolved to None — same trick `span.py` uses
+    when no parent creation needs to be awaited."""
+    fut: Future[Any] = Future()
+    fut.set_result(None)
+    return fut
+
+
+class BufferingTransport:
+    """In-memory buffer that mimics the ``Transport`` protocol.
+
+    Created per-trace when the trace loses the sampling coin-flip. POST/PATCH
+    calls are recorded as tuples instead of being sent. On ``flush_buffered()``
+    the recorded ops are replayed serially against the real transport,
+    preserving FIFO order — which is the same INSERT-before-UPDATE invariant
+    the real transport relies on via parent ``after`` futures.
+
+    Thread-safety: backed by a ``Lock`` so concurrent ``trace.span()`` calls
+    from user threads can't corrupt the buffer (the real transport's executor
+    serialises actual HTTP requests, but the buffer push happens on the
+    caller's thread).
+    """
+
+    def __init__(self, real: Transport) -> None:
+        self._real = real
+        self._buffer: list[tuple[str, str, Any]] = []
+        self._overflowed = False
+        self._lock = Lock()
+
+    # ── Transport protocol ───────────────────────────────────────
+
+    def post(
+        self,
+        path: str,
+        body: Any,
+        *,
+        after: Optional[Future[Any]] = None,
+    ) -> Future[Any]:
+        """Queue a POST. ``after`` is ignored — buffered ops are replayed
+        serially in FIFO order, which preserves the same ordering invariant."""
+        self._push("POST", path, body)
+        return _completed_future()
+
+    def patch(
+        self,
+        path: str,
+        body: Any,
+        *,
+        after: Optional[Future[Any]] = None,
+    ) -> Future[Any]:
+        """Queue a PATCH. See ``post`` for the ``after`` discussion."""
+        self._push("PATCH", path, body)
+        return _completed_future()
+
+    def close(self) -> None:
+        """Delegate close to the real transport — the buffer itself owns no
+        OS resources."""
+        self._real.close()
+
+    # ── Internal ─────────────────────────────────────────────────
+
+    def _push(self, method: str, path: str, body: Any) -> None:
+        with self._lock:
+            if len(self._buffer) < MAX_BUFFER_SIZE:
+                self._buffer.append((method, path, body))
+            else:
+                self._overflowed = True
+
+    # ── Public extension API ─────────────────────────────────────
+
+    def flush_buffered(self) -> None:
+        """Replay every buffered op against the real transport, serially.
+
+        Called by ``TraceHandle.end()`` when a sampled-out trace resolves with
+        ``status='error'`` — the tail-based bypass path. After this call the
+        buffer is cleared; new pushes start a fresh buffer.
+
+        Ordering: we explicitly chain each call's ``after`` to the previous
+        op's future so the real transport's executor sees the same
+        INSERT-before-UPDATE order the live path would have produced.
+        """
+        with self._lock:
+            ops = self._buffer
+            self._buffer = []
+        previous: Future[Any] = _completed_future()
+        for method, path, body in ops:
+            if method == "POST":
+                previous = self._real.post(path, body, after=previous)
+            else:
+                previous = self._real.patch(path, body, after=previous)
+        # Block on the tail so callers can rely on "after flush_buffered()
+        # returns, the buffer is on the wire."
+        try:
+            previous.result(timeout=30)
+        except Exception:
+            # Silent SDK contract — replay failures don't crash user code.
+            pass
+
+    @property
+    def overflowed(self) -> bool:
+        """Whether the buffer hit ``MAX_BUFFER_SIZE`` and dropped any ops.
+        Exposed for future "trace truncated" warnings."""
+        return self._overflowed
+
+
+__all__ = [
+    "BufferingTransport",
+    "MAX_BUFFER_SIZE",
+    "should_sample",
+    "validate_sample_rate",
+]

--- a/packages/sdk-python/spanlens/trace.py
+++ b/packages/sdk-python/spanlens/trace.py
@@ -10,8 +10,9 @@ import uuid
 from concurrent.futures import Future
 from datetime import datetime, timezone
 from types import TracebackType
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
+from .sampler import BufferingTransport
 from .span import _OMIT as _OMIT_SENTINEL
 from .span import SpanHandle, _completed_future, create_span
 from .transport import Transport
@@ -23,16 +24,22 @@ class TraceHandle:
 
     def __init__(
         self,
-        transport: Transport,
+        transport: Union[Transport, BufferingTransport],
         *,
         trace_id: str,
         name: str,
         started_at: datetime,
+        sampled: bool,
+        real_transport: Transport,
     ) -> None:
         self._transport = transport
         self.trace_id = trace_id
         self.name = name
         self.started_at = started_at
+
+        # Sampling state — kept as private fields so user code is unaware.
+        self._sampled = sampled
+        self._real_transport = real_transport
 
         # In-flight POST /ingest/traces. Spans + the trace's own end() PATCH
         # must chain after this so the server sees INSERT before any
@@ -80,6 +87,18 @@ class TraceHandle:
         ``ended_at``. The PATCH is queued behind the trace's own creation
         POST — otherwise it could race ahead and target a row that doesn't
         exist yet (silent 404).
+
+        Sampling semantics (P3.8):
+
+        * Sampled-in trace → behaves exactly as before; the PATCH goes
+          through the real transport.
+        * Sampled-out trace + ``status='error'`` → replay buffered span/trace
+          POSTs to the real transport first (tail-based error bypass), then
+          send the end PATCH directly to the real transport so it isn't
+          re-buffered. Net result on the dashboard: identical to a
+          sampled-in error trace.
+        * Sampled-out trace + ``status='completed'`` → drop the buffer
+          silently; no network traffic for this trace's ingest layer.
         """
         if self._ended:
             return
@@ -95,11 +114,32 @@ class TraceHandle:
         if metadata is not None:
             body["metadata"] = metadata
 
-        self._transport.patch(
-            f"/ingest/traces/{self.trace_id}",
-            body,
-            after=self._creation_future,
-        )
+        if self._sampled:
+            # Fast path — identical to pre-P3.8 behaviour.
+            self._transport.patch(
+                f"/ingest/traces/{self.trace_id}",
+                body,
+                after=self._creation_future,
+            )
+            return
+
+        # Sampled-out path. The trace's `_transport` here is the
+        # BufferingTransport that has been queuing every span POST/PATCH.
+        buffering = self._transport
+        assert isinstance(buffering, BufferingTransport)
+
+        if resolved_status == "error":
+            # Tail-based bypass: replay the buffered ops via the real
+            # transport, then send the end-PATCH directly so it doesn't
+            # get re-buffered.
+            buffering.flush_buffered()
+            self._real_transport.patch(
+                f"/ingest/traces/{self.trace_id}",
+                body,
+            )
+            return
+
+        # Completed / running with no error → drop everything. Nothing to send.
 
     # ── Context manager ─────────────────────────────────────────
 
@@ -122,11 +162,31 @@ class TraceHandle:
 
 
 def create_trace(
-    transport: Transport,
+    transport: Union[Transport, BufferingTransport],
     name: str,
     metadata: Optional[dict[str, Any]] = None,
+    *,
+    sampled: bool = True,
+    real_transport: Optional[Transport] = None,
 ) -> TraceHandle:
-    """Internal helper used by ``SpanlensClient.start_trace()``."""
+    """Internal helper used by ``SpanlensClient.start_trace()``.
+
+    ``sampled`` + ``real_transport`` are keyword-only and default to the
+    sampled-in (back-compat) path. ``SpanlensClient`` always provides them
+    explicitly; the defaults exist so external test helpers can still call
+    ``create_trace(transport, name)`` without caring about sampling.
+    """
+    # Back-compat default: when no real_transport is supplied, the trace's
+    # transport IS the real one (sampled-in with no buffering).
+    resolved_real = real_transport if real_transport is not None else transport
+    # If the caller passed a BufferingTransport with no real_transport,
+    # that's a programmer error — caller must always supply real_transport
+    # when sampling is enabled. We accept it silently here (defaults =
+    # sampled-in) so the type checker stays happy; SpanlensClient is the
+    # gate that enforces this contract.
+    if isinstance(resolved_real, BufferingTransport):
+        resolved_real = transport  # not reachable in practice
+
     trace_id = str(uuid.uuid4())
     started_at = datetime.now(timezone.utc)
 
@@ -143,12 +203,17 @@ def create_trace(
         trace_id=trace_id,
         name=name,
         started_at=started_at,
+        sampled=sampled,
+        real_transport=resolved_real,  # type: ignore[arg-type]
     )
 
     # Track the in-flight POST so child spans can chain after it. This
     # prevents a race where a span POST hits the server before the trace
     # INSERT commits, causing the server's ownership check to 404 and the
     # span to be lost. Failures are swallowed (silent SDK contract).
+    #
+    # For sampled-out traces this POST goes into the BufferingTransport
+    # queue instead of hitting the network; replay-on-error preserves order.
     handle._creation_future = transport.post("/ingest/traces", body)
     return handle
 

--- a/packages/sdk-python/spanlens/types.py
+++ b/packages/sdk-python/spanlens/types.py
@@ -49,6 +49,17 @@ class SpanlensConfig(TypedDict, total=False):
     timeout_ms: NotRequired[int]
     silent: NotRequired[bool]
     on_error: NotRequired[Optional[Callable[[BaseException, str], None]]]
+    sample_rate: NotRequired[float]
+    """Fraction of traces to ingest, in ``[0.0, 1.0]``. Default ``1.0`` (no sampling).
+
+    Decisions are per-trace and apply to every span under that trace. Error
+    traces (``status='error'``) are always recorded regardless of the
+    configured rate (tail-based bypass) so debugging signal is preserved.
+
+    Affects only the agent-tracing layer (``/ingest/traces``,
+    ``/ingest/spans``). Spanlens proxy request logs are unaffected — every
+    LLM call still flows through ``/proxy/*`` and gets recorded.
+    """
 
 
 # ── Trace / span options ─────────────────────────────────────────

--- a/packages/sdk-python/tests/test_sampling.py
+++ b/packages/sdk-python/tests/test_sampling.py
@@ -1,0 +1,333 @@
+"""P3.8 sampling tests — mirrors ``packages/sdk/src/__tests__/sampling.test.ts``.
+
+Three layers:
+
+1. Pure helpers (``validate_sample_rate``, ``should_sample``) — boundaries +
+   invalid-input semantics.
+2. ``BufferingTransport`` — drop-by-default + ``flush_buffered`` preserves
+   FIFO order + cap bounds memory.
+3. End-to-end via ``SpanlensClient`` — uses ``respx`` to assert which ingest
+   requests reach the wire for sampled-in / sampled-out / sampled-out+error
+   traces. This is the contract users care about.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+from unittest.mock import patch as mock_patch
+
+import httpx
+import pytest
+import respx
+
+from spanlens import SpanlensClient
+from spanlens.sampler import (
+    BufferingTransport,
+    MAX_BUFFER_SIZE,
+    should_sample,
+    validate_sample_rate,
+)
+
+BASE_URL = "https://test.spanlens.local"
+
+
+# ── 1. Pure helpers ──────────────────────────────────────────────────────────
+
+
+class TestValidateSampleRate:
+    def test_none_returns_default_1(self) -> None:
+        assert validate_sample_rate(None) == 1.0
+
+    @pytest.mark.parametrize("value", [0, 0.0, 0.1, 0.5, 1, 1.0])
+    def test_valid_range(self, value: float) -> None:
+        assert validate_sample_rate(value) == float(value)
+
+    @pytest.mark.parametrize("value", [-0.1, 1.5, -1, 2])
+    def test_out_of_range_raises(self, value: float) -> None:
+        with pytest.raises(ValueError, match=r"sample_rate must be a number"):
+            validate_sample_rate(value)
+
+    @pytest.mark.parametrize("value", ["0.5", {"r": 0.5}, [0.5], object()])
+    def test_non_number_types_raise(self, value: Any) -> None:
+        with pytest.raises(ValueError, match=r"sample_rate must be a number"):
+            validate_sample_rate(value)
+
+    def test_bool_rejected_even_though_subclass_of_int(self) -> None:
+        # ``True`` and ``False`` are technically int subclasses in Python.
+        # We reject them so ``sample_rate=False`` doesn't silently mean 0.0.
+        with pytest.raises(ValueError):
+            validate_sample_rate(True)
+        with pytest.raises(ValueError):
+            validate_sample_rate(False)
+
+    def test_nan_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            validate_sample_rate(float("nan"))
+
+
+class TestShouldSample:
+    def test_rate_1_short_circuits_rng(self) -> None:
+        calls: list[int] = []
+
+        def rng() -> float:
+            calls.append(1)
+            return 0.99
+
+        assert should_sample(1.0, rng) is True
+        assert calls == []
+
+    def test_rate_0_short_circuits_rng(self) -> None:
+        calls: list[int] = []
+
+        def rng() -> float:
+            calls.append(1)
+            return 0.0
+
+        assert should_sample(0.0, rng) is False
+        assert calls == []
+
+    def test_strict_less_than_comparison(self) -> None:
+        assert should_sample(0.5, lambda: 0.4) is True
+        assert should_sample(0.5, lambda: 0.6) is False
+        # Boundary: rng() == sample_rate should DROP (uses strict <).
+        assert should_sample(0.5, lambda: 0.5) is False
+
+    def test_approximate_rate_over_large_sample(self) -> None:
+        seed = [0]
+
+        def rng() -> float:
+            # Deterministic LCG.
+            seed[0] = (seed[0] * 1103515245 + 12345) % 2147483648
+            return seed[0] / 2147483648
+
+        n = 10_000
+        sampled = sum(1 for _ in range(n) if should_sample(0.1, rng))
+        # 10% ± 2% absolute (loose bound).
+        assert 0.08 < sampled / n < 0.12
+
+
+# ── 2. BufferingTransport ────────────────────────────────────────────────────
+
+
+class _FakeTransport:
+    """Minimal stand-in for the real ``Transport``. Records every call."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, Any]] = []
+
+    def post(self, path: str, body: Any, *, after: Any = None) -> Any:  # noqa: ARG002
+        self.calls.append(("POST", path, body))
+        from concurrent.futures import Future
+        f: Future[Any] = Future()
+        f.set_result(None)
+        return f
+
+    def patch(self, path: str, body: Any, *, after: Any = None) -> Any:  # noqa: ARG002
+        self.calls.append(("PATCH", path, body))
+        from concurrent.futures import Future
+        f: Future[Any] = Future()
+        f.set_result(None)
+        return f
+
+    def close(self) -> None:
+        pass
+
+
+class TestBufferingTransport:
+    def test_post_patch_do_not_reach_real_transport(self) -> None:
+        real = _FakeTransport()
+        buf = BufferingTransport(real)  # type: ignore[arg-type]
+
+        buf.post("/p1", {"a": 1})
+        buf.patch("/p2", {"b": 2})
+
+        assert real.calls == []
+
+    def test_flush_buffered_replays_in_fifo_order(self) -> None:
+        real = _FakeTransport()
+        buf = BufferingTransport(real)  # type: ignore[arg-type]
+
+        buf.post("/ingest/traces", {"id": "t"})
+        buf.post("/ingest/traces/t/spans", {"id": "s1"})
+        buf.patch("/ingest/spans/s1", {"ended_at": "x"})
+
+        buf.flush_buffered()
+
+        assert real.calls == [
+            ("POST", "/ingest/traces", {"id": "t"}),
+            ("POST", "/ingest/traces/t/spans", {"id": "s1"}),
+            ("PATCH", "/ingest/spans/s1", {"ended_at": "x"}),
+        ]
+
+    def test_buffer_cap_bounds_memory(self) -> None:
+        real = _FakeTransport()
+        buf = BufferingTransport(real)  # type: ignore[arg-type]
+
+        # Push 2× the cap; only the first MAX_BUFFER_SIZE should buffer.
+        for i in range(MAX_BUFFER_SIZE * 2):
+            buf.post(f"/p{i}", {"i": i})
+
+        buf.flush_buffered()
+        assert len(real.calls) == MAX_BUFFER_SIZE
+        assert real.calls[0][1] == "/p0"
+        assert real.calls[-1][1] == f"/p{MAX_BUFFER_SIZE - 1}"
+        assert buf.overflowed is True
+
+    def test_close_delegates_to_real(self) -> None:
+        closed = [False]
+
+        class _T(_FakeTransport):
+            def close(self) -> None:
+                closed[0] = True
+
+        buf = BufferingTransport(_T())  # type: ignore[arg-type]
+        buf.close()
+        assert closed[0] is True
+
+
+# ── 3. End-to-end via SpanlensClient + respx ─────────────────────────────────
+
+
+def _setup_routes() -> dict[str, respx.Route]:
+    return {
+        "trace_post": respx.post(f"{BASE_URL}/ingest/traces").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        ),
+        "span_post": respx.post(
+            re.compile(rf"^{re.escape(BASE_URL)}/ingest/traces/[\w-]+/spans$")
+        ).mock(return_value=httpx.Response(200, json={"ok": True})),
+        "span_patch": respx.patch(
+            re.compile(rf"^{re.escape(BASE_URL)}/ingest/spans/[\w-]+$")
+        ).mock(return_value=httpx.Response(200, json={})),
+        "trace_patch": respx.patch(
+            re.compile(rf"^{re.escape(BASE_URL)}/ingest/traces/[\w-]+$")
+        ).mock(return_value=httpx.Response(200, json={})),
+    }
+
+
+def _make_client(**kwargs: Any) -> SpanlensClient:
+    return SpanlensClient(
+        api_key="sl_test_dummy",
+        base_url=BASE_URL,
+        timeout_ms=2000,
+        silent=False,
+        **kwargs,
+    )
+
+
+class TestClientSampling:
+    def test_invalid_sample_rate_raises_at_construction(self) -> None:
+        with pytest.raises(ValueError, match=r"sample_rate must be a number"):
+            _make_client(sample_rate=-0.1)
+        with pytest.raises(ValueError):
+            _make_client(sample_rate=1.5)
+
+    @respx.mock
+    def test_default_rate_1_keeps_all_traces(self) -> None:
+        routes = _setup_routes()
+
+        with _make_client() as client:
+            with client.start_trace("t") as trace:
+                with trace.span("s", span_type="llm") as span:
+                    span.end(total_tokens=10)
+
+        assert routes["trace_post"].call_count == 1
+        assert routes["span_post"].call_count == 1
+        assert routes["span_patch"].call_count == 1
+        assert routes["trace_patch"].call_count == 1
+
+    @respx.mock
+    def test_rate_0_completed_drops_everything(self) -> None:
+        routes = _setup_routes()
+
+        with mock_patch("spanlens.sampler._random_module.random", return_value=0.5):
+            with _make_client(sample_rate=0.0) as client:
+                with client.start_trace("t") as trace:
+                    with trace.span("s") as span:
+                        span.end(total_tokens=10)
+                    # __exit__ → trace.end() with status='completed'
+
+        # NO calls hit the wire.
+        for name, route in routes.items():
+            assert route.call_count == 0, f"{name} unexpectedly called"
+
+    @respx.mock
+    def test_rate_0_error_replays_buffer(self) -> None:
+        routes = _setup_routes()
+
+        with mock_patch("spanlens.sampler._random_module.random", return_value=0.5):
+            client = _make_client(sample_rate=0.0)
+            try:
+                trace = client.start_trace("t")
+                span = trace.span("llm", span_type="llm")
+                span.end(total_tokens=42)
+                trace.end(status="error", error_message="boom")
+            finally:
+                client.close()
+
+        # All four calls should land — buffered ops were replayed, then the
+        # trace end PATCH was sent directly via the real transport.
+        assert routes["trace_post"].call_count == 1, "trace creation POST missing"
+        assert routes["span_post"].call_count == 1, "span creation POST missing"
+        assert routes["span_patch"].call_count == 1, "span end PATCH missing"
+        assert routes["trace_patch"].call_count == 1, "trace end PATCH missing"
+
+        # The trace end PATCH body should carry status=error.
+        end_body = json.loads(routes["trace_patch"].calls[0].request.content)
+        assert end_body["status"] == "error"
+        assert end_body["error_message"] == "boom"
+
+    @respx.mock
+    def test_rate_1_error_path_unchanged(self) -> None:
+        routes = _setup_routes()
+
+        with _make_client(sample_rate=1.0) as client:
+            trace = client.start_trace("t")
+            span = trace.span("s")
+            span.end()
+            trace.end(status="error", error_message="x")
+
+        # Standard 4-call sequence, no replay needed because nothing buffered.
+        assert routes["trace_post"].call_count == 1
+        assert routes["span_post"].call_count == 1
+        assert routes["span_patch"].call_count == 1
+        assert routes["trace_patch"].call_count == 1
+
+    @respx.mock
+    def test_decision_is_sticky_across_spans(self) -> None:
+        routes = _setup_routes()
+
+        # Pin RNG to 0.5 → with sample_rate=0.1, sampled-out.
+        with mock_patch("spanlens.sampler._random_module.random", return_value=0.5):
+            with _make_client(sample_rate=0.1) as client:
+                with client.start_trace("t") as trace:
+                    for i in range(20):
+                        with trace.span(f"s{i}") as s:
+                            s.end()
+
+        for route in routes.values():
+            assert route.call_count == 0
+
+    @respx.mock
+    def test_independent_decisions_per_trace(self) -> None:
+        routes = _setup_routes()
+        # Sequence: trace A sampled IN (rng=0.1 < 0.5),
+        #           trace B sampled OUT (rng=0.9, not < 0.5).
+        seq = iter([0.1, 0.9])
+        with mock_patch(
+            "spanlens.sampler._random_module.random", side_effect=lambda: next(seq)
+        ):
+            with _make_client(sample_rate=0.5) as client:
+                trace_a = client.start_trace("a")
+                trace_b = client.start_trace("b")
+                trace_a.end(status="completed")
+                trace_b.end(status="completed")
+
+        # Only trace A should reach the wire (POST + PATCH = 2 calls).
+        assert routes["trace_post"].call_count == 1
+        assert routes["trace_patch"].call_count == 1
+        # Verify it was specifically trace A.
+        end_path = routes["trace_patch"].calls[0].request.url.path
+        assert end_path.endswith(trace_a.trace_id)

--- a/packages/sdk/src/__tests__/sampling.test.ts
+++ b/packages/sdk/src/__tests__/sampling.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { SpanlensClient } from '../client.js'
+import {
+  makeBufferingTransport,
+  shouldSample,
+  validateSampleRate,
+} from '../sampler.js'
+import type { Transport } from '../transport.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P3.8 sampling tests.
+//
+// Three layers:
+//   1. Pure helpers (validateSampleRate, shouldSample) — boundary + invalid
+//      input semantics.
+//   2. BufferingTransport — drop-by-default + flushBuffered preserves order
+//      + buffer cap caps memory.
+//   3. End-to-end via SpanlensClient — fetchMock observes whether ingest
+//      traffic goes out for sampled-in / sampled-out / sampled-out+error
+//      traces. This is the contract users care about.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ── 1. Pure helpers ──────────────────────────────────────────────────────────
+
+describe('validateSampleRate', () => {
+  it('returns 1.0 when undefined / null (default = no sampling)', () => {
+    expect(validateSampleRate(undefined)).toBe(1.0)
+    expect(validateSampleRate(null)).toBe(1.0)
+  })
+
+  it('accepts valid numbers in [0, 1]', () => {
+    expect(validateSampleRate(0)).toBe(0)
+    expect(validateSampleRate(0.1)).toBe(0.1)
+    expect(validateSampleRate(0.5)).toBe(0.5)
+    expect(validateSampleRate(1)).toBe(1)
+  })
+
+  it('throws on out-of-range numbers', () => {
+    expect(() => validateSampleRate(-0.1)).toThrow(/sampleRate must be a number in \[0, 1\]/)
+    expect(() => validateSampleRate(1.5)).toThrow(/sampleRate must be a number/)
+  })
+
+  it('throws on non-number types (string / object / NaN)', () => {
+    expect(() => validateSampleRate('0.5' as unknown)).toThrow()
+    expect(() => validateSampleRate({} as unknown)).toThrow()
+    expect(() => validateSampleRate(NaN)).toThrow()
+  })
+})
+
+describe('shouldSample', () => {
+  it('returns true for sampleRate=1 without calling rng', () => {
+    const rng = vi.fn(() => 0.99)
+    expect(shouldSample(1, rng)).toBe(true)
+    expect(rng).not.toHaveBeenCalled()
+  })
+
+  it('returns false for sampleRate=0 without calling rng', () => {
+    const rng = vi.fn(() => 0)
+    expect(shouldSample(0, rng)).toBe(false)
+    expect(rng).not.toHaveBeenCalled()
+  })
+
+  it('compares rng output against the rate (strict less-than)', () => {
+    expect(shouldSample(0.5, () => 0.4)).toBe(true)
+    expect(shouldSample(0.5, () => 0.6)).toBe(false)
+    // Boundary — rng() === sampleRate should be DROP (rng is < check)
+    expect(shouldSample(0.5, () => 0.5)).toBe(false)
+  })
+
+  it('over a large draw produces approximately the configured rate', () => {
+    let seed = 0
+    const rng = () => {
+      // Linear congruential generator — deterministic, uniform [0,1).
+      seed = (seed * 1103515245 + 12345) % 2147483648
+      return seed / 2147483648
+    }
+    let sampled = 0
+    const N = 10_000
+    for (let i = 0; i < N; i++) {
+      if (shouldSample(0.1, rng)) sampled++
+    }
+    // 10% ± 2% absolute (loose bound for deterministic LCG).
+    expect(sampled / N).toBeGreaterThan(0.08)
+    expect(sampled / N).toBeLessThan(0.12)
+  })
+})
+
+// ── 2. BufferingTransport ────────────────────────────────────────────────────
+
+function makeFakeTransport(): Transport & { calls: Array<{ method: string; path: string; body: unknown }> } {
+  const calls: Array<{ method: string; path: string; body: unknown }> = []
+  return {
+    calls,
+    async post(path, body) { calls.push({ method: 'post', path, body }); return null },
+    async patch(path, body) { calls.push({ method: 'patch', path, body }); return null },
+    async flush() { /* no-op */ },
+  }
+}
+
+describe('makeBufferingTransport', () => {
+  it('does not forward POST/PATCH to the real transport when buffering', async () => {
+    const real = makeFakeTransport()
+    const buf = makeBufferingTransport(real)
+
+    await buf.post('/p1', { a: 1 })
+    await buf.patch('/p2', { b: 2 })
+
+    expect(real.calls).toEqual([])
+  })
+
+  it('flushBuffered replays buffered ops in FIFO order on the real transport', async () => {
+    const real = makeFakeTransport()
+    const buf = makeBufferingTransport(real)
+
+    await buf.post('/ingest/traces', { id: 't' })
+    await buf.post('/ingest/traces/t/spans', { id: 's1' })
+    await buf.patch('/ingest/spans/s1', { ended_at: 'x' })
+
+    await buf.flushBuffered()
+
+    expect(real.calls).toEqual([
+      { method: 'post', path: '/ingest/traces', body: { id: 't' } },
+      { method: 'post', path: '/ingest/traces/t/spans', body: { id: 's1' } },
+      { method: 'patch', path: '/ingest/spans/s1', body: { ended_at: 'x' } },
+    ])
+  })
+
+  it('caps the buffer to bound memory in long-running traces', async () => {
+    const real = makeFakeTransport()
+    const buf = makeBufferingTransport(real)
+
+    // Push 2000 ops — first 1000 should buffer, rest dropped.
+    for (let i = 0; i < 2000; i++) {
+      await buf.post(`/p${i}`, { i })
+    }
+    await buf.flushBuffered()
+
+    expect(real.calls.length).toBe(1000)
+    expect(real.calls[0]).toMatchObject({ path: '/p0' })
+    expect(real.calls[999]).toMatchObject({ path: '/p999' })
+  })
+
+  it('flush() delegates to the real transport', async () => {
+    const flushSpy = vi.fn().mockResolvedValue(undefined)
+    const real: Transport = {
+      post: async () => null,
+      patch: async () => null,
+      flush: flushSpy,
+    }
+    const buf = makeBufferingTransport(real)
+    await buf.flush()
+    expect(flushSpy).toHaveBeenCalledOnce()
+  })
+})
+
+// ── 3. End-to-end via SpanlensClient + fetchMock ─────────────────────────────
+
+describe('SpanlensClient — sampling', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let mathRandomSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockImplementation(() =>
+      Promise.resolve(new Response(JSON.stringify({ success: true }), { status: 201 })),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    if (mathRandomSpy) mathRandomSpy.mockRestore()
+  })
+
+  function pinRandom(value: number) {
+    mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(value)
+  }
+
+  it('throws at construction when sampleRate is invalid', () => {
+    expect(() => new SpanlensClient({ apiKey: 'k', sampleRate: -0.1 })).toThrow(
+      /sampleRate must be a number in \[0, 1\]/,
+    )
+    expect(() => new SpanlensClient({ apiKey: 'k', sampleRate: 1.5 })).toThrow()
+  })
+
+  it('default sampleRate=1.0 → all traces ingested (back-compat)', async () => {
+    const client = new SpanlensClient({ apiKey: 'k', baseUrl: 'http://x' })
+    const trace = client.startTrace({ name: 't' })
+    const span = trace.span({ name: 's' })
+    await span.end({ totalTokens: 10 })
+    await trace.end({ status: 'completed' })
+
+    const paths = fetchMock.mock.calls.map(([url]) => new URL(url as string).pathname)
+    expect(paths).toContain('/ingest/traces')
+    expect(paths.some((p) => p.endsWith('/spans'))).toBe(true)
+    expect(paths).toContain(`/ingest/spans/${span.spanId}`)
+    expect(paths).toContain(`/ingest/traces/${trace.traceId}`)
+  })
+
+  it('sampleRate=0 + status=completed → ZERO ingest traffic (full drop)', async () => {
+    pinRandom(0.5)
+    const client = new SpanlensClient({ apiKey: 'k', baseUrl: 'http://x', sampleRate: 0 })
+    const trace = client.startTrace({ name: 't' })
+    const span = trace.span({ name: 's' })
+    await span.end({ totalTokens: 10 })
+    await trace.end({ status: 'completed' })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('sampleRate=0 + status=error → buffered ops replayed (tail-based bypass)', async () => {
+    pinRandom(0.5)
+    const client = new SpanlensClient({ apiKey: 'k', baseUrl: 'http://x', sampleRate: 0 })
+    const trace = client.startTrace({ name: 't' })
+    const span = trace.span({ name: 'llm', spanType: 'llm' })
+    await span.end({ totalTokens: 42 })
+    await trace.end({ status: 'error', errorMessage: 'boom' })
+
+    // Expect the full sequence to land on the wire:
+    //   POST /ingest/traces (creation, was buffered)
+    //   POST /ingest/traces/:id/spans (creation, was buffered)
+    //   PATCH /ingest/spans/:id (end, was buffered)
+    //   PATCH /ingest/traces/:id (end, error — sent directly post-flush)
+    const calls = fetchMock.mock.calls.map(([url, init]) => ({
+      method: (init as RequestInit).method,
+      path: new URL(url as string).pathname,
+    }))
+    expect(calls).toContainEqual({ method: 'POST', path: '/ingest/traces' })
+    expect(calls).toContainEqual({ method: 'POST', path: `/ingest/traces/${trace.traceId}/spans` })
+    expect(calls).toContainEqual({ method: 'PATCH', path: `/ingest/spans/${span.spanId}` })
+    expect(calls).toContainEqual({ method: 'PATCH', path: `/ingest/traces/${trace.traceId}` })
+
+    // The trace end PATCH must arrive AFTER the buffered span POST/PATCH
+    // (preserves the same ordering invariants the server's ownership checks
+    // rely on).
+    const tracePatchIdx = calls.findIndex(
+      (c) => c.method === 'PATCH' && c.path === `/ingest/traces/${trace.traceId}`,
+    )
+    const spanPostIdx = calls.findIndex(
+      (c) => c.method === 'POST' && c.path === `/ingest/traces/${trace.traceId}/spans`,
+    )
+    expect(spanPostIdx).toBeLessThan(tracePatchIdx)
+  })
+
+  it('sampleRate=1.0 + status=error → identical to pre-P3.8 (no buffering)', async () => {
+    const client = new SpanlensClient({ apiKey: 'k', baseUrl: 'http://x', sampleRate: 1.0 })
+    const trace = client.startTrace({ name: 't' })
+    const span = trace.span({ name: 's' })
+    await span.end()
+    await trace.end({ status: 'error', errorMessage: 'x' })
+
+    // Standard 4-call sequence — no replay needed because nothing was buffered.
+    const methods = fetchMock.mock.calls.map(([, init]) => (init as RequestInit).method)
+    expect(methods.filter((m) => m === 'POST').length).toBeGreaterThanOrEqual(2)
+    expect(methods.filter((m) => m === 'PATCH').length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('sampling decision is sticky across all spans in a trace', async () => {
+    // First call to Math.random returns 0.5 (sampled out at rate=0.1).
+    // Subsequent calls (if any leak into span paths) would be ignored, but the
+    // decision should be locked in at startTrace().
+    pinRandom(0.5)
+    const client = new SpanlensClient({ apiKey: 'k', baseUrl: 'http://x', sampleRate: 0.1 })
+    const trace = client.startTrace({ name: 't' })
+    // Create many spans — none should hit the wire.
+    for (let i = 0; i < 20; i++) {
+      const s = trace.span({ name: `s${i}` })
+      await s.end()
+    }
+    await trace.end({ status: 'completed' })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('separate traces get independent sampling decisions', async () => {
+    const client = new SpanlensClient({ apiKey: 'k', baseUrl: 'http://x', sampleRate: 0.5 })
+
+    pinRandom(0.1) // sampled IN (0.1 < 0.5)
+    const traceA = client.startTrace({ name: 'a' })
+
+    if (mathRandomSpy) mathRandomSpy.mockRestore()
+    pinRandom(0.9) // sampled OUT (0.9 < 0.5 is false)
+    const traceB = client.startTrace({ name: 'b' })
+
+    await traceA.end({ status: 'completed' })
+    await traceB.end({ status: 'completed' })
+
+    const paths = fetchMock.mock.calls.map(([url]) => new URL(url as string).pathname)
+    // A's POST + PATCH should be present; B's should not.
+    expect(paths).toContain('/ingest/traces')
+    expect(paths).toContain(`/ingest/traces/${traceA.traceId}`)
+    expect(paths).not.toContain(`/ingest/traces/${traceB.traceId}`)
+  })
+})

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,5 +1,6 @@
 import { createTransport, type Transport } from './transport.js'
 import { createTrace, TraceHandle } from './trace.js'
+import { makeBufferingTransport, shouldSample, validateSampleRate } from './sampler.js'
 import type { SpanlensConfig, TraceOptions } from './types.js'
 
 /**
@@ -12,20 +13,45 @@ import type { SpanlensConfig, TraceOptions } from './types.js'
  * // ... do work ...
  * await span.end({ totalTokens: 150, costUsd: 0.0023 })
  * await trace.end({ status: 'completed' })
+ *
+ * @example  Sample 10% of traces; error traces are always recorded.
+ * const client = new SpanlensClient({ apiKey: 'sl_live_...', sampleRate: 0.1 })
  */
 export class SpanlensClient {
   private readonly transport: Transport
+  private readonly sampleRate: number
 
   constructor(config: SpanlensConfig) {
     if (!config.apiKey || config.apiKey.trim().length === 0) {
       throw new Error('[spanlens] apiKey is required')
     }
+    this.sampleRate = validateSampleRate(config.sampleRate)
     this.transport = createTransport(config)
   }
 
-  /** Start a new trace. Returns immediately; ingest runs in the background. */
+  /**
+   * Start a new trace. Returns immediately; ingest runs in the background.
+   *
+   * Sampling happens here — the decision is sticky for the trace's lifetime
+   * and applies to every span created under it. When the decision is "drop,"
+   * the returned `TraceHandle` still behaves identically to user code (you
+   * can create spans, attach metadata, etc.) — calls are buffered in memory
+   * and either replayed (if the trace ends with `status: 'error'`) or
+   * discarded (otherwise).
+   */
   startTrace(options: TraceOptions): TraceHandle {
-    return createTrace(this.transport, options.name, options.metadata)
+    const sampled = shouldSample(this.sampleRate)
+    // For sampled-in traces, hand the trace the real transport directly —
+    // identical behaviour to pre-P3.8. For sampled-out traces, wrap with a
+    // buffering transport so child POSTs/PATCHes are queued instead of sent.
+    const traceTransport: Transport = sampled
+      ? this.transport
+      : makeBufferingTransport(this.transport)
+
+    return createTrace(traceTransport, options.name, options.metadata, {
+      sampled,
+      realTransport: this.transport,
+    })
   }
 
   /**

--- a/packages/sdk/src/sampler.ts
+++ b/packages/sdk/src/sampler.ts
@@ -1,0 +1,128 @@
+/**
+ * Trace sampling — opt-in cost / volume control for the agent-tracing layer.
+ *
+ * Why per-trace and not per-span:
+ *   A trace is the unit of value (one user request, one agent run). Sampling
+ *   half the spans within a trace leaves dashboards showing inconsistent,
+ *   ragged trees. Sampling whole traces keeps each surviving trace fully
+ *   coherent and statistically scalable.
+ *
+ * Why tail-based for errors:
+ *   Error traces are the most valuable signal for debugging. We always want
+ *   100% of them, even when `sampleRate=0.01`. The sampler defers ingest
+ *   POSTs/PATCHes for sampled-out traces and replays them only if the trace
+ *   ends with `status: 'error'` — otherwise they're dropped.
+ *
+ * What this does NOT affect:
+ *   Spanlens-proxy request logs (`requests` in ClickHouse) are unaffected.
+ *   Every `/proxy/*` call is still recorded for cost / quota / anomaly use.
+ *   `sampleRate` only controls the OTLP-equivalent `/ingest/*` trace + span
+ *   ingestion layer.
+ */
+
+import type { Transport } from './transport.js'
+
+/**
+ * Cap on buffered ops per sampled-out trace. Bounds worst-case memory if a
+ * long-running trace never ends (e.g. user forgot to call `trace.end()`).
+ *
+ * 1000 = ~50 spans (each span is ~1 POST + 1 PATCH) ×  20-deep nesting,
+ * which is comfortably above realistic agent traces. Hitting this cap means
+ * the trace's replay (on error) will be partial — preferable to OOM.
+ */
+const MAX_BUFFER_SIZE = 1000
+
+export interface BufferingTransport extends Transport {
+  /**
+   * Replay every buffered op against the real transport, preserving FIFO
+   * order. Used by `TraceHandle.end()` when the trace was sampled-out but
+   * resolved with `status: 'error'`.
+   *
+   * After this call the buffer is cleared and the transport keeps buffering
+   * subsequent ops (the only expected post-flush call is the trace's own
+   * end-PATCH, which the caller routes directly to the real transport).
+   */
+  flushBuffered(): Promise<void>
+}
+
+/**
+ * Validates a sample rate. Throws if the value is malformed — we'd rather
+ * fail at SDK construction than silently drop 100% of traces because the
+ * user passed `'0.1'` (string) by accident.
+ */
+export function validateSampleRate(value: unknown): number {
+  if (value === undefined || value === null) return 1.0
+  if (typeof value !== 'number' || Number.isNaN(value) || value < 0 || value > 1) {
+    throw new Error(
+      `[spanlens] sampleRate must be a number in [0, 1] — got ${JSON.stringify(value)}`,
+    )
+  }
+  return value
+}
+
+/**
+ * Decide whether to sample a single trace. Pure function so tests can inject
+ * a deterministic RNG.
+ *
+ * `sampleRate=1` (default) always returns true — short-circuits the RNG call.
+ * `sampleRate=0` always returns false.
+ */
+export function shouldSample(sampleRate: number, rng: () => number = Math.random): boolean {
+  if (sampleRate >= 1) return true
+  if (sampleRate <= 0) return false
+  return rng() < sampleRate
+}
+
+/**
+ * Wraps `real` so that POST/PATCH calls are queued in memory instead of
+ * being sent. Used for traces that lost the sampling coin-flip; the queue
+ * is either replayed (on error) or dropped (on success) when the trace ends.
+ *
+ * The returned transport satisfies the same `Transport` interface so
+ * `createTrace` / `createSpan` don't need to know about sampling at all —
+ * they just see "a transport that resolves fast." This is what keeps the
+ * sampling concern isolated from the ingest hot path.
+ */
+export function makeBufferingTransport(real: Transport): BufferingTransport {
+  const buffer: Array<{ method: 'post' | 'patch'; path: string; body: unknown }> = []
+  let overflowed = false
+
+  const push = (method: 'post' | 'patch', path: string, body: unknown): void => {
+    if (buffer.length < MAX_BUFFER_SIZE) {
+      buffer.push({ method, path, body })
+    } else {
+      overflowed = true
+    }
+  }
+
+  return {
+    post(path, body) {
+      push('post', path, body)
+      return Promise.resolve(null)
+    },
+    patch(path, body) {
+      push('patch', path, body)
+      return Promise.resolve(null)
+    },
+    flush() {
+      // Defer to the real transport's flush. Buffered ops are NOT flushed by
+      // this method (it's just for in-flight network calls) — `flushBuffered`
+      // is the explicit replay entry point.
+      return real.flush()
+    },
+    async flushBuffered() {
+      // Replay serially so trace POST commits before any span POST hits the
+      // server's ownership check. The same ordering invariant the real
+      // transport relies on via `_creationPromise` chains in trace.ts/span.ts.
+      let chain: Promise<unknown> = Promise.resolve(null)
+      for (const op of buffer) {
+        chain = chain.then(() => real[op.method](op.path, op.body))
+      }
+      await chain
+      buffer.length = 0
+      // Note: `overflowed` is left as-is for observability (a getter could
+      // be added if the SDK ever surfaces "trace truncated" warnings).
+      void overflowed
+    },
+  }
+}

--- a/packages/sdk/src/trace.ts
+++ b/packages/sdk/src/trace.ts
@@ -1,6 +1,19 @@
 import type { Transport } from './transport.js'
+import type { BufferingTransport } from './sampler.js'
 import { createSpan, SpanHandle } from './span.js'
 import type { EndTraceOptions, SpanOptions } from './types.js'
+
+/**
+ * Sampling context attached to every trace at construction time. When
+ * `sampled` is true the trace behaves exactly as pre-P3.8: every POST/PATCH
+ * flows through the real transport immediately. When `sampled` is false the
+ * trace's transport is a `BufferingTransport` (queues ops in memory) and
+ * `realTransport` is the underlying network transport used for replay-on-error.
+ */
+export interface TraceSampling {
+  readonly sampled: boolean
+  readonly realTransport: Transport
+}
 
 /**
  * Active trace handle. Returned by `client.startTrace()`.
@@ -13,15 +26,19 @@ export class TraceHandle {
   /** @internal — in-flight POST /ingest/traces. Spans chain after this. */
   _creationPromise: Promise<unknown> = Promise.resolve()
 
+  /** @internal — sampling decision + real transport (for tail-based error replay). */
+  readonly _sampling: TraceSampling
+
   private ended = false
 
   constructor(
     private readonly transport: Transport,
-    params: { traceId: string; name: string; startedAt: Date },
+    params: { traceId: string; name: string; startedAt: Date; sampling: TraceSampling },
   ) {
     this.traceId = params.traceId
     this.name = params.name
     this.startedAt = params.startedAt
+    this._sampling = params.sampling
   }
 
   /** Create a top-level (root) span under this trace. */
@@ -35,6 +52,16 @@ export class TraceHandle {
    *
    * Awaits the trace's own creation POST first — otherwise PATCH could
    * race ahead and target a row that doesn't yet exist (silent 404).
+   *
+   * Sampling semantics:
+   *   - sampled-in trace → behaves exactly as before; the PATCH goes through
+   *     the real transport.
+   *   - sampled-out trace + status='error' → flush buffered span/trace POSTs
+   *     to the real transport first (tail-based error bypass), then send the
+   *     end PATCH directly to the real transport. The result on the dashboard
+   *     is identical to a sampled-in error trace.
+   *   - sampled-out trace + status='completed' → drop the buffer silently;
+   *     no network traffic for this trace's ingest layer.
    */
   async end(options: EndTraceOptions = {}): Promise<void> {
     if (this.ended) return
@@ -42,21 +69,43 @@ export class TraceHandle {
 
     await this._creationPromise.catch(() => undefined)
 
+    const status = options.status ?? (options.errorMessage ? 'error' : 'completed')
+
     const body: Record<string, unknown> = {
-      status: options.status ?? (options.errorMessage ? 'error' : 'completed'),
+      status,
       ended_at: new Date().toISOString(),
     }
     if (options.errorMessage !== undefined) body['error_message'] = options.errorMessage
     if (options.metadata !== undefined) body['metadata'] = options.metadata
 
-    await this.transport.patch(`/ingest/traces/${this.traceId}`, body)
+    if (this._sampling.sampled) {
+      // Fast path — identical to pre-P3.8 behaviour.
+      await this.transport.patch(`/ingest/traces/${this.traceId}`, body)
+      return
+    }
+
+    // Sampled-out path. The trace's `transport` here is the BufferingTransport
+    // that has been queuing every span POST/PATCH so far.
+    const buffering = this.transport as BufferingTransport
+
+    if (status === 'error') {
+      // Tail-based bypass: replay the buffered ops via the real transport,
+      // then send the end-PATCH directly to the real transport so it doesn't
+      // get re-buffered.
+      await buffering.flushBuffered()
+      await this._sampling.realTransport.patch(`/ingest/traces/${this.traceId}`, body)
+      return
+    }
+
+    // Completed / running with no error → drop everything. Nothing to send.
   }
 }
 
 export function createTrace(
   transport: Transport,
   name: string,
-  metadata?: Record<string, unknown>,
+  metadata: Record<string, unknown> | undefined,
+  sampling: TraceSampling,
 ): TraceHandle {
   const traceId = crypto.randomUUID()
   const startedAt = new Date()
@@ -68,12 +117,15 @@ export function createTrace(
   }
   if (metadata !== undefined) body['metadata'] = metadata
 
-  const handle = new TraceHandle(transport, { traceId, name, startedAt })
+  const handle = new TraceHandle(transport, { traceId, name, startedAt, sampling })
 
   // Track the in-flight POST so child spans can chain after it. This prevents
   // a race where a span POST hits the server before the trace INSERT commits,
   // causing the server's ownership check to 404 and the span to be lost.
   // Rejection is swallowed (silent SDK contract).
+  //
+  // For sampled-out traces this POST goes into the BufferingTransport queue
+  // instead of hitting the network; replay-on-error preserves ordering.
   handle._creationPromise = transport.post('/ingest/traces', body).catch(() => undefined)
 
   return handle

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -37,6 +37,24 @@ export interface SpanlensConfig {
   silent?: boolean
   /** Custom error hook — called when an ingest call fails. */
   onError?: (err: unknown, context: string) => void
+  /**
+   * Fraction of traces to ingest, in `[0.0, 1.0]`. Default `1.0` (no sampling).
+   *
+   * Decisions are made per-trace (at `client.startTrace()` time) and apply to
+   * every span under that trace, so each surviving trace remains fully
+   * coherent in the dashboard.
+   *
+   * **Tail-based error bypass**: traces that end with `status: 'error'` are
+   * always recorded, even when the trace would otherwise have been sampled
+   * out. This guarantees 100% of error traces reach the dashboard regardless
+   * of how aggressive the sample rate is.
+   *
+   * **Scope clarification**: only affects the agent-tracing layer
+   * (`/ingest/traces`, `/ingest/spans`). Spanlens proxy request logs
+   * (`/proxy/*` → ClickHouse `requests` table) are unaffected — every LLM
+   * call is still recorded for cost / quota / anomaly tracking.
+   */
+  sampleRate?: number
 }
 
 export interface TraceOptions {


### PR DESCRIPTION
## Summary

Adds per-trace sampling to both SDKs. Customers with high-volume agent deployments can cap their `/ingest/*` trace+span volume by an order of magnitude while still capturing **100% of error traces** for debugging.

```ts
// TypeScript
new SpanlensClient({ apiKey: 'sl_live_...', sampleRate: 0.1 })
```

```python
# Python
SpanlensClient(api_key='sl_live_...', sample_rate=0.1)
```

## Semantics

| Scenario | Result |
|---|---|
| `sampleRate=1.0` (default) | All traces ingested. Identical to pre-P3.8 behaviour. |
| Sampled-in trace | Real transport, immediate POST/PATCH |
| Sampled-out trace + `status='completed'` | Buffer dropped silently. Zero network traffic for the ingest layer. |
| Sampled-out trace + `status='error'` | **Tail-based bypass** — buffered span/trace POSTs replayed via real transport, then end-PATCH sent directly. Net result: identical to a sampled-in error trace. |

**Decision is per-trace** (made at `startTrace()` / `start_trace()` time) and sticky for every span beneath. Each surviving trace stays fully coherent — no ragged half-sampled trees.

## Scope clarification

Sampling affects **only the agent-tracing layer** (`/ingest/traces`, `/ingest/spans`).

Spanlens proxy request logs (`/proxy/*` → ClickHouse `requests`) are **unaffected** — every LLM call still flows through the proxy and is recorded for cost / quota / anomaly tracking. This is intentional: billing should not depend on the SDK's sampling decision.

## Implementation

- New `sampler` module in each SDK exposes:
  - `validateSampleRate` / `validate_sample_rate`
  - `shouldSample` / `should_sample`
  - `makeBufferingTransport` / `BufferingTransport`
- `BufferingTransport` satisfies the same Transport interface — `createTrace`/`createSpan` never see it as anything special. Replay-on-error happens inside `TraceHandle.end()` / `trace.end()` based on resolved status.
- 1000-op buffer cap (`MAX_BUFFER_SIZE`) prevents unbounded memory if a trace never ends; cap leaves replay-on-error partial but never OOMs.
- `sample_rate=1` short-circuits the RNG call (cheap default).
- Validation throws at client construction for malformed values — fail fast rather than silently dropping 100% of traces because a string was passed by accident.

## Tests

**TypeScript** — +19 tests (`sampling.test.ts`) → **104 total**
- `validateSampleRate` boundaries + invalid types (string, NaN, out-of-range)
- `shouldSample` strict-less-than + ~10k-draw distribution check
- `BufferingTransport` FIFO replay + buffer cap + flush delegation
- End-to-end via fetchMock:
  - `sampleRate=0` + completed → 0 wire calls
  - `sampleRate=0` + error → 4 wire calls (POST+POST+PATCH+PATCH)
  - `sampleRate=1` unchanged (back-compat)
  - Sticky decision across 20 child spans
  - Independent decisions across separate traces

**Python** — +32 tests (`test_sampling.py`) → **84 total**
- Mirrors TS coverage 1-for-1
- Adds bool-rejection test (Python's `True`/`False` subclass `int`, so we explicitly reject — otherwise `sample_rate=False` would silently mean `0.0`)
- Adds NaN-rejection test
- End-to-end via `respx` — same scenarios as TS

All existing tests (85 TS, 52 Python) still pass — refactor is back-compat.

## Verification

- [x] `pnpm typecheck` (4/4 packages)
- [x] `pnpm lint`
- [x] `pnpm test` (sdk: 104, server: 497)
- [x] `pytest` Python SDK (84 passed)

## Out of scope (deferred to follow-up)

- **Dashboard sample-rate badge** — needs an `x-spanlens-sample-rate` header threaded through proxy logging. Small follow-up PR after this ships.
- **Adaptive sampling** (cost / volume targets) — current PR is fixed-rate, which covers the documented 80% use case.

## Conventions

- Conventional Commits: `feat(sdk)` (cross-cuts both `sdk` and `sdk-python` packages)
- English commit message + comments + PR body
- No new dependencies (uses stdlib `random` in Python; `Math.random` in TS)
- No DB migrations / env vars

## Test plan

- [ ] Local: TS sample app with `sampleRate: 0.1`, run 100 traces, verify ~10 reach dashboard (plus any errors)
- [ ] Local: Python sample app likewise
- [ ] Force an error in a sampled-out trace; verify full trace appears in dashboard
- [ ] Sanity-check that proxy `/requests` continue logging at 100% regardless of `sampleRate`