### PR TITLE
chore(server): TEMP — Redis round-trip diag log

### DIFF
--- a/apps/server/src/lib/stats-cache.ts
+++ b/apps/server/src/lib/stats-cache.ts
@@ -92,7 +92,10 @@ export async function withStatsCache<T>(
   loader: () => Promise<T>,
 ): Promise<T> {
   const redis = getRedis()
-  if (!redis) return loader()
+  if (!redis) {
+    console.log('[stats-cache] diag: no-redis', { key: key.slice(0, 60) })
+    return loader()
+  }
 
   let entry: CacheEntry<T> | null = null
   try {
@@ -106,21 +109,32 @@ export async function withStatsCache<T>(
     const ageSeconds = (Date.now() - entry.cachedAt) / 1000
 
     if (ageSeconds < opts.freshSeconds) {
+      console.log('[stats-cache] diag: hit-fresh', { key: key.slice(0, 60), ageSeconds })
       return entry.data
     }
 
     if (ageSeconds < opts.staleSeconds) {
+      console.log('[stats-cache] diag: hit-stale', { key: key.slice(0, 60), ageSeconds })
       refreshInBackground(c, redis, key, opts.staleSeconds, loader)
       return entry.data
     }
     // Beyond stale (defensive — should already be expired by Redis TTL).
   }
 
+  console.log('[stats-cache] diag: miss', { key: key.slice(0, 60), entryWasNull: entry === null, ttl: opts.staleSeconds })
   const fresh = await loader()
   const newEntry: CacheEntry<T> = { data: fresh, cachedAt: Date.now() }
   // Must NOT use .catch() — Vercel drops the pending promise on handler
   // return. fireAndForget routes through @vercel/functions waitUntil.
-  fireAndForget(c, redis.set(key, newEntry, { ex: opts.staleSeconds }))
+  fireAndForget(c, (async () => {
+    try {
+      const result = await redis.set(key, newEntry, { ex: opts.staleSeconds })
+      console.log('[stats-cache] diag: write-ok', { key: key.slice(0, 60), result })
+    } catch (err) {
+      console.error('[stats-cache] diag: write-failed', { key: key.slice(0, 60), err: String(err) })
+      throw err
+    }
+  })())
   return fresh
 }
 

--- a/apps/server/src/lib/stats-cache.ts
+++ b/apps/server/src/lib/stats-cache.ts
@@ -85,6 +85,25 @@ function refreshInBackground<T>(
  *
  * Returns the cached value (fresh or stale) or the loader's fresh result.
  */
+// DIAG: prove Redis round-trip works. One-shot per Lambda cold start.
+let _roundtripChecked = false
+async function checkRoundtrip(redis: Redis): Promise<void> {
+  if (_roundtripChecked) return
+  _roundtripChecked = true
+  const k = 'spanlens:diag:roundtrip:' + Date.now()
+  try {
+    await redis.set(k, { hello: 'world', ts: Date.now() }, { ex: 30 })
+    const back = await redis.get(k)
+    console.log('[stats-cache] diag: roundtrip', {
+      backType: typeof back,
+      backIsNull: back === null,
+      backJson: back === null ? null : JSON.stringify(back).slice(0, 200),
+    })
+  } catch (err) {
+    console.error('[stats-cache] diag: roundtrip failed:', err)
+  }
+}
+
 export async function withStatsCache<T>(
   c: Context,
   key: string,
@@ -96,6 +115,8 @@ export async function withStatsCache<T>(
     console.log('[stats-cache] diag: no-redis', { key: key.slice(0, 60) })
     return loader()
   }
+  // Fires once per Lambda cold start, proves SET→GET round-trip works.
+  fireAndForget(c, checkRoundtrip(redis))
 
   let entry: CacheEntry<T> | null = null
   try {


### PR DESCRIPTION
Follow-up diagnostic to PR #108. Cache writes succeed but subsequent reads miss every time. This one-shot per Lambda cold start round-trip will tell us whether Upstash returns the wrong type from get() or data simply isn't persisting.