### PR TITLE
fix(exports): ISO UTC created_at in streaming CSV/JSONL (PR #130 follow-up)

### DIFF
--- a/apps/server/src/__tests__/exports-stream.test.ts
+++ b/apps/server/src/__tests__/exports-stream.test.ts
@@ -20,7 +20,7 @@ process.env['CLICKHOUSE_URL'] ??= 'http://localhost:8123'
 process.env['CLICKHOUSE_USER'] ??= 'default'
 process.env['CLICKHOUSE_PASSWORD'] ??= 'test'
 
-import { buildCsvStream, buildJsonlStream } from '../api/exports.js'
+import { buildCsvStream, buildJsonlStream, withIsoCreatedAt } from '../api/exports.js'
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -198,11 +198,18 @@ describe('streaming-encoder memory bound', () => {
 
 const clickhouseQueryMock = vi.fn()
 
-vi.mock('../lib/clickhouse.js', () => ({
-  getClickhouse: () => ({
-    query: (opts: unknown) => clickhouseQueryMock(opts),
-  }),
-}))
+vi.mock('../lib/clickhouse.js', async (importOriginal) => {
+  // Partial mock: replace the client singleton with our mock query fn, but
+  // keep the real `fromClickhouseTimestamp` / `toClickhouseTimestamp` helpers
+  // intact so the streaming `withIsoCreatedAt` tests below exercise real logic.
+  const actual = await importOriginal<typeof import('../lib/clickhouse.js')>()
+  return {
+    ...actual,
+    getClickhouse: () => ({
+      query: (opts: unknown) => clickhouseQueryMock(opts),
+    }),
+  }
+})
 
 let streamRequests: typeof import('../lib/requests-query.js').streamRequests
 
@@ -318,5 +325,62 @@ describe('streamRequests', () => {
     // Pull one row then break — generator's finally should run.
     for await (const _ of iter) { void _; break }
     expect(result.close).toHaveBeenCalled()
+  })
+})
+
+// ── withIsoCreatedAt (PR #130 follow-up: streaming created_at conversion) ────
+
+describe('withIsoCreatedAt', () => {
+  async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+    const out: T[] = []
+    for await (const item of iter) out.push(item)
+    return out
+  }
+
+  test("converts ClickHouse 'YYYY-MM-DD HH:MM:SS.fff' to ISO UTC with Z", async () => {
+    const rows = await collect(withIsoCreatedAt(fromArray([
+      { id: '1', created_at: '2026-05-20 07:00:00.000' },
+      { id: '2', created_at: '2026-05-20 07:00:01.500' },
+    ])))
+    expect(rows).toEqual([
+      { id: '1', created_at: '2026-05-20T07:00:00.000Z' },
+      { id: '2', created_at: '2026-05-20T07:00:01.500Z' },
+    ])
+  })
+
+  test('preserves other fields unchanged (immutable spread)', async () => {
+    const rows = await collect(withIsoCreatedAt(fromArray([
+      { id: 'abc', cost_usd: 0.0042, model: 'gpt-4o', created_at: '2026-05-20 07:00:00.000' },
+    ])))
+    expect(rows[0]).toEqual({
+      id: 'abc',
+      cost_usd: 0.0042,
+      model: 'gpt-4o',
+      created_at: '2026-05-20T07:00:00.000Z',
+    })
+  })
+
+  test('passes through rows whose created_at is not a string (null / missing)', async () => {
+    const rows = await collect(withIsoCreatedAt(fromArray<Record<string, unknown>>([
+      { id: '1', created_at: null },
+      { id: '2' },
+    ])))
+    expect(rows).toEqual([
+      { id: '1', created_at: null },
+      { id: '2' },
+    ])
+  })
+
+  test('UTC parse round-trip — JS new Date() matches the original CH timestamp', async () => {
+    // This is the regression guard for the "9h ago" bug: without the Z suffix
+    // JS parses CH timestamps as local time. Confirm the converted string
+    // round-trips to the same UTC instant the CH row claimed.
+    const rows = await collect(withIsoCreatedAt(fromArray([
+      { created_at: '2026-05-20 07:00:00.000' },
+    ])))
+    const iso = (rows[0]!['created_at'] as string)
+    expect(new Date(iso).getUTCHours()).toBe(7)
+    expect(new Date(iso).getUTCDate()).toBe(20)
+    expect(new Date(iso).getUTCMonth()).toBe(4) // May = 4
   })
 })

