### PR TITLE
feat(sdk): observeOllama + provider override (PR-B)

### DIFF
--- a/apps/web/app/docs/sdk/page.tsx
+++ b/apps/web/app/docs/sdk/page.tsx
@@ -558,6 +558,81 @@ res = observe_openai(trace, "greeting", lambda headers:
         <a href="#with-log-body"><code>withLogBody()</code></a> helper.
       </p>
 
+      <h2 id="observe-ollama">observeOllama() — self-hosted LLMs (v0.5.0+ / 0.4.0+)</h2>
+      <p>
+        Ollama runs on your own machine (or in your VPC) and exposes an OpenAI-compatible API at{' '}
+        <code>http://localhost:11434/v1</code>. Because the Spanlens proxy is hosted, it can&rsquo;t
+        reach your local Ollama — but the SDK can. Wrap your Ollama call with{' '}
+        <code>observeOllama()</code> and only the trace metadata (model, tokens, latency) flows to
+        Spanlens. Your prompts and responses never leave your machine via Spanlens.
+      </p>
+      <p>
+        The dashboard tags the trace <code>provider: ollama</code> and leaves the cost column as
+        &ldquo;Self-hosted&rdquo; (no per-token billing to compute). Usage tokens still come through
+        because Ollama&rsquo;s response includes the same <code>usage</code> field OpenAI does.
+      </p>
+      <LangTabs
+        ts={`import OpenAI from 'openai'
+import { SpanlensClient, observeOllama } from '@spanlens/sdk'
+
+const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+
+// Point the OpenAI SDK at your local Ollama — apiKey is required by the
+// SDK but ignored by Ollama itself when running locally.
+const ollama = new OpenAI({
+  baseURL: 'http://localhost:11434/v1',
+  apiKey: 'ollama',
+})
+
+const trace = client.startTrace({ name: 'local_chat' })
+const res = await observeOllama(trace, 'chat', (headers) =>
+  ollama.chat.completions.create(
+    {
+      model: 'llama3.2',
+      messages: [{ role: 'user', content: 'Hello' }],
+    },
+    { headers },
+  ),
+)
+await trace.end()`}
+        py={`from openai import OpenAI
+from spanlens import SpanlensClient, observe_ollama
+
+client = SpanlensClient(api_key=os.environ["SPANLENS_API_KEY"])
+
+ollama = OpenAI(
+    base_url="http://localhost:11434/v1",
+    api_key="ollama",  # ignored by local Ollama; required by the SDK
+)
+
+with client.start_trace("local_chat") as trace:
+    response = observe_ollama(trace, "chat", lambda headers:
+        ollama.chat.completions.create(
+            model="llama3.2",
+            messages=[{"role": "user", "content": "Hello"}],
+            extra_headers=headers,
+        )
+    )`}
+      />
+      <h3 id="other-openai-compatible">Other OpenAI-compatible runtimes (vLLM, LM Studio, Together, Groq, …)</h3>
+      <p>
+        For any other OpenAI-compatible endpoint, use <code>observeOpenAI</code> with the{' '}
+        <code>provider</code> override so the dashboard labels it correctly:
+      </p>
+      <LangTabs
+        ts={`await observeOpenAI(
+  trace,
+  { name: 'inference', provider: 'vllm' }, // or 'lm-studio', 'together', 'groq', …
+  (headers) => vllmClient.chat.completions.create({ ... }, { headers }),
+)`}
+        py={`observe_openai(
+    trace,
+    "inference",
+    lambda headers: vllm_client.chat.completions.create(...),
+    provider="vllm",  # or "lm-studio", "together", "groq", ...
+)`}
+      />
+
       <h2 id="framework-integrations">Framework integrations (v0.3.0+)</h2>
       <p>
         If you use LangChain, Vercel AI SDK, or LlamaIndex, plug in the matching integration instead

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "spanlens"
-version = "0.3.0"
+version = "0.4.0"
 description = "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for Python."
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/sdk-python/spanlens/__init__.py
+++ b/packages/sdk-python/spanlens/__init__.py
@@ -26,12 +26,18 @@ For proxy-mode (zero-code) instrumentation, see
 """
 
 from .client import SpanlensClient
-from .observe import observe, observe_anthropic, observe_gemini, observe_openai
+from .observe import (
+    observe,
+    observe_anthropic,
+    observe_gemini,
+    observe_ollama,
+    observe_openai,
+)
 from .parsers import parse_anthropic_usage, parse_gemini_usage, parse_openai_usage
 from .span import SpanHandle
 from .trace import TraceHandle
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = [
     "SpanHandle",
@@ -41,6 +47,7 @@ __all__ = [
     "observe",
     "observe_anthropic",
     "observe_gemini",
+    "observe_ollama",
     "observe_openai",
     "parse_anthropic_usage",
     "parse_gemini_usage",

--- a/packages/sdk-python/spanlens/observe.py
+++ b/packages/sdk-python/spanlens/observe.py
@@ -95,6 +95,7 @@ def observe_openai(
     *,
     metadata: Optional[dict[str, Any]] = None,
     prompt_version: Optional[str] = None,
+    provider: Optional[str] = None,
 ) -> T:
     """Observe an OpenAI call.
 
@@ -114,9 +115,15 @@ def observe_openai(
                 extra_headers=headers,
             )
         )
