### PR TITLE
perf(server): Step #7.1 — planned count for /api/v1/traces

### DIFF
--- a/apps/server/src/api/traces.ts
+++ b/apps/server/src/api/traces.ts
@@ -20,11 +20,16 @@ tracesRouter.get('/', async (c) => {
   const to = c.req.query('to')
   const { page, limit, offset } = parsePageLimit(c.req.query('page'), c.req.query('limit'))
 
+  // `count: 'planned'` uses the Postgres query planner's row estimate instead
+  // of forcing a COUNT(*) scan. Saves -200~500ms per request on the traces
+  // table, which is fine here because the dashboard only renders the total as
+  // a display number ("N of M traces") — there's no pagination logic that
+  // gates "Next" on the exact total. Plan: docs/plans/dashboard-load-perf-2026-05.md §7.1.
   let query = supabaseAdmin
     .from('traces')
     .select(
       'id, project_id, name, status, started_at, ended_at, duration_ms, span_count, total_tokens, total_cost_usd, error_message, created_at',
-      { count: 'exact' },
+      { count: 'planned' },
     )
     .eq('organization_id', orgId)
     .order('started_at', { ascending: false })


### PR DESCRIPTION
## Summary

Switches \`/api/v1/traces\` list endpoint from \`count: 'exact'\` to \`count: 'planned'\`. Saves the COUNT(\*) scan per request on the Supabase \`traces\` table.

Step #7.1 of [docs/plans/dashboard-load-perf-2026-05.md](./docs/plans/dashboard-load-perf-2026-05.md) §7.

## What changed

\`apps/server/src/api/traces.ts\` GET /api/v1/traces handler: one option flip + comment explaining the trade-off.

## Why this is safe

\`apps/web/app/(dashboard)/traces/traces-client.tsx\` uses \`meta.total\` purely as a display number:
- Line 214: \`{ label: 'Traces', value: meta.total.toLocaleString() }\` (sidebar stat)
- Line 310, 409: \`{traces.length} of {meta.total}\` (showing N of M)

There is **no** pagination logic gating "Next" on the exact total — the table renders the page-1 slice and any infinite-scroll / next-page click uses other state. A small inaccuracy in the displayed number (planned estimate vs reality) is fine for a BI surface.

## Why /requests isn't in this PR

\`/api/v1/requests\` (ClickHouse path) already runs \`countRequests\` as a separate parallel query via \`Promise.all\`. ClickHouse COUNT is cheap on sorted/partitioned data, so the marginal gain is much smaller than the Supabase /traces case.

A future Step #7.2 will address /requests via SWR cache of the no-filter first page — bigger impact than skipping COUNT.

## Verification

### Local
- ✅ \`pnpm --filter server typecheck\` pass
- ✅ \`pnpm --filter server lint\` pass

### Vercel preview (test plan)
- [ ] /traces page loads, total displayed
- [ ] Total may differ slightly from exact COUNT (planned estimate) — acceptable
- [ ] Page response time -200~500ms vs main (measure via Vercel logs)

## Expected impact

- /api/v1/traces response time: **-200~500ms** on orgs with many traces (gain scales with table size)
- /traces page TTFB: same magnitude
- No effect on /requests or /dashboard (separate paths)

## Rollback

One-line revert: \`'planned'\` → \`'exact'\` on line 27 of \`apps/server/src/api/traces.ts\`.