### PR TITLE
fix(server): SWR cache writes drop on Vercel — use fireAndForget

### DIFF
--- a/apps/server/src/api/stats.ts
+++ b/apps/server/src/api/stats.ts
@@ -67,7 +67,7 @@ statsRouter.get('/overview', async (c) => {
   const cacheKey = `org:${orgId}:stats:overview:${from ?? ''}:${to ?? ''}:${projectId ?? ''}:${compare}`
 
   try {
-    const payload = await withStatsCache(cacheKey, STATS_SWR, async () => {
+    const payload = await withStatsCache(c, cacheKey, STATS_SWR, async () => {
       if (compare) {
         // Compute previous period of equal duration, run both in parallel.
         const nowMs = Date.now()
@@ -130,7 +130,7 @@ statsRouter.get('/models', async (c) => {
   const cacheKey = `org:${orgId}:stats:models:${hours}:${projectId ?? ''}:${fromIso}`
 
   try {
-    const payload = await withStatsCache(cacheKey, STATS_SWR, async () => {
+    const payload = await withStatsCache(c, cacheKey, STATS_SWR, async () => {
       const rows = await getStatsModels(orgId, { projectId, from: fromIso })
       const models = rows.map((r) => ({
         provider: r.provider,
@@ -163,7 +163,7 @@ statsRouter.get('/timeseries', async (c) => {
   const cacheKey = `org:${orgId}:stats:timeseries:${from ?? ''}:${to ?? ''}:${projectId ?? ''}:${granularity}`
 
   try {
-    const payload = await withStatsCache(cacheKey, STATS_SWR, async () => {
+    const payload = await withStatsCache(c, cacheKey, STATS_SWR, async () => {
       const rows = await getStatsTimeseries(orgId, {
         projectId,
         from: from ?? null,
@@ -223,7 +223,7 @@ statsRouter.get('/spend-forecast', async (c) => {
 
   let rows: TimeseriesRow[]
   try {
-    rows = await withStatsCache(cacheKey, STATS_SWR_SLOW, () =>
+    rows = await withStatsCache(c, cacheKey, STATS_SWR_SLOW, () =>
       getStatsTimeseries(orgId, {
         projectId,
         from: monthStart,

--- a/apps/server/src/lib/stats-cache.ts
+++ b/apps/server/src/lib/stats-cache.ts
@@ -1,4 +1,6 @@
+import type { Context } from 'hono'
 import { Redis } from '@upstash/redis'
+import { fireAndForget } from './wait-until.js'
 
 /**
  * Stale-while-revalidate (SWR) cache for ClickHouse aggregate queries.
@@ -12,6 +14,11 @@ import { Redis } from '@upstash/redis'
  * Tenancy: the caller is responsible for including `orgId` in `key`. Code
  * review must verify every withStatsCache() call uses a key that starts with
  * `org:<orgId>:` — see docs/plans/dashboard-load-perf-2026-05.md §4.
+ *
+ * Vercel note: redis.set() must run through `fireAndForget(c, ...)` instead
+ * of `.catch()`. Without it Vercel drops the pending Redis write the moment
+ * the handler returns, so cache hits never accumulate. See CLAUDE.md
+ * gotcha #8 — same root cause as the proxy logger race.
  */
 
 let _redis: Redis | null = null
@@ -45,6 +52,7 @@ export interface SwrOptions {
 const _inflight = new Map<string, Promise<unknown>>()
 
 function refreshInBackground<T>(
+  c: Context,
   redis: Redis,
   key: string,
   staleSeconds: number,
@@ -63,11 +71,14 @@ function refreshInBackground<T>(
     }
   })()
   _inflight.set(key, p)
+  fireAndForget(c, p)
 }
 
 /**
  * Wraps a ClickHouse aggregate query with SWR caching.
  *
+ *   `c`       Hono context — required to keep Redis writes alive on Vercel
+ *             (see CLAUDE.md gotcha #8).
  *   `key`     must include orgId for tenant isolation.
  *   `opts`    fresh/stale window in seconds (see {@link STATS_SWR}).
  *   `loader`  the actual query function — invoked only on cache miss / refresh.
@@ -75,6 +86,7 @@ function refreshInBackground<T>(
  * Returns the cached value (fresh or stale) or the loader's fresh result.
  */
 export async function withStatsCache<T>(
+  c: Context,
   key: string,
   opts: SwrOptions,
   loader: () => Promise<T>,
@@ -98,7 +110,7 @@ export async function withStatsCache<T>(
     }
 
     if (ageSeconds < opts.staleSeconds) {
-      refreshInBackground(redis, key, opts.staleSeconds, loader)
+      refreshInBackground(c, redis, key, opts.staleSeconds, loader)
       return entry.data
     }
     // Beyond stale (defensive — should already be expired by Redis TTL).
@@ -106,9 +118,9 @@ export async function withStatsCache<T>(
 
   const fresh = await loader()
   const newEntry: CacheEntry<T> = { data: fresh, cachedAt: Date.now() }
-  redis.set(key, newEntry, { ex: opts.staleSeconds }).catch((err) => {
-    console.warn('[stats-cache] write error (ignored):', err)
-  })
+  // Must NOT use .catch() — Vercel drops the pending promise on handler
+  // return. fireAndForget routes through @vercel/functions waitUntil.
+  fireAndForget(c, redis.set(key, newEntry, { ex: opts.staleSeconds }))
   return fresh
 }
 


### PR DESCRIPTION
## Summary

Production hotfix for PR #106. Cache writes weren't landing because \`.catch()\` on the Redis SET promise gets dropped by Vercel the moment the handler returns. Fix routes the write through \`fireAndForget(c, ...)\` (the same waitUntil pattern the proxy logger uses).

## Discovery

After PR #106 merged and production deployed, I ran fresh-window reload tests on www.spanlens.io. Expected: 2nd request 5~50ms. Observed: every reload showed the same ~750ms cold timings, no cache hits.

Vercel production runtime logs showed exactly **one** \`[stats-cache]\` event (a transient error) and otherwise silence — confirming Redis writes were happening but immediately abandoned by the Lambda lifecycle.

This is documented in CLAUDE.md gotcha #8 — the same root cause as the proxy logger fix that needed \`fireAndForget\` for ClickHouse INSERTs. I missed it on the first pass.

## Fix

\`apps/server/src/lib/stats-cache.ts\`:
- \`withStatsCache(c, key, opts, loader)\` now accepts the Hono Context
- \`refreshInBackground(c, ...)\` similarly threaded
- Replaces \`.catch()\` patterns with \`fireAndForget(c, redis.set(...))\`

\`apps/server/src/api/stats.ts\`:
- All 4 call sites updated to pass \`c\` (/overview, /models, /timeseries, /spend-forecast)

## Why we missed this

1. Local Node dev drains pending promises naturally — bug invisible there
2. Vercel preview was tested through web preview, but web preview's \`/api/*\` proxies to **production** server (not preview). So PR #106's code never actually ran during preview verification.
3. Bug only became measurable after merge to main, on www.spanlens.io itself

## Verification plan (production after merge)

- [ ] Reload www.spanlens.io/dashboard 3× within 10s
- [ ] 2nd+ /api/v1/stats/overview requests should be ~5-50ms
- [ ] Vercel runtime logs should show new \`[stats-cache]\` entries when refresh fires
- [ ] No new error logs
- [ ] Tenant isolation unchanged

## Pre-merge

- typecheck ✅
- lint ✅
- 503/503 unit tests ✅

## Rollback

If anything goes sideways, revert to PR #106's state (cache key conflicts unchanged; you just lose the perf win again).