### PR TITLE
fix(api): convert ClickHouse timestamps to ISO UTC at API boundary

### DIFF
--- a/apps/server/src/api/exports.ts
+++ b/apps/server/src/api/exports.ts
@@ -3,6 +3,7 @@ import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { detectAnomalies } from '../lib/anomaly.js'
 import { requestsScope, selectRequests, streamRequests } from '../lib/requests-query.js'
+import { fromClickhouseTimestamp } from '../lib/clickhouse.js'
 
 export const exportsRouter = new Hono<JwtContext>()
 exportsRouter.use('*', authJwt)
@@ -177,8 +178,14 @@ exportsRouter.get('/requests', async (c) => {
       console.error('[exports:requests] ClickHouse query failed:', err instanceof Error ? err.message : err)
       return c.json({ error: 'Failed to export requests' }, 500)
     }
+    // ClickHouse DateTime64 → ISO UTC (gotcha #18). Streaming CSV/JSONL paths
+    // below still emit raw format; they should be wrapped too in a follow-up.
+    const normalised = rows.map((r) => ({
+      ...r,
+      created_at: fromClickhouseTimestamp(typeof r.created_at === 'string' ? r.created_at : null) ?? r.created_at,
+    }))
     const body = JSON.stringify(
-      { exported_at: new Date().toISOString(), count: rows.length, data: rows },
+      { exported_at: new Date().toISOString(), count: normalised.length, data: normalised },
       null,
       2,
     )
@@ -380,11 +387,15 @@ exportsRouter.get('/security', async (c) => {
   }
 
   // CSV gets the flags column as a string literal; JSON parses it back to an array.
+  // Both formats get a canonical ISO UTC `created_at` (with `Z` suffix) so
+  // downstream consumers don't have to guess the timezone of ClickHouse's
+  // 'YYYY-MM-DD HH:MM:SS.fff' format. Excel still parses ISO datetime fine.
   const rows: Record<string, unknown>[] = data.map((row) => {
-    if (format === 'csv') return row
+    const isoCreated = fromClickhouseTimestamp(row.created_at) ?? row.created_at
+    if (format === 'csv') return { ...row, created_at: isoCreated }
     let parsedFlags: unknown = []
     try { parsedFlags = JSON.parse(row.flags) } catch { parsedFlags = row.flags }
-    return { ...row, flags: parsedFlags }
+    return { ...row, flags: parsedFlags, created_at: isoCreated }
   })
 
   const dateStr = new Date().toISOString().slice(0, 10)

--- a/apps/server/src/api/requests.ts
+++ b/apps/server/src/api/requests.ts
@@ -12,6 +12,7 @@ import {
   countRequests,
   fetchProviderKeyNames,
 } from '../lib/requests-query.js'
+import { fromClickhouseTimestamp } from '../lib/clickhouse.js'
 
 export const requestsRouter = new Hono<JwtContext>()
 
@@ -128,6 +129,10 @@ requestsRouter.get('/', async (c) => {
       cost_usd: row.cost_usd == null ? null : Number(row.cost_usd),
       // ClickHouse returns UInt8 as a number ("0" / "1" depending on driver); normalize.
       truncated: Boolean(Number(row.truncated)),
+      // ClickHouse DateTime64 format ('YYYY-MM-DD HH:MM:SS.fff') has no 'T'/'Z'
+      // so JS new Date() interprets as local time → "9h ago" bug for KST users.
+      // Convert to canonical ISO UTC at the API boundary. See gotcha #18.
+      created_at: fromClickhouseTimestamp(row.created_at) ?? row.created_at,
       provider_key_name: row.provider_key_id ? (keyMap.get(row.provider_key_id) ?? null) : null,
     }))
 
@@ -196,6 +201,8 @@ requestsRouter.get('/:id', async (c) => {
       ...data,
       cost_usd: data.cost_usd == null ? null : Number(data.cost_usd),
       truncated: Boolean(Number(data.truncated)),
+      // ClickHouse timestamp → ISO UTC (see gotcha #18 / list endpoint).
+      created_at: fromClickhouseTimestamp(data.created_at) ?? data.created_at,
       request_body: parseJsonColumn(data.request_body, null),
       response_body: parseJsonColumn(data.response_body, null),
       flags: parseJsonColumn(data.flags, []),

--- a/apps/server/src/api/security.ts
+++ b/apps/server/src/api/security.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { requestsScope, selectRequests, countRequests } from '../lib/requests-query.js'
+import { fromClickhouseTimestamp } from '../lib/clickhouse.js'
 import { getSecuritySummary } from '../lib/stats-queries.js'
 import { parseIntMin, parsePositiveInt } from '../lib/params.js'
 
@@ -61,6 +62,8 @@ securityRouter.get('/flagged', async (c) => {
       cost_usd: r.cost_usd == null ? null : Number(r.cost_usd),
       flags: parseFlags(r.flags),
       response_flags: parseFlags(r.response_flags),
+      // Convert ClickHouse DateTime64 to canonical ISO UTC (gotcha #18).
+      created_at: fromClickhouseTimestamp(r.created_at) ?? r.created_at,
     }))
     return c.json({
       success: true,

--- a/apps/server/src/lib/clickhouse.test.ts
+++ b/apps/server/src/lib/clickhouse.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { toClickhouseTimestamp, fromClickhouseTimestamp } from './clickhouse.js'
+
+describe('toClickhouseTimestamp', () => {
+  it("strips T and Z so ClickHouse's DateTime64 parser accepts it", () => {
+    const fixed = new Date('2026-05-20T07:00:00.000Z')
+    expect(toClickhouseTimestamp(fixed)).toBe('2026-05-20 07:00:00.000')
+  })
+
+  it('defaults to now when no Date is passed', () => {
+    const out = toClickhouseTimestamp()
+    expect(out).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}$/)
+    expect(out).not.toContain('T')
+    expect(out).not.toContain('Z')
+  })
+})
+
+describe('fromClickhouseTimestamp', () => {
+  it('round-trips with toClickhouseTimestamp', () => {
+    const original = new Date('2026-05-20T07:00:00.000Z')
+    const ch = toClickhouseTimestamp(original)
+    const iso = fromClickhouseTimestamp(ch)
+    expect(new Date(iso!).toISOString()).toBe('2026-05-20T07:00:00.000Z')
+  })
+
+  it('produces a string that JS Date parses as UTC, not local time', () => {
+    // Symptom of the bug this helper fixes: without the Z suffix, a Korean
+    // (UTC+9) browser interprets "2026-05-20 07:00:00.000" as 07:00 KST =
+    // 22:00 UTC the previous day. The helper must add the Z back so the
+    // parsed UTC time matches what ClickHouse stored.
+    const ch = '2026-05-20 07:00:00.000'
+    const iso = fromClickhouseTimestamp(ch)
+    expect(iso).toBe('2026-05-20T07:00:00.000Z')
+    // The parsed UTC hours must be 07, regardless of the runtime timezone.
+    expect(new Date(iso!).getUTCHours()).toBe(7)
+    expect(new Date(iso!).getUTCDate()).toBe(20)
+  })
+
+  it('returns null for null/undefined/empty input', () => {
+    expect(fromClickhouseTimestamp(null)).toBeNull()
+    expect(fromClickhouseTimestamp(undefined)).toBeNull()
+    expect(fromClickhouseTimestamp('')).toBeNull()
+  })
+
+  it('handles timestamps without sub-second precision (some CH columns)', () => {
+    expect(fromClickhouseTimestamp('2026-05-20 07:00:00')).toBe('2026-05-20T07:00:00Z')
+  })
+})

--- a/apps/server/src/lib/clickhouse.ts
+++ b/apps/server/src/lib/clickhouse.ts
@@ -126,3 +126,21 @@ export function getOrgClickhouse(organizationId: string): { client: ClickHouseCl
 export function toClickhouseTimestamp(date: Date = new Date()): string {
   return date.toISOString().replace('T', ' ').replace('Z', '')
 }
+
+/**
+ * Inverse of `toClickhouseTimestamp` — converts a ClickHouse DateTime64 string
+ * (`'YYYY-MM-DD HH:MM:SS.fff'`) back to an ISO-8601 UTC string ending in `Z`
+ * so client JS `new Date(...)` parses it as UTC, not local time.
+ *
+ * Symptom of forgetting this on the wire boundary: rows show up "9h ago"
+ * (KST offset) when they were actually created seconds ago — JS without the
+ * `Z` interprets the timestamp as local time. See CLAUDE.md gotcha #18.
+ *
+ * Returns null for null/empty input so callers can pass through nullable
+ * timestamp columns without extra branching.
+ */
+export function fromClickhouseTimestamp(s: string | null | undefined): string | null {
+  if (!s) return null
+  // ClickHouse format: '2026-05-20 07:00:00.000' → '2026-05-20T07:00:00.000Z'
+  return s.replace(' ', 'T') + 'Z'
+}


### PR DESCRIPTION
**Symptom**: \`/requests\` page shows rows as \"9h ago\" right after a fresh call. Surfaced during the 2026-05-20 Azure smoke session — the curl returned 200 but the dashboard relative-time was off by exactly the KST offset (UTC+9).

## Root cause

ClickHouse's \`JSONEachRow\` returns DateTime64 as \`'YYYY-MM-DD HH:MM:SS.fff'\` — no \`'T'\`, no \`'Z'\`. JS \`new Date(...)\` on that interprets the string as **local time** (KST = UTC+9), so a freshly-inserted UTC row gets parsed as 9 hours older than reality.

This is the exact same trap CLAUDE.md gotcha #18 warns about, just on the read side. The write side already uses \`toClickhouseTimestamp\` to strip T/Z (so CH accepts the insert). The read side never added them back.

## Fix

A small \`fromClickhouseTimestamp\` helper in \`lib/clickhouse.ts\` — the inverse of \`toClickhouseTimestamp\` — that adds \`'T'\` and \`'Z'\` back. Apply at the API boundary in every endpoint that returns ClickHouse \`created_at\` to a client:

- \`GET /api/v1/requests\` (list)
- \`GET /api/v1/requests/:id\` (detail)
- \`GET /api/v1/security/flagged\`
- \`GET /api/v1/exports/requests?format=json\`

### Deferred

\`/api/v1/exports/requests?format=csv|jsonl\` still emits raw ClickHouse format because the row iterator is consumed inline by \`buildCsvStream\` / \`buildJsonlStream\`. Wrapping each row would require either a new \`map\` step before the stream builder or a row-transform parameter on the builders. Out of scope for this fix — separate follow-up since CSV consumers (Excel, pandas) generally parse the non-Z format OK as local time, just with the same TZ ambiguity.

## Test plan

- [x] 6 new unit tests in \`lib/clickhouse.test.ts\` (round-trip, the specific \"9h ago\" UTC parsing assertion, null/empty passthrough, sub-second-less timestamps)
- [x] All 520 server tests pass (was 514 — 6 new)
- [x] Server typecheck + lint clean (the 2 pre-existing errors on main unchanged)
- [ ] Manual: after merge → Vercel preview → /requests should show \"2s\" / \"1m\" for fresh rows, not \"9h\"