### PR TITLE
feat(sdk-ts): extend LangChain handler for LangGraph (A1)

### DIFF
--- a/packages/sdk/src/__tests__/integrations-new.test.ts
+++ b/packages/sdk/src/__tests__/integrations-new.test.ts
@@ -149,6 +149,223 @@ describe('createSpanlensCallbackHandler (LangChain)', () => {
 
     expect(spanPatches()).toHaveLength(2)
   })
+
+  // ── LangGraph / chain / tool / retriever (PR #137 expansion) ──────────────
+
+  /** Extract span POST bodies in arrival order — used for tree-shape assertions. */
+  function readSpanPosts(calls: FetchCall[]): Array<Record<string, unknown>> {
+    return calls
+      .filter((c) => c.method === 'POST' && c.url.includes('/spans'))
+      .map((c) => c.body)
+  }
+
+  it('captures chain start/end as a custom span with input + output', async () => {
+    const fixtures = stubFetch()
+    const handler = createSpanlensCallbackHandler({ client: makeClient() })
+
+    handler.handleChainStart({ id: ['langgraph', 'plan'] }, { topic: 'tokyo' }, 'chain-1')
+    await handler.handleChainEnd({ steps: ['a', 'b'] }, 'chain-1')
+    await tick()
+
+    const spanPosts = readSpanPosts(fixtures.calls)
+    expect(spanPosts).toHaveLength(1)
+    expect(spanPosts[0]!['name']).toBe('chain.plan')
+    expect(spanPosts[0]!['span_type']).toBe('custom')
+    expect(spanPosts[0]!['input']).toEqual({ topic: 'tokyo' })
+
+    const patch = fixtures.spanPatches()[0]!.body
+    expect(patch['status']).toBe('completed')
+    expect(patch['output']).toEqual({ steps: ['a', 'b'] })
+  })
+
+  it('wires parent → child via parentRunId (graph → node)', async () => {
+    const fixtures = stubFetch()
+    const handler = createSpanlensCallbackHandler({ client: makeClient() })
+
+    handler.handleChainStart({ id: ['LangGraph'] }, { input: 'q' }, 'graph-1')
+    handler.handleChainStart({ id: ['plan'] }, { input: 'q' }, 'node-1', undefined, undefined, undefined, undefined, 'graph-1')
+    await handler.handleChainEnd({ plan: '...' }, 'node-1')
+    await handler.handleChainEnd({ done: true }, 'graph-1')
+    await tick()
+
+    const spanPosts = readSpanPosts(fixtures.calls)
+    expect(spanPosts).toHaveLength(2)
+    const graphPost = spanPosts.find((s) => s['name'] === 'chain.LangGraph')!
+    const nodePost = spanPosts.find((s) => s['name'] === 'chain.plan')!
+    expect(graphPost['parent_span_id']).toBeUndefined()
+    expect(nodePost['parent_span_id']).toBe(graphPost['id'])
+  })
+
+  it('captures tool calls as tool spans with input + output', async () => {
+    const fixtures = stubFetch()
+    const handler = createSpanlensCallbackHandler({ client: makeClient() })
+
+    handler.handleToolStart({ id: ['TavilySearch'] }, 'best ramen tokyo', 'tool-1')
+    await handler.handleToolEnd(['result1', 'result2'], 'tool-1')
+    await tick()
+
+    const spanPosts = readSpanPosts(fixtures.calls)
+    expect(spanPosts).toHaveLength(1)
+    expect(spanPosts[0]!['name']).toBe('tool.TavilySearch')
+    expect(spanPosts[0]!['span_type']).toBe('tool')
+    expect(spanPosts[0]!['input']).toBe('best ramen tokyo')
+
+    const patch = fixtures.spanPatches()[0]!.body
+    expect(patch['output']).toEqual(['result1', 'result2'])
+  })
+
+  it('captures retriever calls with documents summarised as output', async () => {
+    const fixtures = stubFetch()
+    const handler = createSpanlensCallbackHandler({ client: makeClient() })
+
+    handler.handleRetrieverStart({ id: ['PineconeRetriever'] }, 'q', 'ret-1')
+    await handler.handleRetrieverEnd(
+      [
+        { pageContent: 'doc-a', metadata: { src: '1' } },
+        { pageContent: 'doc-b', metadata: { src: '2' } },
+      ],
+      'ret-1',
+    )
+    await tick()
+
+    const spanPosts = readSpanPosts(fixtures.calls)
+    expect(spanPosts).toHaveLength(1)
+    expect(spanPosts[0]!['name']).toBe('retrieval.PineconeRetriever')
+    expect(spanPosts[0]!['span_type']).toBe('retrieval')
+
+    const patch = fixtures.spanPatches()[0]!.body
+    const out = patch['output'] as Array<{ pageContent: string }>
+    expect(out).toHaveLength(2)
+    expect(out[0]!.pageContent).toBe('doc-a')
+  })
+
+  it('builds a 3-level span tree (graph → node → llm)', async () => {
+    const fixtures = stubFetch()
+    const handler = createSpanlensCallbackHandler({ client: makeClient() })
+
+    handler.handleChainStart({ id: ['LangGraph'] }, { input: 'q' }, 'graph')
+    handler.handleChainStart({ id: ['execute'] }, { input: 'q' }, 'node', undefined, undefined, undefined, undefined, 'graph')
+    handler.handleLLMStart({ id: ['ChatOpenAI'] }, ['p'], 'llm', 'node')
+    await handler.handleLLMEnd(
+      { llmOutput: { tokenUsage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 }, model_name: 'gpt-4o' } },
+      'llm',
+    )
+    await handler.handleChainEnd({ output: 'ok' }, 'node')
+    await handler.handleChainEnd({ done: true }, 'graph')
+    await tick()
+
+    const spanPosts = readSpanPosts(fixtures.calls)
+    expect(spanPosts).toHaveLength(3)
+    const byName = Object.fromEntries(spanPosts.map((p) => [p['name'], p]))
+    expect(byName['chain.LangGraph']!['parent_span_id']).toBeUndefined()
+    expect(byName['chain.execute']!['parent_span_id']).toBe(byName['chain.LangGraph']!['id'])
+    expect(byName['llm.ChatOpenAI']!['parent_span_id']).toBe(byName['chain.execute']!['id'])
+  })
+
+  it('handleChainError ends the span with error status', async () => {
+    const fixtures = stubFetch()
+    const handler = createSpanlensCallbackHandler({ client: makeClient() })
+
+    handler.handleChainStart({ id: ['failing'] }, {}, 'c1')
+    await handler.handleChainError(new Error('boom'), 'c1')
+    await tick()
+
+    const patch = fixtures.spanPatches()[0]!.body
+    expect(patch['status']).toBe('error')
+    expect(patch['error_message']).toBe('boom')
+  })
+
+  it('captureChains: false drops chain spans entirely', async () => {
+    const fixtures = stubFetch()
+    const handler = createSpanlensCallbackHandler({
+      client: makeClient(),
+      captureChains: false,
+    })
+
+    handler.handleChainStart({ id: ['ignored'] }, {}, 'c1')
+    await handler.handleChainEnd({}, 'c1')
+    await tick()
+
+    expect(readSpanPosts(fixtures.calls)).toHaveLength(0)
+  })
+
+  it('captureTools: false drops tool spans entirely', async () => {
+    const fixtures = stubFetch()
+    const handler = createSpanlensCallbackHandler({
+      client: makeClient(),
+      captureTools: false,
+    })
+
+    handler.handleToolStart({ id: ['x'] }, 'in', 't1')
+    await handler.handleToolEnd('out', 't1')
+    await tick()
+
+    expect(readSpanPosts(fixtures.calls)).toHaveLength(0)
+  })
+
+  it('maxInputBytes truncates oversize chain inputs into a marker object', async () => {
+    const fixtures = stubFetch()
+    const handler = createSpanlensCallbackHandler({
+      client: makeClient(),
+      maxInputBytes: 50,
+    })
+
+    const big = { state: 'x'.repeat(500) }
+    handler.handleChainStart({ id: ['big'] }, big, 'c1')
+    await handler.handleChainEnd({}, 'c1')
+    await tick()
+
+    const post = readSpanPosts(fixtures.calls)[0]!
+    const input = post['input'] as Record<string, unknown>
+    expect(input['__truncated']).toBe(true)
+    expect(typeof input['preview']).toBe('string')
+    expect(input['originalBytes']).toBeGreaterThan(50)
+  })
+
+  it('idempotent — duplicate handleChainEnd for same runId is silently ignored', async () => {
+    const fixtures = stubFetch()
+    const handler = createSpanlensCallbackHandler({ client: makeClient() })
+
+    handler.handleChainStart({ id: ['x'] }, {}, 'c1')
+    await handler.handleChainEnd({}, 'c1')
+    await handler.handleChainEnd({}, 'c1') // duplicate
+    await tick()
+
+    expect(fixtures.spanPatches()).toHaveLength(1)
+  })
+
+  it('orphan handleChainEnd (no prior start) is silently ignored', async () => {
+    const fixtures = stubFetch()
+    const handler = createSpanlensCallbackHandler({ client: makeClient() })
+
+    await handler.handleChainEnd({}, 'never-started')
+    await tick()
+
+    expect(fixtures.spanPatches()).toHaveLength(0)
+    expect(fixtures.posts()).toHaveLength(0)
+  })
+
+  it('parallel sibling chains under same parent both attach correctly', async () => {
+    const fixtures = stubFetch()
+    const handler = createSpanlensCallbackHandler({ client: makeClient() })
+
+    handler.handleChainStart({ id: ['parent'] }, {}, 'p')
+    // Two children start before either ends — common in LangGraph branching.
+    handler.handleChainStart({ id: ['left'] }, {}, 'l', undefined, undefined, undefined, undefined, 'p')
+    handler.handleChainStart({ id: ['right'] }, {}, 'r', undefined, undefined, undefined, undefined, 'p')
+    await handler.handleChainEnd({}, 'l')
+    await handler.handleChainEnd({}, 'r')
+    await handler.handleChainEnd({}, 'p')
+    await tick()
+
+    const spanPosts = readSpanPosts(fixtures.calls)
+    expect(spanPosts).toHaveLength(3)
+    const parentPost = spanPosts.find((p) => p['name'] === 'chain.parent')!
+    const leftPost = spanPosts.find((p) => p['name'] === 'chain.left')!
+    const rightPost = spanPosts.find((p) => p['name'] === 'chain.right')!
+    expect(leftPost['parent_span_id']).toBe(parentPost['id'])
+    expect(rightPost['parent_span_id']).toBe(parentPost['id'])
+  })
 })
 
 // ── Vercel AI SDK ──────────────────────────────────────────────────────────

