### PR TITLE
docs(web): bring /docs/{sdk,export,anomalies} up to date with Phase 2/3 features

### DIFF
--- a/apps/web/app/docs/features/anomalies/page.tsx
+++ b/apps/web/app/docs/features/anomalies/page.tsx
@@ -42,8 +42,10 @@ export default function AnomaliesDocs() {
           Group requests in both windows by <code>(provider, model)</code>.
         </li>
         <li>
-          For each bucket with <strong>≥ 30 reference samples</strong>, compute sample mean (μ) and
-          sample standard deviation (σ) on the signal.
+          For each bucket with <strong>≥ 10 reference samples</strong>, compute sample mean (μ) and
+          sample standard deviation (σ) on the signal. Each anomaly is tagged with a{' '}
+          <strong>confidence label</strong> based on how many samples the baseline is built from —
+          see <a href="#confidence">Confidence tiers</a> below.
         </li>
         <li>
           Flag buckets where the observation-window mean sits <strong>3σ or more</strong> above
@@ -57,6 +59,51 @@ if deviations >= sigmaThreshold:
       <p>
         <strong>3σ</strong> corresponds to ~0.13% false-positive rate under a normal distribution —
         generous enough to catch real spikes without flooding your inbox.
+      </p>
+
+      <h3 id="confidence">Confidence tiers</h3>
+      <p>
+        The baseline&apos;s reliability scales with the size of the reference window. New
+        organisations (and rarely-used model buckets) need <em>some</em> directional signal in their
+        first week, but a 12-sample standard deviation is much noisier than a 1,000-sample one. The
+        confidence label tells you which regime you&apos;re in:
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Confidence</th>
+            <th>Reference samples</th>
+            <th>How to read it</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>low</strong></td>
+            <td>10 – 29</td>
+            <td>
+              Directional only. The σ estimate is noisy — treat as an early warning, verify against
+              the underlying requests before paging.
+            </td>
+          </tr>
+          <tr>
+            <td><strong>medium</strong></td>
+            <td>30 – 99</td>
+            <td>The classic 3σ threshold regime. False-positive rate is approximately as advertised.</td>
+          </tr>
+          <tr>
+            <td><strong>high</strong></td>
+            <td>100+</td>
+            <td>
+              Statistically robust. Use as the gate when wiring anomalies into a paging integration —
+              see <code>minSamples</code> below for the API parameter.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Below 10 reference samples the bucket is suppressed entirely (no detection, regardless of
+        observation). Buckets ingested before this tier system was introduced are surfaced with
+        confidence <code>null</code> for back-compat.
       </p>
 
       <h3>Why per-bucket matters</h3>
@@ -125,6 +172,7 @@ if deviations >= sigmaThreshold:
         <li>Baseline mean ± stddev</li>
         <li>Deviations (how many σ above normal)</li>
         <li>Sample counts (both windows)</li>
+        <li><strong>Confidence badge</strong> — <em>low</em> / <em>medium</em> / <em>high</em> based on reference-window size (see <a href="#confidence">Confidence tiers</a>)</li>
         <li><strong>Contributing factors</strong> — a <code>why ·</code> hint explaining the likely root cause</li>
         <li>Acknowledged state (if you&apos;ve silenced it)</li>
       </ul>
@@ -221,6 +269,7 @@ DELETE /api/v1/anomalies/ack?provider=openai&model=gpt-4o&kind=latency`}</CodeBl
 #     "deviations": 39.4,
 #     "sampleCount": 42,
 #     "referenceCount": 18420,
+#     "confidence": "high",        // low | medium | high — reliability of the baseline
 #     "acknowledgedAt": null,      // ISO string if acked, null otherwise
 #     "factors": {                 // root-cause contributing factors
 #       "obsPromptTokensMean": 3200,
@@ -294,11 +343,21 @@ DELETE /api/v1/anomalies/ack?provider=openai&model=gpt-4o&kind=latency`}</CodeBl
             <td>—</td>
             <td>Scope detection to a single project instead of the whole org</td>
           </tr>
