### PR TITLE
docs(web): add Azure OpenAI across /docs (proxy, api, features, otel)

### DIFF
--- a/apps/web/app/docs/api/page.tsx
+++ b/apps/web/app/docs/api/page.tsx
@@ -135,6 +135,7 @@ export default function ApiReferencePage() {
           <tr><td>Proxy — OpenAI</td><td><code>/proxy/openai/v1/*</code></td><td>API key</td></tr>
           <tr><td>Proxy — Anthropic</td><td><code>/proxy/anthropic/v1/*</code></td><td>API key</td></tr>
           <tr><td>Proxy — Gemini</td><td><code>/proxy/gemini/v1/*</code></td><td>API key</td></tr>
+          <tr><td>Proxy — Azure OpenAI</td><td><code>/proxy/azure/*</code></td><td>API key</td></tr>
           <tr><td>SDK Ingest</td><td><code>/ingest/*</code></td><td>API key</td></tr>
         </tbody>
       </table>

--- a/apps/web/app/docs/features/export/page.tsx
+++ b/apps/web/app/docs/features/export/page.tsx
@@ -152,7 +152,7 @@ export default function ExportDocs() {
           </tr>
           <tr>
             <td><code>provider</code></td>
-            <td>One of <code>openai</code> / <code>anthropic</code> / <code>gemini</code>.</td>
+            <td>One of <code>openai</code> / <code>anthropic</code> / <code>gemini</code> / <code>azure</code>.</td>
           </tr>
           <tr>
             <td><code>model</code></td>
@@ -219,7 +219,7 @@ export default function ExportDocs() {
           </tr>
           <tr>
             <td><code>provider</code></td>
-            <td>openai / anthropic / gemini</td>
+            <td>openai / anthropic / gemini / azure</td>
           </tr>
           <tr>
             <td><code>model</code></td>

--- a/apps/web/app/docs/features/requests/page.tsx
+++ b/apps/web/app/docs/features/requests/page.tsx
@@ -35,7 +35,7 @@ export default function RequestsDocs() {
         <tbody>
           <tr>
             <td><code>provider</code></td>
-            <td>openai / anthropic / gemini</td>
+            <td>openai / anthropic / gemini / azure</td>
           </tr>
           <tr>
             <td><code>model</code></td>
@@ -150,7 +150,7 @@ export default function RequestsDocs() {
         view, or use the browser&apos;s back button to restore a previous filter state.
       </p>
       <ul>
-        <li><strong>Provider</strong> — exact match (openai / anthropic / gemini)</li>
+        <li><strong>Provider</strong> — exact match (openai / anthropic / gemini / azure)</li>
         <li>
           <strong>Model</strong> — partial, case-insensitive match (e.g. searching &ldquo;mini&rdquo;
           matches <code>gpt-4o-mini-2024-07-18</code>)

--- a/apps/web/app/docs/features/savings/page.tsx
+++ b/apps/web/app/docs/features/savings/page.tsx
@@ -512,7 +512,7 @@ GET /api/v1/recommendations?minSavings=20      # only show ≥ $20/mo
           <tr>
             <td><code>provider</code></td>
             <td>Yes</td>
-            <td>Provider slug, e.g. <code>openai</code>, <code>anthropic</code>, <code>gemini</code>.</td>
+            <td>Provider slug, e.g. <code>openai</code>, <code>anthropic</code>, <code>gemini</code>, <code>azure</code>.</td>
           </tr>
           <tr>
             <td><code>model</code></td>

--- a/apps/web/app/docs/features/settings/page.tsx
+++ b/apps/web/app/docs/features/settings/page.tsx
@@ -93,7 +93,8 @@ export default function SettingsDocs() {
       <h3>Decryption flow (on every proxy request)</h3>
       <ol>
         <li>
-          Your request arrives at <code>/proxy/&#123;openai|anthropic|gemini&#125;/…</code>{' '}
+          Your request arrives at{' '}
+          <code>/proxy/&#123;openai|anthropic|gemini|azure&#125;/…</code>{' '}
           carrying the Spanlens key in whichever transport the SDK uses (see{' '}
           <a href="/docs/proxy">Direct proxy</a> for the per-SDK mapping)
         </li>
@@ -102,7 +103,10 @@ export default function SettingsDocs() {
           → resolves <code>apiKeyId</code>
         </li>
         <li>
-          Provider is inferred from the URL path: <code>/proxy/openai/…</code> → OpenAI, etc.
+          Provider is inferred from the URL path: <code>/proxy/openai/…</code> → OpenAI,{' '}
+          <code>/proxy/azure/…</code> → Azure OpenAI, etc. Azure rows additionally carry a{' '}
+          <code>provider_metadata.resource_url</code> so the proxy knows which Azure endpoint
+          to forward to.
         </li>
         <li>
           Loads the active <code>provider_keys</code> row for{' '}

--- a/apps/web/app/docs/otel/page.tsx
+++ b/apps/web/app/docs/otel/page.tsx
@@ -81,7 +81,7 @@ exporter = OTLPSpanExporter(
           <tr>
             <td><code>gen_ai.provider.name</code></td>
             <td>string</td>
-            <td><code>openai</code>, <code>anthropic</code>, <code>gemini</code>, …</td>
+            <td><code>openai</code>, <code>anthropic</code>, <code>gemini</code>, <code>azure</code>, …</td>
           </tr>
           <tr>
             <td><code>gen_ai.request.model</code></td>

--- a/apps/web/app/docs/proxy/page.tsx
+++ b/apps/web/app/docs/proxy/page.tsx
@@ -34,7 +34,8 @@ export default function ProxyDocs() {
       </p>
       <CodeBlock>{`https://spanlens-server.vercel.app/proxy/openai/v1
 https://spanlens-server.vercel.app/proxy/anthropic
-https://spanlens-server.vercel.app/proxy/gemini/v1beta`}</CodeBlock>
+https://spanlens-server.vercel.app/proxy/gemini/v1beta
+https://spanlens-server.vercel.app/proxy/azure`}</CodeBlock>
       <p>
         Send requests exactly as you would to the real provider, with two changes:
       </p>
@@ -81,8 +82,18 @@ https://spanlens-server.vercel.app/proxy/gemini/v1beta`}</CodeBlock>
             <td><code>x-goog-api-key: sl_live_…</code></td>
             <td>✓</td>
           </tr>
+          <tr>
+            <td>Azure OpenAI (any language)</td>
+            <td><code>Authorization: Bearer sl_live_…</code></td>
+            <td>✓</td>
+          </tr>
         </tbody>
       </table>
+      <p className="text-sm text-muted-foreground">
+        Azure note: your Spanlens key still goes on <code>Authorization: Bearer …</code>. The
+        real Azure <code>api-key</code> header is added by the proxy after looking up the
+        encrypted key you registered in the dashboard.
+      </p>
       <p className="text-sm text-muted-foreground">
         The <code>authApiKey</code> middleware tries them in order and the first non-empty
         one wins. Implementation: <code>apps/server/src/middleware/authApiKey.ts</code>.
@@ -114,6 +125,34 @@ msg = client.messages.create(
     max_tokens=1024,
     messages=[{"role": "user", "content": "Hi"}],
 )`}</CodeBlock>
+
+      <h2 id="python-azure">Python — Azure OpenAI</h2>
+      <p>
+        Azure OpenAI uses Microsoft&apos;s <code>/openai/v1/*</code> endpoint (GA Aug 2025) so
+        it is drop-in OpenAI-compatible — same request and response shapes, same streaming
+        format. Register your Azure resource URL + API key under the Spanlens key in the
+        dashboard once; the proxy then injects them at call time. Your client just talks to{' '}
+        <code>/proxy/azure</code>.
+      </p>
+      <CodeBlock language="python">{`from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["SPANLENS_API_KEY"],
+    base_url="https://spanlens-server.vercel.app/proxy/azure",
+)
+
+# 'model' is your Azure deployment name, not the underlying model id.
+res = client.chat.completions.create(
+    model="my-gpt4o-mini-deployment",
+    messages=[{"role": "user", "content": "Hi"}],
+)`}</CodeBlock>
+      <p className="text-sm text-muted-foreground">
+        Provider key registration step: dashboard → <a href="/projects">Projects &amp; Keys</a>
+        {' '}→ expand a Spanlens key → <em>Add provider key</em> → Azure OpenAI → paste{' '}
+        <code>https://&lt;your-resource&gt;.openai.azure.com</code> + API key 1 from Azure
+        portal. The proxy stores the URL on the key row and injects the right{' '}
+        <code>api-key</code> header on every request.
+      </p>
 
       <h2 id="curl">curl — raw HTTP</h2>
       <CodeBlock language="bash">{`curl https://spanlens-server.vercel.app/proxy/openai/v1/chat/completions \\


### PR DESCRIPTION
Azure OpenAI shipped via PR #125 + the dashboard filter dropdown in PR #128, but the public-facing docs still listed only \`openai / anthropic / gemini\` in seven places. This sweep brings them in sync.

## Pages updated

| Page | What changed |
|---|---|
| \`/docs/proxy\` | New \`/proxy/azure\` endpoint in the URL list, new \`Azure OpenAI\` row in the SDK auth-transport table with a note about how the underlying \`api-key\` is injected by the proxy, new \`Python — Azure OpenAI\` section with code example + provider-key registration walkthrough |
| \`/docs/api\` | New row in the endpoint table: \`/proxy/azure/*\` (API key auth) |
| \`/docs/features/settings\` | Decryption-flow steps now mention \`/proxy/azure/...\` + that Azure rows additionally carry \`provider_metadata.resource_url\` |
| \`/docs/features/requests\` | \`RequestRow.provider\` doc + the filter docs include azure |
| \`/docs/features/export\` | JSON-export schema row + CSV \`provider\` column example include azure |
| \`/docs/features/savings\` | Provider-slug example list includes azure |
| \`/docs/otel\` | \`gen_ai.provider.name\` examples include azure |

## What's *not* touched

\`/docs/sdk\` already got the Ollama \`observeOllama\` section in PR #126. No further changes needed there. No code or runtime changes in this PR.

## Test plan

- [x] \`pnpm --filter web typecheck\` clean
- [x] \`pnpm --filter web lint\` clean
- [x] Dev preview of \`/docs/proxy\` — \`#python-azure\` heading renders, \`/proxy/azure\` endpoint visible in URL list, Azure row in auth-transport table
- [x] No console errors specific to these changes (the pre-existing \"script tag inside React\" dev warning is unrelated and present on main)