--- a/packages/sdk/src/integrations/langchain.ts
+++ b/packages/sdk/src/integrations/langchain.ts
@@ -1,8 +1,14 @@
 /**
  * LangChain JS callback handler for Spanlens tracing.
  *
- * Records LLM spans (model, tokens, latency) from any LangChain chain or LLM.
- * Designed as a duck-typed integration — no direct import from @langchain/core.
+ * Records LLM / chain / tool / retriever spans from any LangChain or LangGraph
+ * runnable. Designed as a duck-typed integration — no direct import from
+ * `@langchain/core` — so it survives LangChain major version bumps.
+ *
+ * LangGraph reuses LangChain's `BaseCallbackHandler` contract, so this handler
+ * works equally well for plain LangChain chains, LCEL pipelines, and LangGraph
+ * compiled graphs. The `runId` / `parentRunId` pair on every callback gives a
+ * span tree that mirrors the graph topology 1:1 — graph → node → llm/tool.
  *
  * @example
  *   import { SpanlensClient } from '@spanlens/sdk'
@@ -11,26 +17,45 @@
  *   const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
  *   const handler = createSpanlensCallbackHandler({ client })
  *
- *   const result = await chain.invoke({ input }, { callbacks: [handler] })
- *   // or: const res = await llm.invoke(prompt, { callbacks: [handler] })
+ *   // LangChain
+ *   await chain.invoke({ input }, { callbacks: [handler] })
+ *
+ *   // LangGraph
+ *   const graph = workflow.compile()
+ *   await graph.invoke({ input }, { callbacks: [handler] })
  */
 
 import { SpanlensClient } from '../client.js'
 import type { TraceHandle } from '../trace.js'
 import type { SpanHandle } from '../span.js'
