### PR TITLE
perf(web): Step #3 — trim dashboard server prefetch to above-the-fold

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -1,26 +1,25 @@
 import { HydrationBoundary } from '@tanstack/react-query'
 import { prefetchAll } from '@/lib/server/dehydrate'
-import { alertsSpec } from '@/lib/server/queries/alerts'
-import { recommendationsSpec } from '@/lib/server/queries/recommendations'
-import { securitySummarySpec } from '@/lib/server/queries/security'
-import { auditLogsSpec } from '@/lib/server/queries/audit-logs'
 import { dismissalsSpec } from '@/lib/server/queries/dismissals'
-import { statsOverviewSpec, statsTimeseriesSpec, statsModelsSpec, spendForecastSpec } from '@/lib/server/queries/stats'
-import { anomaliesSpec } from '@/lib/server/queries/anomalies'
+import { statsOverviewSpec, statsTimeseriesSpec } from '@/lib/server/queries/stats'
 import { DashboardClient } from './dashboard-client'
 
+/**
+ * Above-the-fold critical path only. The other 7 queries (models, forecast,
+ * anomalies, alerts, recommendations, security, audit logs) mount as client
+ * useQuery() hooks inside DashboardClient — each section already renders a
+ * Skeleton while loading. Cuts TTFB by removing 7 awaits from the page
+ * render's critical path while keeping the KPI row + traffic chart instant.
+ *
+ * No Suspense streaming here — that path was reverted in 16d83e6 due to a
+ * TanStack Query hydration race with React #425/#422. Plain client query
+ * lifecycle is simpler and proven.
+ */
 export default async function DashboardPage() {
   const state = await prefetchAll([
-    statsOverviewSpec(),
-    statsTimeseriesSpec(),
-    statsModelsSpec(),
-    spendForecastSpec(),
-    anomaliesSpec({ observationHours: 24 }),
-    alertsSpec(),
-    recommendationsSpec({ hours: 24 }),
-    securitySummarySpec(24),
-    auditLogsSpec({ limit: 6 }),
-    dismissalsSpec(),
+    statsOverviewSpec(),     // KPI row (above-fold)
+    statsTimeseriesSpec(),   // Traffic chart (above-fold)
+    dismissalsSpec(),        // UI state — cheap PK lookup
   ])
 
   return (


### PR DESCRIPTION
## Summary

Drops the dashboard \`prefetchAll\` from 10 specs to 3. Below-the-fold sections now mount as client useQuery() — each already renders a Skeleton.

Plan: [docs/plans/dashboard-load-perf-2026-05.md](./docs/plans/dashboard-load-perf-2026-05.md) §3.

## What changed

\`apps/web/app/(dashboard)/dashboard/page.tsx\`:

**Before** (10 specs awaited):
\`\`\`ts
const state = await prefetchAll([
  statsOverviewSpec(),       // KPI row
  statsTimeseriesSpec(),     // Chart
  statsModelsSpec(),         // Models breakdown
  spendForecastSpec(),       // Forecast card
  anomaliesSpec({...}),      // Anomaly cards
  alertsSpec(),              // Alerts list
  recommendationsSpec({...}),// Savings
  securitySummarySpec(24),   // Security pills
  auditLogsSpec({...}),      // Recent activity
  dismissalsSpec(),          // UI state
])
\`\`\`

**After** (3 specs awaited):
\`\`\`ts
const state = await prefetchAll([
  statsOverviewSpec(),
  statsTimeseriesSpec(),
  dismissalsSpec(),
])
\`\`\`

The other 7 hooks (\`useStatsModels\`, \`useSpendForecast\`, \`useAnomalies\`, \`useAlerts\`, \`useRecommendations\`, \`useSecuritySummary\`, \`useAuditLogs\`) were already imported in DashboardClient and rendered with Skeleton fallbacks for \`isLoading\`. No client code changes needed.

## Why this is safe (and not Suspense)

The Suspense streaming path was reverted in 16d83e6 due to a TanStack Query hydration race producing React #425 → #422. This PR uses the proven pattern: smaller HydrationBoundary, normal client query lifecycle, existing skeletons. No race.

## Verification

### Local
- ✅ typecheck + lint pass
- ✅ All 5 below-fold section headers render on mount (Top prompts, Models in use, Active alerts, Savings queued, Recent activity)
- ✅ No console errors
- ✅ Failed-to-load chrome only appears because local has no ClickHouse data — independent of this change

### Vercel preview (test plan)
- [ ] Cold dashboard load: KPI row + traffic chart visible < 1 s
- [ ] Below-fold sections render Skeleton briefly then real data
- [ ] No React hydration errors in console
- [ ] Below-fold data eventually fully populates within 2 s
- [ ] Topbar time range change (24h → 7d) still updates everything

## Expected impact

- TTFB: -300 to -800 ms on \`/dashboard\` (whichever of the 7 dropped specs was slowest)
- Above-the-fold first paint with data: \~1.5 s (Fast 3G + Korea)
- Below-fold staggered: each card fades from Skeleton → data as its query resolves

## Rollback

Single-file change. Revert by re-adding the 7 spec imports + calls. No data migration.

Refs: PR #99 (Step #2), PR #101 (Step #5)