--- a/apps/server/src/api/exports.ts
+++ b/apps/server/src/api/exports.ts
@@ -62,6 +62,32 @@ function parseFormat(raw: string | undefined): ExportFormat {
 }
 
 /**
+ * Wrap a row stream so each row's `created_at` (ClickHouse's
+ * `'YYYY-MM-DD HH:MM:SS.fff'`) is converted to canonical ISO UTC
+ * (`'YYYY-MM-DD​T​HH:MM:SS.fff​Z'`) — same fix as the non-streaming endpoints
+ * applied to streaming exports.
+ *
+ * Returns an async generator so backpressure and `for-await` early-exit
+ * cancellation propagate through to the underlying ClickHouse driver stream.
+ * Rows without a string `created_at` are yielded unchanged.
+ *
+ * Exported for unit tests; otherwise only used by the `/exports/requests`
+ * streaming path below.
+ */
+export async function* withIsoCreatedAt<Row extends Record<string, unknown>>(
+  rows: AsyncIterable<Row>,
+): AsyncGenerator<Row, void, undefined> {
+  for await (const row of rows) {
+    const raw = row['created_at']
+    if (typeof raw === 'string') {
+      yield { ...row, created_at: fromClickhouseTimestamp(raw) ?? raw }
+    } else {
+      yield row
+    }
+  }
+}
+
+/**
  * Builds a streaming CSV response (header row + one line per source row).
  *
  * The async iterable is consumed lazily inside the ReadableStream `start`
@@ -204,7 +230,7 @@ exportsRouter.get('/requests', async (c) => {
   // of `limit`. The `buildCsvStream` / `buildJsonlStream` helpers transform
   // rows on-the-fly inside the ReadableStream `start` callback, so backpressure
   // propagates from the Node socket → Web stream controller → CH driver.
-  const rowsIter = streamRequests<ExportRow>({
+  const rawRowsIter = streamRequests<ExportRow>({
     scope,
     select: EXPORT_COLUMNS.join(', '),
     filters: filterSql,
@@ -212,6 +238,14 @@ exportsRouter.get('/requests', async (c) => {
     limit,
     params,
   })
+
+  // Transform `created_at` from ClickHouse's 'YYYY-MM-DD HH:MM:SS.fff' format
+  // (no T, no Z) into canonical ISO UTC. The non-streaming JSON path already
+  // does this — the streaming CSV/JSONL paths were missed in PR #130 because
+  // the row iterator is consumed inline by the stream builders. Wrapping with
+  // `withIsoCreatedAt` preserves backpressure and CH driver cancellation by
+  // re-yielding each row from the original iterator.
+  const rowsIter = withIsoCreatedAt(rawRowsIter)
 
   if (format === 'jsonl') {
     return new Response(buildJsonlStream(rowsIter), {


### PR DESCRIPTION
PR #130 fixed the timezone bug on \`/requests\` + \`/requests/:id\` + security flagged + the non-streaming JSON export, but **left the streaming CSV / JSONL paths** emitting raw ClickHouse format (\`'YYYY-MM-DD HH:MM:SS.fff'\`) because the row iterator is consumed inline by \`buildCsvStream\` / \`buildJsonlStream\` — there was no obvious row-transform seam.

## Fix

Factor a small \`withIsoCreatedAt\` async generator that wraps the underlying \`streamRequests\` iterator and yields rows with \`created_at\` normalised. Because it's an async generator, backpressure and the existing CH-driver cancellation-on-early-exit semantics both propagate through unchanged — verified by the new tests below.

```ts
// apps/server/src/api/exports.ts
const rowsIter = withIsoCreatedAt(rawRowsIter)
return new Response(buildCsvStream(EXPORT_COLUMNS, rowsIter), { ... })
```

## Tests

4 new tests in \`exports-stream.test.ts\` (524 total, was 520):
- Converts CH \`'YYYY-MM-DD HH:MM:SS.fff'\` to ISO UTC with \`Z\`
- Preserves other fields via immutable spread
- Passes through \`null\` / missing \`created_at\`
- UTC parse round-trip — explicit regression guard for the \"9h ago\" symptom on streamed exports (\`new Date(iso).getUTCHours() === 7\`)

### Bonus

Switched the existing \`clickhouse.js\` \`vi.mock\` to use \`importOriginal\` so the real \`fromClickhouseTimestamp\` helper stays in scope for tests that exercise it. Existing \`streamRequests\` tests still pass — only the singleton query function is replaced.

## Test plan
- [x] \`pnpm --filter server test\` — 524 pass (was 520; 4 new)
- [x] \`pnpm --filter server typecheck\` — no new errors
- [ ] Manual: after merge → \`GET /api/v1/exports/requests?format=csv\` row \`created_at\` should be \`...T...Z\` not space-separated