### PR TITLE
perf: /me/role endpoint to skip /members fetch in sidebar

### DIFF
--- a/apps/server/src/api/meRole.ts
+++ b/apps/server/src/api/meRole.ts
@@ -1,0 +1,38 @@
+import { Hono } from 'hono'
+import { authJwt, type JwtContext, type OrgRole } from '../middleware/authJwt.js'
+
+/**
+ * GET /api/v1/me/role — the signed-in user's role within their active workspace.
+ *
+ * Why this exists:
+ *   The sidebar's "show admin links?" check used to call useMembers(), which
+ *   fetches /api/v1/organizations/:orgId/members. That endpoint internally
+ *   does supabaseAdmin.auth.admin.listUsers({ perPage: 200 }) — a 2-3s call
+ *   that scales with total user count in the Supabase project, just to look
+ *   up the current user's role.
+ *
+ * What this does instead:
+ *   authJwt already resolved the active workspace and the user's role inside
+ *   it (via org_members). This endpoint just returns what's already in the
+ *   request context — no DB, no auth admin call, ~5ms response.
+ *
+ * Response shape mirrors the consumers' needs:
+ *   { role: 'admin' | 'editor' | 'viewer' | null, orgId: string | null }
+ */
+
+export const meRoleRouter = new Hono<JwtContext>()
+
+meRoleRouter.use('*', authJwt)
+
+interface MeRoleResponse {
+  role: OrgRole | null
+  orgId: string | null
+}
+
+meRoleRouter.get('/', (c) => {
+  const body: MeRoleResponse = {
+    role: c.get('role'),
+    orgId: c.get('orgId'),
+  }
+  return c.json({ success: true, data: body })
+})

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -43,6 +43,7 @@ import { exportsRouter }       from './api/exports.js'
 import { openapiRouter }       from './api/openapi.js'
 import { providerKeysRouter }  from './api/providerKeys.js'
 import { meRouter }            from './api/me.js'
+import { meRoleRouter }        from './api/meRole.js'
 import { systemRouter }       from './api/system.js'
 import { adminModelPricesRouter } from './api/admin/modelPrices.js'
 import { adminModelRecommendationsRouter } from './api/admin/modelRecommendations.js'
@@ -166,6 +167,7 @@ app.route('/api/v1/me/pending-invitations', meInvitationsRouter)
 app.route('/api/v1/dismissals',     dismissalsRouter)
 app.route('/api/v1/me/profile',     userProfilesRouter)
 app.route('/api/v1/me/consent',     userConsentRouter)
+app.route('/api/v1/me/role',        meRoleRouter)    // JWT-auth — current user's org role (sidebar uses this)
 app.route('/api/v1/me',             meRouter)        // sl_live_* introspection (CLI), registered AFTER other /me/* prefixes
 app.route('/api/v1/webhooks',       webhooksRouter)
 app.route('/api/v1/exports',        exportsRouter)

--- a/apps/web/lib/queries/use-current-role.ts
+++ b/apps/web/lib/queries/use-current-role.ts
@@ -1,6 +1,10 @@
 'use client'
 
-import { useCurrentMember, type OrgRole } from './use-members'
+import { useQuery } from '@tanstack/react-query'
+
+import { apiGet } from '@/lib/api'
+import type { ApiEnvelope } from './types'
+import type { OrgRole } from './use-members'
 
 /**
  * Returns the current user's role in their organization.
@@ -9,9 +13,34 @@ import { useCurrentMember, type OrgRole } from './use-members'
  * IMPORTANT: This is for UI gating only — a visitor can tamper with the
  * value in the browser. Always pair with server-side `requireRole` to
  * enforce the actual permission.
+ *
+ * Implementation note (perf):
+ *   Used to derive the role by fetching the entire team roster via
+ *   useMembers() and finding the row whose email matches the session.
+ *   That call hit /api/v1/organizations/:orgId/members, which internally
+ *   ran auth.admin.listUsers({ perPage: 200 }) — a 2-3s call. Now we hit
+ *   /api/v1/me/role instead, which just returns the role authJwt already
+ *   resolved into the request context (~5ms).
  */
