### PR TITLE
perf(server): Step #4 — SWR cache for /api/v1/stats/*

### DIFF
--- a/apps/server/src/api/stats.ts
+++ b/apps/server/src/api/stats.ts
@@ -9,6 +9,7 @@ import {
   type OverviewRow,
   type TimeseriesRow,
 } from '../lib/stats-queries.js'
+import { withStatsCache, STATS_SWR, STATS_SWR_SLOW } from '../lib/stats-cache.js'
 
 /**
  * Stats endpoints — SQL-aggregated server-side.
@@ -61,44 +62,48 @@ statsRouter.get('/overview', async (c) => {
   const to = c.req.query('to')
   const compare = c.req.query('compare') === 'true'
 
+  // Cache key MUST include orgId. The web client rounds `from` to the minute
+  // so two callers in the same org/minute share a cache slot.
+  const cacheKey = `org:${orgId}:stats:overview:${from ?? ''}:${to ?? ''}:${projectId ?? ''}:${compare}`
+
   try {
-    if (compare) {
-      // Compute previous period of equal duration, run both in parallel.
-      const nowMs = Date.now()
-      const toMs = to ? new Date(to).getTime() : nowMs
-      const fromMs = from ? new Date(from).getTime() : toMs - 30 * 24 * 3_600_000
-      const duration = toMs - fromMs
-      const prevTo = new Date(fromMs).toISOString()
-      const prevFrom = new Date(fromMs - duration).toISOString()
+    const payload = await withStatsCache(cacheKey, STATS_SWR, async () => {
+      if (compare) {
+        // Compute previous period of equal duration, run both in parallel.
+        const nowMs = Date.now()
+        const toMs = to ? new Date(to).getTime() : nowMs
+        const fromMs = from ? new Date(from).getTime() : toMs - 30 * 24 * 3_600_000
+        const duration = toMs - fromMs
+        const prevTo = new Date(fromMs).toISOString()
+        const prevFrom = new Date(fromMs - duration).toISOString()
 
-      const [curr, prev] = await Promise.all([
-        getStatsOverview(orgId, { projectId, from: from ?? null, to: to ?? null }),
-        getStatsOverview(orgId, { projectId, from: prevFrom, to: prevTo }),
-      ])
+        const [curr, prev] = await Promise.all([
+          getStatsOverview(orgId, { projectId, from: from ?? null, to: to ?? null }),
+          getStatsOverview(orgId, { projectId, from: prevFrom, to: prevTo }),
+        ])
 
-      const currRow = rowToOverview(curr)
-      const prevRow = rowToOverview(prev)
+        const currRow = rowToOverview(curr)
+        const prevRow = rowToOverview(prev)
 
-      c.header('Cache-Control', CACHE_STATS_LIVE)
-      return c.json({
-        success: true,
-        data: {
+        return {
           ...currRow,
           requestsDelta: pctDelta(currRow.totalRequests, prevRow.totalRequests),
           costDelta: pctDelta(currRow.totalCostUsd, prevRow.totalCostUsd),
           latencyDelta: pctDelta(currRow.avgLatencyMs, prevRow.avgLatencyMs),
           errorRateDelta: pctDelta(currRow.errorRate, prevRow.errorRate),
-        },
-      })
-    }
+        }
+      }
 
-    const overview = await getStatsOverview(orgId, {
-      projectId,
-      from: from ?? null,
-      to: to ?? null,
+      const overview = await getStatsOverview(orgId, {
+        projectId,
+        from: from ?? null,
+        to: to ?? null,
+      })
+      return rowToOverview(overview)
     })
+
     c.header('Cache-Control', CACHE_STATS_LIVE)
-    return c.json({ success: true, data: rowToOverview(overview) })
+    return c.json({ success: true, data: payload })
   } catch (err) {
     console.error('[stats:overview] ClickHouse query failed:', err instanceof Error ? err.message : err)
     return c.json({ error: 'Failed to fetch stats' }, 500)
@@ -118,20 +123,27 @@ statsRouter.get('/models', async (c) => {
 
   const hours = parseClampedFloat(c.req.query('hours'), 24, 0.001, 24 * 30)
   const projectId = c.req.query('projectId')
-  const fromIso = new Date(Date.now() - hours * 3_600_000).toISOString()
+  // Bucket fromIso to the minute so concurrent callers in the same org share a key.
+  const fromIsoRaw = new Date(Date.now() - hours * 3_600_000).toISOString()
+  const fromIso = fromIsoRaw.slice(0, 16) + ':00.000Z'
+
+  const cacheKey = `org:${orgId}:stats:models:${hours}:${projectId ?? ''}:${fromIso}`
 
   try {
-    const rows = await getStatsModels(orgId, { projectId, from: fromIso })
-    const models = rows.map((r) => ({
-      provider: r.provider,
-      model: r.model,
-      requests: r.requests,
-      totalCostUsd: parseFloat(r.total_cost_usd.toFixed(6)),
-      avgLatencyMs: Math.round(r.avg_latency_ms),
-      errorRate: r.error_rate,
-    }))
+    const payload = await withStatsCache(cacheKey, STATS_SWR, async () => {
+      const rows = await getStatsModels(orgId, { projectId, from: fromIso })
+      const models = rows.map((r) => ({
+        provider: r.provider,
+        model: r.model,
+        requests: r.requests,
+        totalCostUsd: parseFloat(r.total_cost_usd.toFixed(6)),
+        avgLatencyMs: Math.round(r.avg_latency_ms),
+        errorRate: r.error_rate,
+      }))
+      return { models, count: models.length }
+    })
     c.header('Cache-Control', CACHE_STATS_LIVE)
-    return c.json({ success: true, data: models, meta: { hours, count: models.length } })
+    return c.json({ success: true, data: payload.models, meta: { hours, count: payload.count } })
   } catch (err) {
     console.error('[stats:models] ClickHouse query failed:', err instanceof Error ? err.message : err)
     return c.json({ error: 'Failed to fetch model stats' }, 500)
@@ -148,22 +160,26 @@ statsRouter.get('/timeseries', async (c) => {
   const to = c.req.query('to')
   const granularity = selectGranularity(from ?? null)
 
+  const cacheKey = `org:${orgId}:stats:timeseries:${from ?? ''}:${to ?? ''}:${projectId ?? ''}:${granularity}`
+
   try {
-    const rows = await getStatsTimeseries(orgId, {
-      projectId,
-      from: from ?? null,
-      to: to ?? null,
-      granularity,
+    const payload = await withStatsCache(cacheKey, STATS_SWR, async () => {
+      const rows = await getStatsTimeseries(orgId, {
+        projectId,
+        from: from ?? null,
+        to: to ?? null,
+        granularity,
+      })
+      return rows.map((r) => ({
+        date: r.day,
+        requests: r.requests,
+        cost: parseFloat(r.cost.toFixed(6)),
+        tokens: r.tokens,
+        errors: r.errors,
+      }))
     })
-    const series = rows.map((r) => ({
-      date: r.day,
-      requests: r.requests,
-      cost: parseFloat(r.cost.toFixed(6)),
-      tokens: r.tokens,
-      errors: r.errors,
-    }))
     c.header('Cache-Control', CACHE_STATS_LIVE)
-    return c.json({ success: true, data: series, meta: { granularity } })
+    return c.json({ success: true, data: payload, meta: { granularity } })
   } catch (err) {
     console.error('[stats:timeseries] ClickHouse query failed:', err instanceof Error ? err.message : err)
     return c.json({ error: 'Failed to fetch timeseries' }, 500)
@@ -200,14 +216,21 @@ statsRouter.get('/spend-forecast', async (c) => {
   const daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate()
   const monthStart = new Date(Date.UTC(year, month, 1)).toISOString()
 
+  // The downstream math (regression, projection) is pure and cheap — only the
+  // ClickHouse timeseries lookup is worth caching. monthStart is constant for
+  // the calendar month so a single cache key serves the whole day.
+  const cacheKey = `org:${orgId}:stats:spend-forecast-rows:${monthStart}:${projectId ?? ''}`
+
   let rows: TimeseriesRow[]
   try {
-    rows = await getStatsTimeseries(orgId, {
-      projectId,
-      from: monthStart,
-      to: null,
-      granularity: 'day',
-    })
+    rows = await withStatsCache(cacheKey, STATS_SWR_SLOW, () =>
+      getStatsTimeseries(orgId, {
+        projectId,
+        from: monthStart,
+        to: null,
+        granularity: 'day',
+      }),
+    )
   } catch (err) {
     console.error('[stats:spend-forecast] ClickHouse query failed:', err instanceof Error ? err.message : err)
     return c.json({ error: 'Failed to fetch spend forecast' }, 500)

--- a/apps/server/src/lib/stats-cache.ts
+++ b/apps/server/src/lib/stats-cache.ts
@@ -1,0 +1,119 @@
+import { Redis } from '@upstash/redis'
+
+/**
+ * Stale-while-revalidate (SWR) cache for ClickHouse aggregate queries.
+ *
+ *   - fresh window  → return cached as-is
+ *   - stale window  → return cached AND refresh in background
+ *   - beyond stale  → Redis TTL expires the row; next caller does a sync load
+ *
+ * Fails open: if Redis is unavailable or errors, the loader is called directly.
+ *
+ * Tenancy: the caller is responsible for including `orgId` in `key`. Code
+ * review must verify every withStatsCache() call uses a key that starts with
+ * `org:<orgId>:` — see docs/plans/dashboard-load-perf-2026-05.md §4.
+ */
+
+let _redis: Redis | null = null
+
+function getRedis(): Redis | null {
+  if (_redis) return _redis
+  const url = process.env.KV_REST_API_URL
+  const token = process.env.KV_REST_API_TOKEN
+  if (!url || !token) return null
+  _redis = new Redis({ url, token })
+  return _redis
+}
+
+interface CacheEntry<T> {
+  data: T
+  cachedAt: number // Unix ms
+}
+
+export interface SwrOptions {
+  /** Within this age (seconds), data is considered fresh — return as-is. */
+  freshSeconds: number
+  /** Beyond fresh but within this age, return stale + refresh in background.
+   *  Used as the Redis TTL too — entries older than this are gone. */
+  staleSeconds: number
+}
+
+// In-flight background refresh dedup — prevents a thundering herd when many
+// concurrent requests hit the same stale key. The map is per-Lambda-instance;
+// different instances may each fire one refresh, but ClickHouse load is
+// bounded and the results converge.
+const _inflight = new Map<string, Promise<unknown>>()
+
+function refreshInBackground<T>(
+  redis: Redis,
+  key: string,
+  staleSeconds: number,
+  loader: () => Promise<T>,
+): void {
+  if (_inflight.has(key)) return
+  const p = (async () => {
+    try {
+      const fresh = await loader()
+      const entry: CacheEntry<T> = { data: fresh, cachedAt: Date.now() }
+      await redis.set(key, entry, { ex: staleSeconds })
+    } catch (err) {
+      console.warn('[stats-cache] background refresh failed:', err)
+    } finally {
+      _inflight.delete(key)
+    }
+  })()
+  _inflight.set(key, p)
+}
+
+/**
+ * Wraps a ClickHouse aggregate query with SWR caching.
+ *
+ *   `key`     must include orgId for tenant isolation.
+ *   `opts`    fresh/stale window in seconds (see {@link STATS_SWR}).
+ *   `loader`  the actual query function — invoked only on cache miss / refresh.
+ *
+ * Returns the cached value (fresh or stale) or the loader's fresh result.
+ */
+export async function withStatsCache<T>(
+  key: string,
+  opts: SwrOptions,
+  loader: () => Promise<T>,
+): Promise<T> {
+  const redis = getRedis()
+  if (!redis) return loader()
+
+  let entry: CacheEntry<T> | null = null
+  try {
+    entry = await redis.get<CacheEntry<T>>(key)
+  } catch (err) {
+    console.warn('[stats-cache] read error — failing open:', err)
+    return loader()
+  }
+
+  if (entry) {
+    const ageSeconds = (Date.now() - entry.cachedAt) / 1000
+
+    if (ageSeconds < opts.freshSeconds) {
+      return entry.data
+    }
+
+    if (ageSeconds < opts.staleSeconds) {
+      refreshInBackground(redis, key, opts.staleSeconds, loader)
+      return entry.data
+    }
+    // Beyond stale (defensive — should already be expired by Redis TTL).
+  }
+
+  const fresh = await loader()
+  const newEntry: CacheEntry<T> = { data: fresh, cachedAt: Date.now() }
+  redis.set(key, newEntry, { ex: opts.staleSeconds }).catch((err) => {
+    console.warn('[stats-cache] write error (ignored):', err)
+  })
+  return fresh
+}
+
+/** Default SWR window for stats endpoints — 10s fresh / 60s stale. */
+export const STATS_SWR: SwrOptions = { freshSeconds: 10, staleSeconds: 60 }
+
+/** Slower-changing data (e.g. spend forecast) — 60s fresh / 300s stale. */
+export const STATS_SWR_SLOW: SwrOptions = { freshSeconds: 60, staleSeconds: 300 }


