### PR TITLE
perf(server): coalesce + cache org plan + provider key names

### DIFF
--- a/apps/server/src/__tests__/requests-query-cache.test.ts
+++ b/apps/server/src/__tests__/requests-query-cache.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Cache + coalescing behaviour for `getOrgPlan` and `fetchProviderKeyNames`.
+ *
+ * These two paths sit on every dashboard read (/requests, /security, /exports)
+ * and previously fired one Supabase round-trip per concurrent caller. The
+ * coalescing change makes 5+ concurrent callers share one round-trip; the
+ * key-names cache adds a 5-minute TTL on top.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const supabaseFromMock = vi.fn()
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: (...args: unknown[]) => supabaseFromMock(...args),
+  },
+}))
+
+// Import after the mock is registered.
+const {
+  getOrgPlan,
+  resetOrgPlanCache,
+  fetchProviderKeyNames,
+  resetProviderKeyNamesCache,
+} = await import('../lib/requests-query.js')
+
+beforeEach(() => {
+  resetOrgPlanCache()
+  resetProviderKeyNamesCache()
+  supabaseFromMock.mockReset()
+})
+
+/** Returns a chainable mock that ends in `.single()` resolving to `{ data, error }`. */
+function singleChain(data: unknown, error: unknown = null) {
+  const chain: Record<string, unknown> = {}
+  chain['select'] = () => chain
+  chain['eq'] = () => chain
+  chain['single'] = () => Promise.resolve({ data, error })
+  return chain
+}
+
+/** Chainable mock for the org-wide provider_keys SELECT used by the cache. */
+function selectAllChain(data: unknown, error: unknown = null) {
+  const chain: Record<string, unknown> = {}
+  chain['select'] = () => chain
+  // Resolve when the caller does `.eq('organization_id', orgId)` — that returns
+  // a thenable in supabase-js v2.
+  chain['eq'] = () => Promise.resolve({ data, error })
+  return chain
+}
+
+// ── getOrgPlan ────────────────────────────────────────────────────────────
+
+describe('getOrgPlan — coalescing + 30s cache', () => {
+  it('returns the looked-up plan and warms the cache', async () => {
+    supabaseFromMock.mockReturnValueOnce(singleChain({ plan: 'pro' }))
+    expect(await getOrgPlan('org-1')).toBe('pro')
+    // Second call within TTL should not hit Supabase again.
+    expect(await getOrgPlan('org-1')).toBe('pro')
+    expect(supabaseFromMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to free on a Supabase miss / null data', async () => {
+    supabaseFromMock.mockReturnValueOnce(singleChain(null))
+    expect(await getOrgPlan('org-x')).toBe('free')
+  })
+
+  it('coalesces concurrent callers onto a single Supabase round-trip', async () => {
+    // Block the Supabase call so the second caller has a chance to land
+    // before the first one finishes — that is the racy window the change fixes.
+    let resolveFetch: (val: unknown) => void = () => {}
+    const blocker = new Promise((r) => {
+      resolveFetch = r
+    })
+    supabaseFromMock.mockReturnValueOnce({
+      select: () => ({
+        eq: () => ({
+          single: () => blocker,
+        }),
+      }),
+    } as never)
+
+    const p1 = getOrgPlan('org-coalesce')
+    const p2 = getOrgPlan('org-coalesce')
+    const p3 = getOrgPlan('org-coalesce')
+
+    // All three are now awaiting the same in-flight promise.
+    expect(supabaseFromMock).toHaveBeenCalledTimes(1)
+
+    resolveFetch({ data: { plan: 'team' }, error: null })
+    expect(await p1).toBe('team')
+    expect(await p2).toBe('team')
+    expect(await p3).toBe('team')
+    expect(supabaseFromMock).toHaveBeenCalledTimes(1) // still one
+  })
+
+  it('clears the in-flight map after the fetch settles so the next miss refetches', async () => {
+    supabaseFromMock.mockReturnValueOnce(singleChain({ plan: 'free' }))
+    await getOrgPlan('org-2')
+    resetOrgPlanCache()
+    supabaseFromMock.mockReturnValueOnce(singleChain({ plan: 'pro' }))
+    expect(await getOrgPlan('org-2')).toBe('pro')
+    expect(supabaseFromMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ── fetchProviderKeyNames ─────────────────────────────────────────────────
+
+describe('fetchProviderKeyNames — org-wide 5-min cache', () => {
+  it('returns name map for the requested ids', async () => {
+    supabaseFromMock.mockReturnValueOnce(
+      selectAllChain([
+        { id: 'k1', name: 'Production Anthropic' },
+        { id: 'k2', name: 'Staging OpenAI' },
+      ]),
+    )
+    const out = await fetchProviderKeyNames('org-1', ['k1', 'k2'])
+    expect(out.size).toBe(2)
+    expect(out.get('k1')).toBe('Production Anthropic')
+    expect(out.get('k2')).toBe('Staging OpenAI')
+  })
+
+  it('serves a second request for a subset from cache (no extra Supabase hit)', async () => {
+    supabaseFromMock.mockReturnValueOnce(
+      selectAllChain([
+        { id: 'k1', name: 'Alpha' },
+        { id: 'k2', name: 'Beta' },
+        { id: 'k3', name: 'Gamma' },
+      ]),
+    )
+    await fetchProviderKeyNames('org-cache', ['k1', 'k2'])
+    const second = await fetchProviderKeyNames('org-cache', ['k3'])
+    expect(second.get('k3')).toBe('Gamma')
+    expect(supabaseFromMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('filters the cached map to the ids the caller asked about', async () => {
+    supabaseFromMock.mockReturnValueOnce(
+      selectAllChain([
+        { id: 'k1', name: 'A' },
+        { id: 'k2', name: 'B' },
+      ]),
+    )
+    const out = await fetchProviderKeyNames('org-filter', ['k1', 'missing-id'])
+    expect(out.size).toBe(1)
+    expect(out.has('k1')).toBe(true)
+    expect(out.has('missing-id')).toBe(false)
+  })
+
+  it('returns an empty map without calling Supabase when keyIds is empty', async () => {
+    const out = await fetchProviderKeyNames('org-empty', [])
+    expect(out.size).toBe(0)
+    expect(supabaseFromMock).not.toHaveBeenCalled()
+  })
+
+  it('coalesces concurrent first-callers onto one Supabase fetch', async () => {
+    let resolveFetch: (val: unknown) => void = () => {}
+    const blocker = new Promise((r) => {
+      resolveFetch = r
+    })
+    supabaseFromMock.mockReturnValueOnce({
+      select: () => ({
+        eq: () => blocker,
+      }),
+    } as never)
+
+    const p1 = fetchProviderKeyNames('org-coalesce-keys', ['k1'])
+    const p2 = fetchProviderKeyNames('org-coalesce-keys', ['k1'])
+    expect(supabaseFromMock).toHaveBeenCalledTimes(1)
+
+    resolveFetch({ data: [{ id: 'k1', name: 'Same' }], error: null })
+    expect((await p1).get('k1')).toBe('Same')
+    expect((await p2).get('k1')).toBe('Same')
+    expect(supabaseFromMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('refetches after the cache is reset (mimics the invalidate-on-write hook)', async () => {
+    supabaseFromMock.mockReturnValueOnce(selectAllChain([{ id: 'k1', name: 'old' }]))
+    await fetchProviderKeyNames('org-reset', ['k1'])
+
+    resetProviderKeyNamesCache()
+
+    supabaseFromMock.mockReturnValueOnce(selectAllChain([{ id: 'k1', name: 'new' }]))
+    const out = await fetchProviderKeyNames('org-reset', ['k1'])
+    expect(out.get('k1')).toBe('new')
+    expect(supabaseFromMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/server/src/api/providerKeys.ts
+++ b/apps/server/src/api/providerKeys.ts
@@ -4,6 +4,7 @@ import { requireRole } from '../middleware/requireRole.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { getOrgClickhouse } from '../lib/clickhouse.js'
 import { aes256Encrypt } from '../lib/crypto.js'
+import { resetProviderKeyNamesCache } from '../lib/requests-query.js'
 
 /**
  * Provider AI keys (OpenAI / Anthropic / Gemini). Under the nested-keys
@@ -246,6 +247,9 @@ providerKeysRouter.post('/', requireEdit, async (c) => {
     return c.json({ error: 'Failed to store provider key' }, 500)
   }
 
+  // Invalidate the cached org → key-name map so the new key shows up
+  // immediately on /requests instead of waiting for the 5-min TTL.
+  resetProviderKeyNamesCache()
   return c.json({ success: true, data }, 201)
 })
 
@@ -272,6 +276,7 @@ providerKeysRouter.delete('/:id', requireEdit, async (c) => {
 
   if (error) return c.json({ error: 'Failed to delete provider key' }, 500)
 
+  resetProviderKeyNamesCache()
   return c.json({ success: true })
 })
 
@@ -309,5 +314,6 @@ providerKeysRouter.patch('/:id', requireEdit, async (c) => {
 
   if (error || !data) return c.json({ error: 'Provider key not found or access denied' }, 404)
 
+  resetProviderKeyNamesCache()
   return c.json({ success: true, data })
 })

--- a/apps/server/src/lib/requests-query.ts
+++ b/apps/server/src/lib/requests-query.ts
@@ -27,11 +27,21 @@ interface CachedPlan {
 
 const PLAN_CACHE_TTL_MS = 30 * 1000 // 30s — short enough that downgrades take effect quickly
 const planCache = new Map<string, CachedPlan>()
+/**
+ * Request coalescing: when 5+ concurrent dashboard queries hit a cold cache
+ * they used to each fire their own Supabase lookup. With this map a single
+ * in-flight promise is shared until it settles, so a cold page load only
+ * costs one Supabase round-trip per org instead of one per concurrent caller.
+ */
+const planInflight = new Map<string, Promise<Plan>>()
 
 /**
  * Looks up an organization's billing plan. Cached for 30s to avoid hammering
  * Supabase on every dashboard query — the dashboard typically issues 4–6
  * concurrent reads per page load.
+ *
+ * Concurrent callers that arrive while a fetch is in flight share the same
+ * promise (no thundering herd).
  *
  * Falls back to 'free' on any lookup miss (network blip, deleted org, etc.).
  * The conservative fallback never grants extra retention.
@@ -40,20 +50,32 @@ export async function getOrgPlan(organizationId: string): Promise<Plan> {
   const cached = planCache.get(organizationId)
   if (cached && cached.expiresAt > Date.now()) return cached.plan
 
-  const { data } = await supabaseAdmin
-    .from('organizations')
-    .select('plan')
-    .eq('id', organizationId)
-    .single()
+  // Coalesce on in-flight fetch — second+ caller awaits the first one's promise.
+  const existing = planInflight.get(organizationId)
+  if (existing) return existing
 
-  const plan = ((data?.plan as Plan | null | undefined) ?? 'free')
-  planCache.set(organizationId, { plan, expiresAt: Date.now() + PLAN_CACHE_TTL_MS })
-  return plan
+  const fetchPromise = (async (): Promise<Plan> => {
+    try {
+      const { data } = await supabaseAdmin
+        .from('organizations')
+        .select('plan')
+        .eq('id', organizationId)
+        .single()
+      const plan = (data?.plan as Plan | null | undefined) ?? 'free'
+      planCache.set(organizationId, { plan, expiresAt: Date.now() + PLAN_CACHE_TTL_MS })
+      return plan
+    } finally {
+      planInflight.delete(organizationId)
+    }
+  })()
+  planInflight.set(organizationId, fetchPromise)
+  return fetchPromise
 }
 
-/** Test/escape hatch — flush the cache when a plan changes mid-test. */
+/** Test/escape hatch — flush both the cached value AND any in-flight fetch. */
 export function resetOrgPlanCache(): void {
   planCache.clear()
+  planInflight.clear()
 }
 
 export interface RequestsScope {
@@ -111,11 +133,34 @@ export async function requestsScope(
 }
 
 /**
+ * Per-org cache of the full provider_keys (id → name) map. Provider keys
+ * change rarely (registration / rotation events), so a 5-minute TTL is
+ * conservative — UI shows the renamed key within minutes of the update.
+ *
+ * Keyed by orgId; the value is the full org-wide id→name map (not filtered
+ * to a specific request's keyIds). This lets every concurrent /requests page
+ * load hit the cache after the first warmup, instead of each making its own
+ * Supabase IN-list lookup.
+ */
+interface CachedKeyNames {
+  map: Map<string, string | null>
+  expiresAt: number
+}
+
+const KEY_NAMES_CACHE_TTL_MS = 5 * 60 * 1000 // 5 min
+const keyNamesCache = new Map<string, CachedKeyNames>()
+const keyNamesInflight = new Map<string, Promise<Map<string, string | null>>>()
+
+/**
  * Bulk-fetches `provider_keys.name` for a set of IDs and returns a map.
  * Used to replace Supabase's nested-select pattern (`provider_keys ( name )`)
  * at the application layer now that requests lives in a different DB.
  *
  * Returns an empty map for an empty input — safe to call unconditionally.
+ *
+ * Implementation: caches the **full** org's id→name map for 5 min and serves
+ * the requested subset from it. Concurrent callers share an in-flight
+ * promise (same coalescing as `getOrgPlan`).
  */
 export async function fetchProviderKeyNames(
   organizationId: string,
@@ -124,17 +169,52 @@ export async function fetchProviderKeyNames(
   const uniqueIds = [...new Set(keyIds.filter((id): id is string => !!id))]
   if (uniqueIds.length === 0) return new Map()
 
-  const { data } = await supabaseAdmin
-    .from('provider_keys')
-    .select('id, name')
-    .eq('organization_id', organizationId)
-    .in('id', uniqueIds)
+  const orgMap = await getOrgKeyNamesMap(organizationId)
 
-  const map = new Map<string, string | null>()
-  for (const row of data ?? []) {
-    map.set(row.id as string, (row.name as string | null) ?? null)
+  // Return only the ids that were requested.
+  const subset = new Map<string, string | null>()
+  for (const id of uniqueIds) {
+    if (orgMap.has(id)) subset.set(id, orgMap.get(id) ?? null)
   }
-  return map
+  return subset
+}
+
+async function getOrgKeyNamesMap(
+  organizationId: string,
+): Promise<Map<string, string | null>> {
+  const cached = keyNamesCache.get(organizationId)
+  if (cached && cached.expiresAt > Date.now()) return cached.map
+
+  const existing = keyNamesInflight.get(organizationId)
+  if (existing) return existing
+
+  const fetchPromise = (async (): Promise<Map<string, string | null>> => {
+    try {
+      const { data } = await supabaseAdmin
+        .from('provider_keys')
+        .select('id, name')
+        .eq('organization_id', organizationId)
+      const map = new Map<string, string | null>()
+      for (const row of data ?? []) {
+        map.set(row.id as string, (row.name as string | null) ?? null)
+      }
+      keyNamesCache.set(organizationId, {
+        map,
+        expiresAt: Date.now() + KEY_NAMES_CACHE_TTL_MS,
+      })
+      return map
+    } finally {
+      keyNamesInflight.delete(organizationId)
+    }
+  })()
+  keyNamesInflight.set(organizationId, fetchPromise)
+  return fetchPromise
+}
+
+/** Test/escape hatch — also called when a provider key is created/renamed/deleted. */
+export function resetProviderKeyNamesCache(): void {
+  keyNamesCache.clear()
+  keyNamesInflight.clear()
 }
 
 /**


### PR DESCRIPTION
Follow-up to the SSR instrumentation cycle (PR #132/#133). The instrumentation showed two compounding sources of latency on every dashboard page render:

\`\`\`
scope   = getOrgPlan()            = 718 ms
keysMap = fetchProviderKeyNames() = 267 ms
\`\`\`

Multiplied by 5–6 concurrent sidebar / page queries that race a cold 30s plan cache, this was \~1s of compounded latency per page.

## Changes

1. **\`getOrgPlan\` request coalescing.** While a Supabase fetch is in flight, additional concurrent callers \`await\` the same promise via an in-flight map. 5+ concurrent requests after a cold cache collapse to **one** round-trip instead of N.

2. **\`fetchProviderKeyNames\` org-wide 5-min cache + coalescing.** Previously every concurrent /requests page issued its own \`IN (...)\` lookup; the cache now stores the full org \`id→name\` map once and per-request callers serve their subset from it. 5-min TTL is conservative — provider keys change rarely.

3. **Cache invalidation hook.** \`resetProviderKeyNamesCache()\` fires from POST / PATCH / DELETE \`/api/v1/provider-keys\` so a newly registered or renamed key shows up on /requests immediately instead of after 5 minutes.

## Expected impact

Roughly **-200 ms** on warm pages from the keys cache, and a much larger improvement (potentially **-2 s**) on the cold-then-fan-out case where multiple sidebar fetches no longer thunder-herd Supabase. Actual savings depend on production cold-start patterns and will be re-measured once production has had a few traffic-mixed minutes.

## Tests

10 new in \`requests-query-cache.test.ts\` (534 total, was 524):
- \`getOrgPlan\` single lookup + cache hit, free fallback on miss
- coalesces 3 concurrent callers into 1 Supabase round-trip
- clears in-flight map after settlement
- \`fetchProviderKeyNames\` returns requested-only subset
- subsequent caller serves from cached org-wide map
- missing-id requests return only existing ids
- empty keyIds → 0 Supabase calls
- concurrent first-callers coalesce
- \`resetProviderKeyNamesCache\` triggers refetch

## Test plan

- [x] 534 server tests pass
- [x] Typecheck — no new errors (2 pre-existing unchanged)
- [ ] After merge, re-instrument briefly and compare \`scope=\` / \`keysMap=\` numbers vs. PR #132's baseline