+          <tr>
+            <td><code>minSamples</code></td>
+            <td>10</td>
+            <td>
+              Raise to <code>30</code> or <code>100</code> to suppress low/medium-confidence findings
+              when wiring into paging or noisy channels.
+            </td>
+          </tr>
         </tbody>
       </table>
       <p>
-        The minimum reference sample count (30) is fixed and not adjustable — below that, the
-        standard deviation estimate is too noisy to be meaningful.
+        Below <code>minSamples</code> the bucket is suppressed entirely (no row, no notification).
+        The default <code>10</code> surfaces directional signal for new orgs in their first week;
+        the dashboard tags each finding with a <a href="#confidence">confidence badge</a> so you can
+        scan past low-confidence rows visually.
       </p>
 
       <h2>Design choices</h2>
@@ -327,8 +386,9 @@ DELETE /api/v1/anomalies/ack?provider=openai&model=gpt-4o&kind=latency`}</CodeBl
         </li>
         <li>
           <strong>Sparse buckets are skipped.</strong> Any <code>(provider, model, kind)</code>{' '}
-          combination with fewer than 30 requests in the reference window produces no signal — not
-          enough data for a reliable baseline.
+          combination with fewer than <code>minSamples</code> requests (default 10) in the reference
+          window produces no signal — not enough data for any baseline. Buckets between 10 and 29
+          samples surface with <strong>low confidence</strong> so you can decide whether to act.
         </li>
         <li>
           <strong>No anomaly-level alert routing.</strong> You can&apos;t route &ldquo;only

--- a/apps/web/app/docs/features/export/page.tsx
+++ b/apps/web/app/docs/features/export/page.tsx
@@ -3,7 +3,7 @@ import { CodeBlock } from '../../_components/code-block'
 export const metadata = {
   title: 'Data Export · Spanlens Docs',
   description:
-    'Download request logs, traces, anomalies, and security flags as CSV or JSON to feed into BI tools or data pipelines.',
+    'Download request logs, traces, anomalies, and security flags as CSV, JSONL, or JSON to feed into BI tools or data pipelines. Streamed for million-row exports.',
 }
 
 export default function ExportDocs() {
@@ -11,9 +11,10 @@ export default function ExportDocs() {
     <div>
       <h1>Data Export</h1>
       <p className="lead">
-        Download request logs, traces, anomaly snapshots, and security flags as CSV or JSON in one
-        shot. Connect directly to Pandas, Excel, Redash, Metabase, or any other BI tool, or ingest
-        the data on a schedule into your own pipeline.
+        Download request logs, traces, anomaly snapshots, and security flags as CSV, JSONL, or JSON
+        in one shot. CSV and JSONL stream directly from ClickHouse — a million-row export runs in
+        ~30&nbsp;MB of memory and finishes inside the function-execution window. Connect to Pandas,
+        BigQuery, Redash, Metabase, or your own pipeline.
       </p>
 
       <h2>Endpoints</h2>
@@ -61,7 +62,10 @@ export default function ExportDocs() {
           <tr>
             <td><code>format</code></td>
             <td><code>csv</code></td>
-            <td><code>csv</code> or <code>json</code></td>
+            <td>
+              <code>csv</code> · <code>jsonl</code> · <code>json</code>. CSV and JSONL stream; JSON
+              materialises a wrapper object. See <a href="#formats">Formats</a> below.
+            </td>
           </tr>
           <tr>
             <td><code>from</code></td>
@@ -78,11 +82,57 @@ export default function ExportDocs() {
           </tr>
           <tr>
             <td><code>limit</code></td>
-            <td><code>10000</code></td>
-            <td>1–10,000. Maximum 10,000 rows per request. For more data, paginate using <code>from</code>/<code>to</code>.</td>
+            <td>format-dependent</td>
+            <td>
+              CSV / JSONL: 1 – <strong>1,000,000</strong>. JSON: 1 – 10,000.
+              <code>/exports/requests</code> only — other endpoints stay at 10,000.
+            </td>
           </tr>
         </tbody>
       </table>
+
+      <h2 id="formats">Formats — when to pick each</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Format</th>
+            <th>Streamed?</th>
+            <th>Row cap</th>
+            <th>Best for</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>csv</code></td>
+            <td>Yes</td>
+            <td>1,000,000</td>
+            <td>BI tools, spreadsheets, ad-hoc analysis. Default.</td>
+          </tr>
+          <tr>
+            <td><code>jsonl</code></td>
+            <td>Yes</td>
+            <td>1,000,000</td>
+            <td>
+              Pipelines that preserve typing (jq, <code>pandas.read_json(lines=True)</code>,
+              BigQuery, ClickHouse). One JSON object per line, newline-delimited.
+            </td>
+          </tr>
+          <tr>
+            <td><code>json</code></td>
+            <td>No — buffered</td>
+            <td>10,000</td>
+            <td>
+              Wrapper object <code>{`{ exported_at, count, data: [...] }`}</code> for code that
+              wants a single parseable response. Use <code>jsonl</code> for anything larger.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Streamed responses set <code>Cache-Control: no-store</code> so intermediaries don&apos;t
+        buffer the full body. Each ClickHouse batch (~64&nbsp;KB) is the only data held in memory at
+        any point — heap usage stays flat regardless of <code>limit</code>.
+      </p>
 
       <h2>Additional parameters for requests</h2>
       <p>
@@ -297,44 +347,63 @@ curl "https://spanlens-server.vercel.app/api/v1/exports/security?from=2026-05-01
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \\
   -o spanlens-security.csv`}</CodeBlock>
 
