### PR TITLE
fix(web): await params on 3 dynamic-route pages (Next.js 15+)

### DIFF
--- a/apps/web/app/(dashboard)/prompts/[name]/page.tsx
+++ b/apps/web/app/(dashboard)/prompts/[name]/page.tsx
@@ -3,8 +3,14 @@ import { prefetchAll } from '@/lib/server/dehydrate'
 import { promptVersionsSpec, promptExperimentsSpec } from '@/lib/server/queries/prompts'
 import { PromptDetailClient } from './prompt-detail-client'
 
-export default async function PromptDetailPage({ params }: { params: { name: string } }) {
-  const name = decodeURIComponent(params.name)
+// Next.js 15+ — `params` is a Promise (see traces/[id]/page.tsx for the same fix).
+export default async function PromptDetailPage({
+  params,
+}: {
+  params: Promise<{ name: string }>
+}) {
+  const resolved = await params
+  const name = decodeURIComponent(resolved.name)
   const state = await prefetchAll([
     promptVersionsSpec(name),
     promptExperimentsSpec(name),
@@ -12,7 +18,7 @@ export default async function PromptDetailPage({ params }: { params: { name: str
 
   return (
     <HydrationBoundary state={state}>
-      <PromptDetailClient params={params} />
+      <PromptDetailClient params={resolved} />
     </HydrationBoundary>
   )
 }

--- a/apps/web/app/(dashboard)/requests/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/requests/[id]/page.tsx
@@ -3,14 +3,20 @@ import { prefetchAll } from '@/lib/server/dehydrate'
 import { requestSpec } from '@/lib/server/queries/requests'
 import { RequestDetailClient } from './request-detail-client'
 
-export default async function RequestDetailPage({ params }: { params: { id: string } }) {
-  const state = await prefetchAll([requestSpec(params.id)])
+// Next.js 15+ — `params` is a Promise (see traces/[id]/page.tsx for the same fix).
+export default async function RequestDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const state = await prefetchAll([requestSpec(id)])
 
   return (
     <HydrationBoundary state={state}>
-      {/* key={params.id} remounts the client component on id change so
+      {/* key={id} remounts the client component on id change so
           internal tab state resets without a setState-in-effect. */}
-      <RequestDetailClient key={params.id} id={params.id} />
+      <RequestDetailClient key={id} id={id} />
     </HydrationBoundary>
   )
 }

--- a/apps/web/app/(dashboard)/traces/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/traces/[id]/page.tsx
@@ -3,12 +3,20 @@ import { prefetchAll } from '@/lib/server/dehydrate'
 import { traceDetailSpec } from '@/lib/server/queries/traces'
 import { TraceDetailClient } from './trace-detail-client'
 
-export default async function TraceDetailPage({ params }: { params: { id: string } }) {
-  const state = await prefetchAll([traceDetailSpec(params.id)])
+// Next.js 15+ — dynamic route `params` is a Promise that must be awaited.
+// Treating it as sync makes `.id` resolve to undefined, sending the SSR
+// prefetch to `/api/v1/traces/undefined` → 404 → "Trace not found" page.
+export default async function TraceDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const state = await prefetchAll([traceDetailSpec(id)])
 
   return (
     <HydrationBoundary state={state}>
-      <TraceDetailClient id={params.id} />
+      <TraceDetailClient id={id} />
     </HydrationBoundary>
   )
 }


### PR DESCRIPTION
## Bug

Trace / request / prompt detail pages all return **\"not found\"** when navigated to. Confirmed via Vercel logs — every detail-page click generates:

\`\`\`
λ GET /api/v1/traces             200
λ GET /api/v1/traces/undefined   404
\`\`\`

The list view loads fine; the detail SSR prefetch is hitting \`/undefined\` because \`params.id\` resolves to undefined.

## Root cause

Next.js 15+ made dynamic-route \`params\` a Promise. Treating it as a sync object makes \`.id\` / \`.name\` resolve to undefined. Three pages still had the old sync signature:

- \`apps/web/app/(dashboard)/traces/[id]/page.tsx\`
- \`apps/web/app/(dashboard)/requests/[id]/page.tsx\`
- \`apps/web/app/(dashboard)/prompts/[name]/page.tsx\`

The other three dynamic routes (\`datasets/[id]\`, \`experiments/[id]\`, \`users/[userId]\`) already used the correct \`Promise<{...}>\` signature, so no change there.

## Fix

Typed each affected page's \`params\` as \`Promise<{...}>\` and \`await\`ed it before use:

\`\`\`ts
export default async function TraceDetailPage({
  params,
}: {
  params: Promise<{ id: string }>
}) {
  const { id } = await params
  const state = await prefetchAll([traceDetailSpec(id)])
  ...
}
\`\`\`

Inline comments point future readers at the same Next.js change.

## Test plan

- [x] \`pnpm --filter web typecheck\` clean
- [x] \`pnpm --filter web lint\` clean
- [x] Dev server boots without compile errors; navigating to \`/traces/<id>\` reaches the auth gate (= page module loaded successfully)
- [ ] After merge → Vercel preview → click any trace row → detail page renders span list (not 404)