### PR TITLE
fix(sdk-python): ruff import-sort fix to unblock PyPI publish

### DIFF
--- a/packages/sdk-python/spanlens/sampler.py
+++ b/packages/sdk-python/spanlens/sampler.py
@@ -20,7 +20,6 @@ from typing import Any, Callable, Optional
 
 from .transport import Transport
 
-
 # Cap on buffered ops per sampled-out trace. Bounds worst-case memory if a
 # long-running trace never ends. ~1000 ops = ~50 spans × 20-deep nesting.
 MAX_BUFFER_SIZE = 1000

--- a/packages/sdk-python/tests/test_sampling.py
+++ b/packages/sdk-python/tests/test_sampling.py
@@ -24,8 +24,8 @@ import respx
 
 from spanlens import SpanlensClient
 from spanlens.sampler import (
-    BufferingTransport,
     MAX_BUFFER_SIZE,
+    BufferingTransport,
     should_sample,
     validate_sample_rate,
 )


### PR DESCRIPTION
Publish workflow rejected python-sdk-v0.3.0 tag because of two I001 (un-sorted imports) findings in P3.8 sampling files. Auto-fixed with `ruff check --fix`. 84/84 tests still pass.