### PR TITLE
docs(web): post-LangGraph cleanup — Azure/Ollama/framework gaps

### DIFF
--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -70,7 +70,7 @@ export default function DocsIndex() {
             What providers are supported?
           </summary>
           <p className="mt-2 text-muted-foreground">
-            OpenAI, Anthropic, and Google Gemini — including streaming responses. We match the upstream API 1:1, so any SDK that talks to those providers works.
+            OpenAI, Anthropic, Google Gemini, Azure OpenAI, and self-hosted Ollama — including streaming responses. We match each upstream API 1:1, so any SDK that talks to those providers works. For LangChain, LangGraph, LCEL, Vercel AI SDK, and LlamaIndex, see the <a className="underline" href="/docs/sdk#framework-integrations">framework integrations</a>.
           </p>
         </details>
 

--- a/apps/web/app/docs/quick-start/page.tsx
+++ b/apps/web/app/docs/quick-start/page.tsx
@@ -88,6 +88,15 @@ const genAI = createGemini()
 const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash' })
 const result = await model.generateContent('Hi')`}</CodeBlock>
 
+      <h3 id="frameworks">Using LangChain, LangGraph, Vercel AI SDK, or LlamaIndex?</h3>
+      <p>
+        Skip the per-provider helpers above and use a single callback handler instead — it
+        captures LLM, chain, tool, and retriever spans automatically (including the full
+        LangGraph node topology). See{' '}
+        <a className="underline" href="/docs/sdk#framework-integrations">framework integrations</a>{' '}
+        for the per-framework snippet.
+      </p>
+
       <h3>Adding new providers later — no CLI needed</h3>
       <p>
         Once Steps 1 and 2 are done, adding a second or third provider is just:

--- a/apps/web/app/docs/sdk/page.tsx
+++ b/apps/web/app/docs/sdk/page.tsx
@@ -633,11 +633,12 @@ with client.start_trace("local_chat") as trace:
 )`}
       />
 
-      <h2 id="framework-integrations">Framework integrations (v0.3.0+)</h2>
+      <h2 id="framework-integrations">Framework integrations</h2>
       <p>
-        If you use LangChain, Vercel AI SDK, or LlamaIndex, plug in the matching integration instead
-        of wiring callbacks manually. Each one records an LLM span automatically — tokens, latency,
-        model name — without importing from the framework itself (duck-typed, version-agnostic).
+        If you use LangChain, LangGraph (v0.6.0+ / 0.5.0+), Vercel AI SDK, or LlamaIndex, plug in
+        the matching integration instead of wiring callbacks manually. Each one records spans
+        automatically — tokens, latency, model name, and the full chain/tool/retriever topology —
+        without importing from the framework itself (duck-typed, version-agnostic).
       </p>
 
       <h3 id="langchain">LangChain & LangGraph (v0.6.0+ / 0.5.0+)</h3>


### PR DESCRIPTION
Three small gaps in \`/docs\` surfaced after auditing the pages following the LangGraph cycle.

| Gap | Where | Fix |
|---|---|---|
| FAQ \"What providers are supported?\" listed only OpenAI / Anthropic / Gemini | \`/docs\` overview | Add **Azure OpenAI** (PR #125) + **Ollama** (PR #126) + link to framework integrations |
| No quick-start entry point for framework users | \`/docs/quick-start\` | New subsection \"Using LangChain, LangGraph, Vercel AI SDK, or LlamaIndex?\" → links to \`/docs/sdk#framework-integrations\` |
| \"Framework integrations (v0.3.0+)\" heading misleading | \`/docs/sdk\` | Drop the stale single-version tag; roll the actual versioning into the body (LangChain & LangGraph v0.6.0+ / 0.5.0+ already documented in the per-section heading) |

No code change. Lint + typecheck clean.

## Test plan

- [x] \`pnpm --filter web typecheck\` clean
- [x] \`pnpm --filter web lint\` clean
- [x] Dev preview of \`/docs\` — FAQ now reads:
      *\"OpenAI, Anthropic, Google Gemini, Azure OpenAI, and self-hosted Ollama … For LangChain, LangGraph, LCEL, Vercel AI SDK, and LlamaIndex, see the framework integrations.\"*