-      <h3>JSON download</h3>
+      <h3>JSONL download (large exports)</h3>
+      <CodeBlock language="bash">{`# One million rows, streamed. Pipe straight into jq for filtering.
+curl "https://spanlens-server.vercel.app/api/v1/exports/requests?format=jsonl&from=2026-01-01T00:00:00Z&limit=1000000" \\
+  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \\
+  | jq -c 'select(.cost_usd != null and (.cost_usd | tonumber) > 0.01)' \\
+  > expensive-requests.jsonl
+
+# Each line is a self-contained JSON object:
+# {"id":"req_xxx","provider":"openai","model":"gpt-4o-mini-2024-07-18",...}
+# {"id":"req_yyy","provider":"anthropic","model":"claude-sonnet-4-5",...}`}</CodeBlock>
+
+      <h3>JSON download (small, wrapped)</h3>
       <CodeBlock language="bash">{`curl "https://spanlens-server.vercel.app/api/v1/exports/requests?format=json&limit=1000" \\
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN"
 
-# Response shape:
-# [
-#   {
-#     "id": "req_xxx",
-#     "project_id": "proj_xxx",
-#     "provider": "openai",
-#     "model": "gpt-4o-mini-2024-07-18",
-#     "prompt_tokens": 512,
-#     "completion_tokens": 128,
-#     "total_tokens": 640,
-#     "cost_usd": 0.000096,
-#     "latency_ms": 843,
-#     "status_code": 200,
-#     "error_message": null,
-#     "trace_id": null,
-#     "created_at": "2026-05-15T09:00:00.000Z"
-#   },
-#   ...
-# ]`}</CodeBlock>
+# Response shape (buffered, capped at 10,000 rows):
+# {
+#   "exported_at": "2026-05-19T08:30:00.000Z",
+#   "count": 1000,
+#   "data": [
+#     {
+#       "id": "req_xxx",
+#       "project_id": "proj_xxx",
+#       "provider": "openai",
+#       "model": "gpt-4o-mini-2024-07-18",
+#       "prompt_tokens": 512,
+#       "completion_tokens": 128,
+#       "total_tokens": 640,
+#       "cost_usd": 0.000096,
+#       "latency_ms": 843,
+#       "status_code": 200,
+#       "error_message": null,
+#       "trace_id": null,
+#       "created_at": "2026-05-15T09:00:00.000Z"
+#     },
+#     ...
+#   ]
+# }`}</CodeBlock>
 
       <h2>BI tool tips</h2>
 
       <h3>Pandas (Python)</h3>
       <CodeBlock language="python">{`import pandas as pd
-import requests, io
 
 token = "YOUR_SUPABASE_ACCESS_TOKEN"
+
+# Small / medium — CSV, single response.
 url = "https://spanlens-server.vercel.app/api/v1/exports/requests?from=2026-05-01T00:00:00Z&format=csv"
+df = pd.read_csv(url, storage_options={"Authorization": f"Bearer {token}"})
 
-r = requests.get(url, headers={"Authorization": f"Bearer {token}"})
-df = pd.read_csv(io.StringIO(r.text))
-
-# Average cost by model
-print(df.groupby("model")["cost_usd"].mean())`}</CodeBlock>
+# Million-row pipeline — JSONL, streamed line-by-line. Pandas reads it in
+# chunks so peak memory stays bounded.
+url = "https://spanlens-server.vercel.app/api/v1/exports/requests?format=jsonl&limit=1000000"
+chunks = pd.read_json(url, lines=True, chunksize=50_000,
+                      storage_options={"Authorization": f"Bearer {token}"})
+totals = pd.concat(chunk.groupby("model")["cost_usd"].sum() for chunk in chunks).groupby(level=0).sum()
+print(totals)`}</CodeBlock>
 
       <h3>Excel</h3>
       <p>
@@ -347,8 +416,12 @@ print(df.groupby("model")["cost_usd"].mean())`}</CodeBlock>
       <h2>Limitations</h2>
       <ul>
         <li>
