### PR TITLE
feat(proxy): Azure OpenAI via /proxy/azure (PR-A2)

### DIFF
--- a/apps/server/src/__tests__/azure-resource-url.test.ts
+++ b/apps/server/src/__tests__/azure-resource-url.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeAzureResourceUrl } from '../api/providerKeys.js'
+
+describe('normalizeAzureResourceUrl', () => {
+  describe('accepts and normalizes', () => {
+    it('strips trailing slash', () => {
+      const r = normalizeAzureResourceUrl('https://my-res.openai.azure.com/')
+      expect(r).toEqual({ ok: true, url: 'https://my-res.openai.azure.com' })
+    })
+
+    it('preserves canonical origin without trailing slash', () => {
+      const r = normalizeAzureResourceUrl('https://my-res.openai.azure.com')
+      expect(r).toEqual({ ok: true, url: 'https://my-res.openai.azure.com' })
+    })
+
+    it('accepts the Foundry alternate domain (services.ai.azure.com)', () => {
+      const r = normalizeAzureResourceUrl('https://my-res.services.ai.azure.com')
+      expect(r).toEqual({ ok: true, url: 'https://my-res.services.ai.azure.com' })
+    })
+
+    it('lowercases the host', () => {
+      // URL parser already lowercases the hostname — this just confirms behavior.
+      const r = normalizeAzureResourceUrl('https://My-Resource.OpenAI.Azure.com')
+      expect(r).toEqual({ ok: true, url: 'https://my-resource.openai.azure.com' })
+    })
+
+    it('strips paths/queries — only origin is kept', () => {
+      const r = normalizeAzureResourceUrl(
+        'https://my-res.openai.azure.com/openai/v1/?foo=bar',
+      )
+      expect(r).toEqual({ ok: true, url: 'https://my-res.openai.azure.com' })
+    })
+
+    it('trims surrounding whitespace', () => {
+      const r = normalizeAzureResourceUrl('  https://my-res.openai.azure.com  ')
+      expect(r).toEqual({ ok: true, url: 'https://my-res.openai.azure.com' })
+    })
+  })
+
+  describe('rejects', () => {
+    it('non-URL input', () => {
+      const r = normalizeAzureResourceUrl('my-resource')
+      expect(r.ok).toBe(false)
+    })
+
+    it('http (not https)', () => {
+      const r = normalizeAzureResourceUrl('http://my-res.openai.azure.com')
+      expect(r).toMatchObject({ ok: false })
+      if (!r.ok) expect(r.error).toMatch(/https/i)
+    })
+
+    it('arbitrary domain (host hijack prevention)', () => {
+      const r = normalizeAzureResourceUrl('https://evil.example.com')
+      expect(r).toMatchObject({ ok: false })
+      if (!r.ok) expect(r.error).toMatch(/openai\.azure\.com|services\.ai\.azure\.com/)
+    })
+
+    it('domain that contains azure.com but is not an Azure host', () => {
+      // `.azure.com` alone is not enough — the suffix has to be one of the
+      // two recognized families. Prevents lookalike domains like
+      // `myco-openai.azure.com.evil.org` from being accepted (URL parser
+      // would identify the actual host as `evil.org`, but defense-in-depth).
+      const r = normalizeAzureResourceUrl('https://something.azure.com')
+      expect(r).toMatchObject({ ok: false })
+    })
+
+    it('empty string', () => {
+      const r = normalizeAzureResourceUrl('')
+      expect(r.ok).toBe(false)
+    })
+  })
+})