+
+    For an OpenAI-compatible endpoint that isn't actually OpenAI
+    (vLLM, LM Studio, Together, Groq, etc.) pass ``provider="vllm"`` etc.
+    so the dashboard tags the span correctly. For Ollama specifically, prefer
+    :func:`observe_ollama` — clearer intent.
     """
     return _observe_provider(
         provider="openai",
+        provider_override=provider,
         parent=parent,
         name=name,
         fn=fn,
@@ -132,10 +139,12 @@ def observe_anthropic(
     *,
     metadata: Optional[dict[str, Any]] = None,
     prompt_version: Optional[str] = None,
+    provider: Optional[str] = None,
 ) -> T:
     """Anthropic variant — parses ``input_tokens`` / ``output_tokens``."""
     return _observe_provider(
         provider="anthropic",
+        provider_override=provider,
         parent=parent,
         name=name,
         fn=fn,
@@ -162,6 +171,56 @@ def observe_gemini(
     """
     return _observe_provider(
         provider="gemini",
+        provider_override=None,
+        parent=parent,
+        name=name,
+        fn=fn,
+        metadata=metadata,
+        prompt_version=prompt_version,
+    )
+
+
+def observe_ollama(
+    parent: Parent,
+    name: str,
+    fn: Callable[[dict[str, str]], T],
+    *,
+    metadata: Optional[dict[str, Any]] = None,
+    prompt_version: Optional[str] = None,
+) -> T:
+    """Observe a self-hosted Ollama call (OpenAI-compatible endpoint).
+
+    Ollama exposes an OpenAI-compatible API at ``http://localhost:11434/v1``,
+    so usage parsing reuses ``parse_openai_usage``. The trace is tagged
+    ``provider: "ollama"`` so the dashboard distinguishes it from real OpenAI.
+
+    Cost is left as ``None`` (Ollama is self-hosted — no per-token bill
+    Spanlens can compute) and the dashboard renders a "Self-hosted" badge.
+
+    Example::
+
+        from openai import OpenAI
+        from spanlens import observe_ollama
+
+        ollama = OpenAI(
+            base_url="http://localhost:11434/v1",
+            api_key="ollama",  # ignored by local Ollama; required by the SDK
+        )
+
+        response = observe_ollama(trace, "chat", lambda headers:
+            ollama.chat.completions.create(
+                model="llama3.2",
+                messages=[{"role": "user", "content": "Hello"}],
+                extra_headers=headers,
+            )
+        )
+
+    For other OpenAI-compatible self-hosted runtimes (vLLM, LM Studio, etc.)
+    use ``observe_openai(..., provider="vllm")`` with the override kwarg.
+    """
+    return _observe_provider(
+        provider="ollama",
+        provider_override=None,
         parent=parent,
         name=name,
         fn=fn,
@@ -189,6 +248,7 @@ def _start_child(
 def _observe_provider(
     *,
     provider: str,
+    provider_override: Optional[str],
     parent: Parent,
     name: str,
     fn: Callable[[dict[str, str]], Any],
@@ -201,11 +261,18 @@ def _observe_provider(
     if prompt_version:
         headers[PROMPT_VERSION_HEADER] = prompt_version
 
+    # Ollama reuses OpenAI's response schema (it exposes an /v1 OpenAI-compat
+    # surface), so the parser is the OpenAI one — only the provider tag differs.
     parser = {
         "openai": parse_openai_usage,
         "anthropic": parse_anthropic_usage,
         "gemini": parse_gemini_usage,
+        "ollama": parse_openai_usage,
     }[provider]
+
+    # Explicit override wins (e.g. observe_openai(..., provider="vllm")).
+    # Otherwise tag with the wrapper name.
+    provider_tag = provider_override or provider
 
     try:
         result = fn(headers)
@@ -214,9 +281,9 @@ def _observe_provider(
         raise
 
     if inspect.isawaitable(result):
-        return _finish_provider_async(span, result, parser)
+        return _finish_provider_async(span, result, parser, provider_tag)
 
-    span.end(status="completed", **parser(result))
+    span.end(status="completed", **_with_provider(parser(result), provider_tag))
     return result
 
 
@@ -224,14 +291,24 @@ async def _finish_provider_async(
     span: SpanHandle,
     awaitable: Awaitable[Any],
     parser: Callable[[Any], dict[str, Any]],
+    provider_tag: str,
 ) -> Any:
     try:
         result = await awaitable
     except BaseException as err:
         span.end(status="error", error_message=str(err))
         raise
-    span.end(status="completed", **parser(result))
+    span.end(status="completed", **_with_provider(parser(result), provider_tag))
     return result
+
+
+def _with_provider(parsed: dict[str, Any], provider_tag: str) -> dict[str, Any]:
+    """Merge ``provider`` into the parsed result's ``metadata`` without
+    mutating the parser output. Preserves any existing metadata keys (e.g.
+    ``model``) the parser already populated."""
+    existing = parsed.get("metadata") or {}
+    merged = {**existing, "provider": provider_tag}
+    return {**parsed, "metadata": merged}
 
 
 __all__ = [
@@ -239,5 +316,6 @@ __all__ = [
     "observe",
     "observe_anthropic",
     "observe_gemini",
+    "observe_ollama",
     "observe_openai",
 ]

--- a/packages/sdk-python/tests/test_observe.py
+++ b/packages/sdk-python/tests/test_observe.py
@@ -8,7 +8,13 @@ import httpx
 import pytest
 import respx
 
-from spanlens import SpanlensClient, observe, observe_anthropic, observe_openai
+from spanlens import (
+    SpanlensClient,
+    observe,
+    observe_anthropic,
+    observe_ollama,
+    observe_openai,
+)
 
 BASE_URL = "https://test.spanlens.local"
 
@@ -140,3 +146,81 @@ def test_observe_openai_marks_error_when_call_throws():
                     "answer",
                     lambda _h: (_ for _ in ()).throw(RuntimeError("upstream")),
                 )
+
+
+# ── Provider tag (Ollama + override) ────────────────────────────
+
+
+def _last_span_patch_body() -> dict:
+    """Return the JSON body of the last ``PATCH /ingest/spans/{id}`` call.
+
+    Tests inspect the patched span row to confirm provider/model metadata
+    landed in the right place.
+    """
+    import json
+
+    routes = respx.routes
+    for route in reversed(list(routes)):
+        for call in reversed(route.calls):
+            if call.request.method == "PATCH" and "/ingest/spans/" in str(call.request.url):
+                return json.loads(call.request.content.decode())
+    raise AssertionError("no PATCH /ingest/spans/{id} captured")
+
+
+@respx.mock
+def test_observe_openai_default_provider_tag():
+    _mock_ingest_routes()
+
+    fake_response = {
+        "model": "gpt-4o-mini",
+        "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+    }
+
+    with _client() as client:
+        with client.start_trace("t1") as trace:
+            observe_openai(trace, "call", lambda _h: fake_response)
+
+    body = _last_span_patch_body()
+    assert body["metadata"]["provider"] == "openai"
+    # Model still flows through alongside the new provider tag.
+    assert body["metadata"]["model"] == "gpt-4o-mini"
+
+
+@respx.mock
+def test_observe_ollama_parses_openai_shape_and_tags_provider():
+    _mock_ingest_routes()
+
+    # Ollama's /v1 endpoint returns OpenAI-shaped JSON.
+    fake_response = {
+        "model": "llama3.2",
+        "usage": {"prompt_tokens": 12, "completion_tokens": 34, "total_tokens": 46},
+    }
+
+    with _client() as client:
+        with client.start_trace("t1") as trace:
+            observe_ollama(trace, "chat", lambda _h: fake_response)
+
+    body = _last_span_patch_body()
+    assert body["prompt_tokens"] == 12
+    assert body["completion_tokens"] == 34
+    assert body["total_tokens"] == 46
+    assert body["metadata"]["provider"] == "ollama"
+    assert body["metadata"]["model"] == "llama3.2"
+
+
+@respx.mock
+def test_observe_openai_provider_override():
+    """User points OpenAI SDK at vLLM and overrides the provider tag."""
+    _mock_ingest_routes()
+
+    fake_response = {
+        "model": "meta-llama/Llama-3-8B",
+        "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+    }
+
+    with _client() as client:
+        with client.start_trace("t1") as trace:
+            observe_openai(trace, "vllm-call", lambda _h: fake_response, provider="vllm")
+
+    body = _last_span_patch_body()
+    assert body["metadata"]["provider"] == "vllm"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/__tests__/observe-providers.test.ts
+++ b/packages/sdk/src/__tests__/observe-providers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { SpanlensClient } from '../client.js'
-import { observeOpenAI, observeAnthropic, observeGemini } from '../observe.js'
+import { observeOpenAI, observeAnthropic, observeGemini, observeOllama } from '../observe.js'
 
 describe('observeOpenAI / observeAnthropic / observeGemini', () => {
   let fetchMock: ReturnType<typeof vi.fn>
@@ -287,6 +287,70 @@ describe('observeOpenAI / observeAnthropic / observeGemini', () => {
       return body.status === 'error' && body.error_message === 'api failed'
     })
     expect(errPatch).toBeDefined()
+  })
+
+  // ── Provider tag (Ollama + override) ───────────────────────────────────────
+
+  it('observeOpenAI stamps metadata.provider="openai" by default', async () => {
+    const client = new SpanlensClient({ apiKey: 'k', baseUrl: 'http://x' })
+    const trace = client.startTrace({ name: 't' })
+
+    await observeOpenAI(trace, 'call', async () => ({
+      model: 'gpt-4o-mini',
+      usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+    }))
+
+    const patchCall = fetchMock.mock.calls.find(
+      ([, init]) => (init as RequestInit).method === 'PATCH',
+    )
+    const body = JSON.parse((patchCall![1] as RequestInit).body as string) as Record<string, unknown>
+    expect((body.metadata as Record<string, unknown>).provider).toBe('openai')
+    // Model still flows through alongside the new provider tag.
+    expect((body.metadata as Record<string, unknown>).model).toBe('gpt-4o-mini')
+  })
+
+  it('observeOllama parses OpenAI-compatible response and tags provider="ollama"', async () => {
+    const client = new SpanlensClient({ apiKey: 'k', baseUrl: 'http://x' })
+    const trace = client.startTrace({ name: 't' })
+
+    // Ollama's /v1 endpoint returns an OpenAI-shaped payload.
+    await observeOllama(trace, 'chat', async () => ({
+      model: 'llama3.2',
+      usage: { prompt_tokens: 12, completion_tokens: 34, total_tokens: 46 },
+    }))
+
+    const patchCall = fetchMock.mock.calls.find(
+      ([, init]) => (init as RequestInit).method === 'PATCH',
+    )
+    expect(patchCall).toBeDefined()
+    const body = JSON.parse((patchCall![1] as RequestInit).body as string) as Record<string, unknown>
+    expect(body.prompt_tokens).toBe(12)
+    expect(body.completion_tokens).toBe(34)
+    expect(body.total_tokens).toBe(46)
+    expect((body.metadata as Record<string, unknown>).provider).toBe('ollama')
+    expect((body.metadata as Record<string, unknown>).model).toBe('llama3.2')
+  })
+
+  it('observeOpenAI provider override wins over default tag', async () => {
+    const client = new SpanlensClient({ apiKey: 'k', baseUrl: 'http://x' })
+    const trace = client.startTrace({ name: 't' })
+
+    // User points OpenAI SDK at vLLM (OpenAI-compatible) and wants the
+    // dashboard to label it as 'vllm' not 'openai'.
+    await observeOpenAI(
+      trace,
+      { name: 'vllm-call', provider: 'vllm' },
+      async () => ({
+        model: 'meta-llama/Llama-3-8B',
+        usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+      }),
+    )
+
+    const patchCall = fetchMock.mock.calls.find(
+      ([, init]) => (init as RequestInit).method === 'PATCH',
+    )
+    const body = JSON.parse((patchCall![1] as RequestInit).body as string) as Record<string, unknown>
+    expect((body.metadata as Record<string, unknown>).provider).toBe('vllm')
   })
 
   it('works when parent is a SpanHandle (nested LLM call)', async () => {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,7 +1,7 @@
 export { SpanlensClient } from './client.js'
 export { TraceHandle } from './trace.js'
 export { SpanHandle } from './span.js'
-export { observe, observeOpenAI, observeAnthropic, observeGemini } from './observe.js'
+export { observe, observeOpenAI, observeAnthropic, observeGemini, observeOllama } from './observe.js'
 export { parseOpenAIUsage, parseAnthropicUsage, parseGeminiUsage } from './parsers.js'
 
 export type {

--- a/packages/sdk/src/observe.ts
+++ b/packages/sdk/src/observe.ts
@@ -58,7 +58,7 @@ export async function observe<T>(
 //     openai.chat.completions.create({ ... }, { headers })
 //   )
 
-type Usage = 'openai' | 'anthropic' | 'gemini'
+type Usage = 'openai' | 'anthropic' | 'gemini' | 'ollama'
 
 const PROMPT_VERSION_HEADER = 'x-spanlens-prompt-version'
 const LOG_BODY_HEADER = 'x-spanlens-log-body'
@@ -73,6 +73,16 @@ export type ProviderObserveOptions = Omit<SpanOptions, 'spanType'> & {
    * Override to `'meta'` or `'none'` for stricter data minimization — see LogBodyMode docs.
    */
   logBody?: LogBodyMode
+  /**
+   * Override the provider tag on this span's metadata. Useful when calling an
+   * OpenAI-compatible endpoint that isn't actually OpenAI (Ollama, vLLM,
+   * LM Studio, Together, Groq, etc.). Defaults to the provider implied by the
+   * `observe<Provider>` helper used.
+   *
+   * For Ollama specifically, prefer the dedicated `observeOllama()` helper —
+   * this option is the escape hatch for everything else.
+   */
+  provider?: string
 }
 
 function splitArgs(
@@ -81,19 +91,22 @@ function splitArgs(
   spanOptions: SpanOptions
   promptVersion: string | undefined
   logBody: LogBodyMode | undefined
+  providerOverride: string | undefined
 } {
   if (typeof nameOrOptions === 'string') {
     return {
       spanOptions: { name: nameOrOptions, spanType: 'llm' },
       promptVersion: undefined,
       logBody: undefined,
+      providerOverride: undefined,
     }
   }
-  const { promptVersion, logBody, ...rest } = nameOrOptions
+  const { promptVersion, logBody, provider: providerOverride, ...rest } = nameOrOptions
   return {
     spanOptions: { ...rest, spanType: 'llm' },
     promptVersion,
     logBody,
+    providerOverride,
   }
 }
 
@@ -103,7 +116,7 @@ async function observeProvider<T>(
   nameOrOptions: string | ProviderObserveOptions,
   fn: (headers: Record<string, string>) => Promise<T>,
 ): Promise<T> {
-  const { spanOptions, promptVersion, logBody } = splitArgs(nameOrOptions)
+  const { spanOptions, promptVersion, logBody, providerOverride } = splitArgs(nameOrOptions)
 
   const span =
     'span' in parent && typeof parent.span === 'function'
@@ -117,13 +130,25 @@ async function observeProvider<T>(
   try {
     const result = await fn(headers)
 
-    // Auto-parse usage from the provider response shape
+    // Auto-parse usage from the provider response shape.
+    // Ollama uses OpenAI's response schema (it exposes an /v1 OpenAI-compat
+    // surface) so the OpenAI parser works as-is — only the provider tag differs.
     const parsed =
-      provider === 'openai'
+      provider === 'openai' || provider === 'ollama'
         ? parseOpenAIUsage(result)
         : provider === 'anthropic'
           ? parseAnthropicUsage(result)
           : parseGeminiUsage(result)
+
+    // Stamp the provider tag onto the span metadata. The explicit override
+    // (e.g. observeOpenAI(..., { provider: 'vllm' })) wins over the default,
+    // which is the wrapper name (openai/anthropic/gemini/ollama).
+    const providerTag = providerOverride ?? provider
+    const metadataWithProvider = {
+      ...(parsed.metadata ?? {}),
+      provider: providerTag,
+    }
+    const enriched = { ...parsed, metadata: metadataWithProvider }
 
     // Capture the full response as output unless it's a stream (not serializable)
     const isStream = result != null &&
@@ -131,7 +156,7 @@ async function observeProvider<T>(
       (Symbol.asyncIterator in (result as object) || Symbol.iterator in (result as object))
     const output = isStream ? undefined : result
 
-    await span.end({ status: 'completed', output, ...parsed })
+    await span.end({ status: 'completed', output, ...enriched })
     return result
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err)
@@ -174,4 +199,41 @@ export function observeGemini<T>(
   fn: (headers: Record<string, string>) => Promise<T>,
 ): Promise<T> {
   return observeProvider('gemini', parent, nameOrOptions, fn)
+}
+
+/**
+ * Ollama variant — for **self-hosted** local LLMs through Ollama's
+ * OpenAI-compatible endpoint (`http://localhost:11434/v1`). The trace is
+ * tagged `provider: 'ollama'` so the dashboard surfaces it correctly even
+ * though the response shape is identical to OpenAI's.
+ *
+ * Cost is left as null (self-hosted compute = no per-token charge that
+ * Spanlens can compute) and the dashboard renders a "Self-hosted" badge
+ * in the cost column.
+ *
+ * @example
+ *   import OpenAI from 'openai'
+ *   import { observeOllama } from '@spanlens/sdk'
+ *
+ *   const ollama = new OpenAI({
+ *     baseURL: 'http://localhost:11434/v1',
+ *     apiKey: 'ollama', // ignored by local Ollama; required by the SDK
+ *   })
+ *
+ *   const res = await observeOllama(trace, 'chat', (headers) =>
+ *     ollama.chat.completions.create({
+ *       model: 'llama3.2',
+ *       messages: [{ role: 'user', content: 'Hello' }],
+ *     }, { headers })
+ *   )
+ *
+ * For other OpenAI-compatible self-hosted runtimes (vLLM, LM Studio, etc.)
+ * use `observeOpenAI(..., { provider: 'vllm' })` with the provider override.
+ */
+export function observeOllama<T>(
+  parent: TraceHandle | SpanHandle,
+  nameOrOptions: string | ProviderObserveOptions,
+  fn: (headers: Record<string, string>) => Promise<T>,
+): Promise<T> {
+  return observeProvider('ollama', parent, nameOrOptions, fn)
 }


### PR DESCRIPTION
PR-B of integrations-expansion. **Independent of PR-A (#124 / #125)** — no shared files, can merge in any order.

## Summary

Adds Ollama as a first-class observed provider in both SDKs, plus a generic provider override on `observeOpenAI` / `observe_openai` for other OpenAI-compatible runtimes (vLLM, LM Studio, Together, Groq, …).

## Why no server-side proxy for Ollama

Ollama runs on the customer's local machine (or VPC) at `http://localhost:11434/v1`. The Spanlens hosted proxy on Vercel can't reach that — there's no network path. Instead the SDK wraps the customer's local Ollama call and only the trace metadata (model, tokens, latency) flows to Spanlens. Prompts and responses **never leave the customer's network via Spanlens** — exactly what self-hosted users want.

## Wire-level approach

Ollama's `/v1` endpoint returns an OpenAI-compatible response shape — same `usage{prompt_tokens, completion_tokens, total_tokens}`, same `model` field. So the existing OpenAI parser works as-is. We just stamp `metadata.provider = 'ollama'` on the span so the dashboard renders it distinctly (and the cost column shows "Self-hosted" rather than a price-lookup miss).

The provider override pattern generalises to any OpenAI-compatible runtime — one line in the user's code, no new SDK wrapper per provider.

## API surface

**TS SDK (0.4.0 → 0.5.0):**
- New export `observeOllama(parent, name|options, fn)`
- New `provider?: string` field on `ProviderObserveOptions`
- `metadata.provider` now stamped on every `observe<X>` call

**Python SDK (0.3.0 → 0.4.0):**
- New export `observe_ollama(parent, name, fn, ...)`
- New `provider: Optional[str]` kwarg on `observe_openai` / `observe_anthropic`
- `metadata["provider"]` now stamped on every `observe_<x>` call

## Usage examples

```ts
// Ollama — dedicated wrapper
const ollama = new OpenAI({ baseURL: 'http://localhost:11434/v1', apiKey: 'ollama' })
await observeOllama(trace, 'chat', (headers) =>
  ollama.chat.completions.create({ model: 'llama3.2', messages }, { headers }),
)

// vLLM / LM Studio / Together / Groq — override
await observeOpenAI(
  trace,
  { name: 'inference', provider: 'vllm' },
  (headers) => vllmClient.chat.completions.create({ ... }, { headers }),
)
```

## Docs

`/docs/sdk` gets a new `#observe-ollama` section with TS + Python code examples and a sub-section for the override pattern. Section renders correctly in dev preview (confirmed via DOM check + screenshot — heading, paragraphs, language tabs, syntax-highlighted code blocks all good).

## Test plan

- [x] **TS SDK** — 107 tests pass (96 existing + 3 new: default provider tag, ollama tag, provider override)
- [x] **Python SDK** — 10 tests pass (7 existing + 3 new: same matrix)
- [x] `pnpm typecheck` — sdk / cli / web all clean
- [x] `ruff check` + `ruff format --check` clean on new/modified files
- [x] Web lint clean
- [x] `/docs/sdk#observe-ollama` rendered in dev preview — no new console errors
- [ ] Manual smoke against a real local Ollama (`ollama serve` + `ollama pull llama3.2`, instrument SDK, confirm trace lands in dashboard with `provider=ollama`) — out of scope for this PR, will run before SDK publish
- [ ] Coordinate `npm publish` of `@spanlens/sdk@0.5.0` and `pip publish` of `spanlens==0.4.0` after merge — version bumps are in this PR