### PR TITLE
chore(sdk): bump TS 0.6.0, Python 0.5.0 for LangGraph (C)

### DIFF
--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "spanlens"
-version = "0.4.0"
+version = "0.5.0"
 description = "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for Python."
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/sdk-python/spanlens/__init__.py
+++ b/packages/sdk-python/spanlens/__init__.py
@@ -37,7 +37,7 @@ from .parsers import parse_anthropic_usage, parse_gemini_usage, parse_openai_usa
 from .span import SpanHandle
 from .trace import TraceHandle
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 __all__ = [
     "SpanHandle",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Final PR of the LangGraph integration cycle.

| | Before | After |
|---|---|---|
| \`@spanlens/sdk\` | 0.5.0 | **0.6.0** |
| \`spanlens\` | 0.4.0 | **0.5.0** |

semver: **minor** on both — backward-compatible feature addition (PR #137 extended the TS LangChain handler with chain/tool/retriever + tree assembly, PR #138 added the equivalent Python \`SpanlensCallbackHandler\`, PR #139 documented both).

## Publish triggers (after merge)

\`\`\`bash
git tag sdk-v0.6.0        && git push origin sdk-v0.6.0
git tag python-sdk-v0.5.0 && git push origin python-sdk-v0.5.0
\`\`\`

- \`sdk-v*\` → \`publish-sdk.yml\` → npm
- \`python-sdk-v*\` → \`publish-sdk-python.yml\` → PyPI

The Python workflow has a built-in guard that refuses to publish if the version already exists on PyPI.

## Verification (after publish)

\`\`\`bash
npm view @spanlens/sdk version   # → 0.6.0
pip index versions spanlens      # → 0.5.0
\`\`\`

## Test plan
- [x] All 3 version strings updated in lockstep
- [ ] CI green (typecheck + lint + tests)
- [ ] After merge: tag push triggers both publish workflows
- [ ] npm + PyPI confirm new versions live