### PR TITLE
chore(ssr-timing): revert instrumentation + document findings (PR #132 cleanup)

### DIFF
--- a/apps/server/src/api/requests.ts
+++ b/apps/server/src/api/requests.ts
@@ -107,15 +107,8 @@ requestsRouter.get('/', async (c) => {
 
   const combinedFilters = filters.length > 0 ? filters.join(' AND ') : undefined
 
-  // Timing instrumentation (temporary — investigating /requests SSR slow
-  // first-paint on 2026-05-20; remove after root cause lands).
-  const tStart = Date.now()
   try {
-    const tScope0 = Date.now()
     const scope = await requestsScope(orgId)
-    const scopeMs = Date.now() - tScope0
-
-    const tQuery0 = Date.now()
     const [rows, total] = await Promise.all([
       selectRequests<RequestRow>({
         scope,
@@ -128,13 +121,9 @@ requestsRouter.get('/', async (c) => {
       }),
       countRequests({ scope, filters: combinedFilters, params }),
     ])
-    const queryMs = Date.now() - tQuery0
 
     // App-layer replacement for Supabase's `provider_keys ( name )` nested select.
-    const tKeysMap0 = Date.now()
     const keyMap = await fetchProviderKeyNames(orgId, rows.map((r) => r.provider_key_id))
-    const keysMapMs = Date.now() - tKeysMap0
-    console.log(`[ssr-timing] GET /api/v1/requests scope=${scopeMs}ms query=${queryMs}ms keysMap=${keysMapMs}ms total=${Date.now() - tStart}ms rows=${rows.length}`)
     const flat = rows.map((row) => ({
       ...row,
       cost_usd: row.cost_usd == null ? null : Number(row.cost_usd),

--- a/apps/web/lib/server/api.ts
+++ b/apps/web/lib/server/api.ts
@@ -26,16 +26,10 @@ const getServerSession = cache(async () => {
  * Must be called only from Server Components / Route Handlers.
  */
 export async function apiGetServer<T>(path: string): Promise<T> {
-  // Timing instrumentation (temporary — investigating /requests SSR slow
-  // first-paint on 2026-05-20).
-  const tStart = Date.now()
-  const tAuth0 = Date.now()
   const session = await getServerSession()
   const token = session?.access_token ?? null
-  const authMs = Date.now() - tAuth0
 
   const url = path.startsWith('http') ? path : `${API_URL}${path}`
-  const tFetch0 = Date.now()
   const res = await fetch(url, {
     headers: {
       'Content-Type': 'application/json',
@@ -43,13 +37,10 @@ export async function apiGetServer<T>(path: string): Promise<T> {
     },
     cache: 'no-store',
   })
-  const fetchMs = Date.now() - tFetch0
 
   if (!res.ok) {
-    console.log(`[ssr-timing] apiGetServer ${path} FAIL ${res.status} auth=${authMs}ms fetch=${fetchMs}ms total=${Date.now() - tStart}ms`)
     throw new Error(`Server API ${res.status}: ${path}`)
   }
 
-  console.log(`[ssr-timing] apiGetServer ${path} OK auth=${authMs}ms fetch=${fetchMs}ms total=${Date.now() - tStart}ms`)
   return res.json() as Promise<T>
 }

--- a/docs/plans/dashboard-ssr-suspense-stuck-2026-05.md
+++ b/docs/plans/dashboard-ssr-suspense-stuck-2026-05.md
@@ -130,3 +130,57 @@ PR #129 docs 작성 후 한 번 더 들여다봄. **"영구 stuck" 이 아니라
 - PR #129 (이 docs)
 - PR #130 (timestamp fix) — 9h ago 표시의 별도 원인 fix
 - PR #128 (azure filter dropdown) — 직접 관련 없음. Suspense 문제는 머지 전에도 동일했을 가능성 큼 (재현 환경 차이만)
+
+---
+
+## 결론 — instrumentation으로 측정 (2026-05-20 두번째 후속)
+
+PR #132 (`chore/ssr-timing-instrumentation`) 머지 후 `[ssr-timing]` console.log 로 production에서 실제 측정. PR #133 (이 chore/revert-ssr-timing) 에서 revert.
+
+### 측정 결과
+
+**Web SSR** (Vercel function `spanlens-web`):
+```
+[ssr-timing] apiGetServer /api/v1/requests?page=1&limit=50 OK auth=627ms fetch=2496ms total=3123ms
+```
+- `auth` = Supabase `getSession()` = **627ms**
+- `fetch` = web→server Vercel hop = **2496ms** (서버 측 2000ms + 네트워크 hop ~500ms)
+- **Total = 3123ms (~3s)**
+
+**Server** (Vercel function `spanlens-server`):
+```
+[ssr-timing] GET /api/v1/requests scope=718ms query=561ms keysMap=267ms total=1546ms rows=7
+```
+- `scope` = `requestsScope()` (Supabase plan + retention lookup) = **718ms**
+- `query` = ClickHouse `selectRequests` + `countRequests` (parallel) = **561ms**
+- `keysMap` = `fetchProviderKeyNames()` (Supabase batch) = **267ms**
+- **Server total = 1546ms** + ~450ms HTTP encode/auth → 2s 전체 endpoint duration
+
+### 진짜 baseline 정리
+
+| 단계 | 측정값 |
+|---|---|
+| Web SSR (apiGetServer 한 번 호출) | **~3.1s** |
+| 서버 측 `/api/v1/requests` API | **~2.0s** |
+| Cross-Vercel-function hop overhead | **~500ms** |
+| 페이지 hydration + 첫 paint (추정) | ~1~2s |
+| **실 사용자 인지 시간 (추정)** | **~5~6s** |
+
+### "30초 stuck" 의 정체
+
+Chrome MCP 환경 artifact 였음. 같은 페이지를 일반 브라우저 탭에서 열면 사용자는 ~5~6s 안에 정상 렌더 (사용자 screenshot 으로 확인). Chrome MCP 의 extension content script (`chrome-extension://ghoijjgbijaijnlkckidlccocjmlnekp/content-final.js`) 가 React Suspense streaming 과 간섭하는 듯 — instrumentation 후 1~2분 기다려도 skeleton 유지됐고, 같은 시점 Vercel function logs 는 3초 안에 완료 표시. **production bug 아님**.
+
+### 남은 최적화 여지 (별도 cycle 후보, 시급 아님)
+
+| 항목 | 현재 | 최적화 후 (예상) | 효과 |
+|---|---|---|---|
+| `requestsScope()` (Supabase) | 718ms | ~10ms (1분 in-memory cache) | -700ms |
+| `fetchProviderKeyNames()` (Supabase) | 267ms | ~10ms (5분 in-memory cache) | -250ms |
+| Cross-Vercel-function hop | ~500ms | 0 (web SSR이 ClickHouse 직접 호출) | -500ms, 단 큰 refactor |
+| Web `getSession()` | 627ms | ~50ms (단일 호출 cache 유지) | 이미 `react cache()` 적용됨, 추가 개선 가능 |
+
+이 4개 모두 적용 시 web SSR ~3s → ~1.2s. **단 시급도 낮음** — 현재 baseline ~5~6s 이 일반적인 SSR 대시보드 수준.
+
+### Resolution
+
+이 plan 문서는 **resolved** 상태로 표시 — production 측 실제 bug는 없었음. 위 최적화 항목은 별도 perf 개선 cycle 에서 follow-up.


### PR DESCRIPTION
PR #132 added \`[ssr-timing]\` console.log markers to measure the \`/requests\` slow-first-paint complaint. This PR removes them and writes up what the measurements showed.

## Findings (from production Vercel logs after PR #132 deployed)

**Web SSR** (\`spanlens-web\` Vercel function):
\`\`\`
[ssr-timing] apiGetServer /api/v1/requests?page=1&limit=50 OK auth=627ms fetch=2496ms total=3123ms
\`\`\`

**Server API** (\`spanlens-server\` Vercel function):
\`\`\`
[ssr-timing] GET /api/v1/requests scope=718ms query=561ms keysMap=267ms total=1546ms rows=7
\`\`\`

### Baseline

| Stage | ms |
|---|---|
| Supabase \`getSession()\` (web) | 627 |
| Web → server Vercel hop overhead | ~500 |
| Supabase \`requestsScope\` (server) | 718 |
| ClickHouse list + count (parallel) | 561 |
| Supabase \`fetchProviderKeyNames\` (server) | 267 |
| **End-to-end (web SSR total)** | **~3.1s** |

Plus ~1–2s hydration / first paint → **user-perceived ~5–6s**. Not a production bug.

## The \"30s stuck\" mystery

It was a **Chrome MCP environment artifact**. The user's own browser tab rendered the page normally (their earlier screenshot confirmed). Chrome MCP's extension content script (\`chrome-extension://ghoijjgbijaijnlkckidlccocjmlnekp/content-final.js\`) appears to interfere with React Suspense streaming — same page in Chrome MCP stays on \`animate-pulse\` skeleton indefinitely while Vercel logs confirm the SSR completed in 3 s. Reproducible with the instrumentation in place.

## What changed

- Reverted the three diagnostic \`console.log\` blocks from PR #132 (\`apps/web/lib/server/api.ts\`, \`apps/server/src/api/requests.ts\`).
- Updated \`docs/plans/dashboard-ssr-suspense-stuck-2026-05.md\` with the measured numbers and marked the plan **resolved**.
- Listed the residual optimization opportunities (Supabase scope/keys cache, skip the web→server hop) as a separate perf cycle — not urgent.

## Test plan

- [x] \`pnpm --filter web typecheck\` clean
- [x] \`pnpm --filter server typecheck\` — no new errors (2 pre-existing unchanged)
- [x] \`pnpm --filter server test\` — 524 pass