### PR TITLE
fix(web): pin locale on Date toLocale* calls to stop React #418

### DIFF
--- a/apps/web/app/(dashboard)/alerts/[id]/alert-detail-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/[id]/alert-detail-client.tsx
@@ -16,7 +16,7 @@ import { PermissionGate } from '@/components/permission-gate'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { cn } from '@/lib/utils'
+import { cn, formatDateTime } from '@/lib/utils'
 
 function fmtThreshold(type: AlertType, threshold: number): string {
   if (type === 'budget') return `$${threshold}`
@@ -293,7 +293,7 @@ export function AlertDetailClient() {
                       className="grid grid-cols-[150px_90px_1fr_1fr] gap-4 px-4 py-2.5 items-center text-[11.5px]"
                     >
                       <span className="font-mono text-text-muted" suppressHydrationWarning>
-                        {new Date(d.created_at).toLocaleString()}
+                        {formatDateTime(d.created_at)}
                       </span>
                       <span className={cn(
                         'font-mono text-[10px] uppercase tracking-[0.04em] px-1.5 py-0.5 rounded w-fit',

--- a/apps/web/app/(dashboard)/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/alerts-client.tsx
@@ -17,7 +17,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Topbar } from '@/components/layout/topbar'
 import { PermissionGate } from '@/components/permission-gate'
-import { cn } from '@/lib/utils'
+import { cn, formatDateTime } from '@/lib/utils'
 
 function fmtThreshold(type: AlertType, threshold: number): string {
   if (type === 'budget') return `$${threshold}`
@@ -102,7 +102,7 @@ function AlertRuleRow({
           &gt; {fmtThreshold(a.type, a.threshold)}
           <span className="text-text-faint"> for </span>{a.window_minutes}m
           {a.last_triggered_at && (
-            <span className="text-text-faint ml-2" suppressHydrationWarning>· last fired {new Date(a.last_triggered_at).toLocaleString()}</span>
+            <span className="text-text-faint ml-2">· last fired {formatDateTime(a.last_triggered_at)}</span>
           )}
         </div>
       </div>
@@ -414,7 +414,7 @@ export function AlertsClient() {
                 <div className="rounded-[6px] border border-border overflow-hidden">
                   {deliveries.slice(0, 10).map((d) => (
                     <div key={d.id} className="flex items-center gap-4 px-[14px] py-2 border-b border-border last:border-0 text-[11.5px]">
-                      <span className="font-mono text-text-faint" suppressHydrationWarning>{new Date(d.created_at).toLocaleString()}</span>
+                      <span className="font-mono text-text-faint">{formatDateTime(d.created_at)}</span>
                       <span className={cn('font-mono px-1.5 py-0.5 rounded text-[10px] uppercase tracking-[0.04em]',
                         d.status === 'sent' ? 'bg-good/10 text-good' : 'bg-bad/10 text-bad')}>
                         {d.status}

--- a/apps/web/app/(dashboard)/annotation/annotation-client.tsx
+++ b/apps/web/app/(dashboard)/annotation/annotation-client.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from 'react'
 import { Star, Filter, MessageSquare } from 'lucide-react'
 import { Topbar } from '@/components/layout/topbar'
-import { cn } from '@/lib/utils'
+import { cn, formatDateTime } from '@/lib/utils'
 import {
   useAnnotationQueue,
   useSaveHumanEval,
@@ -186,7 +186,7 @@ function ItemCard({ item }: { item: AnnotationQueueItem }) {
             {item.prompt_name ?? '—'}{item.prompt_version != null ? ` · v${item.prompt_version}` : ''}
           </p>
           <p className="font-mono text-[10px] text-text-faint truncate">
-            {item.model} · {new Date(item.created_at).toLocaleString()}
+            {item.model} · {formatDateTime(item.created_at)}
           </p>
         </div>
         <div className="flex items-center gap-3 shrink-0">

--- a/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
@@ -13,7 +13,7 @@ import { useAuditLogs } from '@/lib/queries/use-audit-logs'
 import { usePrompts } from '@/lib/queries/use-prompts'
 import { useSecuritySummary } from '@/lib/queries/use-security'
 import { useDismissals, useDismissCard } from '@/lib/queries/use-dismissals'
-import { cn } from '@/lib/utils'
+import { cn, formatTime } from '@/lib/utils'
 import { linkPrefetchFor } from '@/lib/heavy-pages'
 import dynamic from 'next/dynamic'
 import { WelcomeBanner } from '@/components/dashboard/welcome-banner'
@@ -859,7 +859,7 @@ export function DashboardClient() {
                   {/* Mobile: stacked; Desktop: inline grid */}
                   <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 sm:grid sm:items-baseline" style={{ gridTemplateColumns: '56px 80px 1fr', gap: 14 }}>
                     <span className="font-mono text-[10.5px] text-text-faint shrink-0">
-                      {new Date(e.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false })}
+                      {formatTime(e.created_at)}
                     </span>
                     <span className={cn(
                       'font-mono text-[9px] uppercase tracking-[0.04em] px-[5px] py-[1px] rounded-[3px] border self-center shrink-0',

--- a/apps/web/app/(dashboard)/datasets/datasets-client.tsx
+++ b/apps/web/app/(dashboard)/datasets/datasets-client.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { Database, Plus, Trash2, FileText, Hash } from 'lucide-react'
 import { Topbar } from '@/components/layout/topbar'
+import { formatDate } from '@/lib/utils'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import {
   useDatasets,
@@ -122,7 +123,7 @@ function DatasetRow({ dataset }: { dataset: Dataset }) {
         {dataset.item_count ?? 0}
       </div>
       <div className="font-mono text-[10.5px] text-text-faint w-[140px] text-right">
-        {new Date(dataset.created_at).toLocaleDateString()}
+        {formatDate(dataset.created_at)}
       </div>
       <button
         type="button"

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Beaker, Play, Trash2, Plus, Loader2, AlertTriangle } from 'lucide-react'
 import { Topbar } from '@/components/layout/topbar'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import { cn } from '@/lib/utils'
+import { cn, formatDateTime } from '@/lib/utils'
 import {
   useEvaluators,
   useDeleteEvaluator,
@@ -617,7 +617,7 @@ function EvaluatorRow({
                 >
                   <StatusBadge status={r.status} />
                   <span className="font-mono text-[11.5px] text-text-muted">
-                    {new Date(r.started_at).toLocaleString()}
+                    {formatDateTime(r.started_at)}
                   </span>
                   <span className="font-mono text-[11.5px] text-text-faint">
                     {r.scored_count}/{r.sample_size}

--- a/apps/web/app/(dashboard)/prompts/[name]/tabs/ab-tab.tsx
+++ b/apps/web/app/(dashboard)/prompts/[name]/tabs/ab-tab.tsx
@@ -9,7 +9,7 @@ import {
   type PromptExperiment,
 } from '@/lib/queries/use-prompts'
 import { PermissionGate } from '@/components/permission-gate'
-import { cn } from '@/lib/utils'
+import { cn, formatDate } from '@/lib/utils'
 
 interface Props {
   name: string
@@ -82,7 +82,7 @@ function CreateExperimentForm({ name, versions, onDone }: CreateFormProps) {
   }
 
   const versionLabel = (v: PromptVersion) =>
-    `v${v.version} — ${new Date(v.created_at).toLocaleDateString()}`
+    `v${v.version} — ${formatDate(v.created_at)}`
 
   return (
     <div className="bg-bg-elev border border-border rounded-[8px] p-[18px] space-y-4">
@@ -222,11 +222,11 @@ function ExperimentResults({ experimentId, versions }: ResultsProps) {
             {exp.status}
           </span>
           <span className="font-mono text-[11px] text-text-faint">
-            Started {new Date(exp.started_at).toLocaleDateString()}
+            Started {formatDate(exp.started_at)}
           </span>
           {exp.concluded_at && (
             <span className="font-mono text-[11px] text-text-faint">
-              · Concluded {new Date(exp.concluded_at).toLocaleDateString()}
+              · Concluded {formatDate(exp.concluded_at)}
             </span>
           )}
         </div>
@@ -432,8 +432,8 @@ export function AbTab({ name, versions, experiments }: Props) {
                   {exp.status}
                 </span>
                 <span className="font-mono text-[11px] text-text-muted">
-                  Started {new Date(exp.started_at).toLocaleDateString()}
-                  {exp.concluded_at && ` · Concluded ${new Date(exp.concluded_at).toLocaleDateString()}`}
+                  Started {formatDate(exp.started_at)}
+                  {exp.concluded_at && ` · Concluded ${formatDate(exp.concluded_at)}`}
                 </span>
                 {exp.winner_version_id && (
                   <span className="flex items-center gap-1 font-mono text-[11px] text-good ml-auto">

--- a/apps/web/app/(dashboard)/prompts/[name]/tabs/diff-tab.tsx
+++ b/apps/web/app/(dashboard)/prompts/[name]/tabs/diff-tab.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState } from 'react'
 import { type PromptVersion } from '@/lib/queries/use-prompts'
-import { cn } from '@/lib/utils'
+import { cn, formatDate } from '@/lib/utils'
 
 interface Props {
   versions: PromptVersion[]
@@ -93,7 +93,7 @@ export function DiffTab({ versions }: Props) {
             <option value="">Select version…</option>
             {sorted.map((v) => (
               <option key={v.id} value={String(v.version)}>
-                v{v.version} — {new Date(v.created_at).toLocaleDateString()}
+                v{v.version} — {formatDate(v.created_at)}
               </option>
             ))}
           </select>
@@ -109,7 +109,7 @@ export function DiffTab({ versions }: Props) {
             <option value="">Select version…</option>
             {sorted.map((v) => (
               <option key={v.id} value={String(v.version)}>
-                v{v.version} — {new Date(v.created_at).toLocaleDateString()}
+                v{v.version} — {formatDate(v.created_at)}
               </option>
             ))}
           </select>

--- a/apps/web/app/(dashboard)/prompts/[name]/tabs/versions-tab.tsx
+++ b/apps/web/app/(dashboard)/prompts/[name]/tabs/versions-tab.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Trash2, ChevronDown, ChevronUp, RotateCcw } from 'lucide-react'
 import { useDeletePromptVersion, useRollbackPromptVersion, type PromptVersion } from '@/lib/queries/use-prompts'
 import { PermissionGate } from '@/components/permission-gate'
+import { formatDate } from '@/lib/utils'
 
 interface Props {
   name: string
@@ -87,7 +88,7 @@ export function VersionsTab({ name, versions, isLoading }: Props) {
                 {v.content.length > 120 ? '…' : ''}
               </span>
               <span className="font-mono text-[11px] text-text-faint shrink-0">
-                {new Date(v.created_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
+                {formatDate(v.created_at)}
               </span>
               {isOpen ? (
                 <ChevronUp className="h-3.5 w-3.5 text-text-faint shrink-0" />

--- a/apps/web/app/(dashboard)/prompts/prompts-client.tsx
+++ b/apps/web/app/(dashboard)/prompts/prompts-client.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/lib/queries/use-prompts'
 import { Topbar } from '@/components/layout/topbar'
 import { PermissionGate } from '@/components/permission-gate'
-import { cn } from '@/lib/utils'
+import { cn, formatDate } from '@/lib/utils'
 
 function fmtUsd(v: number): string {
   return v >= 1 ? `$${v.toFixed(2)}` : `$${v.toFixed(5)}`
@@ -431,7 +431,7 @@ export function PromptsClient() {
 
               {/* Updated date */}
               <span className="text-text-faint text-right text-[11px]">
-                {new Date(p.created_at).toLocaleDateString()}
+                {formatDate(p.created_at)}
               </span>
             </button>
           ))}

--- a/apps/web/app/(dashboard)/requests/requests-client.tsx
+++ b/apps/web/app/(dashboard)/requests/requests-client.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { ExportDropdown } from '@/components/ui/export-dropdown'
-import { cn } from '@/lib/utils'
+import { cn, formatDateTime } from '@/lib/utils'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Topbar } from '@/components/layout/topbar'
 import {
@@ -311,7 +311,7 @@ function RequestDrawer({ requestId, visible, onClose, onPrev, onNext, hasPrev, h
           <>
             <div className="font-mono text-[13px] text-text mb-1 truncate">{req.id}</div>
             <div className="flex items-center gap-2 text-[12px] text-text-muted">
-              <span suppressHydrationWarning>{new Date(req.created_at).toLocaleString()}</span>
+              <span>{formatDateTime(req.created_at)}</span>
               {req.status_code >= 400 && (
                 <>
                   <span className="text-text-faint">·</span>

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -19,3 +19,33 @@ export function formatDate(iso: string | null): string {
     day: 'numeric',
   })
 }
+
+/**
+ * Date + time, en-US pinned. Use anywhere the ungated `.toLocaleString()` would
+ * sit in SSR-rendered output and trip React #418.
+ * Example: "May 18, 2026, 11:24 PM"
+ */
+export function formatDateTime(iso: string | null): string {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  })
+}
+
+/**
+ * 24h time only ("HH:mm"), en-US pinned. For activity logs / per-row timestamps
+ * where date is implied by context. Same #418 protection as formatDateTime.
+ */
+export function formatTime(iso: string | null): string {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+}


### PR DESCRIPTION
User reported React #418 hydration mismatch on production dashboard. Per CLAUDE.md gotcha #22, this is the classic SSR-en-US vs browser-ko-KR Date format mismatch.

## What

- Added `formatDateTime` and `formatTime` helpers to `lib/utils.ts` (siblings to existing `formatDate`), all pinned to en-US.
- Replaced every Date `.toLocaleString()` / `.toLocaleDateString()` / `.toLocaleTimeString()` call in dashboard-mounted client components with the appropriate helper.
- Removed several `suppressHydrationWarning` attributes that were masking the issue rather than fixing it.

Number `.toLocaleString()` calls intentionally left alone — en-US and ko-KR both produce "1,234" so they don't trip #418.

## Verification

- typecheck + lint pass
- Affected ~14 call sites across 11 files. No API contract change. Visual output identical for Korean users since the dashboard is English-only anyway.

## Rollback

Revert the commit. The helpers stay (harmless), Date strings go back to runtime-default locale.