+
+interface MeRolePayload {
+  role: OrgRole | null
+  orgId: string | null
+}
+
 export function useCurrentRole(): OrgRole | null {
-  return useCurrentMember()?.role ?? null
+  const query = useQuery({
+    queryKey: ['me', 'role'] as const,
+    queryFn: async () => {
+      const res = await apiGet<ApiEnvelope<MeRolePayload>>('/api/v1/me/role')
+      return res.data ?? { role: null, orgId: null }
+    },
+    // Role rarely changes after onboarding — cache aggressively. The
+    // mutations that DO change it (workspace switch, admin role change)
+    // are responsible for invalidating ['me', 'role'].
+    staleTime: 5 * 60_000,
+  })
+  return query.data?.role ?? null
 }
 
 /**

--- a/apps/web/lib/queries/use-members.ts
+++ b/apps/web/lib/queries/use-members.ts
@@ -91,6 +91,9 @@ export function useUpdateMemberRole() {
     },
     onSuccess: () => {
       if (orgId) void qc.invalidateQueries({ queryKey: membersKey(orgId) })
+      // The current user may have just demoted/promoted themselves —
+      // refetch ['me', 'role'] so the sidebar redraws admin-only items.
+      void qc.invalidateQueries({ queryKey: ['me', 'role'] })
     },
   })
 }
@@ -108,6 +111,8 @@ export function useRemoveMember() {
     },
     onSuccess: () => {
       if (orgId) void qc.invalidateQueries({ queryKey: membersKey(orgId) })
+      // Cover the (rare) case where the current user removes themselves.
+      void qc.invalidateQueries({ queryKey: ['me', 'role'] })
     },
   })
 }


### PR DESCRIPTION
## Summary

Replaces the sidebar's 2-3s \`/members\` fetch (which existed only to look up the current user's role) with a tiny \`/api/v1/me/role\` endpoint that reuses values already in the JWT context.

## The bottleneck

\`useIsAdmin()\` in the sidebar → \`useCurrentMember()\` → \`useMembers()\` → \`GET /api/v1/organizations/:orgId/members\`

That endpoint runs \`supabaseAdmin.auth.admin.listUsers({ perPage: 200 })\` to attach emails to org_members rows. It scales with **total Supabase project users**, not the team size — 2-3s every dashboard load just to answer "am I admin?".

## Fix

**Server** — \`apps/server/src/api/meRole.ts\` (new):
\`\`\`ts
meRoleRouter.get('/', (c) => {
  return c.json({ success: true, data: { role: c.get('role'), orgId: c.get('orgId') } })
})
\`\`\`
~5ms. No DB. No auth admin. authJwt middleware already resolved both values.

Mounted at \`/api/v1/me/role\` before the existing catch-all \`/api/v1/me\` (sl_live_* introspection) router.

**Web** — \`useCurrentRole()\` rewritten to hit \`/me/role\` directly with staleTime 5min. \`useIsAdmin\` / \`useCanEdit\` ride on it. Settings page still uses \`useMembers()\` (rarely opened, accept the 2-3s).

**Invalidation** — \`useUpdateMemberRole\` and \`useRemoveMember\` invalidate \`['me', 'role']\` so self-demote / self-remove updates the sidebar immediately.

## Expected impact

| Metric | Before | After |
|--------|--------|-------|
| /dashboard warm baseline | 4.9s | ~2.5s |
| /api/v1/organizations/:orgId/members in sidebar hot path | yes | no |
| /api/v1/me/role response | n/a | ~5ms |

The 2.8s warm \`/members\` call disappears from every dashboard load. Settings page is the only remaining consumer.

## Verification

- typecheck (server + web) + lint pass
- 503 unit tests pass
- No breaking change at any API contract

## Rollback

Revert this commit. \`/api/v1/me/role\` becomes dead code (harmless). \`useCurrentRole\` goes back to deriving from \`useCurrentMember\`.