### PR TITLE
fix(web): pin locale on remaining Date.toLocale* calls (round 2)

### DIFF
--- a/apps/web/app/(dashboard)/requests/[id]/request-detail-client.tsx
+++ b/apps/web/app/(dashboard)/requests/[id]/request-detail-client.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { ArrowLeft, Check, Copy, Play, RotateCw } from 'lucide-react'
 import { Skeleton } from '@/components/ui/skeleton'
-import { cn } from '@/lib/utils'
+import { cn, formatDateTime } from '@/lib/utils'
 import { useRequest, useReplayRequest, useRunReplay } from '@/lib/queries/use-requests'
 
 // TODO: re-add `usePostHog()` + `cache_breakdown_viewed` capture once the
@@ -81,8 +81,8 @@ export function RequestDetailClient({ id }: { id: string }) {
           <h1 className="font-mono text-[20px] font-medium text-text tracking-[-0.3px]">
             {req.id.slice(0, 8)}…
           </h1>
-          <p suppressHydrationWarning className="font-mono text-[12px] text-text-muted mt-1">
-            {new Date(req.created_at).toLocaleString()}
+          <p className="font-mono text-[12px] text-text-muted mt-1">
+            {formatDateTime(req.created_at)}
           </p>
         </div>
         <div className="flex items-center gap-3 shrink-0">

--- a/apps/web/app/(dashboard)/requests/requests-client.tsx
+++ b/apps/web/app/(dashboard)/requests/requests-client.tsx
@@ -806,7 +806,7 @@ function RequestsTable({
                   <span className={isErr ? 'text-bad' : 'text-good'}>{req.status_code}</span>
                   <span
                     className="text-text-faint text-right"
-                    title={new Date(req.created_at).toLocaleString()}
+                    title={formatDateTime(req.created_at)}
                     suppressHydrationWarning
                   >{relAge(req.created_at)}</span>
                 </div>

--- a/apps/web/app/(dashboard)/settings/cron-jobs-panel.tsx
+++ b/apps/web/app/(dashboard)/settings/cron-jobs-panel.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { formatDateTime } from '@/lib/utils'
 import { useCronRuns, type CronJobSummary } from '@/lib/queries/use-system'
 
 // Known cron schedules for display (mirrors apps/server/vercel.json + cron.ts)
@@ -47,7 +48,8 @@ function JobRow({ job }: { job: CronJobSummary }) {
       </span>
       <span
         className="font-mono text-[11px] text-text-muted shrink-0 w-24 text-right"
-        title={new Date(job.lastRanAt).toLocaleString()}
+        title={formatDateTime(job.lastRanAt)}
+        suppressHydrationWarning
       >
         {relTime(job.lastRanAt)}
       </span>

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -364,7 +364,7 @@ function MembersTab() {
                     {m.email} {isMe && <span className="text-text-faint font-normal">(you)</span>}
                   </span>
                   <span className="font-mono text-[11px] text-text-muted truncate">
-                    joined {new Date(m.createdAt).toLocaleDateString()}
+                    joined {formatDate(m.createdAt)}
                   </span>
                   {isAdmin && !lockedLastAdmin ? (
                     <Select
@@ -995,7 +995,7 @@ function InvoicesTab() {
           </p>
           {subscription ? (
             <p className="font-mono text-[11.5px] text-text-faint">
-              Current subscription · {subscription.plan} · renews {subscription.current_period_end ? new Date(subscription.current_period_end).toLocaleDateString() : '—'}
+              Current subscription · {subscription.plan} · renews {formatDate(subscription.current_period_end)}
             </p>
           ) : (
             <p className="font-mono text-[11.5px] text-text-faint">
@@ -1032,7 +1032,7 @@ function ProfileTab() {
             </FormRow>
             <FormRow label="Account created">
               <div className="font-mono text-[12px] text-text-muted">
-                {new Date(user.created_at).toLocaleDateString()}
+                {formatDate(user.created_at)}
               </div>
             </FormRow>
           </>

--- a/apps/web/app/(dashboard)/traces/traces-client.tsx
+++ b/apps/web/app/(dashboard)/traces/traces-client.tsx
@@ -5,7 +5,7 @@ import { useTraces } from '@/lib/queries/use-traces'
 import type { TraceRow, TraceStatus } from '@/lib/queries/types'
 import { Topbar } from '@/components/layout/topbar'
 import { ExportDropdown } from '@/components/ui/export-dropdown'
-import { cn } from '@/lib/utils'
+import { cn, formatDateTime } from '@/lib/utils'
 
 function fmtDuration(ms: number | null): string {
   if (ms == null) return '—'
@@ -392,7 +392,7 @@ export function TracesClient() {
                       <span className="font-mono text-[9.5px] px-[5px] py-[2px] rounded-[3px] bg-bg-muted text-text-faint border border-border uppercase tracking-[0.04em]">ok</span>
                     )}
                   </span>
-                  <span className="text-text-faint text-right" title={new Date(t.started_at).toLocaleString()} suppressHydrationWarning>
+                  <span className="text-text-faint text-right" title={formatDateTime(t.started_at)} suppressHydrationWarning>
                     {fmtAge(t.started_at)}
                   </span>
                 </button>

--- a/apps/web/app/(dashboard)/users/[userId]/user-detail-client.tsx
+++ b/apps/web/app/(dashboard)/users/[userId]/user-detail-client.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { ArrowLeft } from 'lucide-react'
 import { Skeleton } from '@/components/ui/skeleton'
-import { cn } from '@/lib/utils'
+import { cn, formatDate } from '@/lib/utils'
 import { useUserDetail } from '@/lib/queries/use-users'
 
 // TODO: re-add `usePostHog()` + `user_detail_viewed` capture once the
@@ -67,11 +67,12 @@ export function UserDetailClient({ userId }: { userId: string }) {
     { label: 'Distinct models', value: fmtCount(data.distinct_models) },
     {
       label: 'First seen',
-      value: data.first_seen ? new Date(data.first_seen).toLocaleDateString() : '—',
+      // formatDate pins locale to en-US — see CLAUDE.md gotcha #22.
+      value: formatDate(data.first_seen),
     },
     {
       label: 'Last seen',
-      value: data.last_seen ? new Date(data.last_seen).toLocaleDateString() : '—',
+      value: formatDate(data.last_seen),
     },
   ]
 

--- a/apps/web/app/(dashboard)/users/users-client.tsx
+++ b/apps/web/app/(dashboard)/users/users-client.tsx
@@ -9,7 +9,7 @@ import { ArrowDown, ArrowUp, Search, Users as UsersIcon } from 'lucide-react'
 // capture once PostHog provider lands on main. Event payloads designed
 // in docs/launch/2026-05-14_cache-stream-users.md §3.
 import { Skeleton } from '@/components/ui/skeleton'
-import { cn } from '@/lib/utils'
+import { cn, formatDate } from '@/lib/utils'
 import { useUsers } from '@/lib/queries/use-users'
 
 type SortBy = 'cost' | 'requests' | 'tokens' | 'last_seen'
@@ -36,7 +36,8 @@ function fmtRelativeTime(iso: string): string {
   if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
   if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
   if (diff < 7 * 86_400_000) return `${Math.floor(diff / 86_400_000)}d ago`
-  return new Date(iso).toLocaleDateString()
+  // Locale pinned via formatDate — see CLAUDE.md gotcha #22 (React #418).
+  return formatDate(iso)
 }
 
 interface SearchFormProps {
@@ -221,7 +222,7 @@ export function UsersClient() {
                 <span className="text-text-muted">
                   {u.avg_latency_ms != null ? `${Math.round(Number(u.avg_latency_ms))}ms` : '—'}
                 </span>
-                <span className="text-text-faint text-right">{fmtRelativeTime(u.last_seen)}</span>
+                <span className="text-text-faint text-right" suppressHydrationWarning>{fmtRelativeTime(u.last_seen)}</span>
               </Link>
             ))}
           </div>


### PR DESCRIPTION
## Summary

PR #116 fixed the first batch of `Date.toLocale*()` calls that were tripping React **#418 \"hydration failed — HTML mismatch\"** for Korean-locale browsers. This sweep catches the leftovers.

Why this matters: in a Korean Chrome session, Node SSR resolves `new Date(x).toLocaleDateString()` to `\"5/20/2026\"` (en-US default on Vercel) while client hydration resolves it to `\"2026. 5. 20.\"` — different strings, hydration mismatch, full client re-render of the tree.

## Pages fixed

| Page | Field |
|------|------|
| `/users` (list) | `last_seen` fallback in `fmtRelativeTime` |
| `/users/[userId]` | `first_seen`, `last_seen` stats |
| `/requests` (list) | row `title` attr (hover tooltip) |
| `/requests/[id]` | header `created_at` (visible text) |
| `/traces` (list) | row `title` attr |
| `/settings` → Members | member `joined` date |
| `/settings` → Billing | subscription `renews` date |
| `/settings` → Profile | `Account created` date |
| `/settings` → Cron jobs | `lastRanAt` title attr |

All routed through the existing `formatDate(iso)` / `formatDateTime(iso)` helpers in `lib/utils.ts` (en-US pinned).

## Notes

`fmtRelativeTime` in users-client still uses `Date.now()` for bucketing — wall-clock drift between SSR (T0) and client hydration (T0+200ms) can flip a `\"5h ago\"` → `\"6h ago\"` boundary. The span gets `suppressHydrationWarning` to silence that benign drift. The absolute fallback at >7d is now `formatDate(iso)` so the actual locale problem is gone.

Number `.toLocaleString()` calls intentionally left alone — ko-KR and en-US both emit \`1,234\`, no mismatch (matches PR #116's rationale).

## Test plan

- [x] `pnpm --filter web typecheck` ✅
- [x] `pnpm --filter web lint` ✅
- [ ] Manual: open dashboard in Korean-locale Chrome, navigate /users → /requests → /settings, no #418 in console