--- a/apps/server/src/__tests__/azure-resource-url.test.ts
+++ b/apps/server/src/__tests__/azure-resource-url.test.ts
@@ -52,7 +52,14 @@ describe('normalizeAzureResourceUrl', () => {
     it('arbitrary domain (host hijack prevention)', () => {
       const r = normalizeAzureResourceUrl('https://evil.example.com')
       expect(r).toMatchObject({ ok: false })
-      if (!r.ok) expect(r.error).toMatch(/openai\.azure\.com|services\.ai\.azure\.com/)
+      // Use substring matchers (not regex) — CodeQL's "missing regex anchor"
+      // rule fires when an unanchored alternation could be confused with URL
+      // validation. This is an error-message assertion, but toContain is
+      // strictly clearer anyway.
+      if (!r.ok) {
+        expect(r.error).toContain('.openai.azure.com')
+        expect(r.error).toContain('.services.ai.azure.com')
+      }
     })
 
     it('domain that contains azure.com but is not an Azure host', () => {

--- a/apps/server/src/__tests__/gotcha.test.ts
+++ b/apps/server/src/__tests__/gotcha.test.ts
@@ -91,7 +91,7 @@ describe('getDecryptedProviderKey — Gotcha #5 (decryption empty string → nul
     mockKeyLookup({ data: { id: 'pk-uuid-123', encrypted_key: ciphertext }, error: null })
 
     const result = await getDecryptedProviderKey('api-key-789', 'openai')
-    expect(result).toEqual({ plaintext, id: 'pk-uuid-123' })
+    expect(result).toEqual({ plaintext, id: 'pk-uuid-123', metadata: {} })
   })
 
   it('returns null (not empty plaintext) when ENCRYPTION_KEY is wrong [Known Gotcha #5]', async () => {

--- a/apps/server/src/api/me.ts
+++ b/apps/server/src/api/me.ts
@@ -14,11 +14,17 @@ export const meRouter = new Hono<ApiKeyContext>()
 
 meRouter.use('*', authApiKey)
 
+type KnownProvider = 'openai' | 'anthropic' | 'gemini' | 'azure'
+
+const KNOWN_PROVIDERS: ReadonlySet<KnownProvider> = new Set([
+  'openai', 'anthropic', 'gemini', 'azure',
+])
+
 interface KeyInfoResponse {
   projectId: string
   projectName: string
   /** Providers with an active provider_key under THIS Spanlens key. */
-  providers: Array<'openai' | 'anthropic' | 'gemini'>
+  providers: KnownProvider[]
 }
 
 // GET /api/v1/me/key-info — introspect the presented Spanlens key.
@@ -49,9 +55,7 @@ meRouter.get('/key-info', async (c) => {
 
   const providers = Array.from(
     new Set((providerKeys ?? []).map((row) => row.provider as string)),
-  ).filter((p): p is 'openai' | 'anthropic' | 'gemini' =>
-    p === 'openai' || p === 'anthropic' || p === 'gemini',
-  )
+  ).filter((p): p is KnownProvider => KNOWN_PROVIDERS.has(p as KnownProvider))
 
   const body: KeyInfoResponse = {
     projectId: project.id as string,

--- a/apps/server/src/api/openapi.ts
+++ b/apps/server/src/api/openapi.ts
@@ -117,7 +117,7 @@ export const SPEC: OpenAPIV3.Document = {
         description: 'A request (or response) that matched one or more PII or injection rules.',
         properties: {
           id: { type: 'string', format: 'uuid' },
-          provider: { type: 'string', enum: ['openai', 'anthropic', 'gemini'] },
+          provider: { type: 'string', enum: ['openai', 'anthropic', 'gemini', 'azure'] },
           model: { type: 'string', example: 'gpt-4o-mini' },
           status_code: { type: 'integer' },
           latency_ms: { type: 'integer' },
@@ -131,7 +131,7 @@ export const SPEC: OpenAPIV3.Document = {
         type: 'object',
         properties: {
           id: { type: 'string', format: 'uuid' },
-          provider: { type: 'string', enum: ['openai', 'anthropic', 'gemini'] },
+          provider: { type: 'string', enum: ['openai', 'anthropic', 'gemini', 'azure'] },
           model: { type: 'string', example: 'gpt-4o-mini' },
           prompt_tokens: { type: 'integer', description: 'Gross input tokens (cache portions included).' },
           completion_tokens: { type: 'integer' },
@@ -445,7 +445,7 @@ export const SPEC: OpenAPIV3.Document = {
         security: [{ BearerJWT: [] }],
         parameters: [
           { name: 'projectId', in: 'query', schema: { type: 'string', format: 'uuid' } },
-          { name: 'provider', in: 'query', schema: { type: 'string', enum: ['openai', 'anthropic', 'gemini'] } },
+          { name: 'provider', in: 'query', schema: { type: 'string', enum: ['openai', 'anthropic', 'gemini', 'azure'] } },
           { name: 'model', in: 'query', schema: { type: 'string' } },
           { name: 'from', in: 'query', schema: { type: 'string', format: 'date-time' } },
           { name: 'to', in: 'query', schema: { type: 'string', format: 'date-time' } },

--- a/apps/server/src/api/providerKeys.ts
+++ b/apps/server/src/api/providerKeys.ts
@@ -18,9 +18,48 @@ providerKeysRouter.use('*', authJwt)
 
 const requireEdit = requireRole('admin', 'editor')
 
-const VALID_PROVIDERS = new Set(['openai', 'anthropic', 'gemini'])
+const VALID_PROVIDERS = new Set(['openai', 'anthropic', 'gemini', 'azure'])
 
-const SELECT_COLUMNS = 'id, provider, name, is_active, api_key_id, created_at, updated_at'
+const SELECT_COLUMNS =
+  'id, provider, name, is_active, api_key_id, provider_metadata, created_at, updated_at'
+
+/**
+ * Normalize a user-supplied Azure resource URL.
+ *
+ * Accepts forms customers commonly paste from the Azure portal:
+ *   "https://my-resource.openai.azure.com"
+ *   "https://my-resource.openai.azure.com/"  (trailing slash)
+ *   "https://my-resource.services.ai.azure.com"  (Foundry alternate domain)
+ *
+ * Returns the canonical origin (no trailing slash). Rejects anything
+ * that isn't an https URL on one of the two Azure domain families —
+ * we don't want to let customers proxy through arbitrary hosts.
+ *
+ * Exported for unit tests (see __tests__/azure-resource-url.test.ts).
+ */
+export function normalizeAzureResourceUrl(input: string): { ok: true; url: string } | { ok: false; error: string } {
+  let parsed: URL
+  try {
+    parsed = new URL(input.trim())
+  } catch {
+    return { ok: false, error: 'resource_url must be a valid URL (e.g. https://my-resource.openai.azure.com)' }
+  }
+  if (parsed.protocol !== 'https:') {
+    return { ok: false, error: 'resource_url must use https://' }
+  }
+  const host = parsed.hostname.toLowerCase()
+  const isAzureHost =
+    host.endsWith('.openai.azure.com') ||
+    host.endsWith('.services.ai.azure.com')
+  if (!isAzureHost) {
+    return {
+      ok: false,
+      error:
+        'resource_url host must end in .openai.azure.com or .services.ai.azure.com',
+    }
+  }
+  return { ok: true, url: parsed.origin }
+}
 
 /** Verify the api_key belongs to a project owned by `orgId`. */
 async function assertApiKeyInOrg(apiKeyId: string, orgId: string): Promise<boolean> {
@@ -134,6 +173,8 @@ providerKeysRouter.post('/', requireEdit, async (c) => {
     key?: unknown
     name?: unknown
     api_key_id?: unknown
+    /** Azure only: { resource_url: 'https://x.openai.azure.com' }. Ignored for other providers. */
+    provider_metadata?: unknown
   }
   try {
     body = (await c.req.json()) as typeof body
@@ -142,7 +183,7 @@ providerKeysRouter.post('/', requireEdit, async (c) => {
   }
 
   if (typeof body.provider !== 'string' || !VALID_PROVIDERS.has(body.provider)) {
-    return c.json({ error: 'provider must be one of: openai, anthropic, gemini' }, 400)
+    return c.json({ error: 'provider must be one of: openai, anthropic, gemini, azure' }, 400)
   }
   if (typeof body.key !== 'string' || body.key.trim().length === 0) {
     return c.json({ error: 'key is required' }, 400)
@@ -157,6 +198,25 @@ providerKeysRouter.post('/', requireEdit, async (c) => {
     return c.json({ error: 'api_key_id does not belong to this organization' }, 403)
   }
 
+  // Azure requires a resource_url in provider_metadata. Validate + normalize
+  // BEFORE the DB INSERT so error messages are user-friendly — the DB CHECK
+  // constraint would otherwise return a generic "violates check" message.
+  let providerMetadata: Record<string, unknown> = {}
+  if (body.provider === 'azure') {
+    const meta = body.provider_metadata as { resource_url?: unknown } | undefined
+    if (!meta || typeof meta.resource_url !== 'string') {
+      return c.json(
+        { error: 'provider_metadata.resource_url is required for azure' },
+        400,
+      )
+    }
+    const result = normalizeAzureResourceUrl(meta.resource_url)
+    if (!result.ok) {
+      return c.json({ error: result.error }, 400)
+    }
+    providerMetadata = { resource_url: result.url }
+  }
+
   const apiKeyId = body.api_key_id
   const encryptedKey = await aes256Encrypt(body.key.trim())
 
@@ -168,6 +228,7 @@ providerKeysRouter.post('/', requireEdit, async (c) => {
       provider: body.provider,
       name: body.name.trim(),
       encrypted_key: encryptedKey,
+      provider_metadata: providerMetadata,
     })
     .select(SELECT_COLUMNS)
     .single()

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -5,6 +5,7 @@ import { logger } from 'hono/logger'
 import { openaiProxy }     from './proxy/openai.js'
 import { anthropicProxy }  from './proxy/anthropic.js'
 import { geminiProxy }     from './proxy/gemini.js'
+import { azureProxy }      from './proxy/azure.js'
 
 import { organizationsRouter } from './api/organizations.js'
 import { projectsRouter }      from './api/projects.js'
@@ -113,6 +114,7 @@ app.get('/health/deep', async (c) => {
 app.route('/proxy/openai',    openaiProxy)
 app.route('/proxy/anthropic', anthropicProxy)
 app.route('/proxy/gemini',    geminiProxy)
+app.route('/proxy/azure',     azureProxy)
 
 // ── SDK ingestion routes (authApiKey middleware) ──────────────
 app.route('/ingest',          ingestRouter)

--- a/apps/server/src/lib/cost.ts
+++ b/apps/server/src/lib/cost.ts
@@ -12,7 +12,11 @@
 
 import { getCachedPrices, type ModelPrice } from './model-prices-cache.js'
 
-export type Provider = 'openai' | 'anthropic' | 'gemini'
+// 'azure' shares the OpenAI price table (Azure OpenAI exposes OpenAI models
+// at OpenAI prices). The proxy in proxy/azure.ts calls calculateCost('openai', ...)
+// directly, but the type is included here so type-safe call sites that pass
+// `requests.provider` through don't have to special-case it.
+export type Provider = 'openai' | 'anthropic' | 'gemini' | 'azure'
 
 export interface Usage {
   /** Total input tokens INCLUDING any cached/cache-creation portion. */

--- a/apps/server/src/lib/otlp-mapper.ts
+++ b/apps/server/src/lib/otlp-mapper.ts
@@ -205,7 +205,7 @@ export function mapOtlpSpan(
   let costUsd: number | null = null
   if (model && (promptTokens > 0 || completionTokens > 0)) {
     const result = calculateCost(
-      provider as 'openai' | 'anthropic' | 'gemini',
+      provider as 'openai' | 'anthropic' | 'gemini' | 'azure',
       model,
       { promptTokens, completionTokens },
     )

--- a/apps/server/src/proxy/azure.ts
+++ b/apps/server/src/proxy/azure.ts
@@ -1,0 +1,244 @@
+import { Hono } from 'hono'
+import { stream } from 'hono/streaming'
+import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { enforceQuota } from '../middleware/quota.js'
+import { proxyRateLimit } from '../middleware/rateLimit.js'
+import { calculateCost } from '../lib/cost.js'
+import { logRequestAsync, parseLogBodyMode } from '../lib/logger.js'
+import { resolvePromptVersion } from '../lib/resolve-prompt-version.js'
+import { fireAndForget } from '../lib/wait-until.js'
+import { parseOpenAIResponse } from '../parsers/openai.js'
+import { scanAll } from '../lib/security-scan.js'
+import { getDecryptedProviderKey, buildUpstreamHeaders, buildDownstreamHeaders, isBlockingEnabled } from './utils.js'
+import { logOpenAIStream } from './stream-logger.js'
+import { cancelReaderSilently, makeStreamDeadline, readWithDeadline } from './stream-deadline.js'
+
+// Azure OpenAI v1 endpoint (Microsoft, Aug 2025+). Drop-in compatible with
+// OpenAI request/response shape — no api-version query, no per-deployment
+// URL fragments. Customer's resource origin lives on provider_keys.provider_metadata.resource_url.
+//
+// Request flow:
+//   client → POST /proxy/azure/chat/completions
+//          → upstream POST {resource_url}/openai/v1/chat/completions
+//
+// Differences vs. /proxy/openai:
+//   - Base URL is per-key (Azure resource), not a constant
+//   - Auth header: api-key (not Authorization: Bearer)
+//   - Response includes Azure-only fields (prompt_filter_results, content_filter_results,
+//     system_fingerprint) — OpenAI parser ignores unknown fields, so passthrough works
+const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '35000', 10)
+
+export const azureProxy = new Hono<ApiKeyContext>()
+
+azureProxy.use('*', authApiKey)
+azureProxy.use('*', proxyRateLimit)
+azureProxy.use('*', enforceQuota)
+
+azureProxy.all('/*', async (c) => {
+  const handlerStartMs = Date.now()
+
+  const organizationId = c.get('organizationId')
+  const projectId = c.get('projectId')
+  const apiKeyId = c.get('apiKeyId')
+
+  const providerKey = await getDecryptedProviderKey(apiKeyId, 'azure')
+  if (!providerKey) {
+    return c.json({ error: 'No active Azure provider key registered for this Spanlens key' }, 400)
+  }
+  const decryptedKey = providerKey.plaintext
+
+  // resource_url is enforced NOT NULL at the DB layer for 'azure' rows
+  // (provider_keys_azure_requires_resource_url CHECK constraint).
+  // Defensive empty-string fallback only triggers if a future migration
+  // removes the constraint — surface a clear 500 rather than build a
+  // malformed upstream URL.
+  const resourceUrl = (providerKey.metadata['resource_url'] as string | undefined) ?? ''
+  if (resourceUrl.length === 0) {
+    console.error('[azure-proxy] provider_key missing resource_url:', providerKey.id)
+    return c.json({ error: 'Azure provider key is missing resource_url — re-register it' }, 500)
+  }
+
+  const reqBodyText = await c.req.text()
+  let reqBodyJson: Record<string, unknown> | null = null
+  let isStreaming = false
+
+  try {
+    reqBodyJson = JSON.parse(reqBodyText) as Record<string, unknown>
+    isStreaming = reqBodyJson.stream === true
+
+    if (isStreaming) {
+      reqBodyJson = {
+        ...reqBodyJson,
+        stream_options: { include_usage: true },
+      }
+    }
+  } catch { /* non-JSON body — pass through */ }
+
+  // ── Security scan + blocking ───────────────────────────────────────────────
+  const requestFlags = scanAll(reqBodyJson)
+  const hasInjection = requestFlags.some((f) => f.type === 'injection')
+  if (hasInjection && await isBlockingEnabled(projectId)) {
+    return c.json({
+      error: 'Request blocked by Spanlens security policy: prompt injection detected.',
+      code: 'INJECTION_BLOCKED',
+    }, 422)
+  }
+
+  const path = c.req.path.replace(/^\/proxy\/azure/, '')
+  const upstreamUrl = `${resourceUrl}/openai/v1${path}`
+
+  // Azure uses `api-key` (not Authorization Bearer). Strip authorization
+  // explicitly in case some client lib retransmits one.
+  const headers = buildUpstreamHeaders(c.req.raw.headers, {
+    'api-key': decryptedKey,
+    'Content-Type': 'application/json',
+  })
+  headers.delete('authorization')
+
+  const startMs = Date.now()
+  const fetchBody =
+    c.req.method !== 'GET' && c.req.method !== 'HEAD'
+      ? isStreaming && reqBodyJson ? JSON.stringify(reqBodyJson) : reqBodyText
+      : null
+
+  const upstreamAbort = new AbortController()
+  const upstreamTimer = setTimeout(() => upstreamAbort.abort(), UPSTREAM_TIMEOUT_MS)
+  let upstreamRes: Response
+  try {
+    upstreamRes = await fetch(upstreamUrl, { method: c.req.method, headers, body: fetchBody, signal: upstreamAbort.signal })
+  } catch (err) {
+    clearTimeout(upstreamTimer)
+    const msg = err instanceof Error ? err.message : 'Unknown error'
+    if (err instanceof Error && err.name === 'AbortError') {
+      return c.json({ error: `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms` }, 504)
+    }
+    console.error('[azure-proxy] upstream fetch error:', msg)
+    return c.json({ error: `Upstream request failed: ${msg}` }, 502)
+  }
+  clearTimeout(upstreamTimer)
+  const latencyMs = Date.now() - startMs
+  const proxyOverheadMs = startMs - handlerStartMs
+
+  const model = (reqBodyJson?.model as string | undefined) ?? ''
+  const traceId = c.req.header('x-trace-id') ?? null
+  const resolved = await resolvePromptVersion(
+    organizationId,
+    c.req.header('x-spanlens-prompt-version') ?? null,
+    traceId,
+  )
+  const promptVersionId = resolved?.versionId ?? null
+  const logBase = {
+    organizationId, projectId, apiKeyId,
+    provider: 'azure',
+    latencyMs, proxyOverheadMs, statusCode: upstreamRes.status,
+    requestBody: reqBodyJson,
+    responseBody: null,
+    errorMessage: null,
+    traceId,
+    spanId: c.req.header('x-span-id') ?? null,
+    promptVersionId,
+    providerKeyId: providerKey.id,
+    userId: c.req.header('x-spanlens-user') ?? null,
+    sessionId: c.req.header('x-spanlens-session') ?? null,
+    logBodyMode: parseLogBodyMode(c.req.header('x-spanlens-log-body')),
+    preComputedRequestFlags: requestFlags,
+  }
+
+  // ── Streaming path ────────────────────────────────────────────────────────
+  if (isStreaming && upstreamRes.body) {
+    const downstreamHeaders = buildDownstreamHeaders(upstreamRes.headers)
+    downstreamHeaders.forEach((value, key) => c.header(key, value))
+    c.status(upstreamRes.status as 200)
+
+    const upstreamBody = upstreamRes.body
+
+    return stream(c, async (honoStream) => {
+      const reader = upstreamBody.getReader()
+      const decoder = new TextDecoder()
+      const deadline = makeStreamDeadline(handlerStartMs)
+      let buffer = ''
+      const lines: string[] = []
+      let truncated = false
+
+      pump: for (;;) {
+        const outcome = await readWithDeadline(reader, deadline)
+        switch (outcome.kind) {
+          case 'done':
+            break pump
+          case 'timeout':
+            truncated = true
+            console.warn('[azure-stream] deadline reached, closing gracefully')
+            await cancelReaderSilently(reader)
+            break pump
+          case 'error':
+            console.error('[azure-stream] reader error:', outcome.error)
+            break pump
+          case 'chunk': {
+            await honoStream.write(outcome.value)
+            buffer += decoder.decode(outcome.value, { stream: true })
+            const parts = buffer.split('\n')
+            buffer = parts.pop() ?? ''
+            lines.push(...parts)
+            break
+          }
+        }
+      }
+      if (buffer.length > 0) lines.push(buffer)
+
+      // Azure SSE chunk shape is OpenAI-compatible — same parser works.
+      // The 'azure' provider tag on logBase is what flows into ClickHouse,
+      // not what the parser cares about.
+      await logOpenAIStream(lines, { ...logBase, model }, { truncated }).catch((err) => {
+        console.error('[azure-stream] log error:', err)
+      })
+    })
+  }
+
+  // ── Non-streaming path ────────────────────────────────────────────────────
+  const downstreamHeaders = buildDownstreamHeaders(upstreamRes.headers)
+  const resBodyText = await upstreamRes.text()
+  let resBodyJson: unknown = null
+  try { resBodyJson = JSON.parse(resBodyText) } catch { /* non-JSON response */ }
+
+  let promptTokens = 0
+  let completionTokens = 0
+  let totalTokens = 0
+  let cacheReadTokens = 0
+  let cacheWriteTokens = 0
+  let resolvedModel = model
+
+  if (upstreamRes.ok && resBodyJson) {
+    try {
+      const parsed = parseOpenAIResponse(resBodyJson as Record<string, unknown>)
+      if (parsed) {
+        resolvedModel = parsed.model || model
+        promptTokens = parsed.promptTokens
+        completionTokens = parsed.completionTokens
+        totalTokens = parsed.totalTokens
+        cacheReadTokens = parsed.cacheReadTokens ?? 0
+        cacheWriteTokens = parsed.cacheWriteTokens ?? 0
+      }
+    } catch { /* ignore */ }
+  }
+
+  // Azure exposes OpenAI models at OpenAI prices — reuse the OpenAI price
+  // table rather than maintaining a parallel one. If a customer deploys a
+  // model under a custom deployment name that doesn't match a known model
+  // key, lookupPrice() returns null and cost_usd ends up NULL (existing
+  // behavior, no regression).
+  const cost = calculateCost('openai', resolvedModel, {
+    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens,
+  })
+
+  fireAndForget(c, logRequestAsync({
+    ...logBase,
+    model: resolvedModel,
+    promptTokens, completionTokens, totalTokens,
+    cacheReadTokens, cacheWriteTokens,
+    costUsd: cost?.totalCost ?? null,
+    responseBody: resBodyJson,
+    errorMessage: upstreamRes.ok ? null : resBodyText.slice(0, 1000),
+  }))
+
+  return new Response(resBodyText, { status: upstreamRes.status, headers: downstreamHeaders })
+})

--- a/apps/server/src/proxy/utils.ts
+++ b/apps/server/src/proxy/utils.ts
@@ -6,6 +6,13 @@ export interface ResolvedProviderKey {
   plaintext: string
   /** UUID of the provider_keys row used. Stored on requests.provider_key_id. */
   id: string
+  /**
+   * Provider-specific config. For 'azure': { resource_url: 'https://x.openai.azure.com' }.
+   * For openai/anthropic/gemini this is `{}` (column has DEFAULT '{}' in DB).
+   * Type is `Record<string, unknown>` because the shape varies per provider —
+   * each proxy is responsible for narrowing what it needs.
+   */
+  metadata: Record<string, unknown>
 }
 
 /**
@@ -16,8 +23,9 @@ export interface ResolvedProviderKey {
  * receives the Spanlens key's id from authApiKey + the provider from the
  * URL path, then resolves them here.
  *
- * Returns both plaintext (for upstream Authorization) and the row id (for
- * requests.provider_key_id so the dashboard can show which key was used).
+ * Returns plaintext (for upstream Authorization), the row id (for
+ * requests.provider_key_id so the dashboard can show which key was used),
+ * and provider_metadata (e.g. Azure resource_url).
  */
 export async function getDecryptedProviderKey(
   apiKeyId: string,
@@ -25,7 +33,7 @@ export async function getDecryptedProviderKey(
 ): Promise<ResolvedProviderKey | null> {
   const { data } = await supabaseAdmin
     .from('provider_keys')
-    .select('id, encrypted_key')
+    .select('id, encrypted_key, provider_metadata')
     .eq('api_key_id', apiKeyId)
     .eq('provider', provider)
     .eq('is_active', true)
@@ -34,7 +42,11 @@ export async function getDecryptedProviderKey(
   if (!data) return null
   const decrypted = await aes256Decrypt(data.encrypted_key as string)
   if (decrypted.length === 0) return null
-  return { plaintext: decrypted, id: data.id as string }
+  return {
+    plaintext: decrypted,
+    id: data.id as string,
+    metadata: (data.provider_metadata as Record<string, unknown> | null) ?? {},
+  }
 }
 
 /**
@@ -47,7 +59,7 @@ export async function getDecryptedProviderKeyById(
 ): Promise<ResolvedProviderKey | null> {
   const { data } = await supabaseAdmin
     .from('provider_keys')
-    .select('id, encrypted_key')
+    .select('id, encrypted_key, provider_metadata')
     .eq('id', keyId)
     .eq('organization_id', organizationId)
     .eq('is_active', true)
@@ -56,7 +68,11 @@ export async function getDecryptedProviderKeyById(
   if (!data) return null
   const decrypted = await aes256Decrypt(data.encrypted_key as string)
   if (decrypted.length === 0) return null
-  return { plaintext: decrypted, id: data.id as string }
+  return {
+    plaintext: decrypted,
+    id: data.id as string,
+    metadata: (data.provider_metadata as Record<string, unknown> | null) ?? {},
+  }
 }
 
 /**

--- a/apps/web/app/(dashboard)/projects/projects-client.tsx
+++ b/apps/web/app/(dashboard)/projects/projects-client.tsx
@@ -38,25 +38,33 @@ import {
 } from '@/lib/queries/use-provider-keys'
 import { cn } from '@/lib/utils'
 
-const PROVIDERS = ['openai', 'anthropic', 'gemini'] as const
+const PROVIDERS = ['openai', 'anthropic', 'gemini', 'azure'] as const
 type ProviderName = typeof PROVIDERS[number]
 
 const PROVIDER_LABELS: Record<ProviderName, string> = {
   openai: 'OpenAI',
   anthropic: 'Anthropic',
   gemini: 'Gemini',
+  azure: 'Azure OpenAI',
 }
 
 const PROVIDER_PLACEHOLDERS: Record<ProviderName, string> = {
   openai: 'sk-…',
   anthropic: 'sk-ant-…',
   gemini: 'AIza…',
+  // Azure keys are 32-char hex strings with no prefix — show two groups so users
+  // recognize the format.
+  azure: '0123456789abcdef0123456789abcdef',
 }
 
 /**
  * Code snippet shown after a provider key is added — the customer pastes
  * this into their app and the call routes through Spanlens automatically.
  * No CLI re-run needed once SPANLENS_API_KEY is in their .env.local.
+ *
+ * Azure uses the OpenAI SDK with a Spanlens-routed baseURL. The customer's
+ * Azure resource URL is held server-side on the provider key row — they
+ * don't need to repeat it in client code.
  */
 const PROVIDER_SNIPPETS: Record<ProviderName, string> = {
   openai: `import { createOpenAI } from '@spanlens/sdk/openai'
@@ -74,6 +82,15 @@ const anthropic = createAnthropic()
 const genAI = createGemini()
 const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash' })
 // await model.generateContent('...')`,
+  azure: `import OpenAI from 'openai'
+
+// Azure resource URL is stored on the Spanlens provider key — your client
+// just talks to /proxy/azure and Spanlens forwards to the right Azure endpoint.
+const azure = new OpenAI({
+  baseURL: 'https://api.spanlens.io/proxy/azure',
+  apiKey: process.env.SPANLENS_API_KEY,
+})
+// await azure.chat.completions.create({ model: 'gpt-4o', messages: [...] })`,
 }
 
 export function ProjectsClient() {
@@ -104,6 +121,8 @@ export function ProjectsClient() {
   const [addProvProvider, setAddProvProvider] = useState<ProviderName>('openai')
   const [addProvName, setAddProvName] = useState('')
   const [addProvKey, setAddProvKey] = useState('')
+  // Azure only — empty for all other providers. Server validates + normalizes.
+  const [addProvAzureUrl, setAddProvAzureUrl] = useState('')
   const [addProvError, setAddProvError] = useState<string | null>(null)
   // After a successful add, show the integration snippet instead of closing.
   const [addProvAdded, setAddProvAdded] = useState<ProviderName | null>(null)
@@ -151,6 +170,7 @@ export function ProjectsClient() {
     setAddProvProvider('openai')
     setAddProvName('')
     setAddProvKey('')
+    setAddProvAzureUrl('')
     setAddProvError(null)
     setAddProvAdded(null)
     setAddProvDialogOpen(true)
@@ -164,6 +184,11 @@ export function ProjectsClient() {
         key: addProvKey.trim(),
         name: addProvName.trim(),
         api_key_id: addProvApiKeyId,
+        // Server enforces the resource_url shape (https + Azure host); we just
+        // pass through what the user typed and surface any validation error.
+        ...(addProvProvider === 'azure'
+          ? { provider_metadata: { resource_url: addProvAzureUrl.trim() } }
+          : {}),
       })
       // Don't close yet — switch the dialog to the snippet view so the
       // customer can copy the integration code immediately. They'll click
@@ -720,6 +745,24 @@ export function ProjectsClient() {
                   </Select>
                 </div>
 
+                {addProvProvider === 'azure' && (
+                  <div className="space-y-1.5">
+                    <label className="text-[12.5px] text-text-muted font-medium">
+                      Azure resource URL
+                    </label>
+                    <input
+                      value={addProvAzureUrl}
+                      onChange={(e) => setAddProvAzureUrl(e.target.value)}
+                      placeholder="https://my-resource.openai.azure.com"
+                      autoComplete="off"
+                      className="w-full h-9 px-3 rounded-[6px] border border-border bg-bg text-[13px] font-mono text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong transition-colors"
+                    />
+                    <p className="text-[10.5px] text-text-faint">
+                      Copy from your Azure portal — the endpoint shown on your OpenAI resource overview. Must end in <code>.openai.azure.com</code> or <code>.services.ai.azure.com</code>.
+                    </p>
+                  </div>
+                )}
+
                 <div className="space-y-1.5">
                   <label className="text-[12.5px] text-text-muted font-medium">
                     {PROVIDER_LABELS[addProvProvider]} API key
@@ -755,7 +798,12 @@ export function ProjectsClient() {
 
                 <PrimaryBtn
                   type="submit"
-                  disabled={!addProvKey.trim() || !addProvName.trim() || addProviderKey.isPending}
+                  disabled={
+                    !addProvKey.trim() ||
+                    !addProvName.trim() ||
+                    (addProvProvider === 'azure' && !addProvAzureUrl.trim()) ||
+                    addProviderKey.isPending
+                  }
                 >
                   {addProviderKey.isPending ? 'Saving…' : 'Add provider key'}
                 </PrimaryBtn>

--- a/apps/web/lib/queries/types.ts
+++ b/apps/web/lib/queries/types.ts
@@ -64,6 +64,14 @@ export interface ProviderKey {
   api_key_id: string
   created_at: string
   updated_at: string
+  /**
+   * Provider-specific config.
+   *   - azure: { resource_url: 'https://x.openai.azure.com' }
+   *   - openai/anthropic/gemini: {}
+   * Shape varies — callers must narrow before reading. Optional in case
+   * the server didn't include it (older API versions).
+   */
+  provider_metadata?: Record<string, unknown>
   /** MAX(requests.created_at) — null if never used. */
   last_used_at?: string | null
   /** Latest provider_key_leak_scans timestamp; null if never scanned. */

--- a/apps/web/lib/queries/use-provider-keys.ts
+++ b/apps/web/lib/queries/use-provider-keys.ts
@@ -33,10 +33,15 @@ export function useAddProviderKey() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: async (input: {
-      provider: 'openai' | 'anthropic' | 'gemini'
+      provider: 'openai' | 'anthropic' | 'gemini' | 'azure'
       key: string
       name: string
       api_key_id: string
+      /**
+       * Azure only: { resource_url: 'https://<resource>.openai.azure.com' }.
+       * Server rejects azure inserts without this; ignored for other providers.
+       */
+      provider_metadata?: { resource_url: string }
     }) => {
       const res = await apiPost<ApiEnvelope<ProviderKey>>('/api/v1/provider-keys', input)
       return res.data

--- a/docs/plans/integrations-expansion-azure-ollama.md
+++ b/docs/plans/integrations-expansion-azure-ollama.md
@@ -1,0 +1,268 @@
+# Integrations Expansion — Azure OpenAI + Ollama
+
+**작성일**: 2026-05-20
+**범위**: Phase A (Azure OpenAI), Phase B (Ollama)
+**LangGraph/CrewAI**: 별도 plan 문서로 분리 (SDK 작업 위주, 다른 사이클)
+
+---
+
+## 0. TL;DR
+
+| 항목 | Azure OpenAI | Ollama |
+|---|---|---|
+| 변경 위치 | `apps/server/src/proxy/` + DB | **SDK 문서 + (선택) 모델 가격 시드** |
+| 신규 proxy 필요 | ✅ `/proxy/azure/*` | ❌ (customer 로컬 → Spanlens SaaS 도달 불가) |
+| DB 마이그레이션 | ✅ `provider` enum + metadata 컬럼 | (선택) virtual provider row |
+| 인증 헤더 변경 | `api-key: <key>` (NOT Bearer) | n/a |
+| 스트리밍 파서 | OpenAI parser 재사용 가능 | n/a |
+| 비용 계산 | OpenAI 가격표 + deployment→model 매핑 | self-hosted → 항상 null/0 |
+| 예상 PR 수 | 2 (DB 마이그레이션 1 + 코드 1) | 1 (docs + SDK 검증) |
+| 예상 작업량 | ~5일 | ~1일 |
+
+핵심 결정 사항:
+1. **Azure는 v1 endpoint 채택** (`/openai/v1/...`) — Microsoft가 2025-08 GA로 출시한 OpenAI 호환 경로. `api-version` 쿼리 파라미터 없이 OpenAI SDK 그대로 동작. 레거시 `/openai/deployments/{name}/...` 경로는 지원하지 않음 (단순화).
+2. **Ollama는 proxy 안 만듦.** SDK가 이미 `baseURL` override 지원하므로 customer가 `observeOpenAI({ baseURL: 'http://localhost:11434/v1' })`로 로컬 Ollama 호출을 우리 SDK로 감싸면 trace/span만 SaaS로 전송. proxy 경로는 net 도달 불가 (Vercel → customer localhost) — 시도하면 헛수고.
+
+---
+
+## 1. Azure OpenAI 구현 — 상세
+
+### 1.1 Azure v1 API 사실 정리 (Microsoft 공식 문서 기반)
+
+**Endpoint 형태** (둘 다 허용 — `services.ai.azure.com`은 Foundry 통합 도메인):
+```
+https://{resource}.openai.azure.com/openai/v1/chat/completions
+https://{resource}.services.ai.azure.com/openai/v1/chat/completions
+```
+
+**인증** — 두 가지 방식, 키 인증이 우리 사용 사례:
+- `api-key: <key>` 헤더 (우리가 쓸 방식)
+- `Authorization: Bearer <token>` (Microsoft Entra ID, AAD 토큰)
+
+**스트리밍** — SSE, OpenAI와 거의 동일:
+```
+data: {"id":"chatcmpl-...","object":"chat.completion.chunk","created":...,
+       "model":"gpt-4o","choices":[{"index":0,"delta":{...}}],
+       "system_fingerprint":"fp_...","prompt_filter_results":[...]}
+data: [DONE]
+```
+차이점: `prompt_filter_results`, `content_filter_results` (Azure content filter 응답), `system_fingerprint` 필드 추가 — **OpenAI parser가 알 수 없는 필드를 무시하므로 그대로 통과**.
+
+**비스트리밍 응답 shape** — OpenAI와 거의 동일:
+```json
+{
+  "id": "chatcmpl-...",
+  "model": "gpt-4o",              // ← v1에서는 actual model name (이전 deployment name 아님)
+  "object": "chat.completion",
+  "choices": [...],
+  "usage": { "prompt_tokens": 33, "completion_tokens": 557, "total_tokens": 590 },
+  "prompt_filter_results": [...]  // Azure 전용 — 무시
+}
+```
+**검증 필요** (1.5 참고): v1 endpoint에서 `model` 필드가 실제 모델명을 돌려주는지 vs 여전히 deployment 이름인지. 로컬 테스트로 확인 후 cost.ts 매핑 전략 결정.
+
+### 1.2 데이터 모델 변경
+
+**마이그레이션 1**: `supabase/migrations/YYYYMMDDHHMMSS_provider_keys_azure.sql`
+
+```sql
+-- (a) provider enum 확장
+ALTER TABLE provider_keys
+  DROP CONSTRAINT provider_keys_provider_check;
+ALTER TABLE provider_keys
+  ADD CONSTRAINT provider_keys_provider_check
+  CHECK (provider IN ('openai', 'anthropic', 'gemini', 'azure'));
+
+-- (b) Azure resource endpoint 저장용 metadata 컬럼
+ALTER TABLE provider_keys
+  ADD COLUMN IF NOT EXISTS provider_metadata jsonb DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN provider_keys.provider_metadata IS
+  'Provider-specific metadata. For azure: { "resource_url": "https://x.openai.azure.com" }. ' ||
+  'For openai/anthropic/gemini: {} (unused).';
+```
+
+**왜 metadata jsonb인가?** typed 컬럼 추가하면 (`azure_resource_url text`) 다른 provider 추가할 때마다 컬럼 늘어남. jsonb 하나로 향후 AWS Bedrock의 region, GCP Vertex의 project_id 등도 흡수 가능.
+
+**마이그레이션 후**: `supabase gen types --lang typescript --local > supabase/types.ts` 필수 (CLAUDE.md 규칙).
+
+**ClickHouse `requests` 테이블 변경 불필요**: `provider` 컬럼은 String이고 이미 임의 값 허용. `model` 컬럼에 Azure deployment name 또는 model name이 저장됨.
+
+### 1.3 proxy 라우팅
+
+**파일**: `apps/server/src/proxy/azure.ts` (신규)
+
+OpenAI proxy와 99% 동일하므로 **공통 부분 추출 리팩토링은 하지 않음** — 두 파일 차이가 적어 추출 비용 > 이득. 차이만 표로:
+
+| 항목 | openai.ts | azure.ts (신규) |
+|---|---|---|
+| Path prefix | `/proxy/openai` | `/proxy/azure` |
+| `getDecryptedProviderKey(apiKeyId, ?)` | `'openai'` | `'azure'` |
+| `OPENAI_BASE` | `https://api.openai.com` | dynamic, `providerKey.provider_metadata.resource_url + '/openai/v1'` |
+| Upstream auth header | `Authorization: Bearer <key>` | `api-key: <key>` |
+| `logBase.provider` | `'openai'` | `'azure'` |
+| `calculateCost(provider, ...)` | `'openai'` | `'openai'` (가격표 공유 — 1.4 참고) |
+
+**`getDecryptedProviderKey` 시그니처 확장 필요**: 현재 `{plaintext, id}`만 반환. Azure는 resource_url도 필요. 변경:
+```ts
+export interface ResolvedProviderKey {
+  plaintext: string
+  id: string
+  metadata: Record<string, unknown>  // 추가
+}
+```
+`utils.ts` select에 `provider_metadata` 추가 + 두 호출자(openai/anthropic/gemini는 metadata 무시).
+
+**path 처리**:
+```ts
+const path = c.req.path.replace(/^\/proxy\/azure/, '')
+// e.g. customer가 "/proxy/azure/chat/completions" 호출
+// upstreamUrl = "https://myresource.openai.azure.com/openai/v1/chat/completions"
+const baseUrl = providerKey.metadata.resource_url as string
+const upstreamUrl = `${baseUrl}/openai/v1${path}`
+```
+
+**`app.ts`에 route 등록**:
+```ts
+app.route('/proxy/azure', azureProxy)
+```
+
+### 1.4 비용 계산 전략
+
+Azure는 OpenAI와 **사실상 동일한 모델·가격**을 노출 (Microsoft Foundry 추가 모델 제외). 두 가지 선택:
+
+**옵션 A (권장)**: OpenAI 가격표 재사용. `calculateCost('openai', resolvedModel, ...)` 호출. `resolvedModel`은 응답 body의 `model` 필드. v1 endpoint가 실제 모델명을 돌려준다는 가정 하 (1.5에서 검증).
+
+**옵션 B**: 별도 azure 가격 시드. Foundry 전용 모델(DeepSeek, Grok via Azure)이 향후 늘어나면 필요해질 수 있음. 지금은 over-engineering.
+
+**결정**: 옵션 A로 시작. `lib/cost.ts` 변경 없음. 만약 v1이 deployment name을 돌려주면 → 옵션 A1로 폴백: customer가 provider key 등록 시 deployment → model 매핑을 metadata에 같이 저장 (`{ resource_url, deployments: { "my-gpt4o": "gpt-4o" } }`). 이 경우 azure.ts에서 매핑 lookup 후 `calculateCost`에 model name 전달.
+
+### 1.5 검증 단계 (PR 직전 필수)
+
+로컬 또는 dev tier Azure subscription으로:
+1. v1 endpoint 응답의 `model` 필드 값 확인 (deployment name vs model name)
+2. 스트리밍에서 마지막 `usage` chunk가 OpenAI와 동일하게 오는지 (`stream_options: {include_usage: true}` 자동 injection이 동작하는지)
+3. `prompt_filter_results` / `system_fingerprint` 같은 Azure 전용 필드가 OpenAI parser를 깨뜨리지 않는지
+
+검증 결과에 따라 1.4의 옵션 A vs A1 확정.
+
+### 1.6 UI 변경
+
+`apps/web/app/settings/api-keys/` 등의 provider key 등록 UI:
+- provider 드롭다운에 `Azure OpenAI` 추가
+- provider가 `azure`일 때만 `Azure resource URL` 입력 필드 노출 (예: `https://my-resource.openai.azure.com`)
+- form 제출 시 `provider_metadata: { resource_url: "..." }` 함께 전송
+
+기존 코드 위치 그렙해서 PR에서 정확히 잡을 것:
+```
+apps/web/app/settings/api-keys/**/*.tsx
+apps/web/app/settings/provider-keys/**/*.tsx
+```
+
+### 1.7 코드 reviewer 체크리스트
+
+- [ ] `provider_keys` UNIQUE INDEX `(api_key_id, provider) WHERE is_active` 는 `azure` 추가해도 작동 (provider별 1개 active만 허용)
+- [ ] `requestsScope` / billing 쿼리에서 `provider = 'azure'` 행이 OpenAI와 동등하게 집계되는지 확인
+- [ ] CORS — 변경 없음 (server 도메인은 동일, browser→spanlens 호출이지 spanlens→azure이 아님)
+- [ ] `STRIP_PREFIXES`에 `api-key` 추가하지 말 것 — 우리 헤더가 아니라 upstream(Azure)에 전달할 헤더
+- [ ] 비스트리밍 응답에서 `prompt_filter_results` 같은 Azure 필드가 customer에 그대로 전달되는지 (passthrough 의도 — content filter 결과를 customer가 보고 싶을 수 있음)
+
+---
+
+## 2. Ollama 구현 — 상세
+
+### 2.1 핵심 사실
+
+Ollama는 **customer 로컬 머신**(`localhost:11434`)에서 동작. Spanlens SaaS proxy는 Vercel/공인 IP에서 도는 서버라 customer의 localhost에 도달 불가. 따라서 *proxy 라우트를 만들어도 의미 없음*.
+
+대신 Ollama가 OpenAI 호환 endpoint(`/v1/chat/completions`)를 제공하므로:
+- 응답이 OpenAI 형식과 동일 (usage, choices, model 필드)
+- SDK가 이걸 wrap해서 trace/span만 Spanlens로 보내면 됨
+- Ollama가 stream_options.include_usage를 지원해서 streaming token count도 잡힘
+
+Ollama 공식 문서가 `api_key='ollama'` (any placeholder)를 명시 — 로컬은 인증 없음. Ollama Cloud는 Bearer token 필요 (별도 케이스).
+
+### 2.2 구현 작업 — 최소
+
+**A. SDK 검증** (코드 변경 거의 없음 기대):
+
+```ts
+// packages/sdk/src/openai.ts 의 observeOpenAI 가 이미
+// custom baseURL 받는지 확인
+import OpenAI from 'openai'
+import { observeOpenAI } from '@spanlens/sdk'
+
+const ollama = observeOpenAI(new OpenAI({
+  baseURL: 'http://localhost:11434/v1',
+  apiKey: 'ollama',  // ignored locally
+}), { /* spanlens 옵션 */ })
+
+await ollama.chat.completions.create({
+  model: 'llama3.2',
+  messages: [...],
+})
+```
+
+SDK가 응답을 가로채서 `usage` / `model` 추출 → ingest API로 trace/span 전송. **확인 필요**: 현재 SDK가 baseURL 무관하게 응답 body의 `usage` 필드를 읽는지 (OpenAI 가정 하드코딩 안 되어 있어야 함).
+
+**B. ingest 측 변경**: 없을 가능성 큼. Ollama trace도 결국 `provider: 'openai'`로 ingest되는데, 이건 정직하지 않음. 옵션:
+- B1: SDK가 `baseURL` 패턴 보고 `provider: 'ollama'` 자동 표시 (휴리스틱 — 11434 포트 또는 호스트 매치)
+- B2: `observeOpenAI({ provider: 'ollama' })` 명시 옵션 제공
+- B3: 그냥 `provider: 'openai'` 두고 model name(llama3.2 등)으로 구분
+
+**결정**: B2 (명시 옵션). B1은 휴리스틱이라 깨지기 쉬움, B3는 대시보드 UX 나쁨. 작업: SDK `observeOpenAI` signature에 `provider?: string` 추가 → ingest payload에 그대로 전달.
+
+**C. 비용 계산**: Ollama는 self-hosted → cost=0. `lib/cost.ts`에서 `calculateCost('ollama', ...)` 호출 시 항상 0 또는 null 반환하도록 한 줄 추가. 또는 `requests.cost_usd = null` 로 두고 대시보드에서 "Self-hosted" 배지 표시.
+
+**결정**: cost null + 대시보드 표시. 0이면 차트에서 "비용 절약"으로 오인 가능.
+
+**D. 모델 가격 시드 추가**: 불필요. cost null이면 어차피 lookup 안 함.
+
+**E. 문서**: `apps/web/app/docs/sdk/page.tsx` 또는 해당 mdx에 Ollama 섹션 추가. 위 코드 예제 + "self-hosted이므로 비용은 표시되지 않습니다" 설명.
+
+### 2.3 옵션: Ollama Cloud 지원
+
+Ollama Cloud(ollama.com 호스티드 추론)는 Bearer auth + 공개 endpoint라서 **proxy 만들 수 있음**. 하지만 사용자 수가 매우 적고 (Ollama는 self-hosted가 95% 사용 사례) 우선순위 낮음. 별도 phase로 분리하거나 사용자 요청 들어올 때 추가.
+
+### 2.4 검증
+
+로컬에 Ollama 설치 (`brew install ollama` / `ollama pull llama3.2`) 후:
+1. SDK로 `observeOpenAI({ baseURL: 'localhost:11434/v1', provider: 'ollama' })` 호출
+2. Spanlens 대시보드 `/requests`에 행 들어오는지 확인
+3. usage(prompt/completion tokens) 정상 표시
+4. cost 컬럼 null + UI에서 "Self-hosted" 표시
+5. 스트리밍 trace 정상 (마지막 chunk usage)
+
+---
+
+## 3. PR 분할 계획
+
+| PR | 범위 | 파일 |
+|---|---|---|
+| PR-A1 | DB 마이그레이션 + types 재생성 | `supabase/migrations/*_provider_keys_azure.sql`, `supabase/types.ts` |
+| PR-A2 | Azure proxy + provider key API + UI | `apps/server/src/proxy/azure.ts`, `apps/server/src/proxy/utils.ts`, `apps/server/src/api/providerKeys.ts`, `apps/web/app/settings/**/*.tsx`, `apps/server/src/app.ts`, `apps/server/src/proxy/*.test.ts` |
+| PR-B1 | SDK provider override + Ollama docs | `packages/sdk/src/**`, `apps/web/app/docs/sdk/*` |
+| PR-B2 (선택) | cost.ts ollama=null + 대시보드 self-hosted 배지 | `apps/server/src/lib/cost.ts`, `apps/web/components/requests/*.tsx` |
+
+**PR-A1 먼저 머지 + production 적용** → 그 다음 PR-A2 (CLAUDE.md gotcha #21 의 마이그레이션-deploy 순서). PR-B는 PR-A와 독립.
+
+---
+
+## 4. 위험 / 미확인
+
+| 위험 | 완화 |
+|---|---|
+| Azure v1 endpoint의 `model` 응답 필드가 deployment name이면 cost.ts 매핑 못 함 | 1.5 검증 단계에서 먼저 확인. deployment name이면 1.4 옵션 A1로 fallback |
+| Azure content filter가 200 응답 안에서 `choices[0].finish_reason: "content_filter"`로 막힘 — 비용은 차지 vs 응답 없음 | OpenAI parser는 이미 finish_reason 무관하게 usage 읽음. 추가 작업 불필요. 단 대시보드에서 finish_reason 시각화 검토 (별도 issue) |
+| Customer가 Azure resource URL을 `https://x.openai.azure.com/` (trailing slash) 또는 `x.openai.azure.com` (no scheme) 같이 입력 | provider key 등록 시 정규화: `new URL(input).origin`, 검증 실패 시 400 반환 |
+| `provider_metadata jsonb` 추가가 기존 RLS 정책에 영향 줄 수 있음 | `provider_keys`는 service_role로만 접근 (CLAUDE.md). RLS bypass라 무영향. UI는 항상 `/api/v1/provider-keys` 경유 |
+| Ollama SDK 변경(`provider?` 옵션) 추가 → SDK 메이저 버전 bump 필요한가 | 옵션 추가는 minor (`0.4.0 → 0.5.0`). TS SDK 0.4.0 → 0.5.0, Python SDK 0.3.0 → 0.4.0 |
+
+---
+
+## 5. 미정 결정 (사용자 확인 필요)
+
+1. **Azure provider key UI 입력 form** — resource URL을 단일 텍스트로 받을지 (`https://x.openai.azure.com`) vs resource name만 받고 도메인 자동 결합할지 (`x` → `https://x.openai.azure.com`). 후자가 UX 단순하지만 `services.ai.azure.com` 같은 alternate domain 못 씀.
+2. **Phase A 안에서 비스트리밍/스트리밍 둘 다 한 번에 vs 비스트리밍 먼저** — 한 번에 가는 게 자연스러움 (OpenAI 코드 그대로 복붙).
+3. **Phase B의 SDK 변경을 TS만 먼저 vs TS+Python 동시** — Ollama 사용자는 Python이 더 많을 가능성. 동시 진행 권장.
+4. **Phase C, D (LangGraph, CrewAI)** 는 이 plan 외부에서 별도 진행 — 동의?

--- a/supabase/migrations/20260520100000_provider_keys_azure.sql
+++ b/supabase/migrations/20260520100000_provider_keys_azure.sql
@@ -1,0 +1,52 @@
+-- Migration: provider_keys — add 'azure' provider + provider_metadata jsonb
+--
+-- PR-A1 of integrations-expansion (Azure OpenAI + Ollama). See
+-- docs/plans/integrations-expansion-azure-ollama.md.
+--
+-- Two changes:
+--   1. Extend the provider CHECK constraint to allow 'azure'.
+--   2. Add provider_metadata jsonb for provider-specific config that
+--      doesn't fit a typed column. For 'azure' we store the customer's
+--      Azure resource endpoint there:
+--          { "resource_url": "https://my-resource.openai.azure.com" }
+--      Other providers (openai/anthropic/gemini) keep the default `{}`.
+--
+-- A jsonb column is used over per-provider typed columns so future
+-- additions (AWS Bedrock region, GCP project_id, etc.) don't require
+-- another schema migration each time.
+
+-- ────────────────────────────────────────────────────────────
+-- 1. Swap the CHECK constraint to include 'azure'.
+-- ────────────────────────────────────────────────────────────
+-- The constraint was defined inline in the initial schema, so PG
+-- auto-named it provider_keys_provider_check. Use IF EXISTS in case
+-- a future migration ever renames it.
+ALTER TABLE provider_keys
+  DROP CONSTRAINT IF EXISTS provider_keys_provider_check;
+
+ALTER TABLE provider_keys
+  ADD CONSTRAINT provider_keys_provider_check
+  CHECK (provider IN ('openai', 'anthropic', 'gemini', 'azure'));
+
+-- ────────────────────────────────────────────────────────────
+-- 2. provider_metadata jsonb column.
+-- ────────────────────────────────────────────────────────────
+ALTER TABLE provider_keys
+  ADD COLUMN IF NOT EXISTS provider_metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN provider_keys.provider_metadata IS
+  'Provider-specific metadata. For azure: {"resource_url": "https://<name>.openai.azure.com"}. Empty {} for openai/anthropic/gemini.';
+
+-- ────────────────────────────────────────────────────────────
+-- 3. Constraint: azure rows must carry a resource_url.
+-- ────────────────────────────────────────────────────────────
+-- Validates at INSERT/UPDATE time so the proxy resolver never has to
+-- defensively handle "azure key with no endpoint" — the DB rejects
+-- such rows up front.
+ALTER TABLE provider_keys
+  ADD CONSTRAINT provider_keys_azure_requires_resource_url
+  CHECK (
+    provider <> 'azure'
+    OR (provider_metadata ? 'resource_url'
+        AND length(provider_metadata->>'resource_url') > 0)
+  );

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -1,3 +1,4 @@
+Connecting to db 5432
 export type Json =
   | string
   | number
@@ -7,10 +8,30 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "14.5"
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
   }
   public: {
     Tables: {
@@ -181,6 +202,7 @@ export type Database = {
         Row: {
           baseline_mean: number
           baseline_stddev: number
+          confidence: string | null
           current_value: number
           detected_at: string
           detected_on: string
@@ -196,6 +218,7 @@ export type Database = {
         Insert: {
           baseline_mean: number
           baseline_stddev: number
+          confidence?: string | null
           current_value: number
           detected_at?: string
           detected_on: string
@@ -211,6 +234,7 @@ export type Database = {
         Update: {
           baseline_mean?: number
           baseline_stddev?: number
+          confidence?: string | null
           current_value?: number
           detected_at?: string
           detected_on?: string
@@ -349,6 +373,62 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      billing_downgrade_notifications: {
+        Row: {
+          created_at: string
+          id: string
+          stage: string
+          subscription_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          stage: string
+          subscription_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          stage?: string
+          subscription_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "billing_downgrade_notifications_subscription_id_fkey"
+            columns: ["subscription_id"]
+            isOneToOne: false
+            referencedRelation: "subscriptions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      cron_job_runs: {
+        Row: {
+          duration_ms: number | null
+          error_message: string | null
+          id: string
+          job_name: string
+          ran_at: string
+          status: string
+        }
+        Insert: {
+          duration_ms?: number | null
+          error_message?: string | null
+          id?: string
+          job_name: string
+          ran_at?: string
+          status: string
+        }
+        Update: {
+          duration_ms?: number | null
+          error_message?: string | null
+          id?: string
+          job_name?: string
+          ran_at?: string
+          status?: string
+        }
+        Relationships: []
       }
       dataset_items: {
         Row: {
@@ -874,12 +954,63 @@ export type Database = {
           },
         ]
       }
+      model_price_history: {
+        Row: {
+          cache_read_price_per_1m: number | null
+          cache_write_price_per_1m: number | null
+          change_kind: string
+          changed_at: string
+          changed_by: string | null
+          completion_price_per_1m: number
+          id: string
+          model: string
+          model_price_id: string
+          prompt_price_per_1m: number
+          provider: string
+        }
+        Insert: {
+          cache_read_price_per_1m?: number | null
+          cache_write_price_per_1m?: number | null
+          change_kind: string
+          changed_at?: string
+          changed_by?: string | null
+          completion_price_per_1m: number
+          id?: string
+          model: string
+          model_price_id: string
+          prompt_price_per_1m: number
+          provider: string
+        }
+        Update: {
+          cache_read_price_per_1m?: number | null
+          cache_write_price_per_1m?: number | null
+          change_kind?: string
+          changed_at?: string
+          changed_by?: string | null
+          completion_price_per_1m?: number
+          id?: string
+          model?: string
+          model_price_id?: string
+          prompt_price_per_1m?: number
+          provider?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "model_price_history_model_price_id_fkey"
+            columns: ["model_price_id"]
+            isOneToOne: false
+            referencedRelation: "model_prices"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       model_prices: {
         Row: {
           cache_read_price_per_1m: number | null
           cache_write_price_per_1m: number | null
           completion_price_per_1m: number
           created_at: string
+          effective_from: string
           id: string
           model: string
           prompt_price_per_1m: number
@@ -891,6 +1022,7 @@ export type Database = {
           cache_write_price_per_1m?: number | null
           completion_price_per_1m: number
           created_at?: string
+          effective_from?: string
           id?: string
           model: string
           prompt_price_per_1m: number
@@ -902,10 +1034,56 @@ export type Database = {
           cache_write_price_per_1m?: number | null
           completion_price_per_1m?: number
           created_at?: string
+          effective_from?: string
           id?: string
           model?: string
           prompt_price_per_1m?: number
           provider?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      model_recommendations: {
+        Row: {
+          cost_ratio: number
+          created_at: string
+          current_model: string
+          current_provider: string
+          effective_from: string
+          id: string
+          max_avg_completion_tokens: number
+          max_avg_prompt_tokens: number
+          reason: string
+          suggested_model: string
+          suggested_provider: string
+          updated_at: string
+        }
+        Insert: {
+          cost_ratio: number
+          created_at?: string
+          current_model: string
+          current_provider: string
+          effective_from?: string
+          id?: string
+          max_avg_completion_tokens: number
+          max_avg_prompt_tokens: number
+          reason: string
+          suggested_model: string
+          suggested_provider: string
+          updated_at?: string
+        }
+        Update: {
+          cost_ratio?: number
+          created_at?: string
+          current_model?: string
+          current_provider?: string
+          effective_from?: string
+          id?: string
+          max_avg_completion_tokens?: number
+          max_avg_prompt_tokens?: number
+          reason?: string
+          suggested_model?: string
+          suggested_provider?: string
           updated_at?: string
         }
         Relationships: []
@@ -1315,6 +1493,7 @@ export type Database = {
           name: string
           organization_id: string
           provider: string
+          provider_metadata: Json
           updated_at: string
         }
         Insert: {
@@ -1326,6 +1505,7 @@ export type Database = {
           name: string
           organization_id: string
           provider: string
+          provider_metadata?: Json
           updated_at?: string
         }
         Update: {
@@ -1337,6 +1517,7 @@ export type Database = {
           name?: string
           organization_id?: string
           provider?: string
+          provider_metadata?: Json
           updated_at?: string
         }
         Relationships: [
@@ -1455,6 +1636,36 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      requests_fallback: {
+        Row: {
+          created_at: string
+          id: string
+          last_error: string | null
+          last_retry_at: string | null
+          organization_id: string | null
+          payload: Json
+          retry_count: number
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          last_error?: string | null
+          last_retry_at?: string | null
+          organization_id?: string | null
+          payload: Json
+          retry_count?: number
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          last_error?: string | null
+          last_retry_at?: string | null
+          organization_id?: string | null
+          payload?: Json
+          retry_count?: number
+        }
+        Relationships: []
       }
       saved_filters: {
         Row: {
@@ -1646,6 +1857,7 @@ export type Database = {
           paddle_customer_id: string
           paddle_price_id: string
           paddle_subscription_id: string
+          past_due_since: string | null
           plan: string
           status: string
           updated_at: string
@@ -1661,6 +1873,7 @@ export type Database = {
           paddle_customer_id: string
           paddle_price_id: string
           paddle_subscription_id: string
+          past_due_since?: string | null
           plan: string
           status: string
           updated_at?: string
@@ -1676,6 +1889,7 @@ export type Database = {
           paddle_customer_id?: string
           paddle_price_id?: string
           paddle_subscription_id?: string
+          past_due_since?: string | null
           plan?: string
           status?: string
           updated_at?: string
@@ -1835,6 +2049,36 @@ export type Database = {
           },
         ]
       }
+      user_consents: {
+        Row: {
+          accepted_at: string
+          document: string
+          id: string
+          ip_address: unknown
+          user_agent: string | null
+          user_id: string
+          version: string
+        }
+        Insert: {
+          accepted_at?: string
+          document: string
+          id?: string
+          ip_address?: unknown
+          user_agent?: string | null
+          user_id: string
+          version: string
+        }
+        Update: {
+          accepted_at?: string
+          document?: string
+          id?: string
+          ip_address?: unknown
+          user_agent?: string | null
+          user_id?: string
+          version?: string
+        }
+        Relationships: []
+      }
       user_profiles: {
         Row: {
           created_at: string
@@ -1894,32 +2138,41 @@ export type Database = {
       }
       webhook_deliveries: {
         Row: {
+          attempt_count: number
           delivered_at: string
           duration_ms: number | null
           error_message: string | null
           event_type: string
           http_status: number | null
           id: string
+          next_retry_at: string | null
+          payload: Json | null
           status: string
           webhook_id: string
         }
         Insert: {
+          attempt_count?: number
           delivered_at?: string
           duration_ms?: number | null
           error_message?: string | null
           event_type: string
           http_status?: number | null
           id?: string
+          next_retry_at?: string | null
+          payload?: Json | null
           status: string
           webhook_id: string
         }
         Update: {
+          attempt_count?: number
           delivered_at?: string
           duration_ms?: number | null
           error_message?: string | null
           event_type?: string
           http_status?: number | null
           id?: string
+          next_retry_at?: string | null
+          payload?: Json | null
           status?: string
           webhook_id?: string
         }
@@ -2045,8 +2298,10 @@ export type Database = {
         Args: { p_trace_id: string }
         Returns: undefined
       }
+      prune_cron_job_runs: { Args: never; Returns: undefined }
       prune_logs_by_retention: { Args: never; Returns: Json }
       prune_rate_limit_buckets: { Args: never; Returns: number }
+      set_spanlens_actor: { Args: { actor_id: string }; Returns: undefined }
     }
     Enums: {
       org_role: "admin" | "editor" | "viewer"
@@ -2175,9 +2430,15 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {
       org_role: ["admin", "editor", "viewer"],
     },
   },
 } as const
+
+A new version of Supabase CLI is available: v2.100.1 (currently installed v2.90.0)
+We recommend updating regularly for new features and bug fixes: https://supabase.com/docs/guides/cli/getting-started#updating-the-supabase-cli


### PR DESCRIPTION
**Depends on:** #124 (PR-A1, schema groundwork — `provider_keys.provider_metadata` + `azure` enum). Merge PR-A1 first.

## Summary

PR-A2 of integrations-expansion. Adds Azure OpenAI as a first-class proxy provider, matching the nested-keys model used for OpenAI/Anthropic/Gemini. Customer's Azure resource URL is stored on the `provider_keys` row, so no per-tenant config compiled into the proxy.

## Wire-level approach

Targets Azure's **v1 API endpoint** (`https://<resource>.openai.azure.com/openai/v1/...`) — released GA Aug 2025 by Microsoft. It's drop-in OpenAI-compatible: same request/response shape, same SSE streaming chunks. Only differences:
1. URL — per-resource origin from `provider_metadata.resource_url`
2. Auth header — `api-key: <key>` (not `Authorization: Bearer`)

Azure-only response fields (`prompt_filter_results`, `content_filter_results`, `system_fingerprint`) pass through to the client and are ignored by the OpenAI parser — no parser fork needed.

## Why not the legacy `/openai/deployments/{name}/...` path?

Skipped intentionally. The v1 endpoint dropped the per-deployment URL segment and `api-version` query param specifically to give us a single code path. Supporting both would mean another column on `provider_keys` (api-version) plus deployment→model mapping. v1 alone covers all current Azure OpenAI models.

## Cost

Azure exposes OpenAI models at OpenAI prices, so `proxy/azure.ts` calls `calculateCost('openai', model, ...)` — no parallel price table. If a customer uses a custom deployment name that doesn't match a known model key, `cost_usd` lands as NULL (existing graceful-degradation behavior, no regression).

## Validation defense-in-depth

- **DB layer** (PR-A1) — `provider_keys_azure_requires_resource_url` CHECK rejects azure rows without `resource_url`.
- **API layer** — `normalizeAzureResourceUrl()` in `providerKeys.ts` validates: must parse as URL, https only, host ends in `.openai.azure.com` or `.services.ai.azure.com`. Strips trailing slash + path, lowercases host. Returns canonical origin.
- **Tests** — 11 new unit tests in `azure-resource-url.test.ts` covering normalization + lookalike domain rejection.

## UI changes

`apps/web/app/(dashboard)/projects/projects-client.tsx`:
- Provider dropdown now includes `Azure OpenAI`
- Selecting Azure reveals an extra `Azure resource URL` field above the API key input (placeholder: `https://my-resource.openai.azure.com`)
- Submit button stays disabled until URL is filled (matching existing required-field gating)
- Success snippet shows OpenAI SDK pointed at `/proxy/azure`; the resource URL stays server-side

## Files changed

**Server**
- `proxy/azure.ts` (new, ~220 lines) — clone of `proxy/openai.ts` with Azure-specific auth + per-key base URL
- `proxy/utils.ts` — `ResolvedProviderKey` now carries `metadata: Record<string, unknown>`; both lookup helpers fetch `provider_metadata`
- `app.ts` — mount `/proxy/azure`
- `api/providerKeys.ts` — allow `azure` in `VALID_PROVIDERS`, validate/normalize `provider_metadata.resource_url` on POST, return it in select columns
- `api/me.ts` — `KnownProvider` type now includes `azure`, filter logic generalized
- `api/openapi.ts` — 3 enum locations
- `lib/cost.ts` — `Provider` union extended (call sites still pass `'openai'` for Azure pricing)
- `lib/otlp-mapper.ts` — cast updated for OTLP-ingested Azure traces
- `__tests__/gotcha.test.ts` — adjust assertion shape for new `metadata` field
- `__tests__/azure-resource-url.test.ts` (new) — 11 normalization tests

**Web**
- `lib/queries/types.ts` — `ProviderKey.provider_metadata?: Record<string, unknown>`
- `lib/queries/use-provider-keys.ts` — mutation accepts `'azure'` + `provider_metadata`
- `app/(dashboard)/projects/projects-client.tsx` — Azure entry in PROVIDERS, conditional resource URL field, snippet

## Test plan

- [x] `pnpm --filter server typecheck` — no new errors (2 pre-existing on main unchanged)
- [x] `pnpm --filter web typecheck` clean
- [x] `pnpm --filter server lint` + `pnpm --filter web lint` clean
- [x] 514 tests pass (503 existing + 11 new)
- [x] Web dev server compiles + renders landing page with no console errors
- [ ] After merge to main → Vercel preview → manual auth → /projects → Add provider key → Azure path
- [ ] Smoke against a real Azure subscription before flipping marketing-page provider table from "coming soon" to live