-          <strong>10,000 row maximum.</strong> This is the hard cap per request. For larger datasets,
-          paginate by splitting the time range with <code>from</code>/<code>to</code>.
+          <strong>Row caps.</strong> <code>/exports/requests</code> goes up to 1,000,000 rows on the
+          streamed formats (<code>csv</code>, <code>jsonl</code>) and 10,000 on <code>json</code>.
+          The other endpoints (<code>/traces</code>, <code>/security</code>, <code>/anomalies</code>)
+          stay at 10,000. For datasets above the cap, paginate by splitting the time range with{' '}
+          <code>from</code> / <code>to</code>, or contact support — multi-GB exports with completion
+          emails / S3 pre-signed URLs are on the roadmap.
         </li>
         <li>
           <strong>request_body / response_body are not included.</strong> Body content is excluded
@@ -363,6 +436,11 @@ print(df.groupby("model")["cost_usd"].mean())`}</CodeBlock>
         <li>
           <strong>Rate limit.</strong> Export endpoints are capped at 10 requests per minute. Space
           out calls in bulk batch pipelines.
+        </li>
+        <li>
+          <strong>Plan retention applies.</strong> The window of accessible rows is bounded by your
+          plan&apos;s log retention (Free 14d / Pro 90d / Team 365d). Older rows are unavailable
+          even via <code>from</code>.
         </li>
       </ul>
 

--- a/apps/web/app/docs/sdk/page.tsx
+++ b/apps/web/app/docs/sdk/page.tsx
@@ -330,6 +330,76 @@ openai = OpenAI(
         the bodies.
       </p>
 
+      <h2 id="sample-rate">sampleRate — trace sampling (v0.3.x+)</h2>
+      <p>
+        Cap the volume of trace + span ingestion without changing your application code. The
+        decision is made per-trace at <code>startTrace()</code> / <code>start_trace()</code> time
+        and is sticky for every span beneath that trace, so each surviving trace stays internally
+        coherent in the dashboard (no half-sampled trees).
+      </p>
+      <LangTabs
+        ts={`import { SpanlensClient } from '@spanlens/sdk'
+
+const client = new SpanlensClient({
+  apiKey: process.env.SPANLENS_API_KEY!,
+  sampleRate: 0.1,   // keep 10% of successful traces; 100% of error traces
+})`}
+        py={`from spanlens import SpanlensClient
+
+client = SpanlensClient(
+    api_key="sl_live_...",
+    sample_rate=0.1,  # keep 10% of successful traces; 100% of error traces
+)`}
+      />
+
+      <h3>Tail-based error bypass</h3>
+      <p>
+        Sampled-out traces buffer their span POSTs and PATCHes in memory. When the trace ends:
+      </p>
+      <ul>
+        <li>
+          <strong>status = &quot;error&quot;</strong> → the buffer is replayed against the real
+          transport (preserving FIFO order) and then the trace-end PATCH is sent. The trace appears
+          in the dashboard identically to a sampled-in error trace.
+        </li>
+        <li>
+          <strong>status = &quot;completed&quot;</strong> → the buffer is dropped silently. Zero
+          network traffic for that trace&apos;s ingest layer.
+        </li>
+      </ul>
+      <p>
+        This means you can run aggressive sampling (e.g. <code>0.01</code> = 1%) and still get every
+        failure for debugging. The buffer is capped at 1,000 ops per trace to bound memory for
+        long-running agents.
+      </p>
+
+      <h3>What it does and doesn&apos;t affect</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Subsystem</th>
+            <th>Affected by sampleRate?</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Trace + span ingestion (<code>/ingest/traces</code>, <code>/ingest/spans</code>)</td>
+            <td><strong>Yes</strong> — this is the OTLP-equivalent agent-tracing layer</td>
+          </tr>
+          <tr>
+            <td>Proxy request logs (<code>/proxy/*</code> → ClickHouse <code>requests</code>)</td>
+            <td>
+              <strong>No</strong> — every LLM call is still recorded for cost / quota / anomaly
+              tracking. Billing does not depend on the SDK&apos;s sampling decision.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Validation throws at client construction for values outside <code>[0.0, 1.0]</code> — fail
+        fast rather than silently dropping 100% of traces because a string was passed by accident.
+      </p>
+
       <h2 id="observe">observe() — agent tracing</h2>
       <p>
         Wrap any function to turn it into a span in an agent trace. The callback&rsquo;s return value


### PR DESCRIPTION
## Summary

Three docs pages had drifted from the implementation after the Phase 2/3 PRs merged. This PR closes the gap.

## /docs/sdk — P3.8 sampling
- New section **\"sampleRate — trace sampling\"** between \`withLogBody\` and \`observe\`.
- Documents the config option, tail-based error bypass, scope clarification (only affects \`/ingest/*\` — proxy request logs and billing are unaffected), and construction-time validation.
- TS + Python examples.

## /docs/features/export — P3.11 streaming
- \`format\` now lists \`csv\` / \`jsonl\` / \`json\` (was \`csv\` / \`json\`).
- New **\"Formats — when to pick each\"** table with streaming flag and per-format row cap.
- \`limit\` description: CSV/JSONL up to **1,000,000**; JSON stays 10,000.
- New JSONL curl example showing streaming + jq pipeline.
- JSON example now shows the actual wrapper shape (\`{ exported_at, count, data }\`).
- Pandas example rewritten — both single-CSV and chunked-JSONL flows.
- Limitations bullet refreshed (row caps no longer say \"10,000 max\"; plan retention note added).

## /docs/features/anomalies — P3.2 confidence tiers
- \"≥ 30 reference samples\" → \"≥ 10 reference samples\" + new **\"Confidence tiers\"** section (low 10-29 / medium 30-99 / high 100+; pre-P3.2 \`null\` back-compat).
- Dashboard field list mentions the confidence badge.
- Live-API JSON example includes the new \`confidence\` field.
- Tuning table gains a \`minSamples\` row (default 10).
- Limitations bullet reflects the tier system (10 instead of 30).

## Out of scope (no doc changes needed)
- **/docs/proxy** already documents P2.2 (290s stream deadline + \`truncated: true\` badge).
- **P2.6 ClickHouse fallback queue** is an internal operational concern, not user-facing.
- **P3.1 English conventions** are reflected in CONTRIBUTING.md (not under /docs).
- **P3.3 model recommendations DB**, **P3.6 OpenAPI drift detector**, **P3.9 smart polling** are internal-only.

## Verification

- [x] \`pnpm --filter web typecheck\`
- [x] \`pnpm --filter web lint\`

## Test plan

- [ ] Preview deploy: visit \`/docs/sdk#sample-rate\`, \`/docs/features/export#formats\`, \`/docs/features/anomalies#confidence\` — verify anchors render and tables look right
- [ ] Try the JSONL + jq curl example end-to-end against a populated ClickHouse
- [ ] Try the Pandas chunked-JSONL example