### PR TITLE
feat(web,server): hard-delete projects/provider keys + drop landing anomaly card

### DIFF
--- a/apps/server/src/api/providerKeys.ts
+++ b/apps/server/src/api/providerKeys.ts
@@ -188,7 +188,16 @@ providerKeysRouter.post('/', requireEdit, async (c) => {
   return c.json({ success: true, data }, 201)
 })
 
-// DELETE /api/v1/provider-keys/:id — deactivate provider key (soft delete).
+// DELETE /api/v1/provider-keys/:id — hard delete the provider key row.
+//
+// We used to soft-delete (set is_active=false) so that historic request rows
+// could still resolve provider_key_id → key name. The dashboard then rendered
+// a strikethrough row, which users read as "still here, just dead" — confusing.
+// Users want delete to mean delete.
+//
+// ClickHouse `requests` keeps provider_key_id as a plain UUID with no FK, so
+// orphaning is fine: existing log rows show "(deleted)" via the
+// fetchProviderKeyNames helper's `?? null` fallback in lib/requests-query.ts.
 providerKeysRouter.delete('/:id', requireEdit, async (c) => {
   const keyId = c.req.param('id')
   const orgId = c.get('orgId')
@@ -196,11 +205,11 @@ providerKeysRouter.delete('/:id', requireEdit, async (c) => {
 
   const { error } = await supabaseAdmin
     .from('provider_keys')
-    .update({ is_active: false })
+    .delete()
     .eq('id', keyId)
     .eq('organization_id', orgId)
 
-  if (error) return c.json({ error: 'Failed to deactivate provider key' }, 500)
+  if (error) return c.json({ error: 'Failed to delete provider key' }, 500)
 
   return c.json({ success: true })
 })

--- a/apps/web/app/(dashboard)/projects/projects-client.tsx
+++ b/apps/web/app/(dashboard)/projects/projects-client.tsx
@@ -23,7 +23,7 @@ import {
 import { Topbar } from '@/components/layout/topbar'
 import { PermissionGate } from '@/components/permission-gate'
 import { GhostBtn, PrimaryBtn } from '@/components/ui/primitives'
-import { useCreateProject, useProjects } from '@/lib/queries/use-projects'
+import { useCreateProject, useDeleteProject, useProjects } from '@/lib/queries/use-projects'
 import {
   useApiKeys,
   useIssueApiKey,
@@ -82,6 +82,7 @@ export function ProjectsClient() {
   const providerKeysQuery = useProviderKeys() // org-wide list, grouped client-side by api_key_id
 
   const createProject = useCreateProject()
+  const deleteProject = useDeleteProject()
   const issueApiKey = useIssueApiKey()
   const toggleApiKey = useToggleApiKey()
   const deleteApiKey = useDeleteApiKey()
@@ -123,6 +124,12 @@ export function ProjectsClient() {
   // Delete confirms
   const [deleteApiKeyId, setDeleteApiKeyId] = useState<string | null>(null)
   const [deleteProvKeyId, setDeleteProvKeyId] = useState<string | null>(null)
+  // Project delete requires typing the project name as confirmation —
+  // deleting a project cascades through every Spanlens key, provider key,
+  // and (in ClickHouse) every request row's project_id reference.
+  const [deleteProject_target, setDeleteProject_target] = useState<{ id: string; name: string } | null>(null)
+  const [deleteProject_input, setDeleteProject_input] = useState('')
+  const [deleteProject_error, setDeleteProject_error] = useState<string | null>(null)
 
   // Track which specific toggle is pending
   const [pendingToggleId, setPendingToggleId] = useState<string | null>(null)
@@ -229,6 +236,33 @@ export function ProjectsClient() {
     if (!deleteProvKeyId) return
     await deleteProviderKey.mutateAsync(deleteProvKeyId)
     setDeleteProvKeyId(null)
+  }
+
+  function openDeleteProjectDialog(id: string, name: string) {
+    setDeleteProject_target({ id, name })
+    setDeleteProject_input('')
+    setDeleteProject_error(null)
+  }
+
+  function closeDeleteProjectDialog() {
+    setDeleteProject_target(null)
+    setDeleteProject_input('')
+    setDeleteProject_error(null)
+  }
+
+  async function handleDeleteProject() {
+    if (!deleteProject_target) return
+    if (deleteProject_input !== deleteProject_target.name) {
+      setDeleteProject_error('Project name does not match.')
+      return
+    }
+    setDeleteProject_error(null)
+    try {
+      await deleteProject.mutateAsync(deleteProject_target.id)
+      closeDeleteProjectDialog()
+    } catch (err) {
+      setDeleteProject_error(err instanceof Error ? err.message : 'Failed to delete project')
+    }
   }
 
   const loading =
@@ -385,14 +419,26 @@ export function ProjectsClient() {
                         <h2 className="text-[14px] font-semibold text-text">{proj.name}</h2>
                         <p className="font-mono text-[10.5px] text-text-faint mt-0.5">{proj.id}</p>
                       </div>
-                      <PermissionGate need="edit">
-                        <PrimaryBtn
-                          className="flex items-center gap-1.5 text-[12px] px-3 py-[5px] h-[28px]"
-                          onClick={() => openIssueDialog(proj.id)}
-                        >
-                          <Plus className="h-3.5 w-3.5" /> New Spanlens key
-                        </PrimaryBtn>
-                      </PermissionGate>
+                      <div className="flex items-center gap-2">
+                        <PermissionGate need="edit">
+                          <PrimaryBtn
+                            className="flex items-center gap-1.5 text-[12px] px-3 py-[5px] h-[28px]"
+                            onClick={() => openIssueDialog(proj.id)}
+                          >
+                            <Plus className="h-3.5 w-3.5" /> New Spanlens key
+                          </PrimaryBtn>
+                        </PermissionGate>
+                        <PermissionGate need="edit">
+                          <button
+                            type="button"
+                            onClick={() => openDeleteProjectDialog(proj.id, proj.name)}
+                            title="Delete project"
+                            className="p-1.5 rounded hover:bg-bad/10 text-text-faint hover:text-bad transition-colors"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </button>
+                        </PermissionGate>
+                      </div>
                     </div>
 
                     {/* Spanlens key sections — each is a self-contained group:
@@ -841,18 +887,19 @@ export function ProjectsClient() {
         </DialogContent>
       </Dialog>
 
-      {/* Deactivate provider key confirm */}
+      {/* Delete provider key confirm */}
       <Dialog
         open={deleteProvKeyId !== null}
         onOpenChange={(open) => { if (!open) setDeleteProvKeyId(null) }}
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Deactivate provider key</DialogTitle>
+            <DialogTitle>Delete provider key</DialogTitle>
           </DialogHeader>
           <DialogDescription className="text-[12.5px] text-text-muted mt-1">
-            The Spanlens key will fail when calling this provider until you add a new active key.
-            Existing logs are preserved.
+            This provider key will be permanently removed. The parent Spanlens
+            key will fail when calling this provider until you add a new one.
+            Existing request logs stay intact.
           </DialogDescription>
 
           <div className="space-y-4 mt-2">
@@ -866,10 +913,71 @@ export function ProjectsClient() {
                 disabled={deleteProviderKey.isPending}
                 className="flex-1 h-9 rounded-[6px] bg-bad text-white font-medium text-[13px] hover:opacity-90 transition-opacity disabled:opacity-40"
               >
-                {deleteProviderKey.isPending ? 'Deactivating…' : 'Deactivate'}
+                {deleteProviderKey.isPending ? 'Deleting…' : 'Delete'}
               </button>
             </div>
           </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete project confirm — requires typing the project name */}
+      <Dialog
+        open={deleteProject_target !== null}
+        onOpenChange={(open) => { if (!open) closeDeleteProjectDialog() }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete project</DialogTitle>
+          </DialogHeader>
+          <DialogDescription className="text-[12.5px] text-text-muted mt-1">
+            This permanently deletes the project and cascades through every
+            Spanlens key and provider key under it. Apps using these keys will
+            stop working immediately. Historical request logs are preserved
+            but the project name will no longer resolve.
+          </DialogDescription>
+
+          {deleteProject_target && (
+            <form
+              onSubmit={(e) => { e.preventDefault(); void handleDeleteProject() }}
+              className="space-y-4 mt-3"
+            >
+              <div className="space-y-1.5">
+                <label className="text-[12.5px] text-text-muted">
+                  Type{' '}
+                  <code className="font-mono text-[12px] bg-bg-elev border border-border px-1.5 py-0.5 rounded-[4px] text-text">
+                    {deleteProject_target.name}
+                  </code>
+                  {' '}to confirm.
+                </label>
+                <input
+                  value={deleteProject_input}
+                  onChange={(e) => { setDeleteProject_input(e.target.value); setDeleteProject_error(null) }}
+                  placeholder={deleteProject_target.name}
+                  autoFocus
+                  className="w-full h-9 px-3 rounded-[6px] border border-border bg-bg text-[13px] font-mono text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong transition-colors"
+                />
+              </div>
+
+              {deleteProject_error && (
+                <div className="rounded-md border border-bad/30 bg-bad/10 px-3 py-2 text-[12px] text-bad">
+                  {deleteProject_error}
+                </div>
+              )}
+
+              <div className="flex gap-3">
+                <GhostBtn type="button" className="flex-1" onClick={closeDeleteProjectDialog}>
+                  Cancel
+                </GhostBtn>
+                <button
+                  type="submit"
+                  disabled={deleteProject_input !== deleteProject_target.name || deleteProject.isPending}
+                  className="flex-1 h-9 rounded-[6px] bg-bad text-white font-medium text-[13px] hover:opacity-90 transition-opacity disabled:opacity-40"
+                >
+                  {deleteProject.isPending ? 'Deleting…' : 'Delete project'}
+                </button>
+              </div>
+            </form>
+          )}
         </DialogContent>
       </Dialog>
     </div>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -141,31 +141,6 @@ export default function LandingPage() {
           </Link>
         </div>
 
-        {/* Floating signal pill — hidden on mobile/tablet, visible on lg+ */}
-        <div className="hidden lg:block absolute top-[110px] right-10 w-[300px] bg-bg-elev border border-border rounded-[10px] p-[14px] shadow-[0_8px_24px_rgba(0,0,0,0.06)]">
-          <div className="flex items-center justify-between mb-2">
-            <span className="font-mono text-[11px] text-text-faint tracking-[0.06em] uppercase">Anomaly · 2 min ago</span>
-            <span className="w-2 h-2 rounded-full bg-accent inline-block" />
-          </div>
-          <div className="text-[14px] font-medium mb-1.5">
-            <span className="text-accent">gpt-4o</span> latency{' '}
-            <span className="font-mono">4.2×</span> baseline
-          </div>
-          <div className="text-[12px] text-text-muted leading-snug">
-            7-day p50 was 820ms. Last 20 calls averaged 3,440ms. Upstream?
-          </div>
-          {/* Mini sparkline */}
-          <svg viewBox="0 0 272 36" className="w-full mt-2" style={{ display: 'block' }}>
-            <polyline
-              fill="none"
-              stroke="var(--accent)"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              points="2,30 22,28 42,30 62,27 82,24 102,26 122,22 142,18 162,4 182,3 202,6 222,2 262,1"
-            />
-          </svg>
-        </div>
       </section>
 
       {/* ── Dashboard preview ───────────────────────────────────────── */}


### PR DESCRIPTION
## Summary

Three small, related changes — the common thread is *delete-should-mean-delete* and *the marketing page shouldn't show fake stats*.

### 1. /projects — type-name-to-confirm delete dialog
- New trash button next to "New Spanlens key" in each project header (gated by `PermissionGate need=\"edit\"`).
- Clicking it opens a GitHub-style "type the project name to confirm" modal. Submit stays disabled until the typed input exactly matches `project.name`.
- Cascade copy is explicit: this nukes the project + every Spanlens key + every provider key under it. Apps using these keys stop working immediately. Historical request logs are preserved (project name resolves to null in the UI).
- Wires up the existing `useDeleteProject()` hook — no new API surface needed.

### 2. Provider key DELETE → hard delete
Previously `DELETE /api/v1/provider-keys/:id` did a soft delete (`UPDATE provider_keys SET is_active=false`). The dashboard rendered "dead" rows with a strikethrough, which users consistently read as *"still here, just dead"* — confusing, especially when they want to rotate a key.

Now it's a real `.delete()`. Safe because ClickHouse `requests` keeps `provider_key_id` as a plain UUID with no FK; `fetchProviderKeyNames` in `lib/requests-query.ts` already has a `?? null` fallback so historical request rows render as "(deleted)" instead of broken.

The dialog copy in `projects-client.tsx` updates from "Deactivate provider key" to "Delete provider key" to match.

### 3. Landing page — remove the fake anomaly card
Drops the floating `Anomaly · 2 min ago / gpt-4o latency 4.2× baseline` pill (with the inline sparkline) from `app/page.tsx`. Fabricated metrics on a marketing page erode trust — better to show real product screenshots.

## Test plan

- [x] `pnpm --filter web typecheck` ✅
- [x] `pnpm --filter web lint` ✅
- [x] `pnpm --filter server typecheck` ✅
- [x] `pnpm --filter server lint` ✅
- [x] `pnpm --filter server test` — 503/503 passing ✅
- [ ] Manual: open /projects, click trash, confirm dialog blocks submit until exact name typed
- [ ] Manual: delete a provider key, confirm the row disappears (no strikethrough)
- [ ] Manual: visit landing page, verify the anomaly pill is gone