### PR TITLE
perf(server): reuse JWT email in handlers, skip second auth roundtrip

### DIFF
--- a/apps/server/src/api/invitations.ts
+++ b/apps/server/src/api/invitations.ts
@@ -120,20 +120,21 @@ orgInvitationsRouter.post('/', requireRole('admin'), async (c) => {
     return c.json({ error: 'Failed to create invitation' }, 500)
   }
 
-  // Fetch org name + inviter email for the email body
+  // Fetch org name for the email body. Inviter email comes straight from the
+  // JWT context — no second auth roundtrip needed.
   const { data: org } = await supabaseAdmin
     .from('organizations')
     .select('name')
     .eq('id', orgId)
     .single()
-  const { data: inviter } = await supabaseAdmin.auth.admin.getUserById(userId)
+  const inviterEmail = c.get('email')
 
   const webUrl = process.env.WEB_URL ?? 'http://localhost:3000'
   const acceptUrl = `${webUrl}/invite?token=${encodeURIComponent(token)}`
 
   const { subject, html } = renderInvitationEmail({
     orgName: org?.name ?? 'Spanlens workspace',
-    inviterEmail: inviter?.user?.email ?? 'someone',
+    inviterEmail: inviterEmail || 'someone',
     role,
     acceptUrl,
   })
@@ -234,9 +235,9 @@ invitationsRouter.post('/accept', authJwt, async (c) => {
 
   // Email check: invitation is bound to the invitee's email. Anyone else
   // with the link can't use it. Case-insensitive since auth.users emails
-  // are stored normalized but users type them any which way.
-  const { data: userData } = await supabaseAdmin.auth.admin.getUserById(userId)
-  const currentEmail = userData?.user?.email?.toLowerCase()
+  // are stored normalized but users type them any which way. Email comes
+  // from the JWT context (authJwt set it) — saves a getUserById roundtrip.
+  const currentEmail = c.get('email')
   if (!currentEmail || currentEmail !== inv.email.toLowerCase()) {
     return c.json({ error: 'This invitation was sent to a different email' }, 400)
   }
@@ -335,15 +336,9 @@ interface PendingInvitationRow {
   organizations: { id: string; name: string } | null
 }
 
-async function getCurrentUserEmail(userId: string): Promise<string | null> {
-  const { data } = await supabaseAdmin.auth.admin.getUserById(userId)
-  return data?.user?.email?.toLowerCase() ?? null
-}
-
 // GET /api/v1/me/pending-invitations
 meInvitationsRouter.get('/', async (c) => {
-  const userId = c.get('userId')
-  const email = await getCurrentUserEmail(userId)
+  const email = c.get('email')
   if (!email) return c.json({ success: true, data: [] })
 
   const { data, error } = await supabaseAdmin
@@ -376,7 +371,7 @@ meInvitationsRouter.get('/', async (c) => {
 // is useless without auth.
 meInvitationsRouter.post('/:id/accept', async (c) => {
   const userId = c.get('userId')
-  const email = await getCurrentUserEmail(userId)
+  const email = c.get('email')
   if (!email) return c.json({ error: 'User has no email' }, 400)
 
   const { data: inv } = await supabaseAdmin
@@ -441,8 +436,7 @@ meInvitationsRouter.post('/:id/accept', async (c) => {
 // the dashboard banner again. This matches the user's intent of "after
 // I decline, I never see it again unless explicitly re-invited".
 meInvitationsRouter.delete('/:id', async (c) => {
-  const userId = c.get('userId')
-  const email = await getCurrentUserEmail(userId)
+  const email = c.get('email')
   if (!email) return c.json({ error: 'User has no email' }, 400)
 
   const { error, count } = await supabaseAdmin
@@ -460,8 +454,7 @@ meInvitationsRouter.delete('/:id', async (c) => {
 // POST /api/v1/invitations/decline — token-based variant for the
 // /invite page. Mirrors the existing accept token flow.
 invitationsRouter.post('/decline', authJwt, async (c) => {
-  const userId = c.get('userId')
-  const email = await getCurrentUserEmail(userId)
+  const email = c.get('email')
   if (!email) return c.json({ error: 'User has no email' }, 400)
 
   let body: { token?: unknown }

--- a/apps/server/src/api/organizations.ts
+++ b/apps/server/src/api/organizations.ts
@@ -244,8 +244,8 @@ organizationsRouter.post('/bootstrap', async (c) => {
   }
 
   // Resolve workspace name: explicit body wins; otherwise derive from email.
-  const { data: userData } = await supabaseAdmin.auth.admin.getUserById(userId)
-  const workspaceName = bodyName ?? deriveWorkspaceName(userData?.user?.email)
+  // Email comes from JWT context — no need for a second auth roundtrip.
+  const workspaceName = bodyName ?? deriveWorkspaceName(c.get('email'))
 
   // 1. organization
   const { data: org, error: orgErr } = await supabaseAdmin

--- a/apps/server/src/middleware/authJwt.ts
+++ b/apps/server/src/middleware/authJwt.ts
@@ -7,6 +7,13 @@ export type JwtContext = {
   Variables: {
     userId: string
     /**
+     * The signed-in user's email, lowercased. Populated from the JWT user
+     * record so handlers don't have to make a second `auth.admin.getUserById`
+     * roundtrip just to get it — that pattern previously cost 1.5~3s per
+     * dashboard request. Always present when authJwt runs.
+     */
+    email: string
+    /**
      * Organization id resolved from the user's org_members row.
      * `null` means the user has not joined any org yet (pre-onboarding).
      * Routes that require an org should guard with:
@@ -48,6 +55,10 @@ export const authJwt = createMiddleware<JwtContext>(async (c, next) => {
 
   const userId = data.user.id
   c.set('userId', userId)
+  // Email comes from the same verified user record — no need for handlers to
+  // re-fetch it via auth.admin.getUserById. Lowercased for case-insensitive
+  // matching (Supabase stores emails case-insensitively).
+  c.set('email', (data.user.email ?? '').toLowerCase())
 
   // Workspace resolution order:
   //   1. `sb-ws` cookie — explicit user choice from the sidebar switcher.


### PR DESCRIPTION
## Summary

Removes a second Supabase Auth roundtrip from six handlers that needed the user's email — \`authJwt\` already retrieved the user record, so handlers now read \`c.get('email')\` instead of calling \`supabaseAdmin.auth.admin.getUserById(userId)\`.

## Background

Production measurement on www.spanlens.io (after Sprint 1+2) showed:

| Endpoint | Cold | Warm |
|----------|------|------|
| /api/v1/me/pending-invitations | **7088ms** | 4208ms |

7s for a small Supabase invitation lookup is wildly disproportionate. The culprit was a redundant \`getUserById\` call layered on top of the auth call that authJwt already did.

## Changes

- \`apps/server/src/middleware/authJwt.ts\` — adds \`email: string\` to \`JwtContext.Variables\`, populates it from the same \`auth.getUser()\` call that validates the token.
- \`apps/server/src/api/invitations.ts\` — six handlers switched from \`getUserById\` / \`getCurrentUserEmail\` helper to \`c.get('email')\`. The helper itself is deleted.
- \`apps/server/src/api/organizations.ts\` — bootstrap handler does the same when deriving workspace name from email.

\`billing.ts:82\` (Paddle customer identity in checkout) **intentionally untouched**. A stale email there could miswire a paid customer record — a far worse failure than the perf loss costs.

## Expected impact

| Endpoint | Before | After |
|----------|--------|-------|
| /api/v1/me/pending-invitations cold | 7088ms | ~3500ms |
| /dashboard cold total | 9.9s | ~6.5s |

\`/organizations/:orgId/members\` (3082ms) has a different root cause — \`auth.admin.listUsers({perPage: 200})\` fetching every user in the project. That's a separate PR (also slow but orthogonal).

## Verification

- typecheck + lint pass
- 41 test files, 503 unit tests pass
- No API contract change — response shape and behavior unchanged

## Security note

JWT email is read from \`data.user.email\` on the verified token, the same source \`getUserById\` was hitting. Trust level is identical. Staleness window is bounded by JWT refresh (~1h Supabase default) and matters at zero call sites in this PR — every email use is either a literal match against an invitation record (which is itself immutable post-creation) or cosmetic (workspace name derive, inviter email line in template).