-import type { EndSpanOptions } from '../types.js'
+import type { EndSpanOptions, SpanOptions, SpanType } from '../types.js'
 
 export interface SpanlensLangChainOptions {
   /** Spanlens client instance. */
   client: SpanlensClient
   /**
-   * Optional trace to attach LLM spans to.
-   * When provided, `trace.end()` is NOT called — the caller manages the lifecycle.
-   * When omitted, a new trace is created per LLM run and closed on completion.
+   * Optional pre-existing trace to attach all spans to. When provided,
+   * `trace.end()` is NOT called — the caller owns the lifecycle.
+   * When omitted, a trace is created on the first start-event and closed
+   * when the matching root-level run ends (or on `flush()`).
    */
   trace?: TraceHandle
   /** Name for auto-created traces. Default: 'langchain_run'. */
   traceName?: string
+  /** Capture chain (LangGraph node, LCEL step) spans. Default: true. */
+  captureChains?: boolean
+  /** Capture tool call spans. Default: true. */
+  captureTools?: boolean
+  /** Capture retriever spans. Default: true. */
+  captureRetrieval?: boolean
+  /**
+   * Max bytes to keep in `span.input`. Anything larger is replaced with a
+   * `{ __truncated: true, preview, originalBytes }` marker so the dashboard
+   * still shows something useful. Default 16,384 (16 KB).
+   */
+  maxInputBytes?: number
+  /** Same as `maxInputBytes` but for `span.output`. Default 16,384. */
+  maxOutputBytes?: number
 }
 
 /** Minimal LangChain Serialized shape — only fields we use. */