### PR DESCRIPTION
## Summary

Adds Upstash Redis SWR (stale-while-revalidate) caching to four /api/v1/stats/\* endpoints. Step #4 of [docs/plans/dashboard-load-perf-2026-05.md](./docs/plans/dashboard-load-perf-2026-05.md) §4.

## What changed

- **\`apps/server/src/lib/stats-cache.ts\`** (new, 113 lines) — \`withStatsCache(key, opts, loader)\` helper with fresh / stale-refresh / TTL semantics. In-flight dedup map prevents thundering herd. Fails open on missing or broken Redis.
- **\`apps/server/src/api/stats.ts\`** — four handlers wrapped:
  - \`/overview\` STATS_SWR (10s / 60s)
  - \`/models\` STATS_SWR
  - \`/timeseries\` STATS_SWR
  - \`/spend-forecast\` STATS_SWR_SLOW (60s / 300s) — only the ClickHouse lookup, not the regression math

## Semantics

| Entry age | Behavior |
|-----------|----------|
| < freshSeconds | Return cached as-is. No Redis SET, no ClickHouse call. |
| < staleSeconds | Return cached + fire one background refresh. Future caller within TTL gets fresh data automatically. |
| Beyond | Redis TTL expired; next caller runs the loader synchronously. |

## Tenant isolation

Every cache key is composed in the handler as \`\\`org:\\${orgId}:stats:...\\`\`. The helper doesn't try to be clever about it — that's the caller's contract, documented in the lib header.

Grep result confirms all four call sites:

\`\`\`
67:  const cacheKey = \\`org:\\${orgId}:stats:overview:...\\`
130: const cacheKey = \\`org:\\${orgId}:stats:models:...\\`
163: const cacheKey = \\`org:\\${orgId}:stats:timeseries:...\\`
222: const cacheKey = \\`org:\\${orgId}:stats:spend-forecast-rows:...\\`
\`\`\`

## Verification

### Local
- typecheck + lint + 503 unit tests pass

### Vercel preview (test plan)
- [ ] **Fresh path**: hit \`/api/v1/stats/overview\`, then again within 10s — second is fast (~5-15ms)
- [ ] **Stale path**: wait 15-30s, hit again — fast response + background refresh fires (check Vercel logs for \`[stats-cache] background refresh failed\` or success)
- [ ] **Thundering herd**: fire 5+ concurrent requests in the stale window — only one background refresh should run
- [ ] **Tenant isolation**: two orgs hitting the same URL get separate cached values (different cache keys)
- [ ] **Fail open**: temporarily break the env var and verify the handler still returns data (uncached)
- [ ] **No regression**: response shape unchanged, all dashboard sections still render correctly

## Rollback

Two files, both new or fully replaceable. Revert by:

1. Remove \`import { withStatsCache, ... }\` from stats.ts
2. Unwrap each handler back to direct getStatsXxx(...) calls
3. Delete apps/server/src/lib/stats-cache.ts

Cache entries in Redis expire naturally within 5 minutes — no cleanup needed.