### PR TITLE
perf(web): dedupe getSession() across prefetchAll with React cache()

### DIFF
--- a/apps/web/lib/server/api.ts
+++ b/apps/web/lib/server/api.ts
@@ -12,8 +12,6 @@ const API_URL =
 // Supabase auth roundtrips; with this wrapper it triggers exactly one.
 // Per-render, never cross-user — auth security is unaffected.
 const getServerSession = cache(async () => {
-  // TEMP-VERIFY-STEP2: remove after verification confirms dedup
-  console.log('[perf-step2] getServerSession called')
   const supabase = await createClient()
   const {
     data: { session },

--- a/apps/web/lib/server/api.ts
+++ b/apps/web/lib/server/api.ts
@@ -1,10 +1,25 @@
 import 'server-only'
+import { cache } from 'react'
 import { createClient } from '@/lib/supabase/server'
 
 const API_URL =
   process.env.API_URL ??
   process.env.NEXT_PUBLIC_API_URL ??
   'http://localhost:3001'
+
+// Request-scoped session loader. React `cache()` dedupes calls within a single
+// React render — prefetchAll([...10 specs]) used to trigger 10 separate
+// Supabase auth roundtrips; with this wrapper it triggers exactly one.
+// Per-render, never cross-user — auth security is unaffected.
+const getServerSession = cache(async () => {
+  // TEMP-VERIFY-STEP2: remove after verification confirms dedup
+  console.log('[perf-step2] getServerSession called')
+  const supabase = await createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  return session
+})
 
 /**
  * Server-side API helper that reads the Supabase session from cookies and
@@ -13,10 +28,7 @@ const API_URL =
  * Must be called only from Server Components / Route Handlers.
  */
 export async function apiGetServer<T>(path: string): Promise<T> {
-  const supabase = await createClient()
-  const {
-    data: { session },
-  } = await supabase.auth.getSession()
+  const session = await getServerSession()
   const token = session?.access_token ?? null
 
   const url = path.startsWith('http') ? path : `${API_URL}${path}`


### PR DESCRIPTION
## Summary

- Wraps `supabase.auth.getSession()` in `apiGetServer` with React's `cache()`
- `prefetchAll([...10 queries])` on `/dashboard` now triggers **1 auth roundtrip instead of 10**
- Expected impact: cold dashboard load **-300~600ms** for Korean clients

Part of the dashboard load perf series — see [docs/plans/dashboard-load-perf-2026-05.md](./docs/plans/dashboard-load-perf-2026-05.md) §2.

## What's the problem

`apiGetServer` calls `getSession()` on every invocation. `/dashboard` page.tsx does `prefetchAll([...10 specs])`, so each render fires 10 separate Supabase auth roundtrips. Each takes 30~60ms (Korean client → Supabase) → 300~600ms of dead time before any ClickHouse query starts.

## The change (12 lines)

```ts
const getServerSession = cache(async () => {
  const supabase = await createClient()
  const { data: { session } } = await supabase.auth.getSession()
  return session
})

export async function apiGetServer<T>(path: string): Promise<T> {
  const session = await getServerSession()   // was: inline getSession()
  // ...rest unchanged
}
```

React `cache()` dedupes calls within a single render. Per-render, never cross-user — auth security unaffected.

## Local verification ✅

- typecheck + lint: pass
- Login + `/dashboard` enter, then reload once:
  - `[perf-step2] getServerSession called` log lines: **exactly 2** (one per render)
  - `[prefetchAll] hydrated 5 queries` confirmed prefetchAll actually fired multiple specs
  - Without cache(), we'd expect 5+ lines per render
- No server errors, no console errors

## Test plan (Vercel preview)

- [ ] Login to preview deployment
- [ ] Navigate to `/dashboard`
- [ ] Open Vercel function logs, search for `[perf-step2] getServerSession called`
- [ ] Confirm exactly **1 line per page render**
- [ ] Confirm dashboard data loads normally (production ClickHouse should work)
- [ ] If above passes → follow-up commit removes the temporary `console.log`

## Rollback

Single-file change, ~12 lines. Revert by replacing `getServerSession()` call with the original 4 lines of inline `getSession()`. No schema, no API surface change.

## Files

- `apps/web/lib/server/api.ts` — wrap getSession with `cache()` + temporary instrumentation

## Note

A temporary `console.log('[perf-step2] getServerSession called')` is included **on purpose** for production verification. A follow-up commit on this PR will remove it once preview verification passes. **Do not merge until that follow-up lands.**