@@ -53,6 +78,11 @@ interface LangChainLLMResult {
   generations?: ReadonlyArray<ReadonlyArray<{ text?: string }>>
 }
 
+interface LangChainDocument {
+  pageContent?: string
+  metadata?: Record<string, unknown>
+}
+
 function parseLangChainResult(result: LangChainLLMResult): EndSpanOptions {
   const usage = result.llmOutput?.tokenUsage
   if (!usage) return {}
@@ -68,67 +98,290 @@ function parseLangChainResult(result: LangChainLLMResult): EndSpanOptions {
 }
 
 /**
- * Returns a LangChain-compatible callback handler that records LLM spans to Spanlens.
+ * JSON-encode and truncate at `maxBytes`. Returns the original value when it
+ * fits (so the dashboard receives structured JSON), or a truncation marker
+ * object otherwise.
  *
- * Pass the returned object to the `callbacks` option of any LangChain chain, LLM,
- * or `RunnableConfig`. Concurrent runs are tracked by LangChain's `runId`.
+ * Non-serializable values (functions, circular refs) fall back to a string
+ * representation rather than throwing — span ingest must never crash the
+ * caller's code.
  */
-export function createSpanlensCallbackHandler(options: SpanlensLangChainOptions) {
-  const { client, traceName = 'langchain_run' } = options
+function truncate(value: unknown, maxBytes: number): unknown {
+  if (value == null) return value
+  let json: string
+  try {
+    json = JSON.stringify(value)
+  } catch {
+    json = String(value)
+  }
+  if (json.length <= maxBytes) return value
+  return {
+    __truncated: true,
+    preview: json.slice(0, maxBytes),
+    originalBytes: json.length,
+  }
+}
 
-  const runs = new Map<
-    string,
-    { trace: TraceHandle; span: SpanHandle; isLocalTrace: boolean }
-  >()
+/**
+ * Best-effort name for a Serialized class blob.
+ * `id` is typically `['langchain', 'tools', 'TavilySearch']` etc.; falling back
+ * to `name` or `'call'` keeps the span readable even when LangChain stops
+ * populating one field.
+ */
+function shortName(s: LangChainSerialized | undefined, fallback: string): string {
+  return s?.id?.at(-1) ?? s?.name ?? fallback
+}
 
-  function startRun(runId: string, llm: LangChainSerialized, input: unknown): void {
-    const spanName = `llm.${llm.id?.at(-1) ?? llm.name ?? 'call'}`
-    const isLocalTrace = options.trace === undefined
-    const trace = options.trace ?? client.startTrace({ name: traceName })
-    const span = trace.span({ name: spanName, spanType: 'llm', input })
-    runs.set(runId, { trace, span, isLocalTrace })
+interface RunRecord {
+  span: SpanHandle
+  /** Was this run the one that created the (local) trace? Only that one ends it. */
+  rootOfLocalTrace: boolean
+}
+
+/**
+ * Returns a LangChain-compatible callback handler that records LLM, chain,
+ * tool, and retriever spans to Spanlens.
+ *
+ * Pass the returned object to the `callbacks` option of any LangChain chain,
+ * LLM, agent, or LangGraph compiled graph. Concurrent runs are tracked by
+ * LangChain's per-run UUIDs, so a single handler instance is safe to share
+ * across parallel invocations.
+ */
+export function createSpanlensCallbackHandler(
+  options: SpanlensLangChainOptions,
+) {
+  const { client } = options
+  const traceName = options.traceName ?? 'langchain_run'
+  const captureChains = options.captureChains ?? true
+  const captureTools = options.captureTools ?? true
+  const captureRetrieval = options.captureRetrieval ?? true
+  const maxInputBytes = options.maxInputBytes ?? 16_384
+  const maxOutputBytes = options.maxOutputBytes ?? 16_384
+
+  const runs = new Map<string, RunRecord>()
+  const externalTrace = options.trace ?? null
+
+  /** Lazy trace state — created on first start event when no trace was supplied. */
+  let localTrace: TraceHandle | null = null
+
+  function getTrace(): TraceHandle {
+    if (externalTrace) return externalTrace
+    if (localTrace) return localTrace
+    localTrace = client.startTrace({ name: traceName })
+    return localTrace
+  }
+
+  /** Attach a new span under the right parent (existing run or root trace). */
+  function startSpan(
+    runId: string,
+    parentRunId: string | undefined,
+    spanOpts: SpanOptions,
+  ): void {
+    if (runs.has(runId)) {
+      // Duplicate start (LangChain shouldn't, but be defensive).
+      return
+    }
+    const parentRecord = parentRunId ? runs.get(parentRunId) : undefined
+    const wasRootBefore = externalTrace === null && localTrace === null
+    const trace = getTrace()
+    const isRoot = parentRecord === undefined
+    // Top-level span uses `trace.span()`; nested uses `parent.span.child()`.
+    const span: SpanHandle = isRoot
+      ? trace.span(spanOpts)
+      : parentRecord!.span.child(spanOpts)
+    runs.set(runId, {
+      span,
+      // Mark only the very first run as the owner of the local trace lifecycle.
+      rootOfLocalTrace: isRoot && wasRootBefore && externalTrace === null,
+    })
+  }
+
+  /** End a span by runId and optionally close the local trace. */
+  async function endSpan(
+    runId: string,
+    end: EndSpanOptions,
+  ): Promise<void> {
+    const record = runs.get(runId)
+    if (!record) return
+    runs.delete(runId)
+    await record.span.end(end)
+    if (record.rootOfLocalTrace) {
+      await getTrace().end({
+        status: end.status === 'error' ? 'error' : 'completed',
+      })
+      // Reset so subsequent runs get a fresh trace.
+      localTrace = null
+    }
+  }
+
+  function buildSpanOptions(
+    name: string,
+    spanType: SpanType,
+    input?: unknown,
+  ): SpanOptions {
+    const opts: SpanOptions = { name, spanType }
+    if (input !== undefined) {
+      const trimmed = truncate(input, maxInputBytes)
+      if (trimmed !== undefined) opts.input = trimmed
+    }
+    return opts
   }
 
   return {
     name: 'SpanlensCallbackHandler' as const,
 
-    handleLLMStart(llm: LangChainSerialized, prompts: string[], runId: string): void {
-      startRun(runId, llm, prompts)
+    // ── LLM ────────────────────────────────────────────────────────────────
+
+    handleLLMStart(
+      llm: LangChainSerialized,
+      prompts: string[],
+      runId: string,
+      parentRunId?: string,
+    ): void {
+      startSpan(
+        runId,
+        parentRunId,
+        buildSpanOptions(`llm.${shortName(llm, 'call')}`, 'llm', prompts),
+      )
     },
 
     handleChatModelStart(
       llm: LangChainSerialized,
       messages: unknown[][],
       runId: string,
+      parentRunId?: string,
     ): void {
-      startRun(runId, llm, messages)
+      startSpan(
+        runId,
+        parentRunId,
+        buildSpanOptions(`llm.${shortName(llm, 'call')}`, 'llm', messages),
+      )
     },
 
     async handleLLMEnd(output: LangChainLLMResult, runId: string): Promise<void> {
-      const run = runs.get(runId)
-      if (!run) return
-      runs.delete(runId)
-
       const parsed = parseLangChainResult(output)
       const outputText = output.generations?.[0]?.[0]?.text
-
-      await run.span.end({
-        status: 'completed',
-        ...(outputText !== undefined ? { output: outputText } : {}),
-        ...parsed,
-      })
-
-      if (run.isLocalTrace) await run.trace.end({ status: 'completed' })
+      const end: EndSpanOptions = { status: 'completed', ...parsed }
+      if (outputText !== undefined) {
+        const trimmed = truncate(outputText, maxOutputBytes)
+        if (trimmed !== undefined) end.output = trimmed
+      }
+      await endSpan(runId, end)
     },
 
     async handleLLMError(err: unknown, runId: string): Promise<void> {
-      const run = runs.get(runId)
-      if (!run) return
-      runs.delete(runId)
-
       const errorMessage = err instanceof Error ? err.message : String(err)
-      await run.span.end({ status: 'error', errorMessage })
-      if (run.isLocalTrace) await run.trace.end({ status: 'error', errorMessage })
+      await endSpan(runId, { status: 'error', errorMessage })
+    },
+
+    // ── Chain (LangGraph nodes, LCEL steps, plain chains) ─────────────────
+
+    handleChainStart(
+      chain: LangChainSerialized,
+      inputs: unknown,
+      runId: string,
+      _runType?: string,
+      _tags?: string[],
+      _metadata?: Record<string, unknown>,
+      _runName?: string,
+      parentRunId?: string,
+    ): void {
+      if (!captureChains) return
+      startSpan(
+        runId,
+        parentRunId,
+        buildSpanOptions(`chain.${shortName(chain, 'run')}`, 'custom', inputs),
+      )
+    },
+
+    async handleChainEnd(outputs: unknown, runId: string): Promise<void> {
+      if (!captureChains) return
+      const trimmed = truncate(outputs, maxOutputBytes)
+      await endSpan(runId, {
+        status: 'completed',
+        ...(trimmed !== undefined ? { output: trimmed } : {}),
+      })
+    },
+
+    async handleChainError(err: unknown, runId: string): Promise<void> {
+      if (!captureChains) return
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      await endSpan(runId, { status: 'error', errorMessage })
+    },
+
+    // ── Tool ───────────────────────────────────────────────────────────────
+
+    handleToolStart(
+      tool: LangChainSerialized,
+      input: string,
+      runId: string,
+      parentRunId?: string,
+    ): void {
+      if (!captureTools) return
+      startSpan(
+        runId,
+        parentRunId,
+        buildSpanOptions(`tool.${shortName(tool, 'call')}`, 'tool', input),
+      )
+    },
+
+    async handleToolEnd(output: unknown, runId: string): Promise<void> {
+      if (!captureTools) return
+      const trimmed = truncate(output, maxOutputBytes)
+      await endSpan(runId, {
+        status: 'completed',
+        ...(trimmed !== undefined ? { output: trimmed } : {}),
+      })
+    },
+
+    async handleToolError(err: unknown, runId: string): Promise<void> {
+      if (!captureTools) return
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      await endSpan(runId, { status: 'error', errorMessage })
+    },
+
+    // ── Retriever ──────────────────────────────────────────────────────────
+
+    handleRetrieverStart(
+      retriever: LangChainSerialized,
+      query: string,
+      runId: string,
+      parentRunId?: string,
+    ): void {
+      if (!captureRetrieval) return
+      startSpan(
+        runId,
+        parentRunId,
+        buildSpanOptions(
+          `retrieval.${shortName(retriever, 'query')}`,
+          'retrieval',
+          query,
+        ),
+      )
+    },
+
+    async handleRetrieverEnd(
+      documents: LangChainDocument[],
+      runId: string,
+    ): Promise<void> {
+      if (!captureRetrieval) return
+      // Surface just text + metadata count so output stays readable when
+      // a retriever returns 50+ docs.
+      const summarised = documents.map((d) => ({
+        pageContent: d.pageContent,
+        metadata: d.metadata,
+      }))
+      const trimmed = truncate(summarised, maxOutputBytes)
+      await endSpan(runId, {
+        status: 'completed',
+        ...(trimmed !== undefined ? { output: trimmed } : {}),
+      })
+    },
+
+    async handleRetrieverError(err: unknown, runId: string): Promise<void> {
+      if (!captureRetrieval) return
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      await endSpan(runId, { status: 'error', errorMessage })
     },
   }
 }


### PR DESCRIPTION
PR **A1** of the LangGraph integration plan ([\`docs/plans/langgraph-integration.md\`](https://github.com/spanlens/Spanlens/blob/main/docs/plans/langgraph-integration.md)).

## What

LangGraph reuses LangChain's \`BaseCallbackHandler\` — same \`runId\` / \`parentRunId\` per event. So this PR just implements the rest of the BaseCallbackHandler surface that we were missing:

- \`handleChainStart\` / \`End\` / \`Error\` → \`custom\` spans (LangGraph nodes, LCEL steps, plain chains)
- \`handleToolStart\` / \`End\` / \`Error\` → \`tool\` spans
- \`handleRetrieverStart\` / \`End\` / \`Error\` → \`retrieval\` spans

The \`runId → SpanHandle\` map now resolves \`parentRunId\` on every start, so nested calls (graph → node → llm) form a span tree automatically. Top-level runs also lazily create + close the trace they were the first to enter.

Resulting dashboard trace shape for a 2-node LangGraph:
\`\`\`
trace: langchain_run
└─ span chain.LangGraph
   ├─ span chain.plan
   │  └─ span llm.ChatOpenAI (model + tokens)
   └─ span chain.execute
      ├─ span tool.search (input + output)
      └─ span llm.ChatOpenAI
\`\`\`

## New options (defaults preserve old behaviour)

| Option | Default | Why |
|---|---|---|
| \`captureChains\` | \`true\` | Off → no LangGraph node spans (quieter dashboard) |
| \`captureTools\` | \`true\` | Off → drop tool spans |
| \`captureRetrieval\` | \`true\` | Off → drop retriever spans |
| \`maxInputBytes\` | 16 384 | Truncate huge LangGraph state into \`{ __truncated, preview, originalBytes }\` |
| \`maxOutputBytes\` | 16 384 | Same for outputs |

16 KB matches the typical chain payload size and stays well under server's 64 KB body cap — RAG result lists fit; runaway state objects don't flood ingest.

## Backward compat

Existing \`handleLLMStart\` / \`handleLLMEnd\` behaviour is unchanged. All 107 prior SDK tests still green; 12 new added on top → **119 total**.

## Out of scope (later in same cycle)

- **A2** — \`/docs/sdk\` LangGraph section + smoke checklist
- **B1** — Python \`SpanlensCallbackHandler\` (mirrors this contract)
- **B2** — Python LangGraph docs + smoke
- **C** — \`@spanlens/sdk@0.6.0\` + \`spanlens==0.5.0\` publish

## Test plan

- [x] 12 new unit tests in \`integrations-new.test.ts\` (chain capture, parent-child wiring, tool / retriever, 3-depth tree, error path, capture flags, truncation, idempotent + orphan end, parallel siblings)
- [x] All 119 SDK tests pass
- [x] \`pnpm --filter sdk typecheck\` clean
- [ ] Live smoke against a real \`@langchain/langgraph\` 2-node graph — runs in A2's smoke step before publish