### PR TITLE
chore(sdk): bump TS 0.4.0 + Python 0.3.0 for P3.8 sampling release

### DIFF
--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "spanlens"
-version = "0.2.0"
+version = "0.3.0"
 description = "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for Python."
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/sdk-python/spanlens/__init__.py
+++ b/packages/sdk-python/spanlens/__init__.py
@@ -31,7 +31,7 @@ from .parsers import parse_anthropic_usage, parse_gemini_usage, parse_openai_usa
 from .span import SpanHandle
 from .trace import TraceHandle
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"
 
 __all__ = [
     "SpanHandle",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bumps to publish P3.8 sampling feature to npm + PyPI. After merge, will tag `sdk-v0.4.0` and `python-sdk-v0.3.0` to trigger publish workflows.