### PR TITLE
feat(web): competitor comparison pages and prose polish

### DIFF
--- a/apps/web/app/(dashboard)/alerts/[id]/alert-detail-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/[id]/alert-detail-client.tsx
@@ -199,7 +199,7 @@ export function AlertDetailClient() {
             <ArrowLeft className="h-3 w-3" /> All alerts
           </Link>
 
-          {/* Header — rule state */}
+          {/* Header, rule state */}
           <div className="flex items-center gap-3 mb-1">
             <span
               className={cn(

--- a/apps/web/app/(dashboard)/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/alerts-client.tsx
@@ -374,7 +374,7 @@ export function AlertsClient() {
                 <div className="h-12 bg-bg-elev rounded animate-pulse" />
               ) : channels.length === 0 ? (
                 <div className="rounded-[5px] border border-dashed border-border py-5 text-center font-mono text-[12px] text-text-muted">
-                  No channels yet — add an email or webhook to receive alerts.
+                  No channels yet, add an email or webhook to receive alerts.
                 </div>
               ) : (
                 <div className="rounded-[6px] border border-border overflow-hidden">

--- a/apps/web/app/(dashboard)/annotation/annotation-client.tsx
+++ b/apps/web/app/(dashboard)/annotation/annotation-client.tsx
@@ -47,7 +47,7 @@ function extractRequestUserText(body: Record<string, unknown> | null): string {
 }
 
 function fmtScore(n: number | null | undefined): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   return (n * 100).toFixed(0)
 }
 
@@ -183,7 +183,7 @@ function ItemCard({ item }: { item: AnnotationQueueItem }) {
       <div className="flex items-center px-[14px] py-[10px] bg-bg-muted border-b border-border">
         <div className="flex-1 min-w-0">
           <p className="font-mono text-[12px] text-text font-medium truncate">
-            {item.prompt_name ?? '—'}{item.prompt_version != null ? ` · v${item.prompt_version}` : ''}
+            {item.prompt_name ?? ','}{item.prompt_version != null ? ` · v${item.prompt_version}` : ''}
           </p>
           <p className="font-mono text-[10px] text-text-faint truncate">
             {item.model} · {formatDateTime(item.created_at)}
@@ -209,7 +209,7 @@ function ItemCard({ item }: { item: AnnotationQueueItem }) {
         </div>
       </div>
 
-      {/* Body — user input + response */}
+      {/* Body, user input + response */}
       <div className="grid grid-cols-2 gap-3 p-3">
         <div className="min-w-0">
           <p className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-1">
@@ -219,7 +219,7 @@ function ItemCard({ item }: { item: AnnotationQueueItem }) {
             'font-mono text-[11.5px] text-text-muted leading-relaxed whitespace-pre-wrap',
             !expanded && 'line-clamp-3',
           )}>
-            {userMsg || '—'}
+            {userMsg || ','}
           </p>
         </div>
         <div className="min-w-0">
@@ -239,7 +239,7 @@ function ItemCard({ item }: { item: AnnotationQueueItem }) {
             'font-mono text-[12px] text-text leading-relaxed whitespace-pre-wrap',
             !expanded && 'line-clamp-5',
           )}>
-            {responseText || '—'}
+            {responseText || ','}
           </p>
         </div>
       </div>
@@ -311,7 +311,7 @@ export function AnnotationClient() {
       <div className="px-[22px] py-[10px] border-b border-border flex items-center gap-2 font-mono text-[11px] text-text-muted">
         <MessageSquare className="h-3.5 w-3.5" />
         <span>
-          Manually score responses. Your ratings calibrate against LLM judge scores —
+          Manually score responses. Your ratings calibrate against LLM judge scores ,
           a low correlation signals the judge needs work.
         </span>
       </div>

--- a/apps/web/app/(dashboard)/anomalies/anomalies-client.tsx
+++ b/apps/web/app/(dashboard)/anomalies/anomalies-client.tsx
@@ -177,10 +177,10 @@ function AnomRow({ a, idx, last, onAck, onUnack, ackPending, dimmed }: AnomRowPr
               )}
               title={
                 a.confidence === 'low'
-                  ? `Low confidence — only ${a.referenceCount} baseline samples (< 30). Treat as directional only.`
+                  ? `Low confidence, only ${a.referenceCount} baseline samples (< 30). Treat as directional only.`
                   : a.confidence === 'medium'
-                    ? `Medium confidence — ${a.referenceCount} baseline samples.`
-                    : `High confidence — ${a.referenceCount} baseline samples.`
+                    ? `Medium confidence, ${a.referenceCount} baseline samples.`
+                    : `High confidence, ${a.referenceCount} baseline samples.`
               }
             >
               {a.confidence}
@@ -479,7 +479,7 @@ export function AnomaliesClient() {
                 </p>
                 <p className="font-mono text-[11.5px] text-text-faint">
                   {acked.length > 0
-                    ? `${acked.length} acknowledged — Unack to re-open.`
+                    ? `${acked.length} acknowledged, Unack to re-open.`
                     : 'Baselines look healthy.'}
                 </p>
               </div>

--- a/apps/web/app/(dashboard)/billing/billing-client.tsx
+++ b/apps/web/app/(dashboard)/billing/billing-client.tsx
@@ -169,7 +169,7 @@ export function BillingClient() {
                 <div className="text-right shrink-0">
                   {cancelDone ? (
                     <p className="text-[12.5px] text-good">
-                      Cancellation scheduled — access continues until period end.
+                      Cancellation scheduled, access continues until period end.
                     </p>
                   ) : subscription.cancel_at_period_end ? (
                     <p className="text-[12.5px] text-text-faint">

--- a/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
@@ -440,7 +440,7 @@ export function DashboardClient() {
         {/* Greeting */}
         <div className="px-[22px] py-[22px] border-b border-border">
           <div className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5 mb-1">
-            {/* suppressHydrationWarning: greeting() uses new Date() — server UTC ≠ client local time */}
+            {/* suppressHydrationWarning: greeting() uses new Date(), server UTC ≠ client local time */}
             <span suppressHydrationWarning className="text-[22px] sm:text-[26px] font-medium tracking-[-0.6px]">
               {greeting()}.
             </span>
@@ -607,7 +607,7 @@ export function DashboardClient() {
           )}
         </div>
 
-        {/* Spend forecast — always monthly, independent of time range selector */}
+        {/* Spend forecast, always monthly, independent of time range selector */}
         {spendForecast.isLoading ? (
           <div className="px-[22px] py-5 border-b border-border">
             <Skeleton className="h-[320px] w-full" />

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -19,7 +19,7 @@ export default async function DashboardPage() {
   const state = await prefetchAll([
     statsOverviewSpec(),     // KPI row (above-fold)
     statsTimeseriesSpec(),   // Traffic chart (above-fold)
-    dismissalsSpec(),        // UI state — cheap PK lookup
+    dismissalsSpec(),        // UI state, cheap PK lookup
   ])
 
   return (

--- a/apps/web/app/(dashboard)/datasets/[id]/dataset-detail-client.tsx
+++ b/apps/web/app/(dashboard)/datasets/[id]/dataset-detail-client.tsx
@@ -128,7 +128,7 @@ function AddItemDialog({
               className="w-full px-2 py-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text resize-none"
             />
             <p className="font-mono text-[10px] text-text-faint mt-1">
-              Required for Evals dataset source — judge scores this text against your criterion.
+              Required for Evals dataset source, judge scores this text against your criterion.
             </p>
           </div>
 
@@ -189,7 +189,7 @@ function ItemRow({ item, datasetId }: { item: DatasetItem; datasetId: string }) 
         </div>
         <div className="flex items-center gap-2 shrink-0">
           {!hasExpected && (
-            <span className="font-mono text-[10px] text-warn flex items-center gap-1" title="No expected output — won't be evaluated">
+            <span className="font-mono text-[10px] text-warn flex items-center gap-1" title="No expected output, won't be evaluated">
               <AlertTriangle className="h-3 w-3" />
               no output
             </span>

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -28,12 +28,12 @@ const JUDGE_MODELS = {
 } as const
 
 function fmtUsd(n: number | null | undefined): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   return n >= 0.01 ? `$${n.toFixed(3)}` : `$${n.toFixed(5)}`
 }
 
 function fmtScore(n: number | null | undefined): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   return `${(n * 100).toFixed(1)}`
 }
 
@@ -575,7 +575,7 @@ function EvaluatorRow({
           </p>
         </div>
         <div className="font-mono text-[12px] text-text-muted w-[100px] text-right">
-          {latestCompleted ? fmtScore(latestCompleted.avg_score) : '—'}
+          {latestCompleted ? fmtScore(latestCompleted.avg_score) : ','}
         </div>
         <div className="font-mono text-[11px] text-text-faint w-[80px] text-right">
           {runs.data?.length ?? 0} runs
@@ -653,7 +653,7 @@ function CorrelationCard({ promptName }: { promptName: string }) {
 
   // Interpret r — same buckets as standard correlation rules of thumb.
   const interpretation = r == null
-    ? '—'
+    ? ','
     : Math.abs(r) >= 0.7 ? 'Strong'
     : Math.abs(r) >= 0.4 ? 'Moderate'
     : Math.abs(r) >= 0.2 ? 'Weak'
@@ -670,7 +670,7 @@ function CorrelationCard({ promptName }: { promptName: string }) {
       <div className="flex items-start gap-4">
         {/* Scatter plot */}
         <svg width={W} height={H} className="shrink-0 bg-bg rounded-[4px] border border-border">
-          {/* Diagonal reference line — perfect agreement */}
+          {/* Diagonal reference line, perfect agreement */}
           <line
             x1={PAD} y1={H - PAD} x2={W - PAD} y2={PAD}
             stroke="var(--border-strong, currentColor)"
@@ -696,7 +696,7 @@ function CorrelationCard({ promptName }: { promptName: string }) {
             </p>
             <div className="flex items-baseline gap-2">
               <span className={cn('font-mono text-[22px] font-medium', rColor)}>
-                {r == null ? '—' : r.toFixed(2)}
+                {r == null ? ',' : r.toFixed(2)}
               </span>
               <span className="font-mono text-[10.5px] text-text-muted">
                 Pearson r · {interpretation}
@@ -776,7 +776,7 @@ export function EvalsClient() {
             </span>
           </div>
 
-          {/* Correlation card — appears only if Annotation has paired samples */}
+          {/* Correlation card, appears only if Annotation has paired samples */}
           {list.length > 0 && <CorrelationRow evaluators={list} />}
 
           {evaluators.isLoading ? (

--- a/apps/web/app/(dashboard)/experiments/[id]/experiment-detail-client.tsx
+++ b/apps/web/app/(dashboard)/experiments/[id]/experiment-detail-client.tsx
@@ -11,17 +11,17 @@ import {
 } from '@/lib/queries/use-experiments'
 
 function fmtUsd(n: number | null | undefined): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   return n >= 0.01 ? `$${n.toFixed(3)}` : `$${n.toFixed(5)}`
 }
 
 function fmtScore(n: number | null | undefined): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   return (n * 100).toFixed(1)
 }
 
 function fmtMs(n: number | null | undefined): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   if (n >= 1000) return `${(n / 1000).toFixed(2)}s`
   return `${Math.round(n)}ms`
 }
@@ -84,7 +84,7 @@ function ResultRow({ result, idx }: { result: ExperimentResult; idx: number }) {
           'font-mono text-[11.5px] w-[60px] text-right',
           scoreDelta == null ? 'text-text-faint' : scoreDelta > 0 ? 'text-good' : scoreDelta < 0 ? 'text-bad' : 'text-text-muted',
         )}>
-          {scoreDelta == null ? '—' : (scoreDelta > 0 ? '+' : '') + (scoreDelta * 100).toFixed(1)}
+          {scoreDelta == null ? ',' : (scoreDelta > 0 ? '+' : '') + (scoreDelta * 100).toFixed(1)}
         </span>
         <span className="ml-3 text-text-faint">
           {expanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
@@ -250,7 +250,7 @@ export function ExperimentDetailClient({ experimentId }: { experimentId: string 
                 'font-mono text-[18px] font-medium',
                 delta == null ? 'text-text-faint' : delta > 0 ? 'text-good' : delta < 0 ? 'text-bad' : 'text-text',
               )}>
-                {delta == null ? '—' : (delta > 0 ? '+' : '') + (delta * 100).toFixed(1)}
+                {delta == null ? ',' : (delta > 0 ? '+' : '') + (delta * 100).toFixed(1)}
               </p>
             </div>
             <div className="bg-bg-muted border border-border rounded-[5px] px-3 py-2.5">

--- a/apps/web/app/(dashboard)/experiments/experiments-client.tsx
+++ b/apps/web/app/(dashboard)/experiments/experiments-client.tsx
@@ -22,12 +22,12 @@ const RUN_MODELS = {
 } as const
 
 function fmtUsd(n: number | null | undefined): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   return n >= 0.01 ? `$${n.toFixed(3)}` : `$${n.toFixed(5)}`
 }
 
 function fmtScore(n: number | null | undefined): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   return (n * 100).toFixed(1)
 }
 
@@ -196,7 +196,7 @@ function NewExperimentDialog({ open, onClose }: { open: boolean; onClose: () => 
 
           <div>
             <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
-              Evaluator (optional — for side-by-side scoring)
+              Evaluator (optional, for side-by-side scoring)
             </label>
             <select
               value={evaluatorId}
@@ -307,7 +307,7 @@ function ExperimentRow({ exp }: { exp: Experiment }) {
         'font-mono text-[12px] w-[80px] text-right',
         delta == null ? 'text-text-faint' : delta > 0 ? 'text-good' : delta < 0 ? 'text-bad' : 'text-text-muted',
       )}>
-        {delta == null ? '—' : (delta > 0 ? '+' : '') + (delta * 100).toFixed(1)}
+        {delta == null ? ',' : (delta > 0 ? '+' : '') + (delta * 100).toFixed(1)}
       </div>
       <div className="font-mono text-[11px] text-text-faint w-[80px] text-right">
         {fmtUsd(exp.total_cost_usd)}

--- a/apps/web/app/(dashboard)/projects/projects-client.tsx
+++ b/apps/web/app/(dashboard)/projects/projects-client.tsx
@@ -330,7 +330,7 @@ export function ProjectsClient() {
             <div className="rounded-xl border border-good/30 bg-good-bg px-5 py-4 mb-6">
               <div className="flex items-center justify-between mb-3">
                 <p className="text-[13px] font-medium text-good">
-                  Spanlens key created — copy now (won&apos;t be shown again)
+                  Spanlens key created, copy now (won&apos;t be shown again)
                 </p>
                 <button
                   type="button"
@@ -466,7 +466,7 @@ export function ProjectsClient() {
                       </div>
                     </div>
 
-                    {/* Spanlens key sections — each is a self-contained group:
+                    {/* Spanlens key sections, each is a self-contained group:
                         the key name acts as the header and "+ Add provider key"
                         sits next to it. Provider keys stay always-visible. */}
                     {projApiKeys.length === 0 ? (
@@ -481,7 +481,7 @@ export function ProjectsClient() {
                           )
                           return (
                             <div key={key.id}>
-                              {/* Spanlens key header — name + meta + add button + actions */}
+                              {/* Spanlens key header, name + meta + add button + actions */}
                               <div className="flex items-center gap-3 px-6 py-3 bg-bg/30">
                                 <KeyIcon className="h-3.5 w-3.5 text-text-faint shrink-0" />
                                 <div className="flex-1 min-w-0">
@@ -552,7 +552,7 @@ export function ProjectsClient() {
                                 </div>
                               </div>
 
-                              {/* Provider keys under this Spanlens key — always visible */}
+                              {/* Provider keys under this Spanlens key, always visible */}
                               {keyProvKeys.length === 0 ? (
                                 <p className="px-12 py-2.5 text-[12px] text-text-faint">
                                   No provider keys yet. Add OpenAI / Anthropic / Gemini to enable calls through this Spanlens key.
@@ -725,7 +725,7 @@ export function ProjectsClient() {
               </DialogHeader>
               <DialogDescription className="text-[12.5px] text-text-muted mt-1">
                 Drop this into your code to call {PROVIDER_LABELS[addProvAdded]} through
-                Spanlens. No CLI re-run needed — your existing{' '}
+                Spanlens. No CLI re-run needed, your existing{' '}
                 <code className="font-mono text-[11px]">SPANLENS_API_KEY</code> already
                 covers this provider.
               </DialogDescription>
@@ -755,7 +755,7 @@ export function ProjectsClient() {
 
                 <p className="font-mono text-[10.5px] text-text-faint">
                   Already running this code? It picks up the new provider on the next
-                  request — no redeploy needed.
+                  request, no redeploy needed.
                 </p>
 
                 <PrimaryBtn onClick={() => setAddProvDialogOpen(false)}>
@@ -804,7 +804,7 @@ export function ProjectsClient() {
                       className="w-full h-9 px-3 rounded-[6px] border border-border bg-bg text-[13px] font-mono text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong transition-colors"
                     />
                     <p className="text-[10.5px] text-text-faint">
-                      Copy from your Azure portal — the endpoint shown on your OpenAI resource overview. Must end in <code>.openai.azure.com</code> or <code>.services.ai.azure.com</code>.
+                      Copy from your Azure portal, the endpoint shown on your OpenAI resource overview. Must end in <code>.openai.azure.com</code> or <code>.services.ai.azure.com</code>.
                     </p>
                   </div>
                 )}
@@ -968,7 +968,7 @@ export function ProjectsClient() {
         </DialogContent>
       </Dialog>
 
-      {/* Delete project confirm — requires typing the project name */}
+      {/* Delete project confirm, requires typing the project name */}
       <Dialog
         open={deleteProject_target !== null}
         onOpenChange={(open) => { if (!open) closeDeleteProjectDialog() }}

--- a/apps/web/app/(dashboard)/prompts/[name]/tabs/ab-tab.tsx
+++ b/apps/web/app/(dashboard)/prompts/[name]/tabs/ab-tab.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 function fmtMs(v: number): string {
-  if (v === 0) return '—'
+  if (v === 0) return ','
   if (v >= 1000) return `${(v / 1000).toFixed(2)}s`
   return `${Math.round(v)}ms`
 }
@@ -29,7 +29,7 @@ function fmtPct(v: number): string {
   return `${(v * 100).toFixed(1)}%`
 }
 function fmtLift(lift: number | null): string {
-  if (lift == null) return '—'
+  if (lift == null) return ','
   const sign = lift > 0 ? '+' : ''
   return `${sign}${(lift * 100).toFixed(1)}%`
 }
@@ -82,7 +82,7 @@ function CreateExperimentForm({ name, versions, onDone }: CreateFormProps) {
   }
 
   const versionLabel = (v: PromptVersion) =>
-    `v${v.version} — ${formatDate(v.created_at)}`
+    `v${v.version}, ${formatDate(v.created_at)}`
 
   return (
     <div className="bg-bg-elev border border-border rounded-[8px] p-[18px] space-y-4">
@@ -285,7 +285,7 @@ function ExperimentResults({ experimentId, versions }: ResultsProps) {
                   { label: 'Error rate', value: fmtPct(arm.errorRate),
                     color: arm.errorRate === 0 ? 'text-good' : arm.errorRate < 0.05 ? 'text-warn' : 'text-bad' },
                   { label: 'Avg latency', value: fmtMs(arm.avgLatencyMs) },
-                  { label: 'Avg cost',    value: arm.avgCostUsd > 0 ? fmtUsd(arm.avgCostUsd) : '—' },
+                  { label: 'Avg cost',    value: arm.avgCostUsd > 0 ? fmtUsd(arm.avgCostUsd) : ',' },
                 ].map((m, i) => (
                   <div key={i}>
                     <div className="font-mono text-[10px] text-text-faint mb-0.5">{m.label}</div>

--- a/apps/web/app/(dashboard)/prompts/[name]/tabs/calls-tab.tsx
+++ b/apps/web/app/(dashboard)/prompts/[name]/tabs/calls-tab.tsx
@@ -12,7 +12,7 @@ type DateRange = '7d' | '30d' | '90d'
 const HOURS: Record<DateRange, number> = { '7d': 24 * 7, '30d': 24 * 30, '90d': 24 * 90 }
 
 function fmtMs(v: number): string {
-  if (v === 0) return '—'
+  if (v === 0) return ','
   if (v >= 1000) return `${(v / 1000).toFixed(2)}s`
   return `${Math.round(v)}ms`
 }
@@ -74,7 +74,7 @@ export function CallsTab({ name }: Props) {
                 { label: 'Total errors', value: String(totalErrors), bad: totalErrors > 0 },
                 { label: 'Avg tokens',   value: (() => {
                   const wt = metrics.reduce((s, m) => s + m.sampleCount, 0)
-                  if (wt === 0) return '—'
+                  if (wt === 0) return ','
                   const avg = metrics.reduce((s, m) => s + (m.avgPromptTokens + m.avgCompletionTokens) * m.sampleCount, 0) / wt
                   return Math.round(avg).toLocaleString()
                 })() },
@@ -133,14 +133,14 @@ export function CallsTab({ name }: Props) {
                     )}
                     title={m.qualitySampleCount > 0 ? `${m.qualitySampleCount} eval samples` : 'No evals run'}
                   >
-                    {m.avgQualityScore == null ? '—' : (m.avgQualityScore * 100).toFixed(0)}
+                    {m.avgQualityScore == null ? ',' : (m.avgQualityScore * 100).toFixed(0)}
                   </span>
                   <span className="text-right font-mono text-[12px] text-text-muted">{fmtUsd(m.avgCostUsd)}</span>
                   <span className="text-right font-mono text-[12px] text-text-muted">
-                    {m.avgPromptTokens > 0 ? Math.round(m.avgPromptTokens).toLocaleString() : '—'}
+                    {m.avgPromptTokens > 0 ? Math.round(m.avgPromptTokens).toLocaleString() : ','}
                   </span>
                   <span className="text-right font-mono text-[12px] text-text-muted">
-                    {m.avgCompletionTokens > 0 ? Math.round(m.avgCompletionTokens).toLocaleString() : '—'}
+                    {m.avgCompletionTokens > 0 ? Math.round(m.avgCompletionTokens).toLocaleString() : ','}
                   </span>
                 </Link>
               ))}

--- a/apps/web/app/(dashboard)/prompts/[name]/tabs/diff-tab.tsx
+++ b/apps/web/app/(dashboard)/prompts/[name]/tabs/diff-tab.tsx
@@ -93,7 +93,7 @@ export function DiffTab({ versions }: Props) {
             <option value="">Select version…</option>
             {sorted.map((v) => (
               <option key={v.id} value={String(v.version)}>
-                v{v.version} — {formatDate(v.created_at)}
+                v{v.version}, {formatDate(v.created_at)}
               </option>
             ))}
           </select>
@@ -109,7 +109,7 @@ export function DiffTab({ versions }: Props) {
             <option value="">Select version…</option>
             {sorted.map((v) => (
               <option key={v.id} value={String(v.version)}>
-                v{v.version} — {formatDate(v.created_at)}
+                v{v.version}, {formatDate(v.created_at)}
               </option>
             ))}
           </select>

--- a/apps/web/app/(dashboard)/prompts/[name]/tabs/playground-tab.tsx
+++ b/apps/web/app/(dashboard)/prompts/[name]/tabs/playground-tab.tsx
@@ -165,7 +165,7 @@ export function PlaygroundTab({ versions }: Props) {
           )}
         </div>
 
-        {/* Model — only shown once a key is selected */}
+        {/* Model, only shown once a key is selected */}
         {selectedKey && (
           <div className="space-y-1.5">
             <label className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint">
@@ -281,7 +281,7 @@ export function PlaygroundTab({ versions }: Props) {
           <p className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint">Prompt preview</p>
           <div className="bg-bg-muted rounded-[6px] border border-border p-4 max-h-52 overflow-y-auto">
             <pre className="font-mono text-[12px] text-text-muted whitespace-pre-wrap leading-relaxed">
-              {selectedVersion?.content ?? '—'}
+              {selectedVersion?.content ?? ','}
             </pre>
           </div>
         </div>
@@ -307,7 +307,7 @@ export function PlaygroundTab({ versions }: Props) {
                 {[
                   { label: 'Model',   value: result.model },
                   { label: 'Tokens',  value: result.totalTokens.toLocaleString() },
-                  { label: 'Cost',    value: result.costUsd != null ? fmtUsd(result.costUsd) : '—' },
+                  { label: 'Cost',    value: result.costUsd != null ? fmtUsd(result.costUsd) : ',' },
                   {
                     label: 'Latency',
                     value: result.latencyMs >= 1000

--- a/apps/web/app/(dashboard)/prompts/[name]/tabs/traffic-tab.tsx
+++ b/apps/web/app/(dashboard)/prompts/[name]/tabs/traffic-tab.tsx
@@ -11,7 +11,7 @@ type DateRange = '7d' | '30d' | '90d'
 const HOURS: Record<DateRange, number> = { '7d': 24 * 7, '30d': 24 * 30, '90d': 24 * 90 }
 
 function fmtMs(v: number): string {
-  if (v === 0) return '—'
+  if (v === 0) return ','
   if (v >= 1000) return `${(v / 1000).toFixed(2)}s`
   return `${Math.round(v)}ms`
 }
@@ -67,7 +67,7 @@ export function TrafficTab({ name }: Props) {
                 { label: 'Active versions', value: String(metrics.filter((m) => m.sampleCount > 0).length) },
                 { label: 'Best error rate', value: (() => {
                   const best = metrics.filter((m) => m.sampleCount > 0).sort((a, b) => a.errorRate - b.errorRate)[0]
-                  return best ? `${(best.errorRate * 100).toFixed(1)}%` : '—'
+                  return best ? `${(best.errorRate * 100).toFixed(1)}%` : ','
                 })() },
               ].map((s, i) => (
                 <div key={i} className="bg-bg-elev border border-border rounded-[6px] px-[16px] py-[12px]">

--- a/apps/web/app/(dashboard)/prompts/prompts-client.tsx
+++ b/apps/web/app/(dashboard)/prompts/prompts-client.tsx
@@ -15,13 +15,13 @@ function fmtUsd(v: number): string {
 }
 
 function fmtMs(v: number): string {
-  if (v === 0) return '—'
+  if (v === 0) return ','
   if (v >= 1000) return `${(v / 1000).toFixed(2)}s`
   return `${Math.round(v)}ms`
 }
 
 function QualityBadge({ score }: { score: number | null | undefined }) {
-  if (score == null) return <span className="text-text-faint">—</span>
+  if (score == null) return <span className="text-text-faint">,</span>
   const color = score >= 90 ? 'text-good' : score >= 70 ? 'text-warn' : 'text-bad'
   return <span className={cn('font-mono tabular-nums', color)}>{score}</span>
 }
@@ -104,7 +104,7 @@ export function PromptsClient() {
         crumbs={[{ label: 'Workspace', href: '/dashboard' }, { label: 'Prompts' }]}
         right={
           <div className="flex items-center gap-2">
-            {/* Search — desktop only; mobile search lives in the filter bar */}
+            {/* Search, desktop only; mobile search lives in the filter bar */}
             <div className="hidden md:flex items-center gap-2 px-[10px] py-[5px] border border-border rounded-[6px] bg-bg-elev w-[280px]">
               <span className="text-text-faint text-[14px] leading-none">⌕</span>
               <input
@@ -151,9 +151,9 @@ export function PromptsClient() {
           {[
             { label: 'Prompts',              value: String(all.length)                                         },
             { label: 'Versions',             value: String(totalVersions)                                      },
-            { label: `Calls · ${dateRange}`, value: totalCalls > 0 ? totalCalls.toLocaleString() : '—'        },
-            { label: `Avg quality`,          value: avgQuality != null ? String(avgQuality) : '—'              },
-            { label: `Spend · ${dateRange}`, value: totalSpend > 0 ? fmtUsd(totalSpend) : '—'                 },
+            { label: `Calls · ${dateRange}`, value: totalCalls > 0 ? totalCalls.toLocaleString() : ','        },
+            { label: `Avg quality`,          value: avgQuality != null ? String(avgQuality) : ','              },
+            { label: `Spend · ${dateRange}`, value: totalSpend > 0 ? fmtUsd(totalSpend) : ','                 },
           ].map((s, i) => (
             <div key={i} className={cn('px-[18px] py-[14px]', i < 4 && 'border-r border-border')}>
               <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-2">{s.label}</div>
@@ -165,7 +165,7 @@ export function PromptsClient() {
 
       {/* Filter toolbar */}
       <div className="flex flex-col gap-[6px] px-[22px] py-[10px] border-b border-border shrink-0">
-      {/* Mobile search — shown only on small screens */}
+      {/* Mobile search, shown only on small screens */}
       <div className="md:hidden flex items-center gap-2 px-[10px] py-[5px] border border-border rounded-[6px] bg-bg-elev">
         <span className="text-text-faint text-[14px] leading-none">⌕</span>
         <input
@@ -284,7 +284,7 @@ export function PromptsClient() {
       </div>
       </div>
 
-      {/* Create form panel — outside scroll container so it stays pinned */}
+      {/* Create form panel, outside scroll container so it stays pinned */}
       {formOpen && (
         <div className="px-[22px] py-[14px] bg-bg-elev border-b border-border-strong shrink-0 space-y-3">
           <div className="flex items-center justify-between">
@@ -352,7 +352,7 @@ export function PromptsClient() {
           </div>
         ) : (
           <div className="min-w-[700px]">
-            {/* Column headers — sticky so they stay visible on vertical scroll */}
+            {/* Column headers, sticky so they stay visible on vertical scroll */}
             <div
               className="grid sticky top-0 z-10 font-mono text-[10px] text-text-faint uppercase tracking-[0.05em] px-[22px] py-[9px] bg-bg-muted border-b border-border"
               style={{ gridTemplateColumns: GRID }}
@@ -401,17 +401,17 @@ export function PromptsClient() {
 
               {/* Calls */}
               <span className={cn(p.stats && p.stats.calls > 0 ? 'text-text' : 'text-text-faint')}>
-                {p.stats?.calls ? p.stats.calls.toLocaleString() : '—'}
+                {p.stats?.calls ? p.stats.calls.toLocaleString() : ','}
               </span>
 
               {/* Avg cost */}
               <span className={cn(p.stats?.avgCostUsd != null ? 'text-text' : 'text-text-faint')}>
-                {p.stats?.avgCostUsd != null ? fmtUsd(p.stats.avgCostUsd) : '—'}
+                {p.stats?.avgCostUsd != null ? fmtUsd(p.stats.avgCostUsd) : ','}
               </span>
 
               {/* Avg latency */}
               <span className={cn(p.stats?.avgLatencyMs != null ? 'text-text' : 'text-text-faint')}>
-                {p.stats?.avgLatencyMs != null ? fmtMs(p.stats.avgLatencyMs) : '—'}
+                {p.stats?.avgLatencyMs != null ? fmtMs(p.stats.avgLatencyMs) : ','}
               </span>
 
               {/* Quality score */}
@@ -425,7 +425,7 @@ export function PromptsClient() {
                     A/B
                   </span>
                 ) : (
-                  <span className="text-text-faint">—</span>
+                  <span className="text-text-faint">,</span>
                 )}
               </span>
 

--- a/apps/web/app/(dashboard)/requests/[id]/request-detail-client.tsx
+++ b/apps/web/app/(dashboard)/requests/[id]/request-detail-client.tsx
@@ -11,7 +11,7 @@ import { useRequest, useReplayRequest, useRunReplay } from '@/lib/queries/use-re
 // designed — see docs/launch/2026-05-14_cache-stream-users.md §3.
 
 function fmtCost(n: number | null): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   return '$' + n.toFixed(6)
 }
 
@@ -116,7 +116,7 @@ export function RequestDetailClient({ id }: { id: string }) {
           { label: 'Prompt tokens', value: req.prompt_tokens.toLocaleString() },
           { label: 'Completion tokens', value: req.completion_tokens.toLocaleString() },
           { label: 'Total tokens', value: req.total_tokens.toLocaleString() },
-          { label: 'Trace ID', value: req.trace_id ? req.trace_id.slice(0, 16) + '…' : '—' },
+          { label: 'Trace ID', value: req.trace_id ? req.trace_id.slice(0, 16) + '…' : ',' },
         ].map(({ label, value, warn }) => (
           <div key={label} className="border border-border rounded-[6px] px-4 py-3 bg-bg-elev">
             <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-1.5">{label}</div>
@@ -125,7 +125,7 @@ export function RequestDetailClient({ id }: { id: string }) {
         ))}
       </div>
 
-      {/* End-user attribution row — only rendered when x-spanlens-user was set */}
+      {/* End-user attribution row, only rendered when x-spanlens-user was set */}
       {req.user_id && (
         <div className="flex items-center gap-3 px-4 py-2 border border-border rounded-[6px] bg-bg-elev font-mono text-[12px]">
           <span className="text-[10px] uppercase tracking-[0.05em] text-text-faint">User</span>
@@ -144,7 +144,7 @@ export function RequestDetailClient({ id }: { id: string }) {
         </div>
       )}
 
-      {/* Prompt cache breakdown — only rendered when this request used caching */}
+      {/* Prompt cache breakdown, only rendered when this request used caching */}
       {(req.cache_read_tokens ?? 0) > 0 || (req.cache_write_tokens ?? 0) > 0 ? (
         <div className="border border-border rounded-[6px] bg-bg-elev px-4 py-3">
           <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-2">
@@ -176,7 +176,7 @@ export function RequestDetailClient({ id }: { id: string }) {
               <span className="font-medium">
                 {req.prompt_tokens > 0
                   ? `${(((req.cache_read_tokens ?? 0) / req.prompt_tokens) * 100).toFixed(1)}%`
-                  : '—'}
+                  : ','}
               </span>
             </div>
           </div>
@@ -400,7 +400,7 @@ function ReplayButton({ requestId, originalModel, provider }: ReplayButtonProps)
             <div className="grid grid-cols-2 gap-x-6 gap-y-2">
               {[
                 { label: 'Latency', value: `${run.data.latencyMs} ms` },
-                { label: 'Cost', value: run.data.costUsd != null ? `$${run.data.costUsd.toFixed(6)}` : '—' },
+                { label: 'Cost', value: run.data.costUsd != null ? `$${run.data.costUsd.toFixed(6)}` : ',' },
                 { label: 'Prompt tokens', value: run.data.promptTokens.toLocaleString() },
                 { label: 'Completion tokens', value: run.data.completionTokens.toLocaleString() },
                 { label: 'Total tokens', value: run.data.totalTokens.toLocaleString() },

--- a/apps/web/app/(dashboard)/requests/requests-client.tsx
+++ b/apps/web/app/(dashboard)/requests/requests-client.tsx
@@ -40,7 +40,7 @@ function relAge(dateStr: string): string {
 }
 
 function fmtCost(n: number | null): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   return n < 0.001 ? '$' + n.toFixed(5) : '$' + n.toFixed(4)
 }
 
@@ -87,9 +87,9 @@ function StatStrip() {
   const anomalyCount = (anomalies.data?.data ?? []).length
 
   const stats = [
-    { label: 'Requests · 24h', value: o ? o.totalRequests.toLocaleString() : '—', spark: sparkReqs, warn: false, good: false },
-    { label: 'Avg latency', value: o ? `${o.avgLatencyMs}ms` : '—', spark: [], warn: o ? o.avgLatencyMs > 1000 : false, good: false },
-    { label: 'Spend · 24h', value: o ? '$' + o.totalCostUsd.toFixed(2) : '—', spark: sparkCost, warn: false, good: true },
+    { label: 'Requests · 24h', value: o ? o.totalRequests.toLocaleString() : ',', spark: sparkReqs, warn: false, good: false },
+    { label: 'Avg latency', value: o ? `${o.avgLatencyMs}ms` : ',', spark: [], warn: o ? o.avgLatencyMs > 1000 : false, good: false },
+    { label: 'Spend · 24h', value: o ? '$' + o.totalCostUsd.toFixed(2) : ',', spark: sparkCost, warn: false, good: true },
     { label: 'Error rate', value: errorRateStr, spark: sparkErrors, warn: errorRatePct > 1, good: false },
     { label: 'Anomalies', value: anomalyCount.toString(), spark: [], warn: anomalyCount > 0, good: false },
   ]
@@ -149,7 +149,7 @@ function TrafficBars() {
   const labels = useMemo(() => {
     const pts = (rawTs ?? []).slice(-30)
     const first = pts[0]
-    if (!pts.length || !first) return ['—', '—', '—', '—', 'NOW']
+    if (!pts.length || !first) return [',', ',', ',', ',', 'NOW']
     const fmt = (s: string) => new Date(s).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
     return [
       fmt(first.date),
@@ -341,7 +341,7 @@ function RequestDrawer({ requestId, visible, onClose, onPrev, onNext, hasPrev, h
             </div>
           ))}
 
-          {/* User — clickable analytics + filter link */}
+          {/* User, clickable analytics + filter link */}
           {req.user_id && (
             <div>
               <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-0.5">User</div>
@@ -364,7 +364,7 @@ function RequestDrawer({ requestId, visible, onClose, onPrev, onNext, hasPrev, h
             </div>
           )}
 
-          {/* Session — clickable filter link */}
+          {/* Session, clickable filter link */}
           {req.session_id && (
             <div>
               <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-0.5">Session</div>
@@ -378,7 +378,7 @@ function RequestDrawer({ requestId, visible, onClose, onPrev, onNext, hasPrev, h
             </div>
           )}
 
-          {/* Trace — link to trace page + copy full ID */}
+          {/* Trace, link to trace page + copy full ID */}
           <div>
             <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-0.5">Trace</div>
             {req.trace_id ? (
@@ -392,11 +392,11 @@ function RequestDrawer({ requestId, visible, onClose, onPrev, onNext, hasPrev, h
                 <CopyButton getText={() => req.trace_id!} />
               </div>
             ) : (
-              <div className="font-mono text-[12.5px] text-text">—</div>
+              <div className="font-mono text-[12.5px] text-text">,</div>
             )}
           </div>
 
-          {/* Span — copy full ID */}
+          {/* Span, copy full ID */}
           <div>
             <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-0.5">Span</div>
             {req.span_id ? (
@@ -405,7 +405,7 @@ function RequestDrawer({ requestId, visible, onClose, onPrev, onNext, hasPrev, h
                 <CopyButton getText={() => req.span_id!} />
               </div>
             ) : (
-              <div className="font-mono text-[12.5px] text-text">—</div>
+              <div className="font-mono text-[12.5px] text-text">,</div>
             )}
           </div>
         </div>
@@ -479,7 +479,7 @@ function RequestDrawer({ requestId, visible, onClose, onPrev, onNext, hasPrev, h
         ) : tab === 'response' ? (
           req.response_body == null ? (
             <p className="font-mono text-[11.5px] text-text-faint leading-relaxed">
-              Response body is not stored — the proxy streams the response directly to your application without buffering it.<br /><br />
+              Response body is not stored, the proxy streams the response directly to your application without buffering it.<br /><br />
               Full response capture is planned for a future release.
             </p>
           ) : (
@@ -561,7 +561,7 @@ function TraceTab({ traceId }: { traceId: string | null }) {
         ))}
         {trace.spans.length > 8 && (
           <div className="px-3 py-2 font-mono text-[10.5px] text-text-faint">
-            + {trace.spans.length - 8} more — open the full trace to see them all
+            + {trace.spans.length - 8} more, open the full trace to see them all
           </div>
         )}
       </div>
@@ -793,7 +793,7 @@ function RequestsTable({
                     {req.truncated && (
                       <span
                         className="shrink-0 px-1.5 py-px text-[10px] uppercase tracking-wide rounded bg-accent/10 text-accent border border-accent/30"
-                        title="Stream closed early — request approached the Spanlens proxy deadline"
+                        title="Stream closed early, request approached the Spanlens proxy deadline"
                       >
                         truncated
                       </span>
@@ -971,7 +971,7 @@ export function RequestsClient() {
       <StatStrip />
       <TrafficBars />
 
-      {/* Active URL filter banner — shown when ?promptVersionId / ?userId / ?sessionId
+      {/* Active URL filter banner, shown when ?promptVersionId / ?userId / ?sessionId
          is present in the URL. Click × to clear and return to unfiltered view. */}
       {(promptVersionId || userIdFilter || sessionIdFilter) && (
         <div className="flex items-center gap-2 px-[22px] py-[8px] bg-accent-bg border-b border-accent-border font-mono text-[11px] flex-wrap">
@@ -1051,7 +1051,7 @@ export function RequestsClient() {
           <option value="azure">azure</option>
         </select>
 
-        {/* Model input — debounced, applies 300ms after last keystroke */}
+        {/* Model input, debounced, applies 300ms after last keystroke */}
         <input
           type="text"
           placeholder="Model…"

--- a/apps/web/app/(dashboard)/savings/savings-client.tsx
+++ b/apps/web/app/(dashboard)/savings/savings-client.tsx
@@ -252,7 +252,7 @@ function PercentileGrid({
         <div className="border border-warn/30 bg-warn/5 rounded-[5px] px-3 py-2 font-mono text-[10.5px] text-warn leading-relaxed">
           P95 exceeds the substitute envelope
           {promptWarn && complWarn ? ' for both prompt and completion' : promptWarn ? ' for prompt tokens' : ' for completion tokens'}.
-          {' '}Some requests may degrade in quality on {model.split('/').pop() ?? 'the suggested model'} — run a shadow comparison first.
+          {' '}Some requests may degrade in quality on {model.split('/').pop() ?? 'the suggested model'}, run a shadow comparison first.
         </div>
       )}
     </div>
@@ -295,7 +295,7 @@ function ResultCard({
       <p className="font-mono text-[10px] uppercase tracking-[0.04em] text-text-faint truncate">{label}</p>
       <div className="grid grid-cols-3 gap-2">
         {[
-          { label: 'Cost', value: data.costUsd != null ? `$${data.costUsd.toFixed(5)}` : '—' },
+          { label: 'Cost', value: data.costUsd != null ? `$${data.costUsd.toFixed(5)}` : ',' },
           { label: 'Latency', value: `${data.latencyMs}ms` },
           { label: 'Tokens', value: data.totalTokens.toLocaleString() },
         ].map((m) => (
@@ -385,7 +385,7 @@ function ComparePlaygroundDialog({
               className={selectClass}
             >
               <option value="">
-                {promptsLoading ? 'Loading…' : prompts.length === 0 ? 'No prompts — create one first' : 'Select a prompt…'}
+                {promptsLoading ? 'Loading…' : prompts.length === 0 ? 'No prompts, create one first' : 'Select a prompt…'}
               </option>
               {prompts.map((p) => (
                 <option key={p.id} value={p.id}>
@@ -618,7 +618,7 @@ export function SavingsClient() {
             <>
               <div className="font-mono text-[10px] text-text-faint uppercase tracking-[0.03em] mb-[3px]">ACTUAL / MO</div>
               <div className="font-mono text-[18px] font-medium tracking-[-0.3px] text-good">
-                {r.actualMonthlySavingsUsd != null ? fmtUsd(r.actualMonthlySavingsUsd) : '—'}
+                {r.actualMonthlySavingsUsd != null ? fmtUsd(r.actualMonthlySavingsUsd) : ','}
               </div>
               <div className="font-mono text-[10.5px] text-text-faint mt-0.5">
                 est. {fmtUsd(r.estimatedMonthlySavingsUsd)} projected
@@ -727,7 +727,7 @@ export function SavingsClient() {
             </div>
             <div className="flex items-baseline gap-2 mb-1.5">
               <span className={cn('font-medium leading-none tracking-[-1.6px]', totalOpen > 0 ? 'text-[40px] text-accent' : 'text-[30px] text-text-faint')}>
-                {totalOpen > 0 ? fmtUsd(totalOpen) : '—'}
+                {totalOpen > 0 ? fmtUsd(totalOpen) : ','}
               </span>
               <span className="font-mono text-[10px] text-text-muted">/ mo</span>
             </div>
@@ -758,7 +758,7 @@ export function SavingsClient() {
           {[
             {
               label: `Spend · ${windowLabel}`,
-              value: totalSpend > 0 ? fmtUsd(totalSpend) : '—',
+              value: totalSpend > 0 ? fmtUsd(totalSpend) : ',',
               delta: 'analyzed models',
               good: false,
             },
@@ -770,7 +770,7 @@ export function SavingsClient() {
             },
             {
               label: achieved.length > 0 ? 'Achieved' : (bestConfLevel ? `${bestConfLevel.charAt(0).toUpperCase() + bestConfLevel.slice(1)} conf.` : 'Confidence'),
-              value: achieved.length > 0 ? fmtUsd(totalAchieved) : (bestConfLevel !== null ? String(bestConfCount) : '—'),
+              value: achieved.length > 0 ? fmtUsd(totalAchieved) : (bestConfLevel !== null ? String(bestConfCount) : ','),
               delta: achieved.length > 0 ? `${achieved.length} swap${achieved.length > 1 ? 's' : ''} adopted` : (bestConfLevel ? bestConfLabel[bestConfLevel] : 'no recommendations yet'),
               good: achieved.length > 0 || bestConfLevel === 'high',
             },

--- a/apps/web/app/(dashboard)/security/security-client.tsx
+++ b/apps/web/app/(dashboard)/security/security-client.tsx
@@ -13,7 +13,7 @@ import { cn } from '@/lib/utils'
 
 function formatRelative(iso: string): string {
   const ms = new Date(iso).getTime()
-  if (Number.isNaN(ms)) return '—'
+  if (Number.isNaN(ms)) return ','
   const diff = (Date.now() - ms) / 1000
   if (diff < 0) return 'just now'
   if (diff < 60) return `${Math.floor(diff)}s ago`
@@ -111,10 +111,10 @@ export function SecurityClient() {
       <div className="overflow-x-auto shrink-0 border-b border-border">
         <div className="grid grid-cols-5 min-w-[480px]">
           {[
-            { label: 'Events · 24h',      value: statsReady ? String(totalHits) : '—',  warn: statsReady && totalHits > 0 },
-            { label: 'PII hits',          value: statsReady ? String(piiHits)  : '—',  warn: statsReady && piiHits > 0 },
-            { label: 'Injection attempts',value: statsReady ? String(injHits)  : '—',  warn: statsReady && injHits > 0 },
-            { label: 'Recent flagged',    value: flaggedReady ? String(flaggedTotal) : '—', warn: flaggedReady && flaggedTotal > 0 },
+            { label: 'Events · 24h',      value: statsReady ? String(totalHits) : ',',  warn: statsReady && totalHits > 0 },
+            { label: 'PII hits',          value: statsReady ? String(piiHits)  : ',',  warn: statsReady && piiHits > 0 },
+            { label: 'Injection attempts',value: statsReady ? String(injHits)  : ',',  warn: statsReady && injHits > 0 },
+            { label: 'Recent flagged',    value: flaggedReady ? String(flaggedTotal) : ',', warn: flaggedReady && flaggedTotal > 0 },
             { label: 'Detectors',         value: String(detectors.length),              warn: false },
           ].map((s) => (
             <div key={s.label} className={cn('px-[18px] py-[14px]', s.label !== 'Detectors' && 'border-r border-border')}>
@@ -152,7 +152,7 @@ export function SecurityClient() {
             <div className="border border-border rounded-[6px] px-[16px] py-[14px]">
               <div className="mb-[8px]">
                 <span className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
-                  Injection blocking — per project
+                  Injection blocking, per project
                 </span>
               </div>
               {settings.isLoading ? (
@@ -187,7 +187,7 @@ export function SecurityClient() {
                 </div>
               )}
               <p className="text-[11px] text-text-faint mt-[8px] leading-relaxed">
-                When ON, injection attempts return 422 — request never reaches the LLM.
+                When ON, injection attempts return 422, request never reaches the LLM.
               </p>
             </div>
           </div>
@@ -196,7 +196,7 @@ export function SecurityClient() {
         <div className="px-[22px] pt-[14px] pb-0">
           <div className="flex items-center justify-between mb-3">
             <span className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
-              Detectors — {detectors.length} active · flag-only (no blocking unless enabled above)
+              Detectors, {detectors.length} active · flag-only (no blocking unless enabled above)
             </span>
             <ExportDropdown
               filename="spanlens-security"
@@ -240,7 +240,7 @@ export function SecurityClient() {
                   </span>
                 </span>
                 <span className={cn('text-right', statsReady && d.hits24h > 0 ? 'text-accent font-medium' : 'text-text-faint')}>
-                  {statsReady ? d.hits24h : '—'}
+                  {statsReady ? d.hits24h : ','}
                 </span>
               </div>
             ))}

--- a/apps/web/app/(dashboard)/settings/cron-jobs-panel.tsx
+++ b/apps/web/app/(dashboard)/settings/cron-jobs-panel.tsx
@@ -35,7 +35,7 @@ function StatusDot({ status }: { status: 'ok' | 'error' }) {
 }
 
 function JobRow({ job }: { job: CronJobSummary }) {
-  const schedule = CRON_SCHEDULES[job.jobName] ?? '—'
+  const schedule = CRON_SCHEDULES[job.jobName] ?? ','
 
   return (
     <div className="flex items-center gap-3 px-[22px] py-[11px] border-b border-border last:border-0">
@@ -54,7 +54,7 @@ function JobRow({ job }: { job: CronJobSummary }) {
         {relTime(job.lastRanAt)}
       </span>
       <span className="font-mono text-[11px] text-text-faint shrink-0 w-16 text-right">
-        {job.lastDurationMs != null ? `${job.lastDurationMs}ms` : '—'}
+        {job.lastDurationMs != null ? `${job.lastDurationMs}ms` : ','}
       </span>
       {job.lastStatus === 'error' && job.lastErrorMessage && (
         <span

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -226,7 +226,7 @@ function GeneralTab() {
         </FormRow>
         <FormRow label="Plan">
           <MonoPill variant={org?.plan === 'enterprise' ? 'good' : 'accent'} dot>
-            {org?.plan ?? '—'}
+            {org?.plan ?? ','}
           </MonoPill>
         </FormRow>
       </Section>
@@ -450,7 +450,7 @@ function MembersTab() {
             <DialogTitle>Invite member</DialogTitle>
           </DialogHeader>
           {/* Stacked layout (label above input). The settings page's
-              <FormRow> uses a 260px label column + px-6 — that overflows the
+              <FormRow> uses a 260px label column + px-6, that overflows the
               ~512px dialog width and pushes the inputs past the right edge. */}
           <form onSubmit={(e) => void submitInvite(e)} className="mt-3 space-y-4">
             <div>
@@ -472,9 +472,9 @@ function MembersTab() {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="admin">Admin — manage everything</SelectItem>
-                  <SelectItem value="editor">Editor — create/modify data</SelectItem>
-                  <SelectItem value="viewer">Viewer — read-only</SelectItem>
+                  <SelectItem value="admin">Admin, manage everything</SelectItem>
+                  <SelectItem value="editor">Editor, create/modify data</SelectItem>
+                  <SelectItem value="viewer">Viewer, read-only</SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -550,7 +550,7 @@ function SecurityTabInner() {
             />
           </div>
         </FormRow>
-        <FormRow label="Leaked-key detection" hint="Daily GitGuardian scan against public sources. Email-only — admins decide whether to revoke.">
+        <FormRow label="Leaked-key detection" hint="Daily GitGuardian scan against public sources. Email-only, admins decide whether to revoke.">
           <Toggle
             on={leakDetectionEnabled}
             disabled={updateSecurity.isPending}
@@ -899,10 +899,10 @@ function PlanLimitsTab() {
           </div>
           {[
             ['Requests / month', limitLabel,      usedThisMonth.toLocaleString(), headroom],
-            ['Team seats',       seatLimitLabel,  '—',                            '—'],
-            ['Log retention',    retentionLabel,  '—',                            '—'],
-            ['API keys',         '25',            '—',                            '—'],
-            ['Alert rules',      '100',           '—',                            '—'],
+            ['Team seats',       seatLimitLabel,  ',',                            ','],
+            ['Log retention',    retentionLabel,  ',',                            ','],
+            ['API keys',         '25',            ',',                            ','],
+            ['Alert rules',      '100',           ',',                            ','],
           ].map(([res, lim, used, head]) => (
             <div key={res} className="grid grid-cols-[1.4fr_1fr_1fr_1fr] gap-4 px-6 py-3">
               <span className="font-mono text-[12px] text-text-muted">{res}</span>
@@ -999,7 +999,7 @@ function InvoicesTab() {
             </p>
           ) : (
             <p className="font-mono text-[11.5px] text-text-faint">
-              You&apos;re on the free plan — no invoices generated.
+              You&apos;re on the free plan, no invoices generated.
             </p>
           )}
         </div>
@@ -1025,7 +1025,7 @@ function ProfileTab() {
         ) : user ? (
           <>
             <FormRow label="Email">
-              <div className="font-mono text-[12.5px] text-text">{user.email ?? '—'}</div>
+              <div className="font-mono text-[12.5px] text-text">{user.email ?? ','}</div>
             </FormRow>
             <FormRow label="User ID">
               <div className="font-mono text-[11px] text-text-muted truncate">{user.id}</div>
@@ -1069,7 +1069,7 @@ function NotificationsTab() {
             on the <a href="/alerts" className="text-accent hover:opacity-80 transition-opacity">Alerts page</a>.
           </p>
           <p>
-            Personal notification preferences (per-event mute, quiet hours, mobile push) aren&apos;t built yet —
+            Personal notification preferences (per-event mute, quiet hours, mobile push) aren&apos;t built yet ,
             every rule fires according to the thresholds you set on it.
           </p>
         </div>
@@ -1206,8 +1206,8 @@ function DeliveryHistory({ webhookId }: { webhookId: string }) {
           <MonoPill variant={d.status === 'success' ? 'good' : 'faint'} dot>
             {d.status}
           </MonoPill>
-          <span className="font-mono text-[11px] text-text-muted">{d.http_status ?? '—'}</span>
-          <span className="font-mono text-[11px] text-text-faint truncate">{d.error_message ?? '—'}</span>
+          <span className="font-mono text-[11px] text-text-muted">{d.http_status ?? ','}</span>
+          <span className="font-mono text-[11px] text-text-faint truncate">{d.error_message ?? ','}</span>
         </div>
       ))}
     </div>
@@ -1262,7 +1262,7 @@ function WebhooksTab() {
       setTestResult((prev) => ({
         ...prev,
         [webhook.id]: result
-          ? `${result.status} · HTTP ${result.http_status ?? '—'} · ${result.duration_ms}ms`
+          ? `${result.status} · HTTP ${result.http_status ?? ','} · ${result.duration_ms}ms`
           : 'Sent',
       }))
       setSelectedId(webhook.id)
@@ -1735,7 +1735,7 @@ export function SettingsClient() {
 
   return (
     <div className="-mx-4 -my-4 md:-mx-8 md:-my-7 flex flex-col h-screen overflow-hidden">
-      {/* Mobile nav dropdown — visible only on small screens */}
+      {/* Mobile nav dropdown, visible only on small screens */}
       <div className="md:hidden flex items-center gap-3 px-4 py-3 border-b border-border bg-bg-elev shrink-0">
         <span className="font-mono text-[10px] text-text-faint uppercase tracking-[0.05em] shrink-0">Settings</span>
         <select

--- a/apps/web/app/(dashboard)/traces/traces-client.tsx
+++ b/apps/web/app/(dashboard)/traces/traces-client.tsx
@@ -8,14 +8,14 @@ import { ExportDropdown } from '@/components/ui/export-dropdown'
 import { cn, formatDateTime } from '@/lib/utils'
 
 function fmtDuration(ms: number | null): string {
-  if (ms == null) return '—'
+  if (ms == null) return ','
   if (ms < 1) return '<1ms'
   if (ms < 1000) return `${Math.round(ms)}ms`
   return `${(ms / 1000).toFixed(2)}s`
 }
 
 function fmtCost(n: number): string {
-  if (n <= 0) return '—'
+  if (n <= 0) return ','
   return n < 0.001 ? `$${n.toFixed(5)}` : `$${n.toFixed(4)}`
 }
 
@@ -214,7 +214,7 @@ export function TracesClient() {
             { label: 'Traces',            value: meta.total.toLocaleString(),                         warn: false },
             { label: 'p50 duration',      value: fmtDuration(p50),  tip: 'Current page only',        warn: false },
             { label: 'p95 duration',      value: fmtDuration(p95),  tip: 'Current page only',        warn: p95 != null && p95 > 8000 },
-            { label: 'Avg spans / trace', value: avgSpans != null ? avgSpans.toFixed(1) : '—',        warn: false },
+            { label: 'Avg spans / trace', value: avgSpans != null ? avgSpans.toFixed(1) : ',',        warn: false },
             { label: 'Errors',            value: String(errors),                                       warn: errors > 0 },
           ].map((s, i) => (
             <div
@@ -311,7 +311,7 @@ export function TracesClient() {
           </span>
         </div>
 
-        {/* Rows — header lives inside same scroll container so horizontal scroll is in sync */}
+        {/* Rows, header lives inside same scroll container so horizontal scroll is in sync */}
         <div className="flex-1 overflow-auto">
           {isLoading ? (
             <div className="p-6 space-y-2">

--- a/apps/web/app/(dashboard)/users/[userId]/user-detail-client.tsx
+++ b/apps/web/app/(dashboard)/users/[userId]/user-detail-client.tsx
@@ -10,7 +10,7 @@ import { useUserDetail } from '@/lib/queries/use-users'
 // PostHog provider lands on main (separate PR).
 
 function fmtCost(n: number | null | undefined): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   return '$' + Number(n).toFixed(6)
 }
 
@@ -61,7 +61,7 @@ export function UserDetailClient({ userId }: { userId: string }) {
     { label: 'Total cost', value: fmtCost(data.total_cost_usd ? Number(data.total_cost_usd) : null) },
     {
       label: 'Avg latency',
-      value: data.avg_latency_ms != null ? `${Math.round(Number(data.avg_latency_ms))} ms` : '—',
+      value: data.avg_latency_ms != null ? `${Math.round(Number(data.avg_latency_ms))} ms` : ',',
     },
     { label: 'Error count', value: fmtCount(data.error_requests), warn: data.error_requests > 0 },
     { label: 'Distinct models', value: fmtCount(data.distinct_models) },

--- a/apps/web/app/(dashboard)/users/page.tsx
+++ b/apps/web/app/(dashboard)/users/page.tsx
@@ -3,7 +3,7 @@ import { UsersClient } from './users-client'
 
 export const metadata = {
   title: 'Users · Spanlens',
-  description: 'Per-end-user usage, cost, and behaviour — derived from x-spanlens-user tagged requests.',
+  description: 'Per-end-user usage, cost, and behaviour, derived from x-spanlens-user tagged requests.',
 }
 
 export default function UsersPage() {

--- a/apps/web/app/(dashboard)/users/users-client.tsx
+++ b/apps/web/app/(dashboard)/users/users-client.tsx
@@ -18,7 +18,7 @@ type SortDir = 'asc' | 'desc'
 const PAGE_SIZE = 50
 
 function fmtCost(n: number | null | undefined): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   if (n === 0) return '$0.00'
   return n < 0.01 ? '< $0.01' : '$' + n.toFixed(2)
 }
@@ -145,7 +145,7 @@ export function UsersClient() {
 
       {/* Filter bar */}
       {/* key={search} remounts the form so the local input resets when URL
-          search changes (e.g. back/forward navigation) — no setState-in-effect. */}
+          search changes (e.g. back/forward navigation), no setState-in-effect. */}
       <SearchForm
         key={search}
         initialSearch={search}
@@ -220,7 +220,7 @@ export function UsersClient() {
                 <span className="text-text-muted">{fmtCount(u.total_tokens)}</span>
                 <span>{fmtCost(u.total_cost_usd ? Number(u.total_cost_usd) : null)}</span>
                 <span className="text-text-muted">
-                  {u.avg_latency_ms != null ? `${Math.round(Number(u.avg_latency_ms))}ms` : '—'}
+                  {u.avg_latency_ms != null ? `${Math.round(Number(u.avg_latency_ms))}ms` : ','}
                 </span>
                 <span className="text-text-faint text-right" suppressHydrationWarning>{fmtRelativeTime(u.last_seen)}</span>
               </Link>

--- a/apps/web/app/compare/arize-phoenix/page.tsx
+++ b/apps/web/app/compare/arize-phoenix/page.tsx
@@ -1,0 +1,182 @@
+import { CompareTemplate, type CompareGroup, type ComparePoint } from '@/components/marketing/compare-template'
+
+export const metadata = {
+  title: 'Spanlens vs Arize Phoenix · Compare',
+  description:
+    'Arize Phoenix is open-source LLM observability with deep ML-engineer DNA. Spanlens is built for application developers shipping LLM features, with proxy-first install, 1-line setup, and JS/TS equal-class with Python.',
+}
+
+const whySpanlens: ComparePoint[] = [
+  {
+    title: 'Built for the application developer',
+    body:
+      'Phoenix comes from Arize, an ML-observability company. Its UX reflects that audience (eval studios, embedding projectors, drift charts). Spanlens is built for the dev who shipped an LLM feature to production last week and needs cost, latency, and quality answers fast.',
+  },
+  {
+    title: 'JS/TS is first-class, not second',
+    body:
+      'Phoenix is Python-first and JS support is lighter. Spanlens TypeScript SDK and proxy approach treat Next.js, Hono, Bun, and Cloudflare Workers as first-class citizens, the same surface as Python.',
+  },
+  {
+    title: 'Proxy install, no instrumentation code',
+    body:
+      'Phoenix uses OpenInference SDKs that wrap your client. You touch every call site. Spanlens is a baseURL swap. Existing apps with hundreds of LLM calls get instrumented in one config change.',
+  },
+  {
+    title: 'Managed cloud option without a sales call',
+    body:
+      "Phoenix is OSS-only; Arize's managed product is enterprise-priced. Spanlens has a free managed tier and a transparent $29 Pro plan so you can pick OSS or hosted without a procurement cycle.",
+  },
+  {
+    title: 'Model savings recommender with dollar figures',
+    body:
+      "Spanlens proactively flags routes where a smaller model would match quality. Phoenix has rich analysis but doesn't recommend cost-tier swaps.",
+  },
+  {
+    title: 'Critical Path on agent traces',
+    body:
+      "Spanlens highlights the longest dependency chain in agent traces automatically, the actual bottleneck. Phoenix renders waterfalls but doesn't compute critical path.",
+  },
+]
+
+const whyCompetitor: ComparePoint[] = [
+  {
+    title: "You're an ML engineer, not an app developer",
+    body:
+      "If you work in notebooks, care about embedding drift, and want UMAP projections of your prompt space, Phoenix's ML-engineer DNA is exactly right. Spanlens optimizes for the production app developer instead.",
+  },
+  {
+    title: "You're committed to OpenInference / OTel standards",
+    body:
+      "Phoenix is the reference implementation for the OpenInference spec. If your org has standardized on it, Phoenix is the natural choice. Spanlens supports OTLP ingest but Phoenix's OpenInference lineage is deeper.",
+  },
+  {
+    title: 'You want notebook-driven exploration',
+    body:
+      'Phoenix can be launched inside a notebook for ad-hoc trace exploration during development. Spanlens is a server you point your app at, a different ergonomic.',
+  },
+  {
+    title: "You'll outgrow into Arize Enterprise",
+    body:
+      "If your team plans to graduate to Arize's full ML platform, starting on Phoenix means a smooth upgrade path. Spanlens is a destination, not a stepping-stone.",
+  },
+]
+
+const groups: CompareGroup[] = [
+  {
+    title: 'Audience & ergonomics',
+    rows: [
+      { feature: 'Optimized for app developers', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Optimized for ML engineers / notebook users', spanlens: 'partial', competitor: 'yes' },
+      {
+        feature: 'JS/TS as first-class language',
+        spanlens: 'yes',
+        competitor: 'partial',
+      },
+      { feature: 'Python as first-class language', spanlens: 'yes', competitor: 'yes' },
+    ],
+  },
+  {
+    title: 'Setup',
+    rows: [
+      {
+        feature: '1-line baseURL proxy swap',
+        spanlens: 'yes',
+        competitor: 'no',
+      },
+      { feature: 'OpenInference / OTel SDK instrumentation', spanlens: 'partial', competitor: 'yes' },
+      { feature: 'TypeScript SDK', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Python SDK', spanlens: 'yes', competitor: 'yes' },
+    ],
+  },
+  {
+    title: 'Core observability',
+    rows: [
+      { feature: 'Per-request log with full body', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Cost tracking', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Agent tracing (waterfall)', spanlens: 'yes', competitor: 'yes' },
+      {
+        feature: 'Critical Path on agent traces',
+        spanlens: 'yes',
+        competitor: 'no',
+      },
+      { feature: '3σ anomaly detection on latency/cost', spanlens: 'yes', competitor: 'partial' },
+    ],
+  },
+  {
+    title: 'Prompts & experiments',
+    rows: [
+      { feature: 'Versioned prompt library', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Production A/B traffic split', spanlens: 'yes', competitor: 'no' },
+      { feature: 'Built-in Welch t-test on A/B', spanlens: 'yes', competitor: 'no' },
+    ],
+  },
+  {
+    title: 'Eval & quality',
+    rows: [
+      { feature: 'LLM-as-judge scoring', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Human annotation queue', spanlens: 'yes', competitor: 'partial' },
+      {
+        feature: 'Judge to human correlation tracking',
+        spanlens: 'yes',
+        competitor: 'partial',
+      },
+      { feature: 'Datasets / golden test sets', spanlens: 'yes', competitor: 'yes' },
+      {
+        feature: 'Embedding projector / drift analysis',
+        spanlens: 'no',
+        competitor: 'yes',
+        note: "Phoenix's ML-observability roots show here.",
+      },
+    ],
+  },
+  {
+    title: 'Cost optimization',
+    rows: [
+      {
+        feature: 'Model swap recommendations with $ savings',
+        spanlens: 'yes',
+        competitor: 'no',
+      },
+      { feature: 'Per-model cost breakdown & budget alerts', spanlens: 'yes', competitor: 'partial' },
+    ],
+  },
+  {
+    title: 'Security',
+    rows: [
+      {
+        feature: 'Security scanning (API keys, PII, prompt injection)',
+        spanlens: 'yes',
+        competitor: 'partial',
+        note: 'Spanlens runs detection on every request body at log time.',
+      },
+    ],
+  },
+  {
+    title: 'License & deployment',
+    rows: [
+      { feature: 'Fully open source (MIT-class)', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Docker Compose self-host', spanlens: 'yes', competitor: 'yes' },
+      {
+        feature: 'Managed cloud at transparent SMB price',
+        spanlens: 'yes',
+        competitor: 'no',
+        note: "Arize's managed offering is enterprise-priced.",
+      },
+    ],
+  },
+]
+
+export default function VsArizePhoenixPage() {
+  return (
+    <CompareTemplate
+      competitor="Arize Phoenix"
+      tagline="Built for the production app developer, not the ML engineer in a notebook. JS/TS gets equal billing with Python."
+      tldr="Phoenix has serious ML-observability DNA from Arize and is excellent if you're an ML engineer who lives in Python notebooks. Spanlens is built for the app developer who shipped an LLM feature last week, with proxy-first install, JS/TS equal-class with Python, statistical A/B testing, and a managed tier that doesn't require an enterprise sales call."
+      whySpanlens={whySpanlens}
+      whyCompetitor={whyCompetitor}
+      groups={groups}
+      closing="If you're an ML engineer with a Python-first workflow, Phoenix fits your hands. If you're shipping LLM features in a Next.js, FastAPI, or Hono app and want zero-friction install, try Spanlens."
+    />
+  )
+}

--- a/apps/web/app/compare/braintrust/page.tsx
+++ b/apps/web/app/compare/braintrust/page.tsx
@@ -1,0 +1,154 @@
+import { CompareTemplate, type CompareGroup, type ComparePoint } from '@/components/marketing/compare-template'
+
+export const metadata = {
+  title: 'Spanlens vs Braintrust · Compare',
+  description:
+    'Braintrust is eval-first and closed-source SaaS. Spanlens bundles eval into a full observability platform with proxy-based logging, agent tracing, and cost optimization, and you can self-host it with one Docker command.',
+}
+
+const whySpanlens: ComparePoint[] = [
+  {
+    title: 'Observability plus eval in one tool, not eval-only',
+    body:
+      'Braintrust is excellent at evals but expects you to bring observability from somewhere else. Spanlens combines per-request logging, cost tracking, agent tracing, anomaly detection, and eval into a single product.',
+  },
+  {
+    title: 'Fully MIT and self-hostable',
+    body:
+      "Braintrust is closed-source SaaS only. Spanlens ships under MIT with a docker-compose self-host. That matters when prompts contain customer data you can't send to a third party.",
+  },
+  {
+    title: 'Proxy-based capture, no code changes',
+    body:
+      'Swap your baseURL and every call is captured. Braintrust expects you to log through their SDK, which means touching every call site.',
+  },
+  {
+    title: 'Critical Path agent tracing',
+    body:
+      'For multi-step agents, Spanlens highlights the longest dependency chain, the actual bottleneck, not just the longest span. Braintrust focuses on eval, and its agent-trace surface is lighter.',
+  },
+  {
+    title: 'Model savings recommender',
+    body:
+      "Spanlens proactively flags routes where a smaller model would match quality and shows the dollar savings. Braintrust's strength is comparing outputs side by side, and it doesn't recommend cost tier swaps.",
+  },
+  {
+    title: 'Built-in security scanning',
+    body:
+      'Spanlens runs API key leak detection, PII detection, and prompt-injection pattern matching on every request body at log time. Braintrust focuses on eval workflows and treats security scanning as a separate concern.',
+  },
+]
+
+const whyCompetitor: ComparePoint[] = [
+  {
+    title: 'You live and die by your eval suite',
+    body:
+      "Braintrust's eval UX (diffing two model outputs side by side, scoring rubrics, regression detection) is the most polished in the market. If your team builds dozens of LLM features and evals are your release gate, Braintrust wins on that surface.",
+  },
+  {
+    title: "You don't need self-hosting",
+    body:
+      "If sending prompts to a third-party SaaS is acceptable for your data classification, Braintrust's managed-only model means zero ops. Spanlens cloud is also zero-ops, but its self-host option costs nothing if you ever need it.",
+  },
+  {
+    title: 'You want experiment-driven culture as the product',
+    body:
+      "Braintrust's entire UX is built around the idea that every prompt change is a versioned experiment with a scored result. If that's how your team already works, the cognitive fit is high.",
+  },
+  {
+    title: 'Built-in playgrounds for many models',
+    body:
+      "Braintrust's side-by-side playground for comparing arbitrary models on the same input is more polished than Spanlens's.",
+  },
+]
+
+const groups: CompareGroup[] = [
+  {
+    title: 'Scope',
+    rows: [
+      { feature: 'Per-request observability', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Agent tracing (multi-step waterfall)', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'LLM eval framework', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Cost dashboards & budgets', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Security scanning (PII / keys / injection)', spanlens: 'yes', competitor: 'partial' },
+    ],
+  },
+  {
+    title: 'Setup',
+    rows: [
+      {
+        feature: '1-line baseURL proxy swap',
+        spanlens: 'yes',
+        competitor: 'no',
+      },
+      { feature: 'TypeScript & Python SDKs', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'OpenTelemetry ingest', spanlens: 'yes', competitor: 'partial' },
+    ],
+  },
+  {
+    title: 'Eval',
+    rows: [
+      { feature: 'LLM-as-judge scoring', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Human annotation queue', spanlens: 'yes', competitor: 'yes' },
+      {
+        feature: 'Judge to human correlation tracking',
+        spanlens: 'yes',
+        competitor: 'partial',
+      },
+      { feature: 'Datasets / golden test sets', spanlens: 'yes', competitor: 'yes' },
+      {
+        feature: 'Side-by-side output diff UI',
+        spanlens: 'partial',
+        competitor: 'yes',
+        note: "Braintrust's diff and eval UX is more polished.",
+      },
+    ],
+  },
+  {
+    title: 'Prompts',
+    rows: [
+      { feature: 'Versioned prompt library', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'A/B traffic split in production', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Built-in Welch t-test on A/B', spanlens: 'yes', competitor: 'no' },
+      { feature: 'Gradual rollout via header', spanlens: 'yes', competitor: 'partial' },
+    ],
+  },
+  {
+    title: 'Cost optimization',
+    rows: [
+      {
+        feature: 'Model swap recommendations with $ savings',
+        spanlens: 'yes',
+        competitor: 'no',
+      },
+      { feature: 'Per-model cost breakdown & budget alerts', spanlens: 'yes', competitor: 'partial' },
+    ],
+  },
+  {
+    title: 'License & deployment',
+    rows: [
+      {
+        feature: 'Open source (MIT)',
+        spanlens: 'yes',
+        competitor: 'no',
+        note: 'Braintrust is closed-source SaaS.',
+      },
+      { feature: 'Docker Compose self-host', spanlens: 'yes', competitor: 'no' },
+      { feature: 'Managed cloud option', spanlens: 'yes', competitor: 'yes' },
+    ],
+  },
+]
+
+export default function VsBraintrustPage() {
+  return (
+    <CompareTemplate
+      competitor="Braintrust"
+      tagline="A full observability platform with eval inside, not an eval product asking you to bring observability."
+      tldr="Braintrust has the most polished eval UX in the market and is the right tool if evals are your gate and you're fine with closed-source SaaS. Spanlens bundles eval into a complete observability stack with logging, tracing, anomaly detection, and cost optimization, and ships under MIT so you can self-host it."
+      whySpanlens={whySpanlens}
+      whyCompetitor={whyCompetitor}
+      groups={groups}
+      closing="If your release gate is evals and you don't care about self-hosting, Braintrust is excellent. If you want the same kind of eval quality plus observability, tracing, and the option to run it on your own infra, try Spanlens."
+    />
+  )
+}

--- a/apps/web/app/compare/helicone/page.tsx
+++ b/apps/web/app/compare/helicone/page.tsx
@@ -1,0 +1,171 @@
+import { CompareTemplate, type CompareGroup, type ComparePoint } from '@/components/marketing/compare-template'
+
+export const metadata = {
+  title: 'Spanlens vs Helicone · Compare',
+  description:
+    'Both Spanlens and Helicone are proxy-based LLM observability tools. Spanlens adds Critical Path agent tracing, Prompt A/B with Welch t-test, judge to human correlation tracking, and a ClickHouse fallback-replay safety net.',
+}
+
+const whySpanlens: ComparePoint[] = [
+  {
+    title: 'Critical Path on agent traces',
+    body:
+      'Multi-step agents show as waterfalls in both tools. Only Spanlens highlights the longest dependency chain, the actual bottleneck. Helicone shows you spans, and you find the slow one yourself.',
+  },
+  {
+    title: 'Prompt A/B with built-in Welch t-test',
+    body:
+      'Spanlens lets you split traffic between prompt variants and reports statistical significance (Welch t-test on latency, cost, judge score). Helicone supports prompt versioning, but A/B comparison and significance testing are bring-your-own.',
+  },
+  {
+    title: 'Judge to human correlation tracking',
+    body:
+      'Spanlens lets you annotate by hand and measures how well your LLM judge tracks human raters. If your judge drifts, you see it as a metric. Helicone supports custom scores but does not name this correlation as a first-class feature.',
+  },
+  {
+    title: 'Model savings recommender with dollar figures',
+    body:
+      'Spanlens proactively flags routes where a smaller model would match quality and quotes the monthly savings. Helicone has cost dashboards, and the swap recommendation is left as a manual exercise.',
+  },
+  {
+    title: 'ClickHouse fallback-replay safety net',
+    body:
+      'Spanlens writes to ClickHouse for analytics. If ClickHouse hiccups, requests fall back to a Postgres queue and replay automatically when it recovers, so logs are not silently dropped. This durability layer is a Spanlens-specific design.',
+  },
+  {
+    title: 'Critical Path plus anomaly detection together',
+    body:
+      'Spanlens layers 3σ anomaly detection on top of agent trace data, so a slow critical-path span is also flagged when latency drifts off its 7-day baseline. The two surfaces reinforce each other inside one product.',
+  },
+]
+
+const whyCompetitor: ComparePoint[] = [
+  {
+    title: 'Longer track record and wider docs',
+    body:
+      'Helicone has been public longer with extensive docs and case studies. If proven adoption is your top criterion, Helicone is ahead. Spanlens is younger and is still growing its public footprint.',
+  },
+  {
+    title: 'Wider integration list today',
+    body:
+      "Helicone supports a broad set of SDKs and frameworks out of the box. If you're using a less-common provider or SDK, check both lists before committing.",
+  },
+  {
+    title: 'Simpler ops surface for tiny teams',
+    body:
+      "Helicone is a more focused product. If you want logging and cost dashboards and nothing else, Helicone's narrower scope is easier to onboard.",
+  },
+  {
+    title: 'Gateway features and rate limiting',
+    body:
+      'Helicone leans into proxy-gateway features like custom rate limiting, retries, and caching at the edge. Spanlens currently focuses on observability and leaves gateway concerns to upstream tools.',
+  },
+]
+
+const groups: CompareGroup[] = [
+  {
+    title: 'Architecture',
+    rows: [
+      { feature: 'Proxy-based instrumentation', spanlens: 'yes', competitor: 'yes' },
+      { feature: '1-line baseURL swap', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'OpenTelemetry (OTLP) ingest', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Streaming response support', spanlens: 'yes', competitor: 'yes' },
+    ],
+  },
+  {
+    title: 'Provider coverage',
+    rows: [
+      {
+        feature: 'Major provider proxies',
+        spanlens: 'yes',
+        competitor: 'yes',
+        note: 'OpenAI, Anthropic, Gemini, Azure OpenAI.',
+      },
+      { feature: 'Local LLMs (Ollama) via SDK', spanlens: 'yes', competitor: 'partial' },
+    ],
+  },
+  {
+    title: 'Agent tracing',
+    rows: [
+      { feature: 'Multi-step span trees', spanlens: 'yes', competitor: 'yes' },
+      {
+        feature: 'Critical Path highlighting',
+        spanlens: 'yes',
+        competitor: 'no',
+        note: 'Spanlens computes the longest dependency chain automatically.',
+      },
+      { feature: 'Retry span annotation', spanlens: 'yes', competitor: 'partial' },
+    ],
+  },
+  {
+    title: 'Prompts & experiments',
+    rows: [
+      { feature: 'Versioned prompt library', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Prompt A/B traffic split', spanlens: 'yes', competitor: 'partial' },
+      {
+        feature: 'Built-in Welch t-test on A/B results',
+        spanlens: 'yes',
+        competitor: 'no',
+      },
+      { feature: 'Prompt playground', spanlens: 'yes', competitor: 'yes' },
+    ],
+  },
+  {
+    title: 'Eval & quality',
+    rows: [
+      { feature: 'LLM-as-judge scoring', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Human annotation queue', spanlens: 'yes', competitor: 'partial' },
+      {
+        feature: 'Judge to human correlation tracking',
+        spanlens: 'yes',
+        competitor: 'partial',
+      },
+      { feature: 'Datasets / golden test sets', spanlens: 'yes', competitor: 'partial' },
+    ],
+  },
+  {
+    title: 'Security',
+    rows: [
+      {
+        feature: 'Security scanning (API keys, PII, prompt injection)',
+        spanlens: 'yes',
+        competitor: 'partial',
+      },
+      { feature: 'Per-call log-body opt-out header', spanlens: 'yes', competitor: 'partial' },
+    ],
+  },
+  {
+    title: 'Reliability',
+    rows: [
+      {
+        feature: 'ClickHouse fallback-replay queue',
+        spanlens: 'yes',
+        competitor: 'no',
+        note: 'Postgres fallback queue auto-replays on ClickHouse recovery.',
+      },
+      { feature: 'Stream deadline with truncation flag', spanlens: 'yes', competitor: 'partial' },
+    ],
+  },
+  {
+    title: 'License & deployment',
+    rows: [
+      { feature: 'Fully MIT (entire repo)', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Docker Compose self-host', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Managed cloud option', spanlens: 'yes', competitor: 'yes' },
+    ],
+  },
+]
+
+export default function VsHeliconePage() {
+  return (
+    <CompareTemplate
+      competitor="Helicone"
+      tagline="Same proxy-first architecture, with more observability depth: Critical Path tracing, statistical A/B testing, and a fallback-replay durability layer."
+      tldr="Helicone proved the proxy-based LLM observability model and ships a polished, focused product. Spanlens uses the same architecture and adds Critical Path tracing on agent runs, Welch t-test on A/B prompt experiments, judge to human correlation tracking, and a ClickHouse fallback-replay queue so logs are not silently dropped on infra hiccups."
+      whySpanlens={whySpanlens}
+      whyCompetitor={whyCompetitor}
+      groups={groups}
+      closing="If you want a battle-tested proxy with a focused feature set, Helicone is a strong choice. If you want the same proxy ergonomics plus deeper agent analytics, statistical A/B, and log durability, try Spanlens."
+    />
+  )
+}

--- a/apps/web/app/compare/langfuse/page.tsx
+++ b/apps/web/app/compare/langfuse/page.tsx
@@ -1,0 +1,185 @@
+import { CompareTemplate, type CompareGroup, type ComparePoint } from '@/components/marketing/compare-template'
+
+export const metadata = {
+  title: 'Spanlens vs Langfuse · Compare',
+  description:
+    'Spanlens is a drop-in proxy with eval, agent tracing, and Prompt A/B testing built in. Fully MIT-licensed. Langfuse uses an SDK + OTel model with an EE folder for commercial features. Read the honest comparison.',
+}
+
+const whySpanlens: ComparePoint[] = [
+  {
+    title: 'No code changes, just swap baseURL',
+    body:
+      'Spanlens is proxy-first. Replace api.openai.com with your Spanlens endpoint and every call is captured. Langfuse requires wrapping clients with their SDK or wiring OTel. That works fine for greenfield apps but gets painful when existing codebases have many call sites.',
+  },
+  {
+    title: 'Fully MIT, no EE or commercial folder',
+    body:
+      'Every line of Spanlens ships under MIT. Langfuse is open-source, but features like SSO, audit logs, and some analytics live behind their EE folder under a commercial license. With Spanlens, what you self-host is what we run.',
+  },
+  {
+    title: 'Prompt A/B with Welch t-test built in',
+    body:
+      'Spanlens lets you run prompt variants side by side and gives you a Welch t-test on latency, cost, and judge scores, not just average bars. Langfuse has prompt management and experiments, but statistical significance testing is something you build yourself.',
+  },
+  {
+    title: 'Judge to human correlation surfaced as a metric',
+    body:
+      'Both products let you score traces with humans and with LLMs. Spanlens surfaces the correlation between the two as a first-class metric, so you can tell when your LLM judge starts to drift from human raters. In Langfuse the same correlation is computable but is left as bring-your-own analysis.',
+  },
+  {
+    title: 'Model savings recommender with dollar figures',
+    body:
+      'Spanlens analyzes your traffic and suggests "swap these gpt-4o classification calls to gpt-4o-mini, $412/mo saved" with the evidence. Langfuse shows cost dashboards, but the swap recommendation is a manual exercise.',
+  },
+  {
+    title: 'Critical Path in agent traces',
+    body:
+      "For multi-step agents, Spanlens highlights the longest dependency chain, the actual bottleneck, not just the longest span. Langfuse renders waterfall traces but doesn't compute critical path automatically.",
+  },
+]
+
+const whyCompetitor: ComparePoint[] = [
+  {
+    title: 'Larger community and ecosystem',
+    body:
+      'Langfuse has been public since 2023 with thousands of GitHub stars and a busy community. If proven adoption is your top criterion, Langfuse is ahead. Spanlens is younger and is still growing its community.',
+  },
+  {
+    title: 'You already use OpenTelemetry everywhere',
+    body:
+      "Langfuse is OTel-native and slots in naturally if your stack already has OTel collectors. Spanlens supports OTLP ingest too, but Langfuse's OTel pedigree is deeper.",
+  },
+  {
+    title: 'You need a scoring or eval marketplace',
+    body:
+      'Langfuse offers a richer set of pre-built evaluators like toxicity and helpfulness that you can chain. Spanlens leans on LLM-as-judge with your own rubric plus human annotation.',
+  },
+  {
+    title: 'Datasets-as-a-product workflow',
+    body:
+      "Langfuse's datasets feature is mature for building golden test sets and re-running them on every prompt change. Spanlens has datasets too but they're lighter-weight.",
+  },
+]
+
+const groups: CompareGroup[] = [
+  {
+    title: 'Setup & integration',
+    rows: [
+      {
+        feature: '1-line baseURL proxy swap',
+        spanlens: 'yes',
+        competitor: 'no',
+        note: 'Langfuse requires wrapping with their SDK or wiring OTel exporters.',
+      },
+      { feature: 'OpenTelemetry (OTLP) ingest', spanlens: 'yes', competitor: 'yes' },
+      {
+        feature: 'SDKs & framework integrations',
+        spanlens: 'yes',
+        competitor: 'yes',
+        note: 'TypeScript, Python, LangChain, LlamaIndex, Vercel AI SDK.',
+      },
+    ],
+  },
+  {
+    title: 'Core observability',
+    rows: [
+      { feature: 'Per-request log with full body', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Cost tracking per request and rollups', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Agent tracing (waterfall span tree)', spanlens: 'yes', competitor: 'yes' },
+      {
+        feature: 'Critical Path on agent traces',
+        spanlens: 'yes',
+        competitor: 'no',
+        note: 'Spanlens computes the longest dependency chain automatically.',
+      },
+      {
+        feature: '3σ anomaly detection on latency/cost',
+        spanlens: 'yes',
+        competitor: 'partial',
+        note: 'Langfuse has alerts on metrics, but baseline-driven anomaly detection is BYO.',
+      },
+    ],
+  },
+  {
+    title: 'Prompts & experiments',
+    rows: [
+      { feature: 'Versioned prompt library', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Prompt A/B side-by-side runner', spanlens: 'yes', competitor: 'yes' },
+      {
+        feature: 'Built-in Welch t-test on A/B results',
+        spanlens: 'yes',
+        competitor: 'no',
+        note: 'Statistical significance, not just averages.',
+      },
+      { feature: 'Prompt playground', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Gradual prompt rollout via header', spanlens: 'yes', competitor: 'partial' },
+    ],
+  },
+  {
+    title: 'Eval & quality',
+    rows: [
+      { feature: 'LLM-as-judge scoring', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Human annotation queue', spanlens: 'yes', competitor: 'yes' },
+      {
+        feature: 'Judge to human correlation tracking',
+        spanlens: 'yes',
+        competitor: 'partial',
+        note: 'Langfuse supports both human and LLM scoring; the drift correlation metric is BYO.',
+      },
+      { feature: 'Datasets / golden test sets', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Pre-built evaluators marketplace', spanlens: 'partial', competitor: 'yes' },
+    ],
+  },
+  {
+    title: 'Cost optimization',
+    rows: [
+      {
+        feature: 'Model swap recommendations with $ savings',
+        spanlens: 'yes',
+        competitor: 'no',
+        note: 'e.g. "Swap these classifier calls to gpt-4o-mini for $412/mo saved".',
+      },
+      { feature: 'Per-model cost breakdown & budget alerts', spanlens: 'yes', competitor: 'yes' },
+    ],
+  },
+  {
+    title: 'Security',
+    rows: [
+      {
+        feature: 'Security scanning (API keys, PII, prompt injection)',
+        spanlens: 'yes',
+        competitor: 'partial',
+        note: 'Spanlens ships built-in detectors for API key leaks, PII (SSN, IBAN, passport), and prompt-injection patterns out of the box.',
+      },
+      { feature: 'Per-call log-body opt-out header', spanlens: 'yes', competitor: 'partial' },
+    ],
+  },
+  {
+    title: 'License & deployment',
+    rows: [
+      {
+        feature: 'Fully MIT (entire repo)',
+        spanlens: 'yes',
+        competitor: 'no',
+        note: 'Langfuse has an EE folder under a commercial license.',
+      },
+      { feature: 'Docker Compose self-host', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Managed cloud option', spanlens: 'yes', competitor: 'yes' },
+    ],
+  },
+]
+
+export default function VsLangfusePage() {
+  return (
+    <CompareTemplate
+      competitor="Langfuse"
+      tagline="Proxy-first instead of SDK-first. Fully MIT instead of OSS plus EE. Statistical A/B testing and savings recommendations built in."
+      tldr="Langfuse is the most mature OSS option and the safest pick if community size is the deciding factor. Spanlens wins on integration speed (1-line baseURL swap), license clarity (no EE folder), and built-in features like Prompt A/B with t-tests, judge to human correlation, and model-swap savings recommendations."
+      whySpanlens={whySpanlens}
+      whyCompetitor={whyCompetitor}
+      groups={groups}
+      closing="Both tools are good. Pick Spanlens if you want to be running in 60 seconds and want statistical rigor built in. Pick Langfuse if community size and OTel-native is non-negotiable."
+    />
+  )
+}

--- a/apps/web/app/compare/langsmith/page.tsx
+++ b/apps/web/app/compare/langsmith/page.tsx
@@ -1,0 +1,169 @@
+import { CompareTemplate, type CompareGroup, type ComparePoint } from '@/components/marketing/compare-template'
+
+export const metadata = {
+  title: 'Spanlens vs LangSmith · Compare',
+  description:
+    'LangSmith is excellent inside the LangChain ecosystem. Spanlens is framework-agnostic. A 1-line baseURL swap works with any HTTP client, no LangChain required. Self-hostable under MIT.',
+}
+
+const whySpanlens: ComparePoint[] = [
+  {
+    title: 'Framework-agnostic by design',
+    body:
+      "Spanlens is a proxy. Any HTTP client, any framework, any language sees instant traces. LangSmith is best when you're using LangChain or LangGraph; without them, you fall back to manual SDK calls and miss most of the product surface.",
+  },
+  {
+    title: 'No LangChain lock-in',
+    body:
+      'Adopting LangSmith pushes you toward LangChain abstractions. Spanlens never asks you to rewrite. Keep your raw OpenAI, Anthropic, or Gemini calls, custom orchestration, or whatever framework you already chose.',
+  },
+  {
+    title: 'Fully open source, actually self-hostable',
+    body:
+      'Spanlens is MIT and ships with a single docker-compose self-host. LangSmith Enterprise self-hosting exists but sits behind enterprise sales and pricing.',
+  },
+  {
+    title: 'Drop-in proxy install in 60 seconds',
+    body:
+      'Change one URL. Done. LangSmith requires wrapping your chains, decorating functions, or setting environment variables that only activate when LangChain runs.',
+  },
+  {
+    title: 'Prompt A/B with statistical testing',
+    body:
+      'Spanlens runs prompt variants and reports Welch t-test results on latency, cost, and judge scores. LangSmith has experiments but the statistical layer is something you assemble.',
+  },
+  {
+    title: 'Model savings recommender',
+    body:
+      'Spanlens flags routes where a smaller model would match quality and quotes the monthly savings. LangSmith focuses on evals, and cost-tier suggestions are not its primary surface.',
+  },
+]
+
+const whyCompetitor: ComparePoint[] = [
+  {
+    title: "You're all-in on LangChain or LangGraph",
+    body:
+      "LangSmith is the most deeply integrated tool for the LangChain stack. Auto-instrumentation of chains, graphs, and tools just works. If you're committed to that ecosystem, LangSmith is the natural choice.",
+  },
+  {
+    title: 'You need first-party LangGraph trace support',
+    body:
+      "LangGraph nodes, edges, and state transitions render natively in LangSmith. Spanlens supports OTel spans from LangGraph but doesn't render the graph topology.",
+  },
+  {
+    title: 'You want one vendor for framework + observability',
+    body:
+      'Buying LangChain plus LangSmith from the same vendor means one support contract and aligned roadmaps. Spanlens is a separate vendor purposely.',
+  },
+  {
+    title: 'Hub for sharing community prompts',
+    body:
+      'LangSmith Hub has a sizable community of shared prompts and chains. Spanlens has prompt versioning but no public hub.',
+  },
+]
+
+const groups: CompareGroup[] = [
+  {
+    title: 'Setup & framework coupling',
+    rows: [
+      {
+        feature: '1-line baseURL proxy swap',
+        spanlens: 'yes',
+        competitor: 'no',
+        note: 'LangSmith captures via wrapping or env vars, and only works fully inside LangChain.',
+      },
+      { feature: 'Works without any framework', spanlens: 'yes', competitor: 'partial' },
+      {
+        feature: 'LangChain & LlamaIndex integrations',
+        spanlens: 'yes',
+        competitor: 'yes',
+      },
+      { feature: 'LangGraph native graph view', spanlens: 'no', competitor: 'yes' },
+      { feature: 'Vercel AI SDK', spanlens: 'yes', competitor: 'yes' },
+    ],
+  },
+  {
+    title: 'Core observability',
+    rows: [
+      { feature: 'Per-request log with full body', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Cost tracking', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Agent tracing (waterfall)', spanlens: 'yes', competitor: 'yes' },
+      {
+        feature: 'Critical Path on agent traces',
+        spanlens: 'yes',
+        competitor: 'no',
+      },
+      { feature: '3σ anomaly detection', spanlens: 'yes', competitor: 'partial' },
+    ],
+  },
+  {
+    title: 'Prompts & experiments',
+    rows: [
+      { feature: 'Versioned prompt library', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Public prompt hub', spanlens: 'no', competitor: 'yes' },
+      { feature: 'A/B traffic split', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Built-in Welch t-test on A/B', spanlens: 'yes', competitor: 'no' },
+    ],
+  },
+  {
+    title: 'Eval & quality',
+    rows: [
+      { feature: 'LLM-as-judge scoring', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Human annotation queue', spanlens: 'yes', competitor: 'yes' },
+      {
+        feature: 'Judge to human correlation tracking',
+        spanlens: 'yes',
+        competitor: 'partial',
+      },
+      { feature: 'Datasets', spanlens: 'yes', competitor: 'yes' },
+    ],
+  },
+  {
+    title: 'Cost optimization',
+    rows: [
+      {
+        feature: 'Model swap recommendations with $ savings',
+        spanlens: 'yes',
+        competitor: 'no',
+      },
+      { feature: 'Per-model cost breakdown', spanlens: 'yes', competitor: 'yes' },
+    ],
+  },
+  {
+    title: 'Security',
+    rows: [
+      {
+        feature: 'Security scanning (API keys, PII, prompt injection)',
+        spanlens: 'yes',
+        competitor: 'partial',
+      },
+    ],
+  },
+  {
+    title: 'License & deployment',
+    rows: [
+      { feature: 'Fully MIT (entire repo)', spanlens: 'yes', competitor: 'no' },
+      {
+        feature: 'Single-command Docker self-host',
+        spanlens: 'yes',
+        competitor: 'partial',
+        note: 'LangSmith self-host is gated behind enterprise.',
+      },
+      { feature: 'Managed cloud option', spanlens: 'yes', competitor: 'yes' },
+    ],
+  },
+]
+
+export default function VsLangSmithPage() {
+  return (
+    <CompareTemplate
+      competitor="LangSmith"
+      tagline="Framework-agnostic instead of LangChain-coupled. MIT and self-hostable today, not a sales call away."
+      tldr="LangSmith is the right call if you're committed to LangChain or LangGraph. The integration depth is unmatched. Spanlens is the right call if you want a tool that works with anything, installs with a 1-line baseURL swap, ships fully under MIT, and bundles Prompt A/B with statistical testing."
+      whySpanlens={whySpanlens}
+      whyCompetitor={whyCompetitor}
+      groups={groups}
+      closing="If your codebase already breathes LangChain, LangSmith is the safe pick. If you want zero lock-in and a 60-second install, try Spanlens."
+    />
+  )
+}

--- a/apps/web/app/compare/page.tsx
+++ b/apps/web/app/compare/page.tsx
@@ -1,0 +1,111 @@
+import Link from 'next/link'
+import { Footer } from '@/components/layout/footer'
+import { MarketingNav } from '@/components/layout/marketing-nav'
+
+export const metadata = {
+  title: 'Spanlens vs alternatives · Compare',
+  description:
+    'Honest comparisons of Spanlens against Langfuse, Helicone, LangSmith, Braintrust, and Arize Phoenix, feature by feature.',
+}
+
+interface CompareEntry {
+  slug: string
+  competitor: string
+  blurb: string
+  tag: string
+}
+
+const ENTRIES: CompareEntry[] = [
+  {
+    slug: 'langfuse',
+    competitor: 'Langfuse',
+    blurb:
+      'The most mature OSS LLM observability tool. We diverge on instrumentation model (proxy vs SDK), license boundary (full MIT vs OSS + EE folder), and built-in eval shape.',
+    tag: 'OSS · SDK-based',
+  },
+  {
+    slug: 'helicone',
+    competitor: 'Helicone',
+    blurb:
+      'The closest architectural match. Both are proxy-based. We add Critical Path agent tracing, Prompt A/B with Welch t-test, and tighter logging durability with ClickHouse fallback.',
+    tag: 'Proxy-based',
+  },
+  {
+    slug: 'langsmith',
+    competitor: 'LangSmith',
+    blurb:
+      "LangChain's commercial offering. Excellent if you live inside LangChain, locked-in if you don't. Spanlens is framework-agnostic.",
+    tag: 'LangChain ecosystem',
+  },
+  {
+    slug: 'braintrust',
+    competitor: 'Braintrust',
+    blurb:
+      'Eval-first, closed-source SaaS. Strong eval UX. We bundle eval into a full observability platform that you can self-host with one Docker command.',
+    tag: 'Eval-first · closed source',
+  },
+  {
+    slug: 'arize-phoenix',
+    competitor: 'Arize Phoenix',
+    blurb:
+      'OSS observability from Arize. Python-first, ML-engineer-leaning. Spanlens is built for the application developer running LLM calls in production.',
+    tag: 'OSS · Python-first',
+  },
+]
+
+export default function ComparePage() {
+  return (
+    <div className="min-h-screen bg-bg">
+      <MarketingNav />
+
+      <section className="max-w-[1000px] mx-auto px-6 pt-20 pb-12">
+        <h1 className="text-[40px] sm:text-[48px] font-semibold tracking-[-0.8px] text-text leading-[1.05]">
+          How Spanlens compares
+        </h1>
+        <p className="mt-4 text-[18px] text-text-muted leading-relaxed max-w-[680px]">
+          Honest, side-by-side comparisons. We tell you when the alternative is the better choice
+          for your team. Building trust is more valuable than winning every checkbox.
+        </p>
+      </section>
+
+      <section className="max-w-[1000px] mx-auto px-6 pb-24">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {ENTRIES.map((entry) => (
+            <Link
+              key={entry.slug}
+              href={`/compare/${entry.slug}`}
+              className="group rounded-xl border border-border bg-bg-elev p-6 hover:border-accent transition-colors"
+            >
+              <div className="flex items-baseline justify-between gap-3 mb-3">
+                <h2 className="text-[18px] font-semibold text-text group-hover:text-accent transition-colors">
+                  Spanlens vs {entry.competitor}
+                </h2>
+                <span className="font-mono text-[10.5px] uppercase tracking-[0.06em] text-text-faint shrink-0">
+                  {entry.tag}
+                </span>
+              </div>
+              <p className="text-[13px] text-text-muted leading-relaxed">{entry.blurb}</p>
+              <div className="mt-4 font-mono text-[12px] text-accent opacity-0 group-hover:opacity-100 transition-opacity">
+                Read comparison →
+              </div>
+            </Link>
+          ))}
+        </div>
+
+        <div className="mt-12 rounded-xl border border-border bg-bg p-6">
+          <h3 className="text-[15px] font-semibold text-text mb-2">Don&apos;t see your tool?</h3>
+          <p className="text-[13px] text-text-muted leading-relaxed">
+            We&apos;ll write a comparison for any LLM observability tool that has at least
+            a public docs page. Email{' '}
+            <a href="mailto:support@spanlens.io" className="text-accent hover:underline">
+              support@spanlens.io
+            </a>{' '}
+            and we&apos;ll add it.
+          </p>
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  )
+}

--- a/apps/web/app/demo/alerts/page.tsx
+++ b/apps/web/app/demo/alerts/page.tsx
@@ -255,7 +255,7 @@ export default function DemoAlertsPage() {
             </div>
             {channels.length === 0 ? (
               <div className="rounded-[5px] border border-dashed border-border py-5 text-center font-mono text-[12px] text-text-muted">
-                No channels yet — add an email or webhook to receive alerts.
+                No channels yet, add an email or webhook to receive alerts.
               </div>
             ) : (
               <div className="rounded-[6px] border border-border overflow-hidden">

--- a/apps/web/app/demo/annotation/page.tsx
+++ b/apps/web/app/demo/annotation/page.tsx
@@ -26,7 +26,7 @@ function extractRequestUserText(body: Record<string, unknown> | null): string {
   return ''
 }
 function fmtScore(n: number | null | undefined): string {
-  return n == null ? '—' : (n * 100).toFixed(0)
+  return n == null ? ',' : (n * 100).toFixed(0)
 }
 
 function StarRating({ value, onChange }: { value: number | null; onChange: (v: number) => void }) {
@@ -65,7 +65,7 @@ function ItemCard({ item }: { item: AnnotationQueueItem }) {
 
   function handleSave() {
     if (stars == null) { alert('Pick a rating first'); return }
-    alert('Saving ratings — sign up to use this')
+    alert('Saving ratings, sign up to use this')
   }
 
   return (
@@ -73,7 +73,7 @@ function ItemCard({ item }: { item: AnnotationQueueItem }) {
       <div className="flex items-center px-[14px] py-[10px] bg-bg-muted border-b border-border">
         <div className="flex-1 min-w-0">
           <p className="font-mono text-[12px] text-text font-medium truncate">
-            {item.prompt_name ?? '—'}{item.prompt_version != null ? ` · v${item.prompt_version}` : ''}
+            {item.prompt_name ?? ','}{item.prompt_version != null ? ` · v${item.prompt_version}` : ''}
           </p>
           <p className="font-mono text-[10px] text-text-faint truncate">
             {item.model} · {new Date(item.created_at).toLocaleString()}
@@ -103,7 +103,7 @@ function ItemCard({ item }: { item: AnnotationQueueItem }) {
         <div className="min-w-0">
           <p className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-1">User input</p>
           <p className={cn('font-mono text-[11.5px] text-text-muted leading-relaxed whitespace-pre-wrap', !expanded && 'line-clamp-3')}>
-            {userMsg || '—'}
+            {userMsg || ','}
           </p>
         </div>
         <div className="min-w-0">
@@ -114,7 +114,7 @@ function ItemCard({ item }: { item: AnnotationQueueItem }) {
             </button>
           </div>
           <p className={cn('font-mono text-[12px] text-text leading-relaxed whitespace-pre-wrap', !expanded && 'line-clamp-5')}>
-            {responseText || '—'}
+            {responseText || ','}
           </p>
         </div>
       </div>
@@ -209,7 +209,7 @@ export default function DemoAnnotationPage() {
       <div className="px-[22px] py-[10px] border-b border-border flex items-center gap-2 font-mono text-[11px] text-text-muted">
         <MessageSquare className="h-3.5 w-3.5" />
         <span>
-          Manually score responses. Your ratings calibrate against LLM judge scores —
+          Manually score responses. Your ratings calibrate against LLM judge scores ,
           a low correlation signals the judge needs work.
         </span>
       </div>

--- a/apps/web/app/demo/anomalies/page.tsx
+++ b/apps/web/app/demo/anomalies/page.tsx
@@ -349,7 +349,7 @@ export default function DemoAnomaliesPage() {
       {/* Content */}
       <div className="flex-1 overflow-auto">
         <>
-          {/* Open — high severity */}
+          {/* Open, high severity */}
           {unackedHigh.length > 0 && (
             <div>
               <div className="flex items-center gap-2.5 px-[22px] py-[10px] bg-bg-muted border-b border-border border-t border-t-border">
@@ -369,7 +369,7 @@ export default function DemoAnomaliesPage() {
             </div>
           )}
 
-          {/* Open — medium severity */}
+          {/* Open, medium severity */}
           {unackedMedium.length > 0 && (
             <div>
               <div className="flex items-center gap-2.5 px-[22px] py-[10px] bg-bg-muted border-b border-border border-t border-t-border">
@@ -423,7 +423,7 @@ export default function DemoAnomaliesPage() {
               </p>
               <p className="font-mono text-[11.5px] text-text-faint">
                 {acked.length > 0
-                  ? `${acked.length} acknowledged — Unack to re-open.`
+                  ? `${acked.length} acknowledged, Unack to re-open.`
                   : 'Baselines look healthy.'}
               </p>
             </div>

--- a/apps/web/app/demo/datasets/[id]/page.tsx
+++ b/apps/web/app/demo/datasets/[id]/page.tsx
@@ -29,7 +29,7 @@ function ItemRow({ item }: { item: DatasetItem }) {
         </div>
         <button
           type="button"
-          onClick={(e) => { e.stopPropagation(); alert('Deleting items — sign up to use this') }}
+          onClick={(e) => { e.stopPropagation(); alert('Deleting items, sign up to use this') }}
           className="text-text-faint hover:text-bad shrink-0"
         >
           <Trash2 className="h-3.5 w-3.5" />
@@ -85,7 +85,7 @@ export default function DemoDatasetDetail({ params }: { params: { id: string } }
         right={
           <button
             type="button"
-            onClick={() => alert('Adding items — sign up to use this')}
+            onClick={() => alert('Adding items, sign up to use this')}
             className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 flex items-center gap-1.5"
           >
             <Plus className="h-3.5 w-3.5" />

--- a/apps/web/app/demo/datasets/page.tsx
+++ b/apps/web/app/demo/datasets/page.tsx
@@ -6,7 +6,7 @@ import { Topbar } from '@/components/layout/topbar'
 import { DEMO_DATASETS } from '@/lib/demo-data'
 
 function demoNotice(action: string) {
-  return () => alert(`${action} — sign up to use this`)
+  return () => alert(`${action}, sign up to use this`)
 }
 
 export default function DemoDatasetsPage() {

--- a/apps/web/app/demo/evals/page.tsx
+++ b/apps/web/app/demo/evals/page.tsx
@@ -14,15 +14,15 @@ import type { Evaluator, EvalRunStatus } from '@/lib/queries/use-evals'
 import { pearsonR } from '@/lib/queries/use-human-evals'
 
 function demoNotice(action: string) {
-  return () => alert(`${action} — sign up to use this`)
+  return () => alert(`${action}, sign up to use this`)
 }
 
 function fmtUsd(n: number | null | undefined): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   return n >= 0.01 ? `$${n.toFixed(3)}` : `$${n.toFixed(5)}`
 }
 function fmtScore(n: number | null | undefined): string {
-  return n == null ? '—' : `${(n * 100).toFixed(1)}`
+  return n == null ? ',' : `${(n * 100).toFixed(1)}`
 }
 
 function StatusBadge({ status }: { status: EvalRunStatus }) {
@@ -51,7 +51,7 @@ function CorrelationCard({ promptName }: { promptName: string }) {
   const dotY = (s: number) => H - PAD - s * (H - 2 * PAD)
 
   const interpretation = r == null
-    ? '—'
+    ? ','
     : Math.abs(r) >= 0.7 ? 'Strong'
     : Math.abs(r) >= 0.4 ? 'Moderate'
     : Math.abs(r) >= 0.2 ? 'Weak'
@@ -72,7 +72,7 @@ function CorrelationCard({ promptName }: { promptName: string }) {
             <p className="font-mono text-[11px] text-text-faint mb-0.5 truncate">{promptName}</p>
             <div className="flex items-baseline gap-2">
               <span className={cn('font-mono text-[22px] font-medium', rColor)}>
-                {r == null ? '—' : r.toFixed(2)}
+                {r == null ? ',' : r.toFixed(2)}
               </span>
               <span className="font-mono text-[10.5px] text-text-muted">
                 Pearson r · {interpretation}
@@ -204,7 +204,7 @@ function EvaluatorRow({
           </p>
         </div>
         <div className="font-mono text-[12px] text-text-muted w-[100px] text-right">
-          {latestCompleted ? fmtScore(latestCompleted.avg_score) : '—'}
+          {latestCompleted ? fmtScore(latestCompleted.avg_score) : ','}
         </div>
         <div className="font-mono text-[11px] text-text-faint w-[80px] text-right">
           {runs.length} runs

--- a/apps/web/app/demo/experiments/[id]/page.tsx
+++ b/apps/web/app/demo/experiments/[id]/page.tsx
@@ -9,14 +9,14 @@ import { DEMO_EXPERIMENTS, DEMO_EXPERIMENT_RESULTS } from '@/lib/demo-data'
 import type { ExperimentResult } from '@/lib/queries/use-experiments'
 
 function fmtUsd(n: number | null | undefined): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   return n >= 0.01 ? `$${n.toFixed(3)}` : `$${n.toFixed(5)}`
 }
 function fmtScore(n: number | null | undefined): string {
-  return n == null ? '—' : (n * 100).toFixed(1)
+  return n == null ? ',' : (n * 100).toFixed(1)
 }
 function fmtMs(n: number | null | undefined): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   if (n >= 1000) return `${(n / 1000).toFixed(2)}s`
   return `${Math.round(n)}ms`
 }
@@ -67,7 +67,7 @@ function ResultRow({ result, idx }: { result: ExperimentResult; idx: number }) {
           'font-mono text-[11.5px] w-[60px] text-right',
           scoreDelta == null ? 'text-text-faint' : scoreDelta > 0 ? 'text-good' : scoreDelta < 0 ? 'text-bad' : 'text-text-muted',
         )}>
-          {scoreDelta == null ? '—' : (scoreDelta > 0 ? '+' : '') + (scoreDelta * 100).toFixed(1)}
+          {scoreDelta == null ? ',' : (scoreDelta > 0 ? '+' : '') + (scoreDelta * 100).toFixed(1)}
         </span>
         <span className="ml-3 text-text-faint">
           {expanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
@@ -171,7 +171,7 @@ export default function DemoExperimentDetail({ params }: { params: { id: string 
                 'font-mono text-[18px] font-medium',
                 delta == null ? 'text-text-faint' : delta > 0 ? 'text-good' : delta < 0 ? 'text-bad' : 'text-text',
               )}>
-                {delta == null ? '—' : (delta > 0 ? '+' : '') + (delta * 100).toFixed(1)}
+                {delta == null ? ',' : (delta > 0 ? '+' : '') + (delta * 100).toFixed(1)}
               </p>
             </div>
             <div className="bg-bg-muted border border-border rounded-[5px] px-3 py-2.5">

--- a/apps/web/app/demo/experiments/page.tsx
+++ b/apps/web/app/demo/experiments/page.tsx
@@ -9,11 +9,11 @@ import { DEMO_EXPERIMENTS } from '@/lib/demo-data'
 import type { Experiment, ExperimentStatus } from '@/lib/queries/use-experiments'
 
 function fmtUsd(n: number | null | undefined): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   return n >= 0.01 ? `$${n.toFixed(3)}` : `$${n.toFixed(5)}`
 }
 function fmtScore(n: number | null | undefined): string {
-  return n == null ? '—' : (n * 100).toFixed(1)
+  return n == null ? ',' : (n * 100).toFixed(1)
 }
 
 function StatusBadge({ status }: { status: ExperimentStatus }) {
@@ -60,7 +60,7 @@ function ExperimentRow({ exp }: { exp: Experiment }) {
         'font-mono text-[12px] w-[80px] text-right',
         delta == null ? 'text-text-faint' : delta > 0 ? 'text-good' : delta < 0 ? 'text-bad' : 'text-text-muted',
       )}>
-        {delta == null ? '—' : (delta > 0 ? '+' : '') + (delta * 100).toFixed(1)}
+        {delta == null ? ',' : (delta > 0 ? '+' : '') + (delta * 100).toFixed(1)}
       </div>
       <div className="font-mono text-[11px] text-text-faint w-[80px] text-right">
         {fmtUsd(exp.total_cost_usd)}
@@ -78,7 +78,7 @@ export default function DemoExperimentsPage() {
         right={
           <button
             type="button"
-            onClick={() => alert('Creating experiments — sign up to use this')}
+            onClick={() => alert('Creating experiments, sign up to use this')}
             className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 flex items-center gap-1.5"
           >
             <Plus className="h-3.5 w-3.5" />

--- a/apps/web/app/demo/prompts/[name]/page.tsx
+++ b/apps/web/app/demo/prompts/[name]/page.tsx
@@ -21,7 +21,7 @@ function fmtUsd(v: number): string {
 }
 
 function fmtMs(v: number): string {
-  if (v === 0) return '—'
+  if (v === 0) return ','
   if (v >= 1000) return `${(v / 1000).toFixed(2)}s`
   return `${Math.round(v)}ms`
 }
@@ -182,7 +182,7 @@ function CallsTab() {
             </span>
             <span className="text-text-muted">{r.total_tokens.toLocaleString()}</span>
             <span className="text-text-muted">
-              {r.cost_usd != null ? `$${r.cost_usd.toFixed(5)}` : '—'}
+              {r.cost_usd != null ? `$${r.cost_usd.toFixed(5)}` : ','}
             </span>
             <span className="text-text-muted">{r.latency_ms}ms</span>
             <span className="text-text-faint text-right text-[11px]">
@@ -204,9 +204,9 @@ function TrafficTab({ prompt }: { prompt: (typeof DEMO_PROMPTS)[number] }) {
   const statItems = [
     { label: 'Total calls',   value: stats.calls.toLocaleString() },
     { label: 'Total spend',   value: fmtUsd(stats.totalCostUsd) },
-    { label: 'Avg cost/call', value: stats.avgCostUsd != null ? fmtUsd(stats.avgCostUsd) : '—' },
-    { label: 'Avg latency',   value: stats.avgLatencyMs != null ? fmtMs(stats.avgLatencyMs) : '—' },
-    { label: 'Error rate',    value: stats.errorRate != null ? `${(stats.errorRate * 100).toFixed(1)}%` : '—' },
+    { label: 'Avg cost/call', value: stats.avgCostUsd != null ? fmtUsd(stats.avgCostUsd) : ',' },
+    { label: 'Avg latency',   value: stats.avgLatencyMs != null ? fmtMs(stats.avgLatencyMs) : ',' },
+    { label: 'Error rate',    value: stats.errorRate != null ? `${(stats.errorRate * 100).toFixed(1)}%` : ',' },
   ]
 
   return (

--- a/apps/web/app/demo/prompts/page.tsx
+++ b/apps/web/app/demo/prompts/page.tsx
@@ -11,13 +11,13 @@ function fmtUsd(v: number): string {
 }
 
 function fmtMs(v: number): string {
-  if (v === 0) return '—'
+  if (v === 0) return ','
   if (v >= 1000) return `${(v / 1000).toFixed(2)}s`
   return `${Math.round(v)}ms`
 }
 
 function QualityBadge({ score }: { score: number | null | undefined }) {
-  if (score == null) return <span className="text-text-faint">—</span>
+  if (score == null) return <span className="text-text-faint">,</span>
   const color = score >= 90 ? 'text-good' : score >= 70 ? 'text-warn' : 'text-bad'
   return <span className={cn('font-mono tabular-nums', color)}>{score}</span>
 }
@@ -76,7 +76,7 @@ export default function DemoPromptsPage() {
         crumbs={[{ label: 'Demo', href: '/demo/dashboard' }, { label: 'Prompts' }]}
         right={
           <div className="flex items-center gap-2">
-            {/* Search — desktop only */}
+            {/* Search, desktop only */}
             <div className="hidden md:flex items-center gap-2 px-[10px] py-[5px] border border-border rounded-[6px] bg-bg-elev w-[280px]">
               <span className="text-text-faint text-[14px] leading-none">⌕</span>
               <input
@@ -120,8 +120,8 @@ export default function DemoPromptsPage() {
           {[
             { label: 'Total prompts',             value: String(all.length) },
             { label: 'Total versions',            value: String(totalVersions) },
-            { label: `Total calls`,               value: totalCalls > 0 ? totalCalls.toLocaleString() : '—' },
-            { label: `Total spend`,               value: totalSpend > 0 ? fmtUsd(totalSpend) : '—' },
+            { label: `Total calls`,               value: totalCalls > 0 ? totalCalls.toLocaleString() : ',' },
+            { label: `Total spend`,               value: totalSpend > 0 ? fmtUsd(totalSpend) : ',' },
             { label: `A/B tests`,                 value: String(abCount) },
           ].map((s, i) => (
             <div key={i} className={cn('px-[18px] py-[14px]', i < 4 && 'border-r border-border')}>
@@ -342,17 +342,17 @@ export default function DemoPromptsPage() {
 
                 {/* Calls */}
                 <span className={cn(p.stats && p.stats.calls > 0 ? 'text-text' : 'text-text-faint')}>
-                  {p.stats?.calls ? p.stats.calls.toLocaleString() : '—'}
+                  {p.stats?.calls ? p.stats.calls.toLocaleString() : ','}
                 </span>
 
                 {/* Avg cost */}
                 <span className={cn(p.stats?.avgCostUsd != null ? 'text-text' : 'text-text-faint')}>
-                  {p.stats?.avgCostUsd != null ? fmtUsd(p.stats.avgCostUsd) : '—'}
+                  {p.stats?.avgCostUsd != null ? fmtUsd(p.stats.avgCostUsd) : ','}
                 </span>
 
                 {/* Avg latency */}
                 <span className={cn(p.stats?.avgLatencyMs != null ? 'text-text' : 'text-text-faint')}>
-                  {p.stats?.avgLatencyMs != null ? fmtMs(p.stats.avgLatencyMs) : '—'}
+                  {p.stats?.avgLatencyMs != null ? fmtMs(p.stats.avgLatencyMs) : ','}
                 </span>
 
                 {/* Quality score */}
@@ -366,7 +366,7 @@ export default function DemoPromptsPage() {
                       A/B
                     </span>
                   ) : (
-                    <span className="text-text-faint">—</span>
+                    <span className="text-text-faint">,</span>
                   )}
                 </span>
 

--- a/apps/web/app/demo/requests/[id]/page.tsx
+++ b/apps/web/app/demo/requests/[id]/page.tsx
@@ -8,7 +8,7 @@ import { DEMO_REQUEST_DETAILS } from '@/lib/demo-data'
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function fmtCost(n: number | null): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   return '$' + n.toFixed(6)
 }
 
@@ -88,7 +88,7 @@ export default function DemoRequestDetailPage({ params }: { params: { id: string
     { label: 'Total tokens', value: req.total_tokens.toLocaleString() },
     ...(req.trace_id
       ? [{ label: 'Trace ID', value: req.trace_id.slice(0, 16) + '…', link: `/demo/traces/${req.trace_id}` }]
-      : [{ label: 'Trace ID', value: '—' }]),
+      : [{ label: 'Trace ID', value: ',' }]),
     { label: 'Status', value: String(req.status_code), warn: isErr },
     ...(req.user_id ? [{ label: 'User', value: req.user_id, link: `/demo/requests?userId=${req.user_id}` }] : []),
     ...(req.session_id ? [{ label: 'Session', value: req.session_id, link: `/demo/requests?sessionId=${req.session_id}` }] : []),

--- a/apps/web/app/demo/requests/page.tsx
+++ b/apps/web/app/demo/requests/page.tsx
@@ -26,7 +26,7 @@ function relAge(dateStr: string): string {
 }
 
 function fmtCost(n: number | null): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   return n < 0.001 ? '$' + n.toFixed(5) : '$' + n.toFixed(4)
 }
 
@@ -186,11 +186,11 @@ function TrafficBars() {
 
   const labels = useMemo(() => {
     const pts = ts.slice(-30)
-    if (!pts.length) return ['—', '—', '—', '—', 'NOW']
+    if (!pts.length) return [',', ',', ',', ',', 'NOW']
     const fmt = (s: string) =>
       new Date(s).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
     const first = pts[0]
-    if (!first) return ['—', '—', '—', '—', 'NOW']
+    if (!first) return [',', ',', ',', ',', 'NOW']
     return [
       fmt(first.date),
       fmt((pts[Math.floor(pts.length * 0.25)] ?? first).date),

--- a/apps/web/app/demo/savings/page.tsx
+++ b/apps/web/app/demo/savings/page.tsx
@@ -253,7 +253,7 @@ function DemoPercentileGrid({
         <div className="border border-warn/30 bg-warn/5 rounded-[5px] px-3 py-2 font-mono text-[10.5px] text-warn leading-relaxed">
           P95 exceeds the substitute envelope
           {promptWarn && complWarn ? ' for both prompt and completion' : promptWarn ? ' for prompt tokens' : ' for completion tokens'}.
-          {' '}Some requests may degrade in quality — run a shadow comparison first.
+          {' '}Some requests may degrade in quality, run a shadow comparison first.
         </div>
       )}
     </div>
@@ -338,7 +338,7 @@ function RecRow({
           <>
             <div className="font-mono text-[10px] text-text-faint uppercase tracking-[0.03em] mb-[3px]">ACTUAL / MO</div>
             <div className="font-mono text-[18px] font-medium tracking-[-0.3px] text-good">
-              {r.actualMonthlySavingsUsd != null ? fmtUsd(r.actualMonthlySavingsUsd) : '—'}
+              {r.actualMonthlySavingsUsd != null ? fmtUsd(r.actualMonthlySavingsUsd) : ','}
             </div>
             <div className="font-mono text-[10.5px] text-text-faint mt-0.5">
               est. {fmtUsd(r.estimatedMonthlySavingsUsd)} projected
@@ -456,7 +456,7 @@ export default function DemoSavingsPage() {
   const statTiles = [
     {
       label: `Spend · ${windowLabel}`,
-      value: totalSpend > 0 ? fmtUsd(totalSpend) : '—',
+      value: totalSpend > 0 ? fmtUsd(totalSpend) : ',',
       delta: 'analyzed models',
       good: false,
     },
@@ -468,7 +468,7 @@ export default function DemoSavingsPage() {
     },
     {
       label: achieved.length > 0 ? 'Achieved' : (bestConfLevel ? `${bestConfLevel.charAt(0).toUpperCase() + bestConfLevel.slice(1)} conf.` : 'Confidence'),
-      value: achieved.length > 0 ? fmtUsd(totalAchieved) : (bestConfLevel !== null ? String(bestConfCount) : '—'),
+      value: achieved.length > 0 ? fmtUsd(totalAchieved) : (bestConfLevel !== null ? String(bestConfCount) : ','),
       delta: achieved.length > 0 ? `${achieved.length} swap${achieved.length > 1 ? 's' : ''} adopted` : (bestConfLevel ? bestConfLabel[bestConfLevel] : 'no recommendations yet'),
       good: achieved.length > 0 || bestConfLevel === 'high',
     },
@@ -521,7 +521,7 @@ export default function DemoSavingsPage() {
             <div className="flex items-baseline gap-2 mb-1.5">
               <span className={cn('font-medium leading-none tracking-[-1.6px]',
                 totalOpen > 0 ? 'text-[40px] text-accent' : 'text-[30px] text-text-faint')}>
-                {totalOpen > 0 ? fmtUsd(totalOpen) : '—'}
+                {totalOpen > 0 ? fmtUsd(totalOpen) : ','}
               </span>
               <span className="font-mono text-[10px] text-text-muted">/ mo</span>
             </div>

--- a/apps/web/app/demo/security/page.tsx
+++ b/apps/web/app/demo/security/page.tsx
@@ -8,7 +8,7 @@ import { DEMO_SECURITY_SUMMARY, DEMO_FLAGGED_REQUESTS } from '@/lib/demo-data'
 
 function formatRelative(iso: string): string {
   const ms = new Date(iso).getTime()
-  if (Number.isNaN(ms)) return '—'
+  if (Number.isNaN(ms)) return ','
   const diff = (Date.now() - ms) / 1000
   if (diff < 0) return 'just now'
   if (diff < 60) return `${Math.floor(diff)}s ago`
@@ -281,7 +281,7 @@ export default function DemoSecurityPage() {
             <div className="border border-border rounded-[6px] px-[16px] py-[14px]">
               <div className="mb-[8px]">
                 <span className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
-                  Injection blocking — per project
+                  Injection blocking, per project
                 </span>
               </div>
               <div className="space-y-[6px]">
@@ -298,7 +298,7 @@ export default function DemoSecurityPage() {
                 </div>
               </div>
               <p className="text-[11px] text-text-faint mt-[8px] leading-relaxed">
-                When ON, injection attempts return 422 — request never reaches the LLM.
+                When ON, injection attempts return 422, request never reaches the LLM.
               </p>
               <p className="text-[10.5px] text-text-faint mt-2 font-mono">
                 Sign up to configure →
@@ -311,7 +311,7 @@ export default function DemoSecurityPage() {
         <div className="px-[22px] pt-[14px] pb-0">
           <div className="flex items-center justify-between mb-3">
             <span className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
-              Detectors — {detectors.length} active · flag-only (no blocking unless enabled
+              Detectors, {detectors.length} active · flag-only (no blocking unless enabled
               above)
             </span>
           </div>

--- a/apps/web/app/demo/traces/[id]/page.tsx
+++ b/apps/web/app/demo/traces/[id]/page.tsx
@@ -9,14 +9,14 @@ import type { SpanRow } from '@/lib/queries/types'
 // ── Helpers ────────────────────────────────────────────────────
 
 function fmtDuration(ms: number | null): string {
-  if (ms == null) return '—'
+  if (ms == null) return ','
   if (ms < 1) return '<1ms'
   if (ms < 1000) return `${Math.round(ms)}ms`
   return `${(ms / 1000).toFixed(2)}s`
 }
 
 function fmtCost(n: number | null): string {
-  if (n == null || n <= 0) return '—'
+  if (n == null || n <= 0) return ','
   return n < 0.001 ? `$${n.toFixed(5)}` : `$${n.toFixed(4)}`
 }
 
@@ -67,7 +67,7 @@ function SpanDetailPanel({ span, onClose }: SpanDetailPanelProps) {
           {[
             { label: 'Duration', value: fmtDuration(span.duration_ms) },
             { label: 'Status',   value: span.status },
-            { label: 'Tokens',   value: span.total_tokens > 0 ? span.total_tokens.toLocaleString() : '—' },
+            { label: 'Tokens',   value: span.total_tokens > 0 ? span.total_tokens.toLocaleString() : ',' },
             { label: 'Cost',     value: fmtCost(span.cost_usd) },
           ].map((s) => (
             <div key={s.label} className="rounded-[5px] border border-border bg-bg-elev px-3 py-2">

--- a/apps/web/app/demo/traces/page.tsx
+++ b/apps/web/app/demo/traces/page.tsx
@@ -9,14 +9,14 @@ import type { TraceRow } from '@/lib/queries/types'
 // ── Helpers ────────────────────────────────────────────────────
 
 function fmtDuration(ms: number | null): string {
-  if (ms == null) return '—'
+  if (ms == null) return ','
   if (ms < 1) return '<1ms'
   if (ms < 1000) return `${Math.round(ms)}ms`
   return `${(ms / 1000).toFixed(2)}s`
 }
 
 function fmtCost(n: number): string {
-  if (n <= 0) return '—'
+  if (n <= 0) return ','
   return n < 0.001 ? `$${n.toFixed(5)}` : `$${n.toFixed(4)}`
 }
 
@@ -160,7 +160,7 @@ export default function DemoTracesPage() {
             { label: 'Traces',            value: DEMO_TRACES.length.toLocaleString(), warn: false },
             { label: 'p50 duration',      value: fmtDuration(p50),                   warn: false },
             { label: 'p95 duration',      value: fmtDuration(p95),                   warn: p95 != null && p95 > 8000 },
-            { label: 'Avg spans / trace', value: avgSpans != null ? avgSpans.toFixed(1) : '—', warn: false },
+            { label: 'Avg spans / trace', value: avgSpans != null ? avgSpans.toFixed(1) : ',', warn: false },
             { label: 'Errors',            value: String(errors),                      warn: errors > 0 },
           ].map((s, i) => (
             <div

--- a/apps/web/app/demo/users/[userId]/page.tsx
+++ b/apps/web/app/demo/users/[userId]/page.tsx
@@ -11,7 +11,7 @@ import { DEMO_REQUESTS } from '@/lib/demo-data'
 // ─────────────────────────────────────────────────────────────────────────────
 
 function fmtCost(n: number | null | undefined): string {
-  if (n == null) return '—'
+  if (n == null) return ','
   return '$' + Number(n).toFixed(6)
 }
 
@@ -45,8 +45,8 @@ export default async function DemoUserDetailPage({ params }: { params: Promise<{
     { label: 'Avg latency', value: `${Math.round(avgLatency)} ms` },
     { label: 'Error count', value: fmtCount(errorCount), warn: errorCount > 0 },
     { label: 'Distinct models', value: fmtCount(distinctModels) },
-    { label: 'First seen', value: firstSeen ? new Date(firstSeen).toLocaleDateString() : '—' },
-    { label: 'Last seen', value: lastSeen ? new Date(lastSeen).toLocaleDateString() : '—' },
+    { label: 'First seen', value: firstSeen ? new Date(firstSeen).toLocaleDateString() : ',' },
+    { label: 'Last seen', value: lastSeen ? new Date(lastSeen).toLocaleDateString() : ',' },
   ]
 
   return (

--- a/apps/web/app/docs/_components/lang-tabs.tsx
+++ b/apps/web/app/docs/_components/lang-tabs.tsx
@@ -79,7 +79,7 @@ export function LangTabs({ ts, py }: LangTabsProps) {
         <div className="rounded-b-lg border border-t-0 border-border/40 bg-[#1a1816] px-4 py-6 text-sm text-[#7c7770]">
           {lang === 'py'
             ? 'Python sample coming soon. The TypeScript sample on the other tab works the same way.'
-            : 'TypeScript sample coming soon — see the Python tab.'}
+            : 'TypeScript sample coming soon, see the Python tab.'}
         </div>
       )}
     </div>

--- a/apps/web/app/docs/api/page.tsx
+++ b/apps/web/app/docs/api/page.tsx
@@ -132,17 +132,17 @@ export default function ApiReferencePage() {
           <tr><td>Exports</td><td><code>/api/v1/exports/*</code></td><td>JWT</td></tr>
           <tr><td>Members</td><td><code>/api/v1/organizations/:orgId/members</code></td><td>JWT (admin for writes)</td></tr>
           <tr><td>Invitations</td><td><code>/api/v1/organizations/:orgId/invitations</code></td><td>JWT (admin)</td></tr>
-          <tr><td>Proxy — OpenAI</td><td><code>/proxy/openai/v1/*</code></td><td>API key</td></tr>
-          <tr><td>Proxy — Anthropic</td><td><code>/proxy/anthropic/v1/*</code></td><td>API key</td></tr>
-          <tr><td>Proxy — Gemini</td><td><code>/proxy/gemini/v1/*</code></td><td>API key</td></tr>
-          <tr><td>Proxy — Azure OpenAI</td><td><code>/proxy/azure/*</code></td><td>API key</td></tr>
+          <tr><td>Proxy, OpenAI</td><td><code>/proxy/openai/v1/*</code></td><td>API key</td></tr>
+          <tr><td>Proxy, Anthropic</td><td><code>/proxy/anthropic/v1/*</code></td><td>API key</td></tr>
+          <tr><td>Proxy, Gemini</td><td><code>/proxy/gemini/v1/*</code></td><td>API key</td></tr>
+          <tr><td>Proxy, Azure OpenAI</td><td><code>/proxy/azure/*</code></td><td>API key</td></tr>
           <tr><td>SDK Ingest</td><td><code>/ingest/*</code></td><td>API key</td></tr>
         </tbody>
       </table>
 
       <p>
-        For the full interactive spec — request/response schemas, try-it-out,
-        example curl commands — open the{' '}
+        For the full interactive spec, request/response schemas, try-it-out,
+        example curl commands, open the{' '}
         <a href={swaggerUiUrl} target="_blank" rel="noopener noreferrer">
           Swagger UI
         </a>.

--- a/apps/web/app/docs/features/alerts/page.tsx
+++ b/apps/web/app/docs/features/alerts/page.tsx
@@ -12,7 +12,7 @@ export default function AlertsDocs() {
       <h1>Alerts</h1>
       <p className="lead">
         Define simple threshold rules on your LLM traffic. When a rule fires, Spanlens sends a
-        notification to your chosen channel — email, Slack, or Discord. Runs on a 15-minute cron,
+        notification to your chosen channel, email, Slack, or Discord. Runs on a 15-minute cron,
         honors cooldowns, and logs every delivery so you can audit what fired when.
       </p>
 
@@ -150,7 +150,7 @@ Content-Type: application/json
         <li>
           <strong>Delivery is at-least-once.</strong> If Resend/Slack/Discord returns an error,
           we log it and retry on the next cron. At-most-once semantics would require per-channel
-          idempotency keys — not worth the complexity for ops alerts.
+          idempotency keys, not worth the complexity for ops alerts.
         </li>
         <li>
           <strong>Cron runs on GitHub Actions, not Vercel Cron.</strong> Why: easier to audit,
@@ -167,7 +167,7 @@ Content-Type: application/json
       <ul>
         <li>
           <strong>No PagerDuty / OpsGenie integration yet.</strong> Slack webhooks can be piped
-          through those services if you need escalation — but we don&apos;t natively integrate.
+          through those services if you need escalation, but we don&apos;t natively integrate.
         </li>
         <li>
           <strong>Fixed metric set.</strong> Only budget / error_rate / latency_p95 today. Custom
@@ -175,7 +175,7 @@ Content-Type: application/json
         </li>
         <li>
           <strong>Quota-overage warning emails run on a separate cron</strong> (hourly). Org
-          owners get automatic emails at 80% and 100% of the monthly request quota — no setup
+          owners get automatic emails at 80% and 100% of the monthly request quota, no setup
           required. Content is context-aware: at 100% with overage billing enabled, the email
           tells the user that overage charges are now active (not that their requests are being
           rejected). Toggle in <a href="/settings">/settings</a>.

--- a/apps/web/app/docs/features/annotation/page.tsx
+++ b/apps/web/app/docs/features/annotation/page.tsx
@@ -35,7 +35,7 @@ export default function AnnotationDocs() {
         <li>
           Use the top filters: select a prompt / enable <strong>Unscored only</strong> (show
           only what you haven&apos;t rated yet) / enable{' '}
-          <strong>Low judge score</strong> (judge scored below 50 — highest validation priority).
+          <strong>Low judge score</strong> (judge scored below 50, highest validation priority).
         </li>
         <li>
           Each card shows the user input and response in two columns. Click{' '}
@@ -82,10 +82,10 @@ export default function AnnotationDocs() {
       <p>
         A <code>UNIQUE (request_id, reviewer_id)</code> constraint ensures each user leaves
         at most one score per request. Rating the same row again performs an{' '}
-        <strong>upsert</strong> — it updates <code>raw_score</code>, <code>score</code>, and{' '}
+        <strong>upsert</strong>, it updates <code>raw_score</code>, <code>score</code>, and{' '}
         <code>comment</code>.
       </p>
-      <p>Multiple reviewers can rate the same request — each gets their own row.</p>
+      <p>Multiple reviewers can rate the same request, each gets their own row.</p>
 
       <h2>Correlation card on the Evals page</h2>
       <p>
@@ -95,13 +95,13 @@ export default function AnnotationDocs() {
       </p>
       <ul>
         <li>
-          <strong>r ≥ 0.7</strong> — Strong: judge can be trusted
+          <strong>r ≥ 0.7</strong>, Strong: judge can be trusted
         </li>
         <li>
-          <strong>0.4 ≤ r &lt; 0.7</strong> — Moderate
+          <strong>0.4 ≤ r &lt; 0.7</strong>, Moderate
         </li>
         <li>
-          <strong>r &lt; 0.4</strong> — Revisit the judge criterion
+          <strong>r &lt; 0.4</strong>, Revisit the judge criterion
         </li>
       </ul>
       <p>
@@ -111,9 +111,9 @@ export default function AnnotationDocs() {
 
       <h2>RLS policy</h2>
       <ul>
-        <li><strong>SELECT</strong> — any org member (you can see others&apos; scores)</li>
-        <li><strong>INSERT</strong> — any org member</li>
-        <li><strong>UPDATE / DELETE</strong> — own rows only (<code>reviewer_id = auth.uid()</code>)</li>
+        <li><strong>SELECT</strong>, any org member (you can see others&apos; scores)</li>
+        <li><strong>INSERT</strong>, any org member</li>
+        <li><strong>UPDATE / DELETE</strong>, own rows only (<code>reviewer_id = auth.uid()</code>)</li>
       </ul>
 
       <h2>API</h2>
@@ -148,7 +148,7 @@ export default function AnnotationDocs() {
         </tbody>
       </table>
 
-      <h3>Example — save a rating</h3>
+      <h3>Example, save a rating</h3>
       <CodeBlock language="bash">{`# 4 stars + comment
 curl https://spanlens-server.vercel.app/api/v1/human-evals \\
   -H "Authorization: Bearer $SPANLENS_JWT" \\

--- a/apps/web/app/docs/features/anomalies/page.tsx
+++ b/apps/web/app/docs/features/anomalies/page.tsx
@@ -13,7 +13,7 @@ export default function AnomaliesDocs() {
       <p className="lead">
         Spanlens continuously watches your request stream for latency spikes, cost spikes, and error
         rate increases that fall outside normal variation. No thresholds to configure, no baselines
-        to set — it uses textbook 3-sigma statistics against a rolling 7-day reference window,
+        to set, it uses textbook 3-sigma statistics against a rolling 7-day reference window,
         computed per <code>(provider, model)</code> bucket.
       </p>
 
@@ -44,7 +44,7 @@ export default function AnomaliesDocs() {
         <li>
           For each bucket with <strong>≥ 10 reference samples</strong>, compute sample mean (μ) and
           sample standard deviation (σ) on the signal. Each anomaly is tagged with a{' '}
-          <strong>confidence label</strong> based on how many samples the baseline is built from —
+          <strong>confidence label</strong> based on how many samples the baseline is built from ,
           see <a href="#confidence">Confidence tiers</a> below.
         </li>
         <li>
@@ -57,7 +57,7 @@ export default function AnomaliesDocs() {
 if deviations >= sigmaThreshold:
   flag as anomaly`}</CodeBlock>
       <p>
-        <strong>3σ</strong> corresponds to ~0.13% false-positive rate under a normal distribution —
+        <strong>3σ</strong> corresponds to ~0.13% false-positive rate under a normal distribution ,
         generous enough to catch real spikes without flooding your inbox.
       </p>
 
@@ -81,7 +81,7 @@ if deviations >= sigmaThreshold:
             <td><strong>low</strong></td>
             <td>10 – 29</td>
             <td>
-              Directional only. The σ estimate is noisy — treat as an early warning, verify against
+              Directional only. The σ estimate is noisy, treat as an early warning, verify against
               the underlying requests before paging.
             </td>
           </tr>
@@ -94,7 +94,7 @@ if deviations >= sigmaThreshold:
             <td><strong>high</strong></td>
             <td>100+</td>
             <td>
-              Statistically robust. Use as the gate when wiring anomalies into a paging integration —
+              Statistically robust. Use as the gate when wiring anomalies into a paging integration ,
               see <code>minSamples</code> below for the API parameter.
             </td>
           </tr>
@@ -147,7 +147,7 @@ if deviations >= sigmaThreshold:
         </tbody>
       </table>
       <p>
-        Each signal is computed against its own baseline — no coupling. Latency and cost baselines
+        Each signal is computed against its own baseline, no coupling. Latency and cost baselines
         use success-only rows (failed requests are fast and would distort the latency baseline).
         Error-rate detection intentionally includes all rows.
       </p>
@@ -155,7 +155,7 @@ if deviations >= sigmaThreshold:
       <h3>On-demand detection + daily history</h3>
       <p>
         The &ldquo;right now&rdquo; view runs on-demand when you open the dashboard or hit the API,
-        always using the current time — so the view is always fresh. A background cron job also runs
+        always using the current time, so the view is always fresh. A background cron job also runs
         once a day at 01:00 UTC to persist a snapshot into the 30-day history log.
       </p>
 
@@ -172,16 +172,16 @@ if deviations >= sigmaThreshold:
         <li>Baseline mean ± stddev</li>
         <li>Deviations (how many σ above normal)</li>
         <li>Sample counts (both windows)</li>
-        <li><strong>Confidence badge</strong> — <em>low</em> / <em>medium</em> / <em>high</em> based on reference-window size (see <a href="#confidence">Confidence tiers</a>)</li>
-        <li><strong>Contributing factors</strong> — a <code>why ·</code> hint explaining the likely root cause</li>
+        <li><strong>Confidence badge</strong>, <em>low</em> / <em>medium</em> / <em>high</em> based on reference-window size (see <a href="#confidence">Confidence tiers</a>)</li>
+        <li><strong>Contributing factors</strong>, a <code>why ·</code> hint explaining the likely root cause</li>
         <li>Acknowledged state (if you&apos;ve silenced it)</li>
       </ul>
       <p>
-        No anomalies? The page tells you — that&apos;s the good state. Your infrastructure is
+        No anomalies? The page tells you, that&apos;s the good state. Your infrastructure is
         behaving predictably.
       </p>
 
-      <h3>Understanding why — Contributing factors</h3>
+      <h3>Understanding why, Contributing factors</h3>
       <p>
         When a bucket is flagged, Spanlens automatically fetches root-cause context so you don&apos;t
         have to dig through raw logs first. The <code>why ·</code> line appears beneath each anomaly
@@ -199,7 +199,7 @@ if deviations >= sigmaThreshold:
           <tr>
             <td><strong>Latency</strong> or <strong>Cost</strong></td>
             <td>
-              The token type that changed most between obs and reference windows —
+              The token type that changed most between obs and reference windows ,
               e.g. <em>Prompt tokens ↑ 3,200 (was 890, +259%)</em>
             </td>
             <td>
@@ -210,7 +210,7 @@ if deviations >= sigmaThreshold:
           <tr>
             <td><strong>Error rate</strong></td>
             <td>
-              Top HTTP status codes in the observation window, ranked by frequency —
+              Top HTTP status codes in the observation window, ranked by frequency ,
               e.g. <em>429: 45 req · 500: 8 req</em>
             </td>
             <td>
@@ -242,7 +242,7 @@ Content-Type: application/json
   "provider": "openai",
   "model": "gpt-4o",
   "kind": "latency",
-  "projectId": "proj_xxx"   // optional — omit for org-wide ack
+  "projectId": "proj_xxx"   // optional, omit for org-wide ack
 }
 
 # Un-acknowledge
@@ -250,7 +250,7 @@ DELETE /api/v1/anomalies/ack?provider=openai&model=gpt-4o&kind=latency`}</CodeBl
       <p>
         Requires <strong>admin</strong> or <strong>editor</strong> role.
         Acks are scoped per <code>(org, project, provider, model, kind)</code>
-        — acknowledging a bucket org-wide doesn&apos;t silence it inside a specific project, and
+       , acknowledging a bucket org-wide doesn&apos;t silence it inside a specific project, and
         vice versa.
       </p>
 
@@ -269,7 +269,7 @@ DELETE /api/v1/anomalies/ack?provider=openai&model=gpt-4o&kind=latency`}</CodeBl
 #     "deviations": 39.4,
 #     "sampleCount": 42,
 #     "referenceCount": 18420,
-#     "confidence": "high",        // low | medium | high — reliability of the baseline
+#     "confidence": "high",        // low | medium | high, reliability of the baseline
 #     "acknowledgedAt": null,      // ISO string if acked, null otherwise
 #     "factors": {                 // root-cause contributing factors
 #       "obsPromptTokensMean": 3200,
@@ -287,7 +287,7 @@ DELETE /api/v1/anomalies/ack?provider=openai&model=gpt-4o&kind=latency`}</CodeBl
 
       <h3>30-day history</h3>
       <p>
-        The history view shows past daily snapshots — useful for spotting recurring patterns
+        The history view shows past daily snapshots, useful for spotting recurring patterns
         (&ldquo;every Monday morning, latency spikes on gpt-4o&rdquo;).
       </p>
       <CodeBlock language="bash">{`GET /api/v1/anomalies/history?days=30
@@ -299,7 +299,7 @@ DELETE /api/v1/anomalies/ack?provider=openai&model=gpt-4o&kind=latency`}</CodeBl
       <h3>High-severity auto-notifications (≥5σ)</h3>
       <p>
         Anomalies that reach <strong>5σ or more</strong> are automatically delivered to your
-        configured notification channels (Slack, email, Discord) by the daily snapshot job — no
+        configured notification channels (Slack, email, Discord) by the daily snapshot job, no
         alert rule needed. Medium-severity anomalies (3–5σ) are dashboard-only; use{' '}
         <a href="/docs/features/alerts">threshold-based alert rules</a> for finer-grained routing.
       </p>
@@ -326,7 +326,7 @@ DELETE /api/v1/anomalies/ack?provider=openai&model=gpt-4o&kind=latency`}</CodeBl
           <tr>
             <td><code>observationHours</code></td>
             <td>1</td>
-            <td>Bigger (6, 24) if you have low traffic — avoids small-sample noise</td>
+            <td>Bigger (6, 24) if you have low traffic, avoids small-sample noise</td>
           </tr>
           <tr>
             <td><code>referenceHours</code></td>
@@ -340,7 +340,7 @@ DELETE /api/v1/anomalies/ack?provider=openai&model=gpt-4o&kind=latency`}</CodeBl
           </tr>
           <tr>
             <td><code>projectId</code></td>
-            <td>—</td>
+            <td>,</td>
             <td>Scope detection to a single project instead of the whole org</td>
           </tr>
           <tr>
@@ -363,7 +363,7 @@ DELETE /api/v1/anomalies/ack?provider=openai&model=gpt-4o&kind=latency`}</CodeBl
       <h2>Design choices</h2>
       <ul>
         <li>
-          <strong>Sample stddev (n−1 denominator).</strong> Bessel&apos;s correction — unbiased
+          <strong>Sample stddev (n−1 denominator).</strong> Bessel&apos;s correction, unbiased
           estimator for a finite sample.
         </li>
         <li>
@@ -372,7 +372,7 @@ DELETE /api/v1/anomalies/ack?provider=openai&model=gpt-4o&kind=latency`}</CodeBl
           at current scale and harder to explain.
         </li>
         <li>
-          <strong>One-sided detection.</strong> Only &ldquo;spike above baseline&rdquo; triggers —
+          <strong>One-sided detection.</strong> Only &ldquo;spike above baseline&rdquo; triggers ,
           drops in latency or cost are good news, not incidents.
         </li>
       </ul>
@@ -387,7 +387,7 @@ DELETE /api/v1/anomalies/ack?provider=openai&model=gpt-4o&kind=latency`}</CodeBl
         <li>
           <strong>Sparse buckets are skipped.</strong> Any <code>(provider, model, kind)</code>{' '}
           combination with fewer than <code>minSamples</code> requests (default 10) in the reference
-          window produces no signal — not enough data for any baseline. Buckets between 10 and 29
+          window produces no signal, not enough data for any baseline. Buckets between 10 and 29
           samples surface with <strong>low confidence</strong> so you can decide whether to act.
         </li>
         <li>

--- a/apps/web/app/docs/features/audit-logs/page.tsx
+++ b/apps/web/app/docs/features/audit-logs/page.tsx
@@ -3,7 +3,7 @@ import { CodeBlock } from '../../_components/code-block'
 export const metadata = {
   title: 'Audit Logs · Spanlens Docs',
   description:
-    'Chronological record of every organization-level change — API key creation, provider key additions, member invitations, role changes, and billing plan switches.',
+    'Chronological record of every organization-level change, API key creation, provider key additions, member invitations, role changes, and billing plan switches.',
 }
 
 export default function AuditLogsDocs() {
@@ -12,7 +12,7 @@ export default function AuditLogsDocs() {
       <h1>Audit Logs</h1>
       <p className="lead">
         Spanlens records every significant action within your organization. Track who changed what
-        and when — API key creation, provider key additions, member invitations, role changes, and
+        and when, API key creation, provider key additions, member invitations, role changes, and
         plan switches. View the log directly in Settings → <strong>Audit log</strong> or query it
         via the REST API to feed into an external SIEM or compliance tool.
       </p>

--- a/apps/web/app/docs/features/billing/page.tsx
+++ b/apps/web/app/docs/features/billing/page.tsx
@@ -12,7 +12,7 @@ export default function BillingDocs() {
       <h1>Billing &amp; quotas</h1>
       <p className="lead">
         Spanlens pricing is designed to be predictable. You pay a flat monthly fee for your plan,
-        and if you go past your included request quota, you pay only for what you used — capped
+        and if you go past your included request quota, you pay only for what you used, capped
         at a multiple of your plan so you can&apos;t get a surprise bill.
       </p>
 
@@ -61,13 +61,13 @@ export default function BillingDocs() {
       </table>
       <p>
         A <strong>request</strong> is one LLM call that flows through the{' '}
-        <a href="/docs/features/requests">Spanlens proxy</a> — regardless of which provider
+        <a href="/docs/features/requests">Spanlens proxy</a>, regardless of which provider
         (OpenAI, Anthropic, Gemini) or model. Streaming and non-streaming both count as one
         request each. Failed requests that reached our proxy also count (so a 500 from upstream
         still uses one).
       </p>
       <p>
-        Counting is per UTC calendar month — your counter resets at 00:00 UTC on the 1st of
+        Counting is per UTC calendar month, your counter resets at 00:00 UTC on the 1st of
         every month. This is simpler than per-subscription-period billing and matches what the
         dashboard shows you.
       </p>
@@ -78,7 +78,7 @@ export default function BillingDocs() {
         hard cap. You stay in control.
       </p>
 
-      <h3>Free plan — hard block at 50,000</h3>
+      <h3>Free plan, hard block at 50,000</h3>
       <p>
         The 50,001st request returns HTTP <code>429 Too Many Requests</code> with a JSON body:
       </p>
@@ -92,7 +92,7 @@ export default function BillingDocs() {
 }`}</CodeBlock>
       <p>Requests resume at the next UTC month rollover, or when you upgrade.</p>
 
-      <h3>Paid plans — overage billing (default)</h3>
+      <h3>Paid plans, overage billing (default)</h3>
       <p>
         Pro and Team default to <em>allow overage</em>. When you pass your included quota,
         requests keep flowing and extra usage is billed on your next invoice. The response
@@ -104,15 +104,15 @@ export default function BillingDocs() {
         will be billed.
       </p>
 
-      <h3>Paid plans — with overage disabled</h3>
+      <h3>Paid plans, with overage disabled</h3>
       <p>
         If you flip <strong>Allow overage charges</strong> off in{' '}
-        <a href="/settings">/settings</a>, paid plans behave like Free — hard block at the
+        <a href="/settings">/settings</a>, paid plans behave like Free, hard block at the
         quota, returning <code>429</code> with <code>reason: &quot;overage_disabled&quot;</code>.
         Choose this when you want cost certainty above all else.
       </p>
 
-      <h3>Hard cap — safety ceiling</h3>
+      <h3>Hard cap, safety ceiling</h3>
       <p>
         Even with overage enabled, we never let usage run unbounded. Your{' '}
         <strong>hard cap</strong> is:
@@ -123,7 +123,7 @@ export default function BillingDocs() {
       <p>
         Requests past the hard cap return <code>429</code> with{' '}
         <code>reason: &quot;hard_cap&quot;</code>. You can raise or lower the multiplier (1–100)
-        in <a href="/settings">/settings</a> to match your risk tolerance — for example set it
+        in <a href="/settings">/settings</a> to match your risk tolerance, for example set it
         to <code>1</code> to never pay more than the base plan fee, or <code>10</code> to
         absorb a huge traffic spike.
       </p>
@@ -160,22 +160,22 @@ export default function BillingDocs() {
           <tr>
             <td>Enterprise</td>
             <td>Negotiated</td>
-            <td>Included or custom — contact sales</td>
+            <td>Included or custom, contact sales</td>
           </tr>
         </tbody>
       </table>
       <p>
-        Free plan has no overage rate — past 50K, it&apos;s a hard block. Upgrade to enable
+        Free plan has no overage rate, past 50K, it&apos;s a hard block. Upgrade to enable
         overage billing.
       </p>
 
       <h2 id="invoices">What your invoice looks like</h2>
       <p>
         Paddle generates one invoice per billing period. Overage from the prior period is
-        bundled into the next invoice as an additional line item — you get <strong>one email
+        bundled into the next invoice as an additional line item, you get <strong>one email
         per month</strong>, not one per charge:
       </p>
-      <CodeBlock language="text">{`Invoice — May 1, 2026
+      <CodeBlock language="text">{`Invoice, May 1, 2026
 
   Spanlens Pro Subscription                        $29.00
   Pro - Overage unit (per 100,000 requests) × 2    $16.00
@@ -191,18 +191,18 @@ export default function BillingDocs() {
       </p>
       <ul>
         <li>
-          <strong>80%</strong> — heads-up that you&apos;re approaching the limit. Message varies
+          <strong>80%</strong>, heads-up that you&apos;re approaching the limit. Message varies
           based on whether overage is on (&ldquo;overage will absorb the overflow&rdquo;) or off
           (&ldquo;extra requests will 429&rdquo;).
         </li>
         <li>
-          <strong>100%</strong> — with overage on: &ldquo;overage billing is now active, you&apos;ll
+          <strong>100%</strong>, with overage on: &ldquo;overage billing is now active, you&apos;ll
           be billed on the next invoice.&rdquo; With overage off: &ldquo;requests are being
           rejected.&rdquo;
         </li>
       </ul>
       <p>
-        Each threshold fires at most once per calendar month per org — no spam. See{' '}
+        Each threshold fires at most once per calendar month per org, no spam. See{' '}
         <a href="/docs/features/alerts">Alerts</a> for the counting semantics.
       </p>
 
@@ -210,7 +210,7 @@ export default function BillingDocs() {
 
       <h3>Can I change plans mid-month? Is it prorated?</h3>
       <p>
-        Yes — Paddle handles plan changes with automatic proration. Upgrading mid-month gives
+        Yes, Paddle handles plan changes with automatic proration. Upgrading mid-month gives
         you the new plan&apos;s higher quota immediately; the monthly fee difference is charged
         proportionally for the remainder of the period. Downgrading takes effect at the next
         period boundary.
@@ -233,7 +233,7 @@ export default function BillingDocs() {
 
       <h3>Do I pay for retries / failed requests?</h3>
       <p>
-        Yes — any request that reaches our proxy counts, regardless of the upstream response
+        Yes, any request that reaches our proxy counts, regardless of the upstream response
         code. A 500 from OpenAI still uses one request. Rationale: the proxy did the work
         (auth, logging, forwarding, response buffering) and we have no way to distinguish
         &ldquo;legitimate retry&rdquo; from &ldquo;duplicate because you have a bug.&rdquo;
@@ -241,14 +241,14 @@ export default function BillingDocs() {
 
       <h3>Do streaming requests count differently?</h3>
       <p>
-        No — one stream = one request. Token cost is captured accurately via our stream parser
+        No, one stream = one request. Token cost is captured accurately via our stream parser
         (see <a href="/docs/features/cost-tracking">Cost tracking</a>), but the request counter
         increments by 1.
       </p>
 
       <h3>What if I self-host?</h3>
       <p>
-        Self-hosted Spanlens has no billing — you pay your own infra costs. Plan quotas and
+        Self-hosted Spanlens has no billing, you pay your own infra costs. Plan quotas and
         overage logic only exist on the hosted service at{' '}
         <a href="https://www.spanlens.io">spanlens.io</a>. See{' '}
         <a href="/docs/self-host">self-hosting</a>.

--- a/apps/web/app/docs/features/cost-tracking/page.tsx
+++ b/apps/web/app/docs/features/cost-tracking/page.tsx
@@ -13,13 +13,13 @@ export default function CostTrackingDocs() {
       <p className="lead">
         Every request row carries a <code>cost_usd</code> field computed at ingest time from your
         actual token usage and the provider&apos;s current list price. No approximations, no
-        post-hoc math in the dashboard — the number is deterministic and auditable.
+        post-hoc math in the dashboard, the number is deterministic and auditable.
       </p>
 
       <h2>Why it matters</h2>
       <p>
         Provider dashboards show spend a day late and at the billing-period level. That&apos;s
-        useless for the daily question — &ldquo;is my new feature&apos;s LLM usage going to blow
+        useless for the daily question, &ldquo;is my new feature&apos;s LLM usage going to blow
         up the budget?&rdquo; Spanlens computes cost the moment the response lands, so you can
         track per-minute, per-project, per-user cost without waiting for an invoice.
       </p>
@@ -28,7 +28,7 @@ export default function CostTrackingDocs() {
 
       <h3>Price table</h3>
       <p>
-        Prices live in the <code>model_prices</code> Supabase table — USD per 1M tokens,
+        Prices live in the <code>model_prices</code> Supabase table, USD per 1M tokens,
         separately for prompt, completion, and cache read/write. The proxy reads them
         through an in-memory cache (5-minute stale-while-revalidate) with a hardcoded
         fallback in <code>apps/server/src/lib/model-prices-cache.ts</code> for cold-start.
@@ -76,7 +76,7 @@ totalCost       = promptCost + cacheReadCost + cacheWriteCost + completionCost`}
       </p>
       <p>
         Historical rows (pre-2026-05-14) keep their original <code>cost_usd</code> and have{' '}
-        <code>cache_*_tokens = 0</code> — backfill isn&apos;t possible because the raw breakdown
+        <code>cache_*_tokens = 0</code>, backfill isn&apos;t possible because the raw breakdown
         wasn&apos;t recorded.
       </p>
 
@@ -92,7 +92,7 @@ totalCost       = promptCost + cacheReadCost + cacheWriteCost + completionCost`}
         <code>calculateCost()</code> handles this by:
       </p>
       <ol>
-        <li>Exact match first — if <code>gpt-4o-mini-2024-07-18</code> is in the table, use it.</li>
+        <li>Exact match first, if <code>gpt-4o-mini-2024-07-18</code> is in the table, use it.</li>
         <li>
           Otherwise, <strong>longest boundary-aware prefix match</strong>. The model id must start
           with a registered key followed by <code>-</code>, so <code>gpt-4</code> does not
@@ -109,11 +109,11 @@ totalCost       = promptCost + cacheReadCost + cacheWriteCost + completionCost`}
         If a request comes in for a model we don&apos;t have pricing for (brand-new release,
         fine-tuned custom model), <code>calculateCost()</code> returns <code>null</code> and the
         row&apos;s <code>cost_usd</code> is <code>NULL</code>. Dashboard filters this out of
-        cost aggregates — we never estimate or fabricate. The gap is visible, not hidden.
+        cost aggregates, we never estimate or fabricate. The gap is visible, not hidden.
       </p>
       <p>
         Fix: a Spanlens operator can add the row directly to{' '}
-        <code>model_prices</code> via the admin API (<code>POST /api/v1/admin/model-prices</code>) —
+        <code>model_prices</code> via the admin API (<code>POST /api/v1/admin/model-prices</code>) ,
         the cache picks it up within 5 minutes, no deploy required. Backfill isn&apos;t
         retroactive; cost appears on new requests only.
       </p>
@@ -149,11 +149,11 @@ GET /api/v1/stats?sinceHours=720&groupBy=model
           retroactively change. Audit-friendly.
         </li>
         <li>
-          <strong>Stored as <code>numeric(14,8)</code>.</strong> 8 decimal places of precision —
+          <strong>Stored as <code>numeric(14,8)</code>.</strong> 8 decimal places of precision ,
           enough to represent fractional cents on very cheap models without rounding error.
         </li>
         <li>
-          <strong>Table, not API.</strong> We don&apos;t fetch live prices from provider APIs —
+          <strong>Table, not API.</strong> We don&apos;t fetch live prices from provider APIs ,
           they don&apos;t expose one. Hand-maintained table is the reality for the industry.
         </li>
       </ul>
@@ -175,8 +175,8 @@ GET /api/v1/stats?sinceHours=720&groupBy=model
       <hr />
       <p className="text-sm text-muted-foreground">
         Note: this page is about <em>per-request USD cost</em> (how much each LLM call cost you
-        at the provider). For <em>Spanlens subscription billing</em> — plan quotas, overage
-        rates, invoicing — see <a href="/docs/features/billing">Billing &amp; quotas</a>.
+        at the provider). For <em>Spanlens subscription billing</em>, plan quotas, overage
+        rates, invoicing, see <a href="/docs/features/billing">Billing &amp; quotas</a>.
       </p>
       <p className="text-sm text-muted-foreground">
         Related: <a href="/docs/features/requests">Requests</a>, <a href="/docs/features/savings">Savings</a>,{' '}

--- a/apps/web/app/docs/features/datasets/page.tsx
+++ b/apps/web/app/docs/features/datasets/page.tsx
@@ -21,15 +21,15 @@ export default function DatasetsDocs() {
       <h2>When to use a dataset</h2>
       <ul>
         <li>
-          <strong>No production traffic yet</strong> — you want to evaluate a prompt before the
+          <strong>No production traffic yet</strong>, you want to evaluate a prompt before the
           first real calls accumulate.
         </li>
         <li>
-          <strong>Sensitive production data</strong> — healthcare, finance, or other regulated
+          <strong>Sensitive production data</strong>, healthcare, finance, or other regulated
           domains where you need an anonymized set.
         </li>
         <li>
-          <strong>Regression test set</strong> — a curated golden set of 30 past failure cases
+          <strong>Regression test set</strong>, a curated golden set of 30 past failure cases
           that every new prompt version must handle correctly.
         </li>
       </ul>
@@ -38,24 +38,24 @@ export default function DatasetsDocs() {
 
       <h3><code>datasets</code> table</h3>
       <ul>
-        <li><code>name</code> — unique within the organization</li>
-        <li><code>description</code> — free text</li>
-        <li><code>archived_at</code> — soft delete</li>
+        <li><code>name</code>, unique within the organization</li>
+        <li><code>description</code>, free text</li>
+        <li><code>archived_at</code>, soft delete</li>
       </ul>
 
       <h3><code>dataset_items</code> table</h3>
       <ul>
         <li>
-          <code>input</code> (jsonb) — two shapes are accepted:
+          <code>input</code> (jsonb), two shapes are accepted:
           <CodeBlock language="json">{`{ "variables": { "company_name": "Acme", "customer_name": "Alice" } }
 { "messages": [{ "role": "user", "content": "..." }] }`}</CodeBlock>
         </li>
         <li>
-          <code>expected_output</code> — reference answer text (optional). Used as the scoring
+          <code>expected_output</code>, reference answer text (optional). Used as the scoring
           target when running Evals in dataset mode. Items without a value are skipped.
         </li>
         <li>
-          <code>source_request_id</code> — set when the item was imported from a production request.
+          <code>source_request_id</code>, set when the item was imported from a production request.
         </li>
       </ul>
 
@@ -67,8 +67,8 @@ export default function DatasetsDocs() {
         <strong>Add item</strong>, then toggle between two input modes:
       </p>
       <ul>
-        <li><strong>User message</strong> — a single chat-style user message</li>
-        <li><strong>Variables JSON</strong> — for prompts with <code>{`{{var}}`}</code> placeholders</li>
+        <li><strong>User message</strong>, a single chat-style user message</li>
+        <li><strong>Variables JSON</strong>, for prompts with <code>{`{{var}}`}</code> placeholders</li>
       </ul>
 
       <h3>2. Import from production requests (API)</h3>
@@ -97,7 +97,7 @@ export default function DatasetsDocs() {
         <code>expected_output</code> are skipped.
       </p>
       <p>
-        This is called &quot;replay mode&quot; — scoring already-generated outputs.{' '}
+        This is called &quot;replay mode&quot;, scoring already-generated outputs.{' '}
         <em>Fresh run mode</em> (run the prompt against each dataset input and then score the new
         outputs) is handled by <a href="/docs/features/experiments">Experiments</a>.
       </p>

--- a/apps/web/app/docs/features/evals/page.tsx
+++ b/apps/web/app/docs/features/evals/page.tsx
@@ -3,7 +3,7 @@ import { CodeBlock } from '../../_components/code-block'
 export const metadata = {
   title: 'Evals · Spanlens Docs',
   description:
-    'LLM-as-judge evaluation — automatically score production responses on a 0..1 scale and quantify quality per prompt version.',
+    'LLM-as-judge evaluation, automatically score production responses on a 0..1 scale and quantify quality per prompt version.',
 }
 
 export default function EvalsDocs() {
@@ -12,7 +12,7 @@ export default function EvalsDocs() {
       <h1>Evals</h1>
       <p className="lead">
         Automatically score production response quality using an LLM-as-judge. Cost and latency
-        are already measured — Evals adds quality to the picture so you can answer{' '}
+        are already measured, Evals adds quality to the picture so you can answer{' '}
         <em>did this prompt actually get better?</em>
       </p>
 
@@ -32,16 +32,16 @@ export default function EvalsDocs() {
       <h3>Define an evaluator</h3>
       <p>An evaluator is a reusable definition of <em>how to score responses</em>.</p>
       <ul>
-        <li><code>prompt_name</code> — which prompt this evaluator targets</li>
-        <li><code>name</code> — e.g. &quot;Helpfulness check&quot;</li>
-        <li><code>type</code> — <code>llm_judge</code> (the only type in this release)</li>
+        <li><code>prompt_name</code>, which prompt this evaluator targets</li>
+        <li><code>name</code>, e.g. &quot;Helpfulness check&quot;</li>
+        <li><code>type</code>, <code>llm_judge</code> (the only type in this release)</li>
         <li>
           <code>config</code>:
           <ul>
-            <li><code>criterion</code> — scoring criterion sentence</li>
-            <li><code>judge_provider</code> — <code>openai</code> / <code>anthropic</code></li>
-            <li><code>judge_model</code> — e.g. <code>gpt-4o-mini</code></li>
-            <li><code>scale_min</code>, <code>scale_max</code> — score range (normalized to 0..1 on save)</li>
+            <li><code>criterion</code>, scoring criterion sentence</li>
+            <li><code>judge_provider</code>, <code>openai</code> / <code>anthropic</code></li>
+            <li><code>judge_model</code>, e.g. <code>gpt-4o-mini</code></li>
+            <li><code>scale_min</code>, <code>scale_max</code>, score range (normalized to 0..1 on save)</li>
           </ul>
         </li>
       </ul>
@@ -114,13 +114,13 @@ export default function EvalsDocs() {
       <p>
         The <strong>Quality</strong> column in Prompts → a specific prompt → Calls sub-tab shows
         the average <code>eval_results</code> score from evaluators run on this page. Versions that
-        have never been evaluated show <code>—</code>.
+        have never been evaluated show <code>,</code>.
       </p>
       <p>Color thresholds:</p>
       <ul>
-        <li><strong>≥70</strong> — good (green)</li>
-        <li><strong>40–69</strong> — warn (yellow)</li>
-        <li><strong>&lt;40</strong> — bad (red)</li>
+        <li><strong>≥70</strong>, good (green)</li>
+        <li><strong>40–69</strong>, warn (yellow)</li>
+        <li><strong>&lt;40</strong>, bad (red)</li>
       </ul>
 
       <h2>LLM judge reliability</h2>
@@ -131,9 +131,9 @@ export default function EvalsDocs() {
         page.
       </p>
       <ul>
-        <li><strong>r ≥ 0.7</strong> — Strong (judge can be trusted)</li>
-        <li><strong>0.4 ≤ r &lt; 0.7</strong> — Moderate</li>
-        <li><strong>r &lt; 0.4</strong> — Revisit the criterion</li>
+        <li><strong>r ≥ 0.7</strong>, Strong (judge can be trusted)</li>
+        <li><strong>0.4 ≤ r &lt; 0.7</strong>, Moderate</li>
+        <li><strong>r &lt; 0.4</strong>, Revisit the criterion</li>
       </ul>
 
       <h2>Cost</h2>
@@ -188,7 +188,7 @@ export default function EvalsDocs() {
         </tbody>
       </table>
 
-      <h2>Example — create and run an evaluator</h2>
+      <h2>Example, create and run an evaluator</h2>
       <CodeBlock language="bash">{`# 1. Define the evaluator
 curl https://spanlens-server.vercel.app/api/v1/evaluators \\
   -H "Authorization: Bearer $SPANLENS_JWT" \\
@@ -238,7 +238,7 @@ curl https://spanlens-server.vercel.app/api/v1/eval-runs/<run-id> \\
           The UI shows this as &quot;47/50 scored&quot;.
         </li>
         <li>
-          <strong>The judge itself can be inaccurate.</strong> That&apos;s why Annotation exists —
+          <strong>The judge itself can be inaccurate.</strong> That&apos;s why Annotation exists ,
           use it to validate the judge&apos;s reliability before relying on the scores.
         </li>
       </ul>

--- a/apps/web/app/docs/features/experiments/page.tsx
+++ b/apps/web/app/docs/features/experiments/page.tsx
@@ -3,7 +3,7 @@ import { CodeBlock } from '../../_components/code-block'
 export const metadata = {
   title: 'Experiments · Spanlens Docs',
   description:
-    'Offline side-by-side comparison — run a dataset against two prompt versions and compare outputs, scores, and cost without touching production traffic.',
+    'Offline side-by-side comparison, run a dataset against two prompt versions and compare outputs, scores, and cost without touching production traffic.',
 }
 
 export default function ExperimentsDocs() {
@@ -89,8 +89,8 @@ export default function ExperimentsDocs() {
       <h2>Word-level diff highlighting</h2>
       <p>Expanding a result row shows both outputs side by side, with differences color-coded.</p>
       <ul>
-        <li><strong>Red</strong> — words present in A but not in B</li>
-        <li><strong>Green</strong> — words present in B but not in A</li>
+        <li><strong>Red</strong>, words present in A but not in B</li>
+        <li><strong>Green</strong>, words present in B but not in A</li>
         <li>Identical words have no highlight</li>
       </ul>
       <p>
@@ -163,11 +163,11 @@ export default function ExperimentsDocs() {
       </p>
       <ul>
         <li>
-          <code>{`{ "variables": {...} }`}</code> — substitutes <code>{`{{var}}`}</code>{' '}
+          <code>{`{ "variables": {...} }`}</code>, substitutes <code>{`{{var}}`}</code>{' '}
           placeholders in the prompt content and passes the result as the user message.
         </li>
         <li>
-          <code>{`{ "messages": [...] }`}</code> — extracts the last user message and passes it
+          <code>{`{ "messages": [...] }`}</code>, extracts the last user message and passes it
           in the user role (prompt content becomes the system role).
         </li>
       </ul>

--- a/apps/web/app/docs/features/export/page.tsx
+++ b/apps/web/app/docs/features/export/page.tsx
@@ -12,7 +12,7 @@ export default function ExportDocs() {
       <h1>Data Export</h1>
       <p className="lead">
         Download request logs, traces, anomaly snapshots, and security flags as CSV, JSONL, or JSON
-        in one shot. CSV and JSONL stream directly from ClickHouse — a million-row export runs in
+        in one shot. CSV and JSONL stream directly from ClickHouse, a million-row export runs in
         ~30&nbsp;MB of memory and finishes inside the function-execution window. Connect to Pandas,
         BigQuery, Redash, Metabase, or your own pipeline.
       </p>
@@ -28,19 +28,19 @@ export default function ExportDocs() {
         <tbody>
           <tr>
             <td><code>GET /api/v1/exports/requests</code></td>
-            <td>Request logs — provider, model, tokens, cost, latency, etc.</td>
+            <td>Request logs, provider, model, tokens, cost, latency, etc.</td>
           </tr>
           <tr>
             <td><code>GET /api/v1/exports/traces</code></td>
-            <td>Traces — span count, total cost, duration, etc.</td>
+            <td>Traces, span count, total cost, duration, etc.</td>
           </tr>
           <tr>
             <td><code>GET /api/v1/exports/anomalies</code></td>
-            <td>Anomaly snapshots — daily history of buckets that exceeded 3σ</td>
+            <td>Anomaly snapshots, daily history of buckets that exceeded 3σ</td>
           </tr>
           <tr>
             <td><code>GET /api/v1/exports/security</code></td>
-            <td>Security flags — PII detections and prompt injection hits</td>
+            <td>Security flags, PII detections and prompt injection hits</td>
           </tr>
         </tbody>
       </table>
@@ -69,7 +69,7 @@ export default function ExportDocs() {
           </tr>
           <tr>
             <td><code>from</code></td>
-            <td>—</td>
+            <td>,</td>
             <td>
               ISO 8601 start time (e.g. <code>2026-05-01T00:00:00Z</code>). Defaults to 30 days
               ago if omitted.
@@ -77,7 +77,7 @@ export default function ExportDocs() {
           </tr>
           <tr>
             <td><code>to</code></td>
-            <td>—</td>
+            <td>,</td>
             <td>ISO 8601 end time. Defaults to now if omitted.</td>
           </tr>
           <tr>
@@ -85,13 +85,13 @@ export default function ExportDocs() {
             <td>format-dependent</td>
             <td>
               CSV / JSONL: 1 – <strong>1,000,000</strong>. JSON: 1 – 10,000.
-              <code>/exports/requests</code> only — other endpoints stay at 10,000.
+              <code>/exports/requests</code> only, other endpoints stay at 10,000.
             </td>
           </tr>
         </tbody>
       </table>
 
-      <h2 id="formats">Formats — when to pick each</h2>
+      <h2 id="formats">Formats, when to pick each</h2>
       <table>
         <thead>
           <tr>
@@ -119,7 +119,7 @@ export default function ExportDocs() {
           </tr>
           <tr>
             <td><code>json</code></td>
-            <td>No — buffered</td>
+            <td>No, buffered</td>
             <td>10,000</td>
             <td>
               Wrapper object <code>{`{ exported_at, count, data: [...] }`}</code> for code that
@@ -131,7 +131,7 @@ export default function ExportDocs() {
       <p>
         Streamed responses set <code>Cache-Control: no-store</code> so intermediaries don&apos;t
         buffer the full body. Each ClickHouse batch (~64&nbsp;KB) is the only data held in memory at
-        any point — heap usage stays flat regardless of <code>limit</code>.
+        any point, heap usage stays flat regardless of <code>limit</code>.
       </p>
 
       <h2>Additional parameters for requests</h2>
@@ -200,7 +200,7 @@ export default function ExportDocs() {
         </tbody>
       </table>
 
-      <h2>CSV columns — requests</h2>
+      <h2>CSV columns, requests</h2>
       <table>
         <thead>
           <tr>
@@ -264,7 +264,7 @@ export default function ExportDocs() {
         </tbody>
       </table>
 
-      <h2>CSV columns — traces</h2>
+      <h2>CSV columns, traces</h2>
       <table>
         <thead>
           <tr>
@@ -327,22 +327,22 @@ export default function ExportDocs() {
       <h2>curl examples</h2>
 
       <h3>CSV download</h3>
-      <CodeBlock language="bash">{`# Request logs — specific date range, GPT-4o only, CSV
+      <CodeBlock language="bash">{`# Request logs, specific date range, GPT-4o only, CSV
 curl "https://spanlens-server.vercel.app/api/v1/exports/requests?from=2026-05-01T00:00:00Z&to=2026-05-15T23:59:59Z&provider=openai&model=gpt-4o&format=csv" \\
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \\
   -o spanlens-requests.csv
 
-# Traces — last 7 days, JSON
+# Traces, last 7 days, JSON
 curl "https://spanlens-server.vercel.app/api/v1/exports/traces?from=2026-05-08T00:00:00Z&format=json" \\
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \\
   -o spanlens-traces.json
 
-# Anomaly history — defaults (30 days, CSV)
+# Anomaly history, defaults (30 days, CSV)
 curl "https://spanlens-server.vercel.app/api/v1/exports/anomalies" \\
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \\
   -o spanlens-anomalies.csv
 
-# Security flags — from a specific date
+# Security flags, from a specific date
 curl "https://spanlens-server.vercel.app/api/v1/exports/security?from=2026-05-01T00:00:00Z" \\
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \\
   -o spanlens-security.csv`}</CodeBlock>
@@ -393,11 +393,11 @@ curl "https://spanlens-server.vercel.app/api/v1/exports/requests?format=jsonl&fr
 
 token = "YOUR_SUPABASE_ACCESS_TOKEN"
 
-# Small / medium — CSV, single response.
+# Small / medium, CSV, single response.
 url = "https://spanlens-server.vercel.app/api/v1/exports/requests?from=2026-05-01T00:00:00Z&format=csv"
 df = pd.read_csv(url, storage_options={"Authorization": f"Bearer {token}"})
 
-# Million-row pipeline — JSONL, streamed line-by-line. Pandas reads it in
+# Million-row pipeline, JSONL, streamed line-by-line. Pandas reads it in
 # chunks so peak memory stays bounded.
 url = "https://spanlens-server.vercel.app/api/v1/exports/requests?format=jsonl&limit=1000000"
 chunks = pd.read_json(url, lines=True, chunksize=50_000,
@@ -409,7 +409,7 @@ print(totals)`}</CodeBlock>
       <p>
         Download the <code>.csv</code> file with curl, then import it into Excel via{' '}
         <strong>Data → From Text/CSV</strong>. The <code>created_at</code> column is an ISO 8601
-        string — convert it with <code>DATEVALUE</code> + <code>TIMEVALUE</code> or Power Query&apos;s
+        string, convert it with <code>DATEVALUE</code> + <code>TIMEVALUE</code> or Power Query&apos;s
         date/time type conversion before using it in pivot tables.
       </p>
 
@@ -420,7 +420,7 @@ print(totals)`}</CodeBlock>
           streamed formats (<code>csv</code>, <code>jsonl</code>) and 10,000 on <code>json</code>.
           The other endpoints (<code>/traces</code>, <code>/security</code>, <code>/anomalies</code>)
           stay at 10,000. For datasets above the cap, paginate by splitting the time range with{' '}
-          <code>from</code> / <code>to</code>, or contact support — multi-GB exports with completion
+          <code>from</code> / <code>to</code>, or contact support, multi-GB exports with completion
           emails / S3 pre-signed URLs are on the roadmap.
         </li>
         <li>

--- a/apps/web/app/docs/features/members-invitations/page.tsx
+++ b/apps/web/app/docs/features/members-invitations/page.tsx
@@ -13,7 +13,7 @@ export default function MembersInvitationsDocs() {
       <p className="lead">
         Spanlens is multi-user out of the box. Invite teammates by email,
         hand out roles, switch between workspaces, and watch every membership
-        event in the audit log. Nothing here costs extra — it&rsquo;s the
+        event in the audit log. Nothing here costs extra, it&rsquo;s the
         same flow on the Free plan as on Enterprise.
       </p>
 
@@ -46,18 +46,18 @@ export default function MembersInvitationsDocs() {
             <td><strong>editor</strong></td>
             <td>✓</td>
             <td>✓</td>
-            <td>—</td>
+            <td>,</td>
           </tr>
           <tr>
             <td><strong>viewer</strong></td>
             <td>✓</td>
-            <td>—</td>
-            <td>—</td>
+            <td>,</td>
+            <td>,</td>
           </tr>
         </tbody>
       </table>
       <p>
-        The <strong>last admin</strong> in a workspace is protected — the
+        The <strong>last admin</strong> in a workspace is protected, the
         API rejects any attempt to demote or remove them. Promote a second
         admin first if you need to leave.
       </p>
@@ -69,7 +69,7 @@ export default function MembersInvitationsDocs() {
         <code>/api/v1/organizations/:orgId/invitations</code>; the server
         creates an <code>org_invitations</code> row with a 7-day expiry and
         a sha256-hashed token. The raw token only ever lives in the email
-        URL — a database leak cannot turn into working invite links.
+        URL, a database leak cannot turn into working invite links.
       </p>
 
       <h3>Two ways the recipient sees it</h3>
@@ -83,8 +83,8 @@ export default function MembersInvitationsDocs() {
         </li>
         <li>
           <strong>Dashboard banner.</strong> Even if the email never
-          arrives — bounce, spam folder, admin DM&rsquo;d the invite
-          instead — the recipient&rsquo;s next dashboard navigation
+          arrives, bounce, spam folder, admin DM&rsquo;d the invite
+          instead, the recipient&rsquo;s next dashboard navigation
           surfaces a banner across the top:{' '}
           <em>&ldquo;Acme Inc. invited you as editor.&rdquo;</em> with{' '}
           <strong>Accept</strong> / <strong>Decline</strong> buttons. The
@@ -100,7 +100,7 @@ export default function MembersInvitationsDocs() {
         sets <code>onboarded_at</code> on the user&rsquo;s profile (so the
         dashboard layout&rsquo;s onboarding gate lets them through), and
         returns the joined organization id. The client writes that id to
-        the <code>sb-ws</code> cookie and hard-reloads — the user lands
+        the <code>sb-ws</code> cookie and hard-reloads, the user lands
         in the joined workspace immediately.
       </p>
 
@@ -111,12 +111,12 @@ export default function MembersInvitationsDocs() {
       </p>
       <ul>
         <li>
-          <strong>Decline</strong> — DELETEs the invitation row. The user
+          <strong>Decline</strong>, DELETEs the invitation row. The user
           will not see this invite again unless an admin re-invites the
           same email (which creates a new row).
         </li>
         <li>
-          <strong>⨯ Dismiss</strong> — session-only hide. Refreshing the
+          <strong>⨯ Dismiss</strong>, session-only hide. Refreshing the
           page brings the banner back. Use this for &ldquo;I see it, just
           not now.&rdquo;
         </li>
@@ -154,7 +154,7 @@ export default function MembersInvitationsDocs() {
         Click the workspace box at the top-left of the sidebar and pick
         a workspace from the <strong>Workspaces</strong> section. The
         sidebar writes the new id to <code>sb-ws</code> and hard-reloads
-        the page — middleware re-resolves, every TanStack Query cache is
+        the page, middleware re-resolves, every TanStack Query cache is
         cleared, and the dashboard re-renders against the new org.
       </p>
       <p>
@@ -210,7 +210,7 @@ DELETE /api/v1/organizations/:orgId/members/:userId`}</CodeBlock>
         not configured, the server skips the send and returns the accept
         URL as <code>devAcceptUrl</code> in the API response so an admin
         can hand-deliver it. Set up a verified Resend sender to avoid
-        spam folders — see <a href="/docs/self-host#env">self-host env vars</a>.
+        spam folders, see <a href="/docs/self-host#env">self-host env vars</a>.
       </p>
     </div>
   )

--- a/apps/web/app/docs/features/projects/page.tsx
+++ b/apps/web/app/docs/features/projects/page.tsx
@@ -12,12 +12,12 @@ export default function ProjectsDocs() {
       <h1>Projects, Spanlens keys &amp; provider keys</h1>
       <p className="lead">
         A Spanlens organization contains one or more <strong>projects</strong>. Each project
-        owns one or more <strong>Spanlens keys</strong> (<code>sl_live_…</code>) — the value
+        owns one or more <strong>Spanlens keys</strong> (<code>sl_live_…</code>), the value
         you put in your app&apos;s <code>SPANLENS_API_KEY</code> env. Each Spanlens key in
         turn owns its own pool of <strong>provider keys</strong> (the real OpenAI / Anthropic
         / Gemini credentials), so two Spanlens keys in the same project can carry different
         underlying credentials. Projects let you separate dev/staging/prod, per-service, or
-        per-team — whatever scoping makes sense.
+        per-team, whatever scoping makes sense.
       </p>
 
       <h2>Why projects</h2>
@@ -41,7 +41,7 @@ export default function ProjectsDocs() {
       <ul>
         <li>
           <strong>Real provider keys never ship to clients.</strong> Frontend bundles, mobile
-          apps, anywhere — they only ever see the revocable <code>sl_live_…</code>.
+          apps, anywhere, they only ever see the revocable <code>sl_live_…</code>.
         </li>
         <li>
           <strong>Centralized rotation.</strong> Replace the OpenAI key on the dashboard
@@ -61,7 +61,7 @@ export default function ProjectsDocs() {
       <h3>Spanlens key format</h3>
       <p>
         Keys are <code>sl_live_</code> + 48 random hex chars. At creation time the plaintext
-        is shown once in the dashboard — copy it immediately. On the server we compute{' '}
+        is shown once in the dashboard, copy it immediately. On the server we compute{' '}
         <strong>SHA-256</strong> over the key and store only the hash in{' '}
         <code>api_keys.key_hash</code>.
       </p>
@@ -77,16 +77,16 @@ export default function ProjectsDocs() {
         Provider keys (the real <code>sk-…</code> / <code>sk-ant-…</code> / <code>AIza…</code>{' '}
         values) are stored encrypted with <strong>AES-256-GCM</strong>. See{' '}
         <a href="/docs/features/settings">Keys &amp; encryption</a> for the cryptographic
-        details — fresh IV per key, authenticated, decrypted only in memory for the duration
+        details, fresh IV per key, authenticated, decrypted only in memory for the duration
         of one upstream <code>fetch()</code>.
       </p>
 
       <h3>Per-key metadata tracked</h3>
       <ul>
-        <li><code>name</code> — human label (e.g. &ldquo;prod-backend&rdquo;)</li>
-        <li><code>key_prefix</code> — first 15 chars (Spanlens key only), shown in UI for ID</li>
-        <li><code>last_used_at</code> — updated on every successful auth</li>
-        <li><code>is_active</code> — revoke flag; inactive keys return 401</li>
+        <li><code>name</code>, human label (e.g. &ldquo;prod-backend&rdquo;)</li>
+        <li><code>key_prefix</code>, first 15 chars (Spanlens key only), shown in UI for ID</li>
+        <li><code>last_used_at</code>, updated on every successful auth</li>
+        <li><code>is_active</code>, revoke flag; inactive keys return 401</li>
       </ul>
 
       <h2>Using it</h2>
@@ -109,7 +109,7 @@ export default function ProjectsDocs() {
           After you save a provider key the dialog flips to a success view showing the
           one-line integration snippet for that provider (<code>createOpenAI()</code>,{' '}
           <code>createAnthropic()</code>, <code>createGemini()</code>). Drop it into your
-          code — no CLI re-run needed.
+          code, no CLI re-run needed.
         </li>
       </ol>
 
@@ -119,7 +119,7 @@ export default function ProjectsDocs() {
       <ul>
         <li>
           <strong>Toggled active/inactive</strong> via the switch on the Spanlens key row.
-          Inactive keys return 401 immediately — no cache to invalidate.
+          Inactive keys return 401 immediately, no cache to invalidate.
         </li>
         <li>
           <strong>Provider keys rotated</strong> via the pencil icon on each provider key
@@ -127,7 +127,7 @@ export default function ProjectsDocs() {
           changes.
         </li>
         <li>
-          <strong>Provider keys deactivated</strong> via the trash icon (soft delete — flips{' '}
+          <strong>Provider keys deactivated</strong> via the trash icon (soft delete, flips{' '}
           <code>is_active = false</code>, preserves request logs).
         </li>
         <li>
@@ -140,7 +140,7 @@ export default function ProjectsDocs() {
         The page also surfaces a wizard hint: <code>npx @spanlens/cli init</code> can
         bootstrap an existing OpenAI/Anthropic/Gemini codebase by rewriting{' '}
         <code>new OpenAI(...)</code> → <code>createOpenAI()</code> in one pass. For{' '}
-        <em>new</em> code, you don&apos;t need the CLI — copy the snippet from the dashboard
+        <em>new</em> code, you don&apos;t need the CLI, copy the snippet from the dashboard
         and you&apos;re done.
       </p>
 
@@ -198,7 +198,7 @@ DELETE /api/v1/provider-keys/:id             # soft delete (is_active=false)`}</
         </li>
         <li>
           <strong>Provider keys are scoped to one Spanlens key.</strong> A stolen Spanlens
-          key only unlocks the provider keys you registered under it — not the org&apos;s
+          key only unlocks the provider keys you registered under it, not the org&apos;s
           other Spanlens keys&apos; provider keys. (UNIQUE INDEX <code>(api_key_id,
           provider) WHERE is_active = true</code> enforces 1 active per Spanlens key per
           provider.)
@@ -208,7 +208,7 @@ DELETE /api/v1/provider-keys/:id             # soft delete (is_active=false)`}</
       <h2>Limitations</h2>
       <ul>
         <li>
-          <strong>No per-key rate limits yet.</strong> Enterprise ask — on roadmap.
+          <strong>No per-key rate limits yet.</strong> Enterprise ask, on roadmap.
         </li>
         <li>
           <strong>No automatic rotation.</strong> Provider key rotation is manual (pencil
@@ -221,7 +221,7 @@ DELETE /api/v1/provider-keys/:id             # soft delete (is_active=false)`}</
         </li>
         <li>
           <strong>Spanlens key plaintext shown once.</strong> No &ldquo;reveal existing
-          key&rdquo; escape hatch — by design. If CI lost the value, delete the key, create
+          key&rdquo; escape hatch, by design. If CI lost the value, delete the key, create
           a new one, and update the secret in your CI settings.
         </li>
       </ul>

--- a/apps/web/app/docs/features/prompt-ab/page.tsx
+++ b/apps/web/app/docs/features/prompt-ab/page.tsx
@@ -17,7 +17,7 @@ export default function PromptAbDocs() {
         users to make the final call.
       </p>
 
-      <h2>A/B vs Experiments — which one to use</h2>
+      <h2>A/B vs Experiments, which one to use</h2>
       <p>
         Spanlens has two places where the word &quot;experiment&quot; appears. Here is how they
         differ:
@@ -44,7 +44,7 @@ export default function PromptAbDocs() {
             </tr>
             <tr>
               <td>User exposure</td>
-              <td>Yes — real users see it</td>
+              <td>Yes, real users see it</td>
               <td>None</td>
             </tr>
             <tr>
@@ -171,7 +171,7 @@ export default function PromptAbDocs() {
             </tr>
             <tr>
               <td><code>stopped</code></td>
-              <td>Manually stopped before conclusion — no winner declared</td>
+              <td>Manually stopped before conclusion, no winner declared</td>
             </tr>
           </tbody>
         </table>
@@ -211,7 +211,7 @@ export default function PromptAbDocs() {
       </div>
       <p>
         A <strong>p-value &lt; 0.05</strong> means the difference is statistically significant.
-        With small sample sizes (tens of requests), p-values cluster near 1 — wait a few days for
+        With small sample sizes (tens of requests), p-values cluster near 1, wait a few days for
         data to accumulate before drawing conclusions.
       </p>
       <p>

--- a/apps/web/app/docs/features/prompts-playground/page.tsx
+++ b/apps/web/app/docs/features/prompts-playground/page.tsx
@@ -3,7 +3,7 @@ import { CodeBlock } from '../../_components/code-block'
 export const metadata = {
   title: 'Prompts Playground · Spanlens Docs',
   description:
-    'Interactive console inside the Prompts tab — select a version, set model, temperature, and variables, then run it immediately and see cost and token counts.',
+    'Interactive console inside the Prompts tab, select a version, set model, temperature, and variables, then run it immediately and see cost and token counts.',
 }
 
 export default function PromptsPlaygroundDocs() {
@@ -11,7 +11,7 @@ export default function PromptsPlaygroundDocs() {
     <div>
       <h1>Prompts Playground</h1>
       <p className="lead">
-        Like a SQL query console for prompts — select a version, adjust model, temperature, and
+        Like a SQL query console for prompts, select a version, adjust model, temperature, and
         variables, then click <strong>Run</strong> to get an immediate result with cost and token
         counts. Verify how a prompt actually behaves before deploying it to production.
       </p>
@@ -63,12 +63,12 @@ export default function PromptsPlaygroundDocs() {
       <h2>Supported providers</h2>
       <p>The Playground currently supports:</p>
       <ul>
-        <li><strong>OpenAI</strong> — GPT model family</li>
-        <li><strong>Anthropic</strong> — Claude model family</li>
+        <li><strong>OpenAI</strong>, GPT model family</li>
+        <li><strong>Anthropic</strong>, Claude model family</li>
       </ul>
       <p>
         Runs use your own <strong>provider key</strong> stored in Spanlens. The cost of each run
-        is billed directly to your provider account — Spanlens does not cover it.
+        is billed directly to your provider account, Spanlens does not cover it.
       </p>
 
       <h2>Run parameters</h2>
@@ -86,19 +86,19 @@ export default function PromptsPlaygroundDocs() {
             <tr>
               <td><code>promptVersionId</code></td>
               <td>string (UUID)</td>
-              <td>—</td>
+              <td>,</td>
               <td>ID of the prompt version to run (required)</td>
             </tr>
             <tr>
               <td><code>providerKeyId</code></td>
               <td>string (UUID)</td>
-              <td>—</td>
+              <td>,</td>
               <td>Provider key to use (required)</td>
             </tr>
             <tr>
               <td><code>model</code></td>
               <td>string</td>
-              <td>—</td>
+              <td>,</td>
               <td>Model to run (e.g. <code>gpt-4o-mini</code>, <code>claude-3-5-haiku-20241022</code>)</td>
             </tr>
             <tr>

--- a/apps/web/app/docs/features/prompts/page.tsx
+++ b/apps/web/app/docs/features/prompts/page.tsx
@@ -3,7 +3,7 @@ import { CodeBlock } from '../../_components/code-block'
 export const metadata = {
   title: 'Prompts · Spanlens Docs',
   description:
-    'Version-controlled prompt templates with real-data A/B comparison — latency, cost, and error rate per version.',
+    'Version-controlled prompt templates with real-data A/B comparison, latency, cost, and error rate per version.',
 }
 
 export default function PromptsDocs() {
@@ -13,13 +13,13 @@ export default function PromptsDocs() {
       <p className="lead">
         Store your prompt templates as named, versioned assets. Every time you tweak a prompt, Spanlens
         creates a new immutable version. Then compare versions side-by-side with real production
-        metrics — average latency, error rate, and cost per call.
+        metrics, average latency, error rate, and cost per call.
       </p>
 
       <h2>Why it matters</h2>
       <p>
         Prompts get edited constantly: a line added here, an example rewritten there, a tone shift
-        on Friday afternoon. The unanswered question is always the same — <em>is this actually
+        on Friday afternoon. The unanswered question is always the same, <em>is this actually
         better, or does it just feel better?</em>
       </p>
       <p>
@@ -44,10 +44,10 @@ export default function PromptsDocs() {
 
       <p>Each version stores:</p>
       <ul>
-        <li><code>content</code> — the template body (up to 100K chars)</li>
-        <li><code>variables</code> — typed placeholders like <code>{'{{userName}}'}</code> with description and <code>required</code> flag</li>
-        <li><code>metadata</code> — free-form JSON for tags (team, task type, model target, etc.)</li>
-        <li><code>project_id</code> — optional project scope</li>
+        <li><code>content</code>, the template body (up to 100K chars)</li>
+        <li><code>variables</code>, typed placeholders like <code>{'{{userName}}'}</code> with description and <code>required</code> flag</li>
+        <li><code>metadata</code>, free-form JSON for tags (team, task type, model target, etc.)</li>
+        <li><code>project_id</code>, optional project scope</li>
       </ul>
 
       <h3>A/B comparison on real traffic</h3>
@@ -161,7 +161,7 @@ export default function PromptsDocs() {
             <td><code>POST /api/v1/prompts/:name/:version/rollback</code></td>
             <td>
               Copy an older version&apos;s content as a new (latest) version. The old version is
-              not modified — the version counter always increases. Returns the newly created version.
+              not modified, the version counter always increases. Returns the newly created version.
             </td>
           </tr>
           <tr>
@@ -174,10 +174,10 @@ export default function PromptsDocs() {
       <h2>Tagging requests with a prompt version</h2>
       <p>
         For the A/B table to fill up, each LLM request needs to declare which version it
-        used. The SDK ships two ways to do that — pick whichever fits your call site.
+        used. The SDK ships two ways to do that, pick whichever fits your call site.
       </p>
 
-      <h3>Option 1 — <code>withPromptVersion()</code> per call</h3>
+      <h3>Option 1, <code>withPromptVersion()</code> per call</h3>
       <CodeBlock language="ts">{`import { createOpenAI, withPromptVersion } from '@spanlens/sdk/openai'
 
 const openai = createOpenAI()
@@ -194,7 +194,7 @@ const res = await openai.chat.completions.create(
 )`}</CodeBlock>
       <p>Same helper exists on <code>@spanlens/sdk/anthropic</code> for Claude calls.</p>
 
-      <h3>Option 2 — <code>observeOpenAI()</code> with promptVersion option</h3>
+      <h3>Option 2, <code>observeOpenAI()</code> with promptVersion option</h3>
       <p>If you&apos;re already using agent tracing, just add one option:</p>
       <CodeBlock language="ts">{`import { observeOpenAI } from '@spanlens/sdk'
 
@@ -239,29 +239,29 @@ const res = await observeOpenAI(
       </p>
       <ul>
         <li>
-          <strong>Versions</strong> — full version list with expandable content preview.{' '}
+          <strong>Versions</strong>, full version list with expandable content preview.{' '}
           Each version has a <strong>Roll back</strong> button that copies its content as a new
-          latest version (the old version is never deleted — the version counter always increases).
+          latest version (the old version is never deleted, the version counter always increases).
         </li>
-        <li><strong>Diff</strong> — select any two versions for an LCS-based line-level diff (+/− colors)</li>
+        <li><strong>Diff</strong>, select any two versions for an LCS-based line-level diff (+/− colors)</li>
         <li>
-          <strong>Traffic</strong> — per-version traffic share with quality color coding
+          <strong>Traffic</strong>, per-version traffic share with quality color coding
           (≥90 green / 70–89 yellow / &lt;70 red)
         </li>
         <li>
-          <strong>Calls</strong> — per-version call count, latency, error rate,{' '}
+          <strong>Calls</strong>, per-version call count, latency, error rate,{' '}
           <strong>QUALITY</strong>, cost, and token totals. Clicking a row drills down to{' '}
           <code>/requests?promptVersionId=...</code>.{' '}
           The <strong>Quality column</strong> shows the average <code>eval_results</code> score
           from <a href="/docs/features/evals">Evals</a>.
         </li>
         <li>
-          <strong>A/B</strong> — live production traffic A/B routing. Different from offline{' '}
+          <strong>A/B</strong>, live production traffic A/B routing. Different from offline{' '}
           <a href="/docs/features/experiments">Experiments</a> (see table below). →{' '}
           <a href="/docs/features/prompt-ab">Full Prompt A/B docs</a>
         </li>
         <li>
-          <strong>Playground</strong> — select a version, configure provider key, model,
+          <strong>Playground</strong>, select a version, configure provider key, model,
           temperature, and variables, then run immediately. Results are not saved to the{' '}
           <code>requests</code> table. Rate limit: 20 req/min/user. →{' '}
           <a href="/docs/features/prompts-playground">Full Playground docs</a>
@@ -270,7 +270,7 @@ const res = await observeOpenAI(
 
       <h2>A/B routing vs Experiments</h2>
       <p>
-        The word &quot;experiment&quot; appears in two places in Spanlens — here is how they differ:
+        The word &quot;experiment&quot; appears in two places in Spanlens, here is how they differ:
       </p>
       <div className="overflow-x-auto">
         <table>
@@ -313,7 +313,7 @@ const res = await observeOpenAI(
       <p>Honest view of what the feature does <em>not</em> do yet:</p>
       <ul>
         <li>
-          <strong>No editor affordances.</strong> The create/edit form is a plain textarea —
+          <strong>No editor affordances.</strong> The create/edit form is a plain textarea ,
           no diff view, no syntax highlighting, no variable autocomplete. Good enough for now;
           polish deferred to post-launch.
         </li>

--- a/apps/web/app/docs/features/requests/page.tsx
+++ b/apps/web/app/docs/features/requests/page.tsx
@@ -3,7 +3,7 @@ import { CodeBlock } from '../../_components/code-block'
 export const metadata = {
   title: 'Requests · Spanlens Docs',
   description:
-    'Complete log of every LLM call routed through Spanlens — model, tokens, cost, latency, full request/response bodies.',
+    'Complete log of every LLM call routed through Spanlens, model, tokens, cost, latency, full request/response bodies.',
 }
 
 export default function RequestsDocs() {
@@ -12,7 +12,7 @@ export default function RequestsDocs() {
       <h1>Requests</h1>
       <p className="lead">
         Every LLM call that flows through the Spanlens proxy produces one row in the{' '}
-        <code>requests</code> table — backed by ClickHouse for fast analytical reads.{' '}
+        <code>requests</code> table, backed by ClickHouse for fast analytical reads.{' '}
         <a href="/requests">/requests</a> is the viewer: filter, sort, drill down, and read the
         actual request and response bodies. This is the raw substrate every other feature
         (Traces, Anomalies, Savings, etc.) aggregates from.
@@ -20,9 +20,9 @@ export default function RequestsDocs() {
 
       <h2>Why it matters</h2>
       <p>
-        Aggregate views summarize — they smooth over individual outliers. When something goes wrong
-        — a user reports a wrong answer, a cost spike is unaccounted for, a prompt injection slips
-        through — you need to see the <em>actual bytes that went out</em> and{' '}
+        Aggregate views summarize, they smooth over individual outliers. When something goes wrong
+       , a user reports a wrong answer, a cost spike is unaccounted for, a prompt injection slips
+        through, you need to see the <em>actual bytes that went out</em> and{' '}
         <em>came back</em>. Requests gives you that exact record.
       </p>
 
@@ -146,18 +146,18 @@ export default function RequestsDocs() {
       </p>
       <p>
         The main table is paginated (up to 100 rows/page) with these filters. Filter state is{' '}
-        <strong>synced to the URL</strong> — copy and share the URL to hand off a pre-filtered
+        <strong>synced to the URL</strong>, copy and share the URL to hand off a pre-filtered
         view, or use the browser&apos;s back button to restore a previous filter state.
       </p>
       <ul>
-        <li><strong>Provider</strong> — exact match (openai / anthropic / gemini / azure)</li>
+        <li><strong>Provider</strong>, exact match (openai / anthropic / gemini / azure)</li>
         <li>
-          <strong>Model</strong> — partial, case-insensitive match (e.g. searching &ldquo;mini&rdquo;
+          <strong>Model</strong>, partial, case-insensitive match (e.g. searching &ldquo;mini&rdquo;
           matches <code>gpt-4o-mini-2024-07-18</code>)
         </li>
-        <li><strong>Provider key</strong> — dropdown of your registered keys, to isolate traffic by key</li>
-        <li><strong>Status</strong> — All / OK (2xx) / 4xx / 5xx</li>
-        <li><strong>Date range</strong> — from / to</li>
+        <li><strong>Provider key</strong>, dropdown of your registered keys, to isolate traffic by key</li>
+        <li><strong>Status</strong>, All / OK (2xx) / 4xx / 5xx</li>
+        <li><strong>Date range</strong>, from / to</li>
       </ul>
 
       <h4>URL-only filters</h4>
@@ -206,7 +206,7 @@ export default function RequestsDocs() {
       <h3>Replay</h3>
       <p>
         Every request detail page has a <strong>Replay</strong> button. It opens a modal where you
-        can re-run the original call against a different model and compare the result inline —
+        can re-run the original call against a different model and compare the result inline ,
         without touching your application code.
       </p>
       <ul>
@@ -231,7 +231,7 @@ export default function RequestsDocs() {
 
       <h3>Detail drawer</h3>
       <p>
-        Clicking any row opens a 480 px right-side drawer — no page navigation. The drawer shows:
+        Clicking any row opens a 480 px right-side drawer, no page navigation. The drawer shows:
       </p>
       <ul>
         <li>Request ID, timestamp, and error badge (if applicable)</li>
@@ -242,7 +242,7 @@ export default function RequestsDocs() {
         </li>
         <li>Metrics row: Latency, Cost, Total tokens (with prompt / completion breakdown)</li>
         <li>
-          <strong>Prev / Next</strong> navigation buttons — step through the current result set one
+          <strong>Prev / Next</strong> navigation buttons, step through the current result set one
           row at a time. When you reach the end of a page the drawer automatically loads the next
           page and jumps to the first (or last) row. An <em>Open →</em> link opens the standalone
           detail page <code>/requests/[id]</code> if you need a shareable URL.
@@ -298,7 +298,7 @@ export default function RequestsDocs() {
 
       <h2>API</h2>
 
-      <CodeBlock language="bash">{`# List requests — paginated, sortable, filterable
+      <CodeBlock language="bash">{`# List requests, paginated, sortable, filterable
 GET /api/v1/requests
   ?projectId=<uuid>      # filter by project
   &provider=openai       # exact match
@@ -318,11 +318,11 @@ GET /api/v1/requests
 # One request by id (includes full request_body + response_body)
 GET /api/v1/requests/:id
 
-# Replay — curl snippet (proxy-ready payload)
+# Replay, curl snippet (proxy-ready payload)
 POST /api/v1/requests/:id/replay
   Body: { "model": "gpt-4o-mini" }  # optional model override
 
-# Replay — execute server-side and return result (latency / tokens / cost)
+# Replay, execute server-side and return result (latency / tokens / cost)
 POST /api/v1/requests/:id/replay/run
   Body: { "model": "gpt-4o-mini" }  # optional model override`}</CodeBlock>
 
@@ -336,7 +336,7 @@ POST /api/v1/requests/:id/replay/run
       <ul>
         <li>
           <strong>Authorization headers are stripped</strong> from <code>request_body</code> before
-          it&apos;s stored — your OpenAI/Anthropic/Gemini key never appears in logs.
+          it&apos;s stored, your OpenAI/Anthropic/Gemini key never appears in logs.
         </li>
         <li>
           <strong>API key patterns are auto-masked</strong> in stored bodies. Anything matching{' '}
@@ -359,7 +359,7 @@ POST /api/v1/requests/:id/replay/run
         <li>
           <strong>Retention policy.</strong> Free plan: 14 days. Pro: 90 days. Team and
           Enterprise: 365 days (Enterprise is extendable by contract). Enforced by the
-          table&apos;s TTL plus a per-plan query-time clip — older rows are dropped by
+          table&apos;s TTL plus a per-plan query-time clip, older rows are dropped by
           ClickHouse&apos;s background merge.
         </li>
         <li>
@@ -379,7 +379,7 @@ POST /api/v1/requests/:id/replay/run
         <li>
           <strong>No full-text body search in the UI yet.</strong> The model filter uses
           case-insensitive substring match; there is no free-text search over request/response
-          body content. ClickHouse can do it efficiently — the dashboard hasn&apos;t exposed it
+          body content. ClickHouse can do it efficiently, the dashboard hasn&apos;t exposed it
           yet.
         </li>
         <li>
@@ -387,7 +387,7 @@ POST /api/v1/requests/:id/replay/run
           are tee&apos;d while pass-through to the client. After the stream closes, the assistant
           text is reassembled and written to <code>response_body</code> in the upstream&apos;s
           standard non-streaming shape (so the dashboard renders it identically to a non-stream
-          response). Tool calls / images / non-text content blocks are not preserved — only the
+          response). Tool calls / images / non-text content blocks are not preserved, only the
           assistant-visible text portion. Aborted streams keep whatever was received up to the
           break.
         </li>

--- a/apps/web/app/docs/features/saved-filters/page.tsx
+++ b/apps/web/app/docs/features/saved-filters/page.tsx
@@ -11,15 +11,15 @@ export default function SavedFiltersDocs() {
     <div>
       <h1>Saved Filters</h1>
       <p className="lead">
-        Save any filter combination set on the <a href="/requests">/requests</a> page — provider,
-        model, status, date range, and more — under a name, then restore the entire state in one
+        Save any filter combination set on the <a href="/requests">/requests</a> page, provider,
+        model, status, date range, and more, under a name, then restore the entire state in one
         click on future visits. Useful for recurring debug queries or shared team views.
       </p>
 
       <h2>How to use</h2>
       <ol>
         <li>
-          Go to <a href="/requests">/requests</a> and configure your filters — provider, model,
+          Go to <a href="/requests">/requests</a> and configure your filters, provider, model,
           status, date range, etc.
         </li>
         <li>
@@ -98,14 +98,14 @@ Content-Type: application/json
           <tr>
             <td><code>name</code></td>
             <td><code>string</code></td>
-            <td>1–80 characters. Must be unique per user — returns 409 on duplicate.</td>
+            <td>1–80 characters. Must be unique per user, returns 409 on duplicate.</td>
           </tr>
           <tr>
             <td><code>filters</code></td>
             <td><code>object</code></td>
             <td>
               Free-form JSON object containing the filter values. Stored as JSONB without
-              server-side parsing — the UI reads and writes it in its own format.
+              server-side parsing, the UI reads and writes it in its own format.
             </td>
           </tr>
           <tr>

--- a/apps/web/app/docs/features/savings/page.tsx
+++ b/apps/web/app/docs/features/savings/page.tsx
@@ -21,7 +21,7 @@ export default function SavingsDocs() {
       <h2>Why it matters</h2>
       <p>
         The most common LLM cost mistake is <em>using GPT-4 for everything</em>. Extraction,
-        classification, short-form generation, intent detection — these workloads are
+        classification, short-form generation, intent detection, these workloads are
         indistinguishable from GPT-4o-mini at 1/15 the price, but teams default to the most
         capable model out of caution and never revisit.
       </p>
@@ -40,9 +40,9 @@ export default function SavingsDocs() {
         <code>(provider, model)</code>, computing:
       </p>
       <ul>
-        <li><code>sampleCount</code> — how many requests in the bucket</li>
+        <li><code>sampleCount</code>, how many requests in the bucket</li>
         <li><code>avgPromptTokens</code>, <code>avgCompletionTokens</code></li>
-        <li><code>totalCostUsdLastNDays</code> — actual spend over the window</li>
+        <li><code>totalCostUsdLastNDays</code>, actual spend over the window</li>
         <li>Extrapolated monthly cost = window total ÷ window days × 30</li>
       </ul>
 
@@ -126,7 +126,7 @@ export default function SavingsDocs() {
       </table>
       <p>
         A recommendation fires only if <strong>both</strong> avg-prompt and avg-completion fit
-        inside the envelope. This is the conservative guard — if your average request exceeds the
+        inside the envelope. This is the conservative guard, if your average request exceeds the
         envelope, the suggested cheaper model probably will underperform on your actual workload,
         and we don&apos;t show it.
       </p>
@@ -148,7 +148,7 @@ monthlyCostSuggested = monthlyCostCurrent * substitute.costRatio
 estimatedMonthlySavingsUsd = monthlyCostCurrent - monthlyCostSuggested`}</CodeBlock>
       <p>
         Only recommendations with <code>estimatedMonthlySavingsUsd ≥ $5</code> surface in the
-        dashboard by default — below that, the signal-to-noise isn&apos;t worth your attention.
+        dashboard by default, below that, the signal-to-noise isn&apos;t worth your attention.
         You can override this with the <code>?minSavings=</code> query parameter.
       </p>
 
@@ -205,13 +205,13 @@ dropPct = (priorWindowCost − currentWindowCost) / priorWindowCost`}</CodeBlock
       </p>
       <ul>
         <li>A green <strong>ACHIEVED</strong> badge instead of SWAP</li>
-        <li><strong>ACTUAL / MO</strong> — the realized monthly savings based on the observed drop</li>
+        <li><strong>ACTUAL / MO</strong>, the realized monthly savings based on the observed drop</li>
         <li>The drop percentage vs. the prior window (&ldquo;usage dropped 72% vs prior 7d&rdquo;)</li>
         <li>The originally projected savings for comparison</li>
       </ul>
       <p>
         Achieved recommendations live in a separate collapsible section below the open list. They
-        bypass the <code>minSavings</code> filter (you&apos;ve already made the change — hiding the
+        bypass the <code>minSavings</code> filter (you&apos;ve already made the change, hiding the
         row would be confusing) but still require the prior window spend to be meaningful (≥ the{' '}
         <code>minSavings</code> threshold annualized).
       </p>
@@ -233,18 +233,18 @@ dropPct = (priorWindowCost − currentWindowCost) / priorWindowCost`}</CodeBlock
       </p>
       <ul>
         <li>
-          <strong>7 days</strong> — most responsive to recent model usage changes; default.
+          <strong>7 days</strong>, most responsive to recent model usage changes; default.
         </li>
         <li>
-          <strong>14 days</strong> — smooths out weekly spikes; useful when traffic is seasonal.
+          <strong>14 days</strong>, smooths out weekly spikes; useful when traffic is seasonal.
         </li>
         <li>
-          <strong>30 days</strong> — highest sample counts, most stable confidence tiers.
+          <strong>30 days</strong>, highest sample counts, most stable confidence tiers.
         </li>
       </ul>
       <p>
         Changing the window re-fetches the API with a different <code>?hours=</code> value and
-        recomputes all savings estimates in-page — no page reload needed. The achieved tracking
+        recomputes all savings estimates in-page, no page reload needed. The achieved tracking
         prior window always equals the same duration as the selected analysis window.
       </p>
 
@@ -256,34 +256,34 @@ dropPct = (priorWindowCost − currentWindowCost) / priorWindowCost`}</CodeBlock
       </p>
       <ul>
         <li>
-          <strong>Hero tile</strong> — shows your total projected open savings, best confidence
+          <strong>Hero tile</strong>, shows your total projected open savings, best confidence
           tier, and (when present) achieved monthly savings. The three stat tiles to the right
           show spend in the window, open count, and achieved savings / best confidence tier.
-          Hero tile totals are computed from the <em>unfiltered</em> open set — active filters
+          Hero tile totals are computed from the <em>unfiltered</em> open set, active filters
           don&apos;t shrink the headline number.
         </li>
         <li>
-          <strong>Sort &amp; filter bar</strong> — sort by Savings (default), Confidence, or Name;
+          <strong>Sort &amp; filter bar</strong>, sort by Savings (default), Confidence, or Name;
           filter by Provider (OpenAI / Anthropic / Gemini) or Confidence tier (High / Medium / Low).
           Sort and filter state is persisted in <code>localStorage</code> across page reloads.
           A filter badge shows how many recommendations are visible vs. total when filters are
           active. A &ldquo;Clear filters&rdquo; empty state appears if filters exclude all open rows.
         </li>
         <li>
-          <strong>Open recommendations</strong> — each row shows: current model → suggested model,
+          <strong>Open recommendations</strong>, each row shows: current model → suggested model,
           the confidence bar, rationale text, projected monthly savings, and three action buttons:{' '}
           <strong>Compare</strong> (opens the{' '}
           <a href="#compare-dialog">Compare dialog</a>), <strong>Simulate</strong> (opens the{' '}
           <a href="#simulate-dialog">Simulate dialog</a>), and <strong>Hide</strong>.
         </li>
         <li>
-          <strong>Achieved section</strong> — a collapsible section (click to expand) listing
+          <strong>Achieved section</strong>, a collapsible section (click to expand) listing
           recommendations where Spanlens detected a ≥70% spend drop. Rows show a green ACHIEVED
           badge, the realized monthly savings, and the drop percentage vs. the prior window. No
-          Simulate button — you already switched.
+          Simulate button, you already switched.
         </li>
         <li>
-          <strong>Hidden section</strong> — recommendations you&apos;ve dismissed live here. A
+          <strong>Hidden section</strong>, recommendations you&apos;ve dismissed live here. A
           &ldquo;Show hidden&rdquo; toggle expands the section; each row has an{' '}
           <strong>Unhide</strong> button to restore it.
         </li>
@@ -296,17 +296,17 @@ dropPct = (priorWindowCost − currentWindowCost) / priorWindowCost`}</CodeBlock
       </p>
       <ol>
         <li>
-          <strong>Pick a prompt version</strong> — choose any saved{' '}
+          <strong>Pick a prompt version</strong>, choose any saved{' '}
           <a href="/docs/features/prompts">Prompts</a> version as the input. The playground will
           fill in the prompt template automatically.
         </li>
         <li>
-          <strong>Choose provider keys</strong> — select the provider key to use for each model
+          <strong>Choose provider keys</strong>, select the provider key to use for each model
           (current and suggested). Both models must have an active key registered in{' '}
           <a href="/projects">/projects</a>.
         </li>
         <li>
-          <strong>Run</strong> — both models execute in parallel. While running, each column shows
+          <strong>Run</strong>, both models execute in parallel. While running, each column shows
           a loading spinner.
         </li>
       </ol>
@@ -337,24 +337,24 @@ dropPct = (priorWindowCost − currentWindowCost) / priorWindowCost`}</CodeBlock
       </p>
       <ul>
         <li>
-          <strong>Cost summary</strong> — spend in the current window, projected monthly savings,
+          <strong>Cost summary</strong>, spend in the current window, projected monthly savings,
           and the projection formula for transparency.
         </li>
         <li>
-          <strong>Token distribution</strong> — a P50 / P95 / P99 table for prompt and completion
+          <strong>Token distribution</strong>, a P50 / P95 / P99 table for prompt and completion
           tokens, computed from your actual requests (not just the average). Each row is compared
-          against the substitute rule&apos;s <em>envelope</em> — the maximum average token count
+          against the substitute rule&apos;s <em>envelope</em>, the maximum average token count
           the cheaper model is rated for.
         </li>
       </ul>
       <p>
         If <strong>P95 exceeds the envelope</strong> for prompt or completion tokens, a yellow
         warning box appears: &ldquo;P95 exceeds the substitute envelope for prompt tokens. Some
-        requests may degrade in quality — run a shadow comparison first.&rdquo; This is the key
+        requests may degrade in quality, run a shadow comparison first.&rdquo; This is the key
         signal that the average looks safe but the tail of your distribution might not be.
       </p>
       <p>
-        Token distribution data is fetched lazily — the API call only fires when you open the
+        Token distribution data is fetched lazily, the API call only fires when you open the
         dialog, not on page load.
       </p>
 
@@ -363,12 +363,12 @@ dropPct = (priorWindowCost − currentWindowCost) / priorWindowCost`}</CodeBlock
         Click <strong>Hide</strong> on a row to dismiss a recommendation you&apos;ve already
         evaluated and decided against. Dismissed rows move to the collapsible &ldquo;Hidden
         recommendations&rdquo; section at the bottom of the page and are stored in{' '}
-        <code>localStorage</code> — they persist across page reloads in the same browser. Click{' '}
+        <code>localStorage</code>, they persist across page reloads in the same browser. Click{' '}
         <strong>Unhide</strong> inside the hidden section to bring a row back.
       </p>
       <p>
         When all visible recommendations have been hidden, the empty state message changes from the
-        generic &ldquo;no opportunities&rdquo; copy to &ldquo;All recommendations are hidden —
+        generic &ldquo;no opportunities&rdquo; copy to &ldquo;All recommendations are hidden ,
         use Show hidden to review them.&rdquo;
       </p>
 
@@ -386,7 +386,7 @@ dropPct = (priorWindowCost − currentWindowCost) / priorWindowCost`}</CodeBlock
         <li>A direct link to the Savings dashboard</li>
       </ul>
       <p>
-        Notifications are idempotent — each (org, swap pair) triggers at most one email, stored
+        Notifications are idempotent, each (org, swap pair) triggers at most one email, stored
         in the <code>recommendation_notifications</code> table. Future cron runs skip already-
         notified pairs. A new notification fires only if a net-new high-confidence recommendation
         appears (e.g., more traffic builds confidence on a previously low-tier swap).
@@ -459,7 +459,7 @@ GET /api/v1/recommendations?minSavings=20      # only show ≥ $20/mo
           <tr>
             <td><code>maxPromptTokens</code></td>
             <td><code>number</code></td>
-            <td>The substitute rule&apos;s max avg prompt token envelope — used by the Simulate dialog.</td>
+            <td>The substitute rule&apos;s max avg prompt token envelope, used by the Simulate dialog.</td>
           </tr>
           <tr>
             <td><code>maxCompletionTokens</code></td>
@@ -529,7 +529,7 @@ GET /api/v1/recommendations?minSavings=20      # only show ≥ $20/mo
       <p>
         Returns <code>null</code> in <code>data</code> if fewer than 5 requests with non-null
         token counts exist in the window. Computed in-database via{' '}
-        <code>percentile_cont</code> ordered-set aggregation — no row scanning in application code.
+        <code>percentile_cont</code> ordered-set aggregation, no row scanning in application code.
       </p>
 
       <h2>Design choices</h2>
@@ -547,7 +547,7 @@ GET /api/v1/recommendations?minSavings=20      # only show ≥ $20/mo
         </li>
         <li>
           <strong>No A/B auto-rollout.</strong> We show you the recommendation; you decide whether
-          to switch. Automated multi-armed-bandit model routing is out of scope for launch — it&apos;s
+          to switch. Automated multi-armed-bandit model routing is out of scope for launch, it&apos;s
           a different product surface.
         </li>
         <li>
@@ -562,7 +562,7 @@ GET /api/v1/recommendations?minSavings=20      # only show ≥ $20/mo
         </li>
         <li>
           <strong>P95 vs. P99 for envelope warnings.</strong> P95 was chosen as the warning
-          threshold rather than P99 — P99 would suppress warnings for tails that are meaningfully
+          threshold rather than P99, P99 would suppress warnings for tails that are meaningfully
           out-of-envelope. P99 is shown for reference in the Simulate dialog.
         </li>
       </ul>
@@ -573,11 +573,11 @@ GET /api/v1/recommendations?minSavings=20      # only show ≥ $20/mo
           <strong>Token-based, not task-based.</strong> A 200-token prompt can be &ldquo;summarize
           this article&rdquo; (gpt-4o-mini is fine) or &ldquo;generate the JSON schema for my
           domain model&rdquo; (gpt-4o is better). The envelope catches most cases but occasional
-          false positives are possible — hence the manual-approval loop.
+          false positives are possible, hence the manual-approval loop.
         </li>
         <li>
           <strong>No cross-provider recommendations yet.</strong> We don&apos;t suggest
-          &ldquo;switch from gpt-4o-mini to claude-haiku&rdquo; even when cheaper — accuracy
+          &ldquo;switch from gpt-4o-mini to claude-haiku&rdquo; even when cheaper, accuracy
           comparisons across providers are too workload-dependent to ship blind.
         </li>
         <li>
@@ -587,7 +587,7 @@ GET /api/v1/recommendations?minSavings=20      # only show ≥ $20/mo
         <li>
           <strong>Achieved tracking requires two full windows of data.</strong> If your organization
           has been on Spanlens for less than 2× the analysis window, the prior window will be empty
-          and <code>priorWindowCostUsd</code> will be <code>null</code> — achieved detection is
+          and <code>priorWindowCostUsd</code> will be <code>null</code>, achieved detection is
           not possible for that period.
         </li>
       </ul>

--- a/apps/web/app/docs/features/security/page.tsx
+++ b/apps/web/app/docs/features/security/page.tsx
@@ -3,7 +3,7 @@ import { CodeBlock } from '../../_components/code-block'
 export const metadata = {
   title: 'Security (PII + prompt injection) · Spanlens Docs',
   description:
-    'Automatic PII detection and prompt-injection scanning on every LLM request and response — with optional blocking mode and real-time alert emails.',
+    'Automatic PII detection and prompt-injection scanning on every LLM request and response, with optional blocking mode and real-time alert emails.',
 }
 
 export default function SecurityDocs() {
@@ -25,7 +25,7 @@ export default function SecurityDocs() {
         PII in LLM calls is the #1 thing enterprise security teams ask about. If your chatbot
         receives a user&apos;s credit card number and that request body lands in OpenAI&apos;s
         training data (or your logs, or your support ticket queue), you have a GDPR/PCI incident
-        on your hands. Catching it at the proxy layer — before it hits the provider — is the
+        on your hands. Catching it at the proxy layer, before it hits the provider, is the
         cheapest mitigation point.
       </p>
       <p>
@@ -58,7 +58,7 @@ export default function SecurityDocs() {
           </tr>
           <tr>
             <td><code>iban</code></td>
-            <td>IBAN — EU 27 + UK, CH, NO and 30+ countries. Compact and spaced forms. mod-97 validated.</td>
+            <td>IBAN, EU 27 + UK, CH, NO and 30+ countries. Compact and spaced forms. mod-97 validated.</td>
             <td><code>GB82WEST12345698765432</code></td>
           </tr>
           <tr>
@@ -149,7 +149,7 @@ export default function SecurityDocs() {
 }`}</CodeBlock>
       <p>
         Request flags → <code>requests.flags</code>. Response flags → <code>requests.response_flags</code>.
-        The <code>sample</code> is a <strong>masked 6-character excerpt</strong> around the match —
+        The <code>sample</code> is a <strong>masked 6-character excerpt</strong> around the match ,
         just enough for you to audit what was flagged without storing raw PII back into the
         database. The original match is never persisted in readable form.
       </p>
@@ -167,7 +167,7 @@ export default function SecurityDocs() {
   "code": "INJECTION_BLOCKED"
 }`}</CodeBlock>
       <p>
-        PII flags are <strong>never</strong> blocked — PII may be legitimate user data (e.g. a
+        PII flags are <strong>never</strong> blocked, PII may be legitimate user data (e.g. a
         healthcare app). Only injection patterns trigger blocking. Toggle it in the{' '}
         <a href="/security">/security</a> dashboard under <em>Per-project blocking</em>.
       </p>
@@ -191,7 +191,7 @@ export default function SecurityDocs() {
       <p>
         Spanlens scans both directions: the request body (user input) and the LLM response body
         (model output). This catches cases where the model itself leaks PII it was given in
-        context — for example, echoing a credit card number back in a summary. Response flags are
+        context, for example, echoing a credit card number back in a summary. Response flags are
         stored separately in <code>requests.response_flags</code> and shown in the dashboard with
         a <em>↩</em> prefix to distinguish them from request flags.
       </p>
@@ -204,13 +204,13 @@ export default function SecurityDocs() {
       </p>
       <ul>
         <li>
-          <strong>Settings</strong> — Alert email toggle (org-wide) + per-project blocking toggles
+          <strong>Settings</strong>, Alert email toggle (org-wide) + per-project blocking toggles
         </li>
         <li>
-          <strong>Summary</strong> — Counts per rule over the selected window (24h / 7d / 30d)
+          <strong>Summary</strong>, Counts per rule over the selected window (24h / 7d / 30d)
         </li>
         <li>
-          <strong>Flagged</strong> — Paginated list of flagged requests with masked samples and
+          <strong>Flagged</strong>, Paginated list of flagged requests with masked samples and
           direction labels (request vs response), direct link to the full{' '}
           <a href="/requests">/requests</a> row for context
         </li>
@@ -238,7 +238,7 @@ PATCH /api/v1/security/projects/{projectId}/block
       <p>
         Separately from the request-time scan above, every body that lands in ClickHouse passes
         through a pattern-based key scrubber first. The goal is narrow: catch API keys that
-        accidentally end up in prompts, tool output, or error messages — so a compromised
+        accidentally end up in prompts, tool output, or error messages, so a compromised
         Spanlens row never leaks a customer&apos;s upstream credentials.
       </p>
       <table>
@@ -284,7 +284,7 @@ PATCH /api/v1/security/projects/{projectId}/block
         Source: <code>apps/server/src/lib/pii-mask.ts</code>.
       </p>
 
-      <h2 id="body-retention">Body retention modes — <code>logBody</code></h2>
+      <h2 id="body-retention">Body retention modes, <code>logBody</code></h2>
       <p>
         Pattern masking covers <em>structured</em> secrets. It does <strong>not</strong> redact
         natural-language PII (names, emails, addresses, medical information) that the regex
@@ -330,9 +330,9 @@ PATCH /api/v1/security/projects/{projectId}/block
       </p>
       <p className="text-sm text-muted-foreground">
         Spanlens does NOT ship automatic natural-language PII redaction. Pattern matching on
-        free text produces too many false positives/negatives to be the default — we&apos;d
+        free text produces too many false positives/negatives to be the default, we&apos;d
         rather give you a clean opt-out and let your prompts that need full bodies keep them.
-        Enterprise customers needing in-place redaction (medical / financial) — reach out.
+        Enterprise customers needing in-place redaction (medical / financial), reach out.
       </p>
 
       <h2>Limitations</h2>
@@ -358,7 +358,7 @@ PATCH /api/v1/security/projects/{projectId}/block
         <li>
           <strong>Regex is not ML.</strong> A sufficiently motivated attacker can rephrase
           injection phrases to slip through. What we catch is the long tail of accidentally bad
-          inputs and low-effort attacks — which covers 90%+ of real incidents.
+          inputs and low-effort attacks, which covers 90%+ of real incidents.
         </li>
         <li>
           <strong>Natural-language PII is not auto-redacted.</strong> The{' '}

--- a/apps/web/app/docs/features/settings/page.tsx
+++ b/apps/web/app/docs/features/settings/page.tsx
@@ -29,12 +29,12 @@ export default function SettingsDocs() {
       <ol>
         <li>
           <strong>Your real keys never ship to the client.</strong> Frontend code, mobile apps,
-          anywhere — none of them need the sensitive provider key. They only need your
+          anywhere, none of them need the sensitive provider key. They only need your
           revocable Spanlens key.
         </li>
         <li>
           <strong>Centralized rotation.</strong> Replace the underlying provider key with the
-          pencil icon on its card in <a href="/projects">/projects</a> — all your services pick
+          pencil icon on its card in <a href="/projects">/projects</a>, all your services pick
           it up next request. Your <code>sl_live_…</code> stays the same. No redeploys.
         </li>
       </ol>
@@ -43,7 +43,7 @@ export default function SettingsDocs() {
       <p>
         Each <strong>Spanlens key</strong> owns its own pool of provider keys. So two
         Spanlens keys in the same project can carry different OpenAI / Anthropic / Gemini
-        credentials — useful for dev/prod splits or per-team accounting where the same
+        credentials, useful for dev/prod splits or per-team accounting where the same
         provider key shouldn&apos;t be shared.
       </p>
       <ul>
@@ -58,7 +58,7 @@ export default function SettingsDocs() {
           with the same 400.
         </li>
         <li>
-          Provider keys are uniquely active per <code>(spanlens_key, provider)</code> — only
+          Provider keys are uniquely active per <code>(spanlens_key, provider)</code>, only
           one OpenAI key per Spanlens key can be active at a time. Add a second OpenAI key
           when you want to rotate, then deactivate the old one.
         </li>
@@ -69,7 +69,7 @@ export default function SettingsDocs() {
       <h3>Storage flow</h3>
       <ol>
         <li>
-          You add a provider key to a Spanlens key in <a href="/projects">/projects</a> — click{' '}
+          You add a provider key to a Spanlens key in <a href="/projects">/projects</a>, click{' '}
           <em>+ Add provider key</em> next to the Spanlens key, pick the provider, paste your
           real <code>sk-…</code> / <code>sk-ant-…</code> / <code>AIza…</code> key
         </li>
@@ -135,7 +135,7 @@ export default function SettingsDocs() {
         </li>
         <li>
           <strong>Nonce-misuse awareness.</strong> One fresh IV per key ensures no two
-          ciphertexts share a keystream. (Reusing an IV with GCM is catastrophic — we
+          ciphertexts share a keystream. (Reusing an IV with GCM is catastrophic, we
           don&apos;t.)
         </li>
         <li>
@@ -154,7 +154,7 @@ export default function SettingsDocs() {
           <strong>Self-host</strong>: you generate it yourself (
           <code>openssl rand -base64 32</code>) and set it on the container.{' '}
           <strong>Back it up.</strong> Losing the encryption key makes every stored provider
-          key unrecoverable — you&apos;d need to re-register them all.
+          key unrecoverable, you&apos;d need to re-register them all.
         </li>
       </ul>
 
@@ -162,7 +162,7 @@ export default function SettingsDocs() {
 
       <h3>Dashboard</h3>
       <p>
-        Open <a href="/projects">/projects</a>. The flow is two steps — issue a Spanlens key,
+        Open <a href="/projects">/projects</a>. The flow is two steps, issue a Spanlens key,
         then attach provider keys to it.
       </p>
       <ol>
@@ -177,7 +177,7 @@ export default function SettingsDocs() {
         </li>
         <li>
           After saving, the dialog flips to a success view showing the exact integration
-          snippet for that provider — <code>createOpenAI()</code> /{' '}
+          snippet for that provider, <code>createOpenAI()</code> /{' '}
           <code>createAnthropic()</code> / <code>createGemini()</code>. Copy it into your
           codebase. No CLI re-run needed; the same <code>SPANLENS_API_KEY</code> already covers
           the new provider.
@@ -188,7 +188,7 @@ export default function SettingsDocs() {
       <p>
         Each provider key row has a pencil icon. Click it, paste the new{' '}
         <code>sk-…</code> / <code>sk-ant-…</code> / <code>AIza…</code> value, save. Your{' '}
-        <code>sl_live_…</code> Spanlens key and all deployed code stay unchanged — Spanlens
+        <code>sl_live_…</code> Spanlens key and all deployed code stay unchanged, Spanlens
         silently swaps the underlying credential on the next request.
       </p>
 

--- a/apps/web/app/docs/features/traces/page.tsx
+++ b/apps/web/app/docs/features/traces/page.tsx
@@ -13,7 +13,7 @@ export default function TracesDocs() {
       <p className="lead">
         When your code makes one LLM call, a flat request log is enough. When it makes ten calls
         orchestrated across retrieval, generation, tool-use, and re-ranking, you need a tree.
-        Spanlens Traces give you that tree — automatically when you wrap code in{' '}
+        Spanlens Traces give you that tree, automatically when you wrap code in{' '}
         <code>observe()</code>, or manually with the low-level span API.
       </p>
 
@@ -22,7 +22,7 @@ export default function TracesDocs() {
         Agent workflows are hard to debug because the interesting failure is never in one call.
         It&apos;s in the interaction: retrieval returned garbage, so generation hallucinated, so the
         re-ranker picked a bad answer. Flat logs show three unrelated lines. A trace shows one tree
-        with timings — immediately obvious where the bug lives.
+        with timings, immediately obvious where the bug lives.
       </p>
       <p>
         LangSmith and LangFuse popularized this view. Spanlens delivers the same thing without
@@ -34,7 +34,7 @@ export default function TracesDocs() {
       <h3>The data model</h3>
       <p>
         A <strong>trace</strong> groups related spans under one id. A <strong>span</strong> is any
-        piece of async work — an LLM call, a vector DB search, a tool invocation, a custom
+        piece of async work, an LLM call, a vector DB search, a tool invocation, a custom
         function. Spans nest via <code>parent_span_id</code>, forming a tree.
       </p>
       <CodeBlock language="text">{`trace: "user-session-abc123"
@@ -52,13 +52,13 @@ export default function TracesDocs() {
       <p>
         The database schema intentionally does NOT enforce a foreign key on <code>parent_span_id</code>.
         This lets you fire off parallel children, record them as they finish, and close the parent
-        later — no ordering constraints. Essential for real agent code that runs{' '}
+        later, no ordering constraints. Essential for real agent code that runs{' '}
         <code>Promise.all([agentA(), agentB()])</code>.
       </p>
 
       <h2>Using it</h2>
 
-      <h3>Option 1 — <code>observe()</code> (recommended)</h3>
+      <h3>Option 1, <code>observe()</code> (recommended)</h3>
       <p>
         Wrap any async function. Nested <code>observe()</code> calls automatically become child
         spans:
@@ -80,7 +80,7 @@ const answer = await observe('answer-question', async () => {
   return response.choices[0].message.content
 }, { trace: 'user-session-abc123' })`}</CodeBlock>
 
-      <h3>Option 2 — <code>observeOpenAI()</code> for single-call convenience</h3>
+      <h3>Option 2, <code>observeOpenAI()</code> for single-call convenience</h3>
       <CodeBlock language="ts">{`import { observeOpenAI } from '@spanlens/sdk/openai'
 
 const res = await observeOpenAI(openai, {
@@ -92,7 +92,7 @@ const res = await observeOpenAI(openai, {
         Same thing exists for Anthropic (<code>observeAnthropic</code>) and Gemini (<code>observeGemini</code>).
       </p>
 
-      <h3>Option 3 — Low-level handles (for parallel spans)</h3>
+      <h3>Option 3, Low-level handles (for parallel spans)</h3>
       <CodeBlock language="ts">{`import { SpanlensClient } from '@spanlens/sdk'
 
 const client = new SpanlensClient()
@@ -108,10 +108,10 @@ const [resA, resB] = await Promise.all([
 
 await trace.end()`}</CodeBlock>
 
-      <h3>Option 4 — OpenTelemetry SDK (OTLP)</h3>
+      <h3>Option 4, OpenTelemetry SDK (OTLP)</h3>
       <p>
         Already using an OTel SDK in Python, Go, Java, or another language? Point its OTLP exporter
-        at Spanlens and spans flow in automatically — no code rewrite required. Spanlens reads the{' '}
+        at Spanlens and spans flow in automatically, no code rewrite required. Spanlens reads the{' '}
         <a
           href="https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/"
           target="_blank"
@@ -182,8 +182,8 @@ await trace.end()`}</CodeBlock>
           <strong>σ (sigma) annotation.</strong> When a trace contains three or more spans of the
           same type, Spanlens computes the mean and standard deviation for that type. Any span whose
           duration is ≥ 2σ above the mean receives a <code>2.3σ latency</code> label in the
-          waterfall. This surfaces statistical outliers — a retrieval call that took five times longer
-          than usual — without you having to compare numbers manually.
+          waterfall. This surfaces statistical outliers, a retrieval call that took five times longer
+          than usual, without you having to compare numbers manually.
         </li>
         <li>
           <strong>Span drawer.</strong> Click any span bar to open the detail drawer. It has four
@@ -198,11 +198,11 @@ await trace.end()`}</CodeBlock>
         <li>
           <strong>Fire-and-forget ingest.</strong> <code>startTrace()</code> and{' '}
           <code>span()</code> return synchronously; network POSTs to Spanlens run in the background.
-          Your request hot path is never blocked by span ingest — typical overhead is under 1ms per
+          Your request hot path is never blocked by span ingest, typical overhead is under 1ms per
           span call.
         </li>
         <li>
-          <strong>Client-generated UUIDs.</strong> Idempotent — if your retry loop calls{' '}
+          <strong>Client-generated UUIDs.</strong> Idempotent, if your retry loop calls{' '}
           <code>span.end()</code> twice with the same UUID, the second call is a server-side
           no-op. No duplicated spans.
         </li>
@@ -223,7 +223,7 @@ await trace.end()`}</CodeBlock>
         <li>
           <strong>No zoom or pan yet.</strong> The waterfall fits the trace
           duration to the viewport width. For traces with thousands of spans
-          you&apos;ll want to drill into a sub-tree — that lives on the
+          you&apos;ll want to drill into a sub-tree, that lives on the
           roadmap.
         </li>
         <li>
@@ -234,13 +234,13 @@ await trace.end()`}</CodeBlock>
         </li>
         <li>
           <strong>No OpenTelemetry export yet.</strong> Spanlens accepts OTLP{' '}
-          <em>ingest</em> (OTel SDK → Spanlens), but the reverse direction — exporting
-          Spanlens spans into Datadog, Honeycomb, or another APM — is not yet supported.
+          <em>ingest</em> (OTel SDK → Spanlens), but the reverse direction, exporting
+          Spanlens spans into Datadog, Honeycomb, or another APM, is not yet supported.
           Planned for a future release.
         </li>
         <li>
           <strong>Trace IDs are opaque strings.</strong> We don&apos;t yet enforce W3C traceparent
-          format — so linking Spanlens traces to your app&apos;s APM traces requires you to pass the
+          format, so linking Spanlens traces to your app&apos;s APM traces requires you to pass the
           same id to both.
         </li>
       </ul>

--- a/apps/web/app/docs/features/users/page.tsx
+++ b/apps/web/app/docs/features/users/page.tsx
@@ -19,7 +19,7 @@ export default function UsersDocs() {
       <h2>How tagging works</h2>
       <p>
         Set the <code>x-spanlens-user</code> header on any proxied request. The value is a string
-        of your choosing — Spanlens never interprets it. Typical patterns: your DB user UUID,
+        of your choosing, Spanlens never interprets it. Typical patterns: your DB user UUID,
         email hash, or a workspace identifier.
       </p>
       <p>
@@ -41,16 +41,16 @@ await openai.chat.completions.create(
       <h2>What the dashboard shows</h2>
       <ul>
         <li>
-          <strong><a href="/users">/users</a></strong> — sortable table of every tagged end-user
+          <strong><a href="/users">/users</a></strong>, sortable table of every tagged end-user
           with total requests, tokens, cost, average latency, error count, distinct models, and
           first/last seen.
         </li>
         <li>
-          <strong>Row click</strong> opens <code>/users/[id]</code> — the same stats plus the last
+          <strong>Row click</strong> opens <code>/users/[id]</code>, the same stats plus the last
           50 requests for that user, each linkable to its full <a href="/docs/features/requests">request detail</a>.
         </li>
         <li>
-          <strong>Filter pivot</strong> — from any request drawer the user_id chip links to the
+          <strong>Filter pivot</strong>, from any request drawer the user_id chip links to the
           analytics page; the small <em>filter</em> link next to it scopes <code>/requests</code> to
           just that user.
         </li>
@@ -69,16 +69,16 @@ await openai.chat.completions.create(
           <tr><td><code>cost</code> (default)</td><td>Highest-spending users first.</td></tr>
           <tr><td><code>requests</code></td><td>Most-active users first.</td></tr>
           <tr><td><code>tokens</code></td><td>Heaviest token consumers (large prompts).</td></tr>
-          <tr><td><code>last_seen</code></td><td>Most recently active first — useful for triage.</td></tr>
+          <tr><td><code>last_seen</code></td><td>Most recently active first, useful for triage.</td></tr>
         </tbody>
       </table>
 
       <h2>API</h2>
       <p>Both endpoints scope to your organization automatically via JWT.</p>
-      <CodeBlock language="bash">{`# List — sort by cost desc, page 1
+      <CodeBlock language="bash">{`# List, sort by cost desc, page 1
 GET /api/v1/users?sortBy=cost&sortDir=desc&page=1&limit=50
 
-# Detail — aggregates + recent 50 requests
+# Detail, aggregates + recent 50 requests
 GET /api/v1/users/<user-id>?projectId=<optional>&from=<iso>&to=<iso>`}</CodeBlock>
 
       <h2>Limitations</h2>

--- a/apps/web/app/docs/features/webhooks/page.tsx
+++ b/apps/web/app/docs/features/webhooks/page.tsx
@@ -12,7 +12,7 @@ export default function WebhooksDocs() {
       <h1>Webhooks</h1>
       <p className="lead">
         Deliver Spanlens events to your own server as HTTP POST payloads in real time. Three event
-        types are supported — request created, trace completed, and alert triggered — all signed with
+        types are supported, request created, trace completed, and alert triggered, all signed with
         HMAC-SHA256 so you can verify authenticity. Use webhooks to build custom Slack bots, data
         pipelines, CI/CD triggers, or any other automation beyond the dashboard.
       </p>
@@ -117,7 +117,7 @@ GET    /api/v1/webhooks/:id/deliveries    # Last 10 delivery records`}</CodeBloc
 }`}</CodeBlock>
       <p>
         The <code>secret</code> is a 32-character hex string returned only at registration time.
-        Store it securely — it cannot be recovered if lost. Subsequent GET responses show only a
+        Store it securely, it cannot be recovered if lost. Subsequent GET responses show only a
         masked value.
       </p>
 
@@ -238,13 +238,13 @@ app.post('/hooks/spanlens', express.raw({ type: 'application/json' }), (req, res
             <td>Create / update / delete</td>
             <td>✓</td>
             <td>✓</td>
-            <td>—</td>
+            <td>,</td>
           </tr>
           <tr>
             <td>Test delivery</td>
             <td>✓</td>
             <td>✓</td>
-            <td>—</td>
+            <td>,</td>
           </tr>
         </tbody>
       </table>

--- a/apps/web/app/docs/layout.tsx
+++ b/apps/web/app/docs/layout.tsx
@@ -6,7 +6,7 @@ import { Footer } from '@/components/layout/footer'
 export const metadata = {
   title: 'Docs · Spanlens',
   description:
-    'Spanlens documentation — quick start, SDK reference, proxy API, self-hosting.',
+    'Spanlens documentation, quick start, SDK reference, proxy API, self-hosting.',
 }
 
 export default function DocsLayout({ children }: { children: React.ReactNode }) {

--- a/apps/web/app/docs/otel/page.tsx
+++ b/apps/web/app/docs/otel/page.tsx
@@ -20,7 +20,7 @@ export default function OtelDocs() {
         >
           gen_ai semantic conventions
         </a>
-        . No code rewrite required — configure your existing OTel exporter and spans flow
+        . No code rewrite required, configure your existing OTel exporter and spans flow
         directly into the waterfall dashboard.
       </p>
 
@@ -38,7 +38,7 @@ Authorization: Bearer sl_live_<your-key>`}</CodeBlock>
         Use your Spanlens project API key (<code>sl_live_…</code>) as a Bearer token.
         Most OTel SDKs let you inject custom headers into the exporter:
       </p>
-      <CodeBlock language="python">{`# Python — opentelemetry-exporter-otlp-proto-http
+      <CodeBlock language="python">{`# Python, opentelemetry-exporter-otlp-proto-http
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
 exporter = OTLPSpanExporter(
@@ -131,7 +131,7 @@ exporter = OTLPSpanExporter(
         </tbody>
       </table>
 
-      <h2>Quick start — Python (opentelemetry-sdk)</h2>
+      <h2>Quick start, Python (opentelemetry-sdk)</h2>
       <CodeBlock language="python">{`from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -160,7 +160,7 @@ with tracer.start_as_current_span("answer-question") as span:
     # ... call your LLM here
 `}</CodeBlock>
 
-      <h2>Quick start — Python with openai-agents SDK</h2>
+      <h2>Quick start, Python with openai-agents SDK</h2>
       <p>
         The{' '}
         <a
@@ -183,7 +183,7 @@ set_trace_processor(
 )
 `}</CodeBlock>
 
-      <h2>Quick start — Node.js</h2>
+      <h2>Quick start, Node.js</h2>
       <CodeBlock language="ts">{`import { NodeSDK } from '@opentelemetry/sdk-node'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 
@@ -230,7 +230,7 @@ sdk.start()
           <tr>
             <td>415</td>
             <td><code>{`{"error":"..."}`}</code></td>
-            <td>Protobuf encoding not supported — use <code>application/json</code></td>
+            <td>Protobuf encoding not supported, use <code>application/json</code></td>
           </tr>
         </tbody>
       </table>
@@ -239,7 +239,7 @@ sdk.start()
       <ul>
         <li>
           <strong>Trace IDs are external.</strong> OTel trace IDs (32-char hex) are stored separately
-          from Spanlens&apos; internal UUIDs. Duplicate exports of the same OTel trace are idempotent —
+          from Spanlens&apos; internal UUIDs. Duplicate exports of the same OTel trace are idempotent ,
           the trace row is upserted on <code>(organization_id, external_trace_id)</code>.
         </li>
         <li>
@@ -251,7 +251,7 @@ sdk.start()
         <li>
           <strong>Cost calculation.</strong> If <code>gen_ai.provider.name</code> and{' '}
           <code>gen_ai.request.model</code> match a known entry in Spanlens&apos; model price
-          table, cost is calculated automatically — no extra configuration required.
+          table, cost is calculated automatically, no extra configuration required.
         </li>
         <li>
           <strong>Protobuf not supported.</strong> Configure your OTel SDK to use HTTP/JSON

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -12,7 +12,7 @@ export default function DocsIndex() {
     <div className="not-prose">
       <h1 className="text-4xl font-bold tracking-tight mb-3">Spanlens Docs</h1>
       <p className="text-lg text-muted-foreground mb-10">
-        LLM observability — cost tracking (with prompt-cache breakdown), per-end-user analytics, agent tracing, PII + prompt-injection detection, and model recommendations for OpenAI / Anthropic / Gemini calls.
+        LLM observability, cost tracking (with prompt-cache breakdown), per-end-user analytics, agent tracing, PII + prompt-injection detection, and model recommendations for OpenAI / Anthropic / Gemini calls.
       </p>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-12">
@@ -44,7 +44,7 @@ export default function DocsIndex() {
             Does Spanlens add latency to my requests?
           </summary>
           <p className="mt-2 text-muted-foreground">
-            Typical overhead is 10–50ms per call — a thin pass-through proxy. Your requests flow to OpenAI / Anthropic / Gemini; responses stream back. Logging is fire-and-forget via Vercel&apos;s{' '}
+            Typical overhead is 10–50ms per call, a thin pass-through proxy. Your requests flow to OpenAI / Anthropic / Gemini; responses stream back. Logging is fire-and-forget via Vercel&apos;s{' '}
             <code className="text-xs bg-bg-elev rounded px-1">waitUntil</code>, so it never blocks the response.
           </p>
         </details>
@@ -61,7 +61,7 @@ export default function DocsIndex() {
             Can I use Spanlens with my existing Langfuse / Helicone setup?
           </summary>
           <p className="mt-2 text-muted-foreground">
-            Yes — Spanlens is a drop-in replacement at the baseURL level. You can keep both running side-by-side during migration.
+            Yes, Spanlens is a drop-in replacement at the baseURL level. You can keep both running side-by-side during migration.
           </p>
         </details>
 
@@ -70,7 +70,7 @@ export default function DocsIndex() {
             What providers are supported?
           </summary>
           <p className="mt-2 text-muted-foreground">
-            OpenAI, Anthropic, Google Gemini, Azure OpenAI, and self-hosted Ollama — including streaming responses. We match each upstream API 1:1, so any SDK that talks to those providers works. For LangChain, LangGraph, LCEL, Vercel AI SDK, and LlamaIndex, see the <a className="underline" href="/docs/sdk#framework-integrations">framework integrations</a>.
+            OpenAI, Anthropic, Google Gemini, Azure OpenAI, and self-hosted Ollama, including streaming responses. We match each upstream API 1:1, so any SDK that talks to those providers works. For LangChain, LangGraph, LCEL, Vercel AI SDK, and LlamaIndex, see the <a className="underline" href="/docs/sdk#framework-integrations">framework integrations</a>.
           </p>
         </details>
 
@@ -81,7 +81,7 @@ export default function DocsIndex() {
           <p className="mt-2 text-muted-foreground">
             Yes. Tag each call with the <code className="text-xs bg-bg-elev rounded px-1">x-spanlens-user</code> header (SDK helper{' '}
             <code className="text-xs bg-bg-elev rounded px-1">withUser()</code>) and the{' '}
-            <Link href="/users" className="text-accent hover:underline">/users</Link> page shows a sortable per-end-user breakdown — cost, requests, tokens, error rate, models used. Drill into any user for their full request history. See{' '}
+            <Link href="/users" className="text-accent hover:underline">/users</Link> page shows a sortable per-end-user breakdown, cost, requests, tokens, error rate, models used. Drill into any user for their full request history. See{' '}
             <Link href="/docs/features/users" className="text-accent hover:underline">users docs</Link>.
           </p>
         </details>
@@ -135,19 +135,19 @@ const SECTIONS = [
     icon: Code,
     title: '@spanlens/sdk',
     href: '/docs/sdk',
-    description: 'TypeScript SDK reference — createOpenAI, observe, span helpers, trace API.',
+    description: 'TypeScript SDK reference, createOpenAI, observe, span helpers, trace API.',
   },
   {
     icon: Globe,
     title: 'Direct proxy (any language)',
     href: '/docs/proxy',
-    description: 'Use Python, Ruby, Go, or raw HTTP — just swap the base URL.',
+    description: 'Use Python, Ruby, Go, or raw HTTP, just swap the base URL.',
   },
   {
     icon: Activity,
     title: 'OpenTelemetry (OTLP)',
     href: '/docs/otel',
-    description: 'Already using an OTel SDK? Point it at Spanlens — Python, Go, Java, Node.js all work.',
+    description: 'Already using an OTel SDK? Point it at Spanlens, Python, Go, Java, Node.js all work.',
   },
   {
     icon: Server,

--- a/apps/web/app/docs/proxy/page.tsx
+++ b/apps/web/app/docs/proxy/page.tsx
@@ -2,7 +2,7 @@ import { CodeBlock } from '../_components/code-block'
 
 export const metadata = {
   title: 'Direct proxy · Spanlens Docs',
-  description: 'Use Spanlens from any language — Python, Ruby, Go, curl. Just swap the base URL.',
+  description: 'Use Spanlens from any language, Python, Ruby, Go, curl. Just swap the base URL.',
 }
 
 export default function ProxyDocs() {
@@ -20,7 +20,7 @@ export default function ProxyDocs() {
           The proxy runs on Vercel Pro with a <strong>300-second hard ceiling</strong>, and Spanlens
           gracefully closes streams at <strong>290 seconds</strong> to make room for the log to flush.
           Long requests (large <code>max_tokens</code>, slow models, JSON mode with big outputs) should
-          use <code>stream: true</code> — first byte arrives in ~200 ms regardless of total duration.
+          use <code>stream: true</code>, first byte arrives in ~200 ms regardless of total duration.
           If a stream gets cut off at the deadline, the row is logged with{' '}
           <code>truncated: true</code> (visible as a badge in <a href="/requests">/requests</a>) so
           you can see when it happens and tune <code>max_tokens</code> accordingly. Non-streaming
@@ -41,12 +41,12 @@ https://spanlens-server.vercel.app/proxy/azure`}</CodeBlock>
       </p>
       <ol>
         <li>
-          <strong>Base URL</strong> — point your SDK at the Spanlens proxy
+          <strong>Base URL</strong>, point your SDK at the Spanlens proxy
         </li>
         <li>
-          <strong>API key</strong> — use your Spanlens API key (starts with{' '}
+          <strong>API key</strong>, use your Spanlens API key (starts with{' '}
           <code>sl_live_</code>) instead of the provider&apos;s. The real provider key
-          registered under your Spanlens key is decrypted server-side and forwarded — your
+          registered under your Spanlens key is decrypted server-side and forwarded, your
           client never sees it.
         </li>
       </ol>
@@ -54,7 +54,7 @@ https://spanlens-server.vercel.app/proxy/azure`}</CodeBlock>
       <h3 id="auth-transports">Authentication transports per SDK</h3>
       <p>
         Each provider&apos;s SDK puts the API key on the wire differently. Spanlens accepts
-        whichever shape the SDK sends — you don&apos;t need to override anything when using
+        whichever shape the SDK sends, you don&apos;t need to override anything when using
         the upstream client. If you&apos;re writing a hand-rolled client (curl, raw fetch, a
         language without an official SDK), pick whichever transport is convenient.
       </p>
@@ -99,7 +99,7 @@ https://spanlens-server.vercel.app/proxy/azure`}</CodeBlock>
         one wins. Implementation: <code>apps/server/src/middleware/authApiKey.ts</code>.
       </p>
 
-      <h2 id="python-openai">Python — OpenAI</h2>
+      <h2 id="python-openai">Python, OpenAI</h2>
       <CodeBlock language="python">{`from openai import OpenAI
 
 client = OpenAI(
@@ -112,7 +112,7 @@ res = client.chat.completions.create(
     messages=[{"role": "user", "content": "Hi"}],
 )`}</CodeBlock>
 
-      <h2 id="python-anthropic">Python — Anthropic</h2>
+      <h2 id="python-anthropic">Python, Anthropic</h2>
       <CodeBlock language="python">{`from anthropic import Anthropic
 
 client = Anthropic(
@@ -126,10 +126,10 @@ msg = client.messages.create(
     messages=[{"role": "user", "content": "Hi"}],
 )`}</CodeBlock>
 
-      <h2 id="python-azure">Python — Azure OpenAI</h2>
+      <h2 id="python-azure">Python, Azure OpenAI</h2>
       <p>
         Azure OpenAI uses Microsoft&apos;s <code>/openai/v1/*</code> endpoint (GA Aug 2025) so
-        it is drop-in OpenAI-compatible — same request and response shapes, same streaming
+        it is drop-in OpenAI-compatible, same request and response shapes, same streaming
         format. Register your Azure resource URL + API key under the Spanlens key in the
         dashboard once; the proxy then injects them at call time. Your client just talks to{' '}
         <code>/proxy/azure</code>.
@@ -154,7 +154,7 @@ res = client.chat.completions.create(
         <code>api-key</code> header on every request.
       </p>
 
-      <h2 id="curl">curl — raw HTTP</h2>
+      <h2 id="curl">curl, raw HTTP</h2>
       <CodeBlock language="bash">{`curl https://spanlens-server.vercel.app/proxy/openai/v1/chat/completions \\
   -H "Authorization: Bearer $SPANLENS_API_KEY" \\
   -H "Content-Type: application/json" \\
@@ -193,7 +193,7 @@ res, _ := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
 
       <h2>Streaming</h2>
       <p>
-        Server-Sent Events streaming works transparently. Spanlens tees the stream — one copy flows to
+        Server-Sent Events streaming works transparently. Spanlens tees the stream, one copy flows to
         you in real time, the other is parsed asynchronously to extract token usage. Latency overhead
         is negligible (10–50ms).
       </p>
@@ -215,7 +215,7 @@ res, _ := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
 # or
 -H "X-Spanlens-Prompt-Version: ae1c3c1e-99eb-2b98-5f05-012345678901"`}</CodeBlock>
       <p className="text-sm text-muted-foreground">
-        Invalid or unknown values silently resolve to null — the proxy never fails because a
+        Invalid or unknown values silently resolve to null, the proxy never fails because a
         prompt tag is stale. The request just isn&apos;t linked to a version.
       </p>
 
@@ -233,13 +233,13 @@ res, _ := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
         <a href="/docs/features/users">Users docs</a> for tagging strategy and SDK helpers.
       </p>
 
-      <h3>Controlling body retention — <code>X-Spanlens-Log-Body</code></h3>
+      <h3>Controlling body retention, <code>X-Spanlens-Log-Body</code></h3>
       <p>
         Spanlens stores the full request and response bodies by default (with API-key auto-masking
-        — see below). For PII-sensitive workloads, opt out per call with the{' '}
+       , see below). For PII-sensitive workloads, opt out per call with the{' '}
         <code>X-Spanlens-Log-Body</code> header:
       </p>
-      <CodeBlock>{`-H "X-Spanlens-Log-Body: full"   # default — store bodies (with key masking)
+      <CodeBlock>{`-H "X-Spanlens-Log-Body: full"   # default, store bodies (with key masking)
 -H "X-Spanlens-Log-Body: meta"   # drop bodies; keep tokens/cost/latency/user/session
 -H "X-Spanlens-Log-Body: none"   # same as meta + drop user_id/session_id`}</CodeBlock>
       <p>
@@ -264,7 +264,7 @@ res, _ := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
         <li>Google: <code>AIza*</code></li>
       </ul>
       <p>
-        This is <strong>pattern-based, not ML-based</strong> — it catches keys that slip into
+        This is <strong>pattern-based, not ML-based</strong>, it catches keys that slip into
         prompts/tool output/error strings, but it does <em>not</em> redact natural-language PII
         (names, emails, card numbers). For those, use <code>X-Spanlens-Log-Body: meta</code>.
         See <a href="/docs/features/security">Security docs</a> for full details.

--- a/apps/web/app/docs/quick-start/page.tsx
+++ b/apps/web/app/docs/quick-start/page.tsx
@@ -22,11 +22,11 @@ export default function QuickStart() {
           A project at <a href="/projects">/projects</a>
         </li>
         <li>
-          A <strong>Spanlens key</strong> (<code>sl_live_…</code>) — click{' '}
+          A <strong>Spanlens key</strong> (<code>sl_live_…</code>), click{' '}
           <em>+ New Spanlens key</em> on the project card
         </li>
         <li>
-          One or more <strong>provider keys</strong> registered under that Spanlens key —
+          One or more <strong>provider keys</strong> registered under that Spanlens key ,
           click <em>+ Add provider key</em> next to it (OpenAI, Anthropic, and/or Gemini)
         </li>
       </ol>
@@ -35,18 +35,18 @@ export default function QuickStart() {
         need separate keys per provider.
       </p>
 
-      <h2 id="path-a">Path A — Starting from scratch (no CLI)</h2>
+      <h2 id="path-a">Path A, Starting from scratch (no CLI)</h2>
       <p>
         If your code doesn&apos;t already call OpenAI / Anthropic / Gemini directly, this
         is the simpler path. Three steps, never run the CLI.
       </p>
 
-      <h3>Step 1 — Install the SDK</h3>
+      <h3>Step 1, Install the SDK</h3>
       <CodeBlock language="bash">{`pnpm add @spanlens/sdk
 # or: npm install @spanlens/sdk
 # or: yarn add @spanlens/sdk`}</CodeBlock>
 
-      <h3>Step 2 — Add the env variable</h3>
+      <h3>Step 2, Add the env variable</h3>
       <p>
         Copy the <code>sl_live_…</code> value shown when you issued the Spanlens key
         (it&apos;s only displayed once) and put it in your env file:
@@ -54,9 +54,9 @@ export default function QuickStart() {
       <CodeBlock language="env">{`# .env.local
 SPANLENS_API_KEY=sl_live_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`}</CodeBlock>
 
-      <h3>Step 3 — Use the helper for each provider you registered</h3>
+      <h3>Step 3, Use the helper for each provider you registered</h3>
       <p>
-        Each helper is a drop-in replacement for the provider&apos;s normal client — same
+        Each helper is a drop-in replacement for the provider&apos;s normal client, same
         methods, same return types. <code>SPANLENS_API_KEY</code> is read automatically.
       </p>
 
@@ -90,14 +90,14 @@ const result = await model.generateContent('Hi')`}</CodeBlock>
 
       <h3 id="frameworks">Using LangChain, LangGraph, Vercel AI SDK, or LlamaIndex?</h3>
       <p>
-        Skip the per-provider helpers above and use a single callback handler instead — it
+        Skip the per-provider helpers above and use a single callback handler instead, it
         captures LLM, chain, tool, and retriever spans automatically (including the full
         LangGraph node topology). See{' '}
         <a className="underline" href="/docs/sdk#framework-integrations">framework integrations</a>{' '}
         for the per-framework snippet.
       </p>
 
-      <h3>Adding new providers later — no CLI needed</h3>
+      <h3>Adding new providers later, no CLI needed</h3>
       <p>
         Once Steps 1 and 2 are done, adding a second or third provider is just:
       </p>
@@ -111,7 +111,7 @@ const result = await model.generateContent('Hi')`}</CodeBlock>
         <code>SPANLENS_API_KEY</code> already covers the new provider.
       </p>
 
-      <h2 id="path-b">Path B — Migrating existing OpenAI / Anthropic / Gemini code (CLI)</h2>
+      <h2 id="path-b">Path B, Migrating existing OpenAI / Anthropic / Gemini code (CLI)</h2>
       <p>
         If your codebase already has direct calls like{' '}
         <code>new OpenAI(&#123; apiKey: ... &#125;)</code>, the CLI rewrites them in place
@@ -135,7 +135,7 @@ const result = await model.generateContent('Hi')`}</CodeBlock>
         <li>
           Patches every <code>new OpenAI(...)</code> / <code>new Anthropic(...)</code> /{' '}
           <code>new GoogleGenerativeAI(...)</code> call to the matching{' '}
-          <code>createXxx()</code> helper — only for providers you have keys for
+          <code>createXxx()</code> helper, only for providers you have keys for
         </li>
         <li>Runs <code>tsc --noEmit</code> to verify the patch compiles</li>
       </ol>
@@ -143,7 +143,7 @@ const result = await model.generateContent('Hi')`}</CodeBlock>
       <p>Then deploy:</p>
       <ol>
         <li>Add <code>SPANLENS_API_KEY</code> to your production env (Vercel / Railway / Fly)</li>
-        <li>Redeploy — new env values don&apos;t apply to existing deployments</li>
+        <li>Redeploy, new env values don&apos;t apply to existing deployments</li>
       </ol>
 
       <p className="text-sm text-muted-foreground">
@@ -153,7 +153,7 @@ const result = await model.generateContent('Hi')`}</CodeBlock>
 
       <h3>When does the CLI need to run again?</h3>
       <p>
-        Almost never. Once a file is patched it stays patched — rotating, adding, or
+        Almost never. Once a file is patched it stays patched, rotating, adding, or
         deactivating provider keys in the dashboard doesn&apos;t require a re-run. The
         only time you re-run is when:
       </p>
@@ -184,7 +184,7 @@ const result = await model.generateContent('Hi')`}</CodeBlock>
 
       <h2>What about /traces?</h2>
       <p>
-        The proxy setup above populates <a href="/requests">/requests</a> only —{' '}
+        The proxy setup above populates <a href="/requests">/requests</a> only ,{' '}
         <a href="/traces">/traces</a> will be empty. That&apos;s expected.
       </p>
       <p>
@@ -194,7 +194,7 @@ const result = await model.generateContent('Hi')`}</CodeBlock>
         parent trace.
       </p>
       <p>
-        See the <a href="/docs/sdk">SDK reference</a> to add tracing in a few lines — or
+        See the <a href="/docs/sdk">SDK reference</a> to add tracing in a few lines, or
         jump straight to <a href="/docs/features/traces">how traces work</a> if you want to
         understand the model first.
       </p>
@@ -207,9 +207,9 @@ const result = await model.generateContent('Hi')`}</CodeBlock>
           Confirm <code>SPANLENS_API_KEY</code> is set in <em>both</em>{' '}
           <code>.env.local</code> AND your deployment environment
         </li>
-        <li>After adding env vars in Vercel, <strong>redeploy</strong> — new values don&apos;t apply retroactively</li>
+        <li>After adding env vars in Vercel, <strong>redeploy</strong>, new values don&apos;t apply retroactively</li>
         <li>
-          Check the Network tab — your request should hit{' '}
+          Check the Network tab, your request should hit{' '}
           <code>server.spanlens.io/proxy/*</code>, not{' '}
           <code>api.openai.com</code> directly
         </li>
@@ -219,7 +219,7 @@ const result = await model.generateContent('Hi')`}</CodeBlock>
       <p>
         You called a provider you haven&apos;t registered yet. Open{' '}
         <a href="/projects">/projects</a>, find the Spanlens key, and click{' '}
-        <em>+ Add provider key</em> — pick the matching provider (OpenAI / Anthropic /
+        <em>+ Add provider key</em>, pick the matching provider (OpenAI / Anthropic /
         Gemini) and paste your AI key.
       </p>
 
@@ -228,7 +228,7 @@ const result = await model.generateContent('Hi')`}</CodeBlock>
         Either <code>SPANLENS_API_KEY</code> is missing in the runtime, or you&apos;re
         still constructing the upstream client directly (<code>new OpenAI(...)</code>) and
         passing the wrong <code>baseURL</code>. The simplest fix is to use the SDK helper
-        — <code>createOpenAI()</code> sets both <code>apiKey</code> and{' '}
+       , <code>createOpenAI()</code> sets both <code>apiKey</code> and{' '}
         <code>baseURL</code> for you.
       </p>
 

--- a/apps/web/app/docs/sdk/page.tsx
+++ b/apps/web/app/docs/sdk/page.tsx
@@ -4,7 +4,7 @@ import { LangTabs } from '../_components/lang-tabs'
 export const metadata = {
   title: 'Spanlens SDK · Spanlens Docs',
   description:
-    'Official SDK reference for TypeScript and Python — createOpenAI, createAnthropic, createGemini, observe(), and the trace / span API.',
+    'Official SDK reference for TypeScript and Python, createOpenAI, createAnthropic, createGemini, observe(), and the trace / span API.',
 }
 
 export default function SdkReference() {
@@ -13,7 +13,7 @@ export default function SdkReference() {
       <h1>Spanlens SDK</h1>
       <p className="lead">
         Thin wrappers around the official OpenAI / Anthropic / Gemini SDKs that route traffic through
-        Spanlens and add agent tracing primitives. Zero lock-in — response types and method signatures
+        Spanlens and add agent tracing primitives. Zero lock-in, response types and method signatures
         match the upstream SDKs 1:1. Available for TypeScript and Python.
       </p>
 
@@ -21,7 +21,7 @@ export default function SdkReference() {
         <p className="m-0 font-semibold text-accent">⚡ Tip: use streaming for long responses</p>
         <p className="mt-1 mb-0 text-accent">
           For requests with large <code>max_tokens</code>, slower models, or big JSON outputs, enable
-          streaming — first byte arrives in ~200ms and total duration is unbounded. If you still want a
+          streaming, first byte arrives in ~200ms and total duration is unbounded. If you still want a
           single object back, accumulate chunks server-side and return the merged result from your route
           handler. See the <a href="#observe-streaming">streaming example</a> below.
         </p>
@@ -47,7 +47,7 @@ pip install "spanlens[all]"`}
         Python, use the matching extras shown above.
       </p>
 
-      <h2 id="create-openai">createOpenAI() — proxy mode</h2>
+      <h2 id="create-openai">createOpenAI(), proxy mode</h2>
       <p>
         Constructs the official provider client with <code>base_url</code> pointed at the Spanlens proxy
         and <code>api_key</code> set to your Spanlens key. Your real OpenAI key never leaves the
@@ -57,8 +57,8 @@ pip install "spanlens[all]"`}
         ts={`import { createOpenAI } from '@spanlens/sdk/openai'
 
 const openai = createOpenAI({
-  apiKey: process.env.SPANLENS_API_KEY,   // optional — defaults to env
-  project: 'my-app',                      // optional — project scope
+  apiKey: process.env.SPANLENS_API_KEY,   // optional, defaults to env
+  project: 'my-app',                      // optional, project scope
 })
 
 const res = await openai.chat.completions.create({
@@ -152,7 +152,7 @@ print(res.json())
 # configure_gemini()  # routes all genai calls through Spanlens`}
       />
 
-      <h2 id="with-prompt-version">withPromptVersion() — tag a request with a prompt version</h2>
+      <h2 id="with-prompt-version">withPromptVersion(), tag a request with a prompt version</h2>
       <p>
         Link a logged request to a specific <a href="/docs/features/prompts">Prompts</a> version so
         it appears in the A/B comparison table. Pass the helper as the second argument (TS) or
@@ -185,8 +185,8 @@ res = client.chat.completions.create(
       />
       <p>Accepted formats:</p>
       <ul>
-        <li><code>{'<name>@<version>'}</code> — e.g. <code>chatbot-system@3</code></li>
-        <li><code>{'<name>@latest'}</code> — auto-resolves server-side on every call</li>
+        <li><code>{'<name>@<version>'}</code>, e.g. <code>chatbot-system@3</code></li>
+        <li><code>{'<name>@latest'}</code>, auto-resolves server-side on every call</li>
         <li>Raw <code>prompt_versions.id</code> UUID</li>
       </ul>
       <p>
@@ -194,7 +194,7 @@ res = client.chat.completions.create(
         set the header directly: <code>x-spanlens-prompt-version: &lt;id&gt;</code>.
       </p>
 
-      <h2 id="with-user">withUser() / withSession() — end-user tracking (v0.2.7+)</h2>
+      <h2 id="with-user">withUser() / withSession(), end-user tracking (v0.2.7+)</h2>
       <p>
         Tag a call with an end-user ID and session ID. The values are stored in{' '}
         <code>requests.user_id</code> / <code>requests.session_id</code> and can be filtered on
@@ -221,7 +221,7 @@ const res = await openai.chat.completions.create(
     },
   },
 )`}
-        py={`# Python SDK support coming soon — pass headers directly in the meantime
+        py={`# Python SDK support coming soon, pass headers directly in the meantime
 import openai
 
 client = openai.OpenAI(
@@ -239,11 +239,11 @@ client = openai.OpenAI(
       </p>
       <p>
         All three headers are stripped by the <code>STRIP_PREFIXES</code> (<code>x-spanlens-*</code>)
-        policy before forwarding to upstream providers (OpenAI/Anthropic/Gemini) — they are used
+        policy before forwarding to upstream providers (OpenAI/Anthropic/Gemini), they are used
         only as Spanlens internal metadata.
       </p>
 
-      <h2 id="with-log-body">withLogBody() — control body retention (v0.3.x+)</h2>
+      <h2 id="with-log-body">withLogBody(), control body retention (v0.3.x+)</h2>
       <p>
         Opt out of storing request/response bodies in your dashboard while keeping token counts,
         cost, latency, and identifiers. Use when prompts may contain end-user PII you don&apos;t
@@ -309,7 +309,7 @@ const res2 = await openai.chat.completions.create(
     },
   },
 )`}
-        py={`# Python helper coming soon — set the header directly
+        py={`# Python helper coming soon, set the header directly
 from openai import OpenAI
 
 openai = OpenAI(
@@ -326,11 +326,11 @@ openai = OpenAI(
   -d '{"model": "gpt-4o-mini", "messages": [...]}'`}</CodeBlock>
       <p className="text-sm text-muted-foreground">
         Note: <code>withUser</code> / <code>withSession</code> become no-ops when{' '}
-        <code>logBody: &apos;none&apos;</code> is set — the server drops those columns alongside
+        <code>logBody: &apos;none&apos;</code> is set, the server drops those columns alongside
         the bodies.
       </p>
 
-      <h2 id="sample-rate">sampleRate — trace sampling (v0.3.x+)</h2>
+      <h2 id="sample-rate">sampleRate, trace sampling (v0.3.x+)</h2>
       <p>
         Cap the volume of trace + span ingestion without changing your application code. The
         decision is made per-trace at <code>startTrace()</code> / <code>start_trace()</code> time
@@ -384,26 +384,26 @@ client = SpanlensClient(
         <tbody>
           <tr>
             <td>Trace + span ingestion (<code>/ingest/traces</code>, <code>/ingest/spans</code>)</td>
-            <td><strong>Yes</strong> — this is the OTLP-equivalent agent-tracing layer</td>
+            <td><strong>Yes</strong>, this is the OTLP-equivalent agent-tracing layer</td>
           </tr>
           <tr>
             <td>Proxy request logs (<code>/proxy/*</code> → ClickHouse <code>requests</code>)</td>
             <td>
-              <strong>No</strong> — every LLM call is still recorded for cost / quota / anomaly
+              <strong>No</strong>, every LLM call is still recorded for cost / quota / anomaly
               tracking. Billing does not depend on the SDK&apos;s sampling decision.
             </td>
           </tr>
         </tbody>
       </table>
       <p>
-        Validation throws at client construction for values outside <code>[0.0, 1.0]</code> — fail
+        Validation throws at client construction for values outside <code>[0.0, 1.0]</code>, fail
         fast rather than silently dropping 100% of traces because a string was passed by accident.
       </p>
 
-      <h2 id="observe">observe() — agent tracing</h2>
+      <h2 id="observe">observe(), agent tracing</h2>
       <p>
         Wrap any function to turn it into a span in an agent trace. The callback&rsquo;s return value
-        is automatically captured as the span&rsquo;s <strong>output</strong> — no extra code needed.
+        is automatically captured as the span&rsquo;s <strong>output</strong>, no extra code needed.
         Pass <code>input</code> in the span options to record the inputs too.
       </p>
       <LangTabs
@@ -455,7 +455,7 @@ with client.start_trace("answer-question") as trace:
         <p className="mt-1 mb-0 text-green-700 dark:text-green-400">
           If you route through the Spanlens proxy via <code>createOpenAI()</code>,{' '}
           <code>createAnthropic()</code>, or <code>createGemini()</code>, the proxy captures the
-          completed response server-side and writes it to your span automatically — no extra code
+          completed response server-side and writes it to your span automatically, no extra code
           needed. The <code>return accumulated</code> pattern below is the fallback for direct
           (non-proxy) calls.
         </p>
@@ -497,7 +497,7 @@ with client.start_trace("answer-question") as trace:
     return accumulated   // ← auto-saved as output; no need to pass output: here
   },
 )`}
-        py={`# Python streaming — accumulate manually, return for auto-capture
+        py={`# Python streaming, accumulate manually, return for auto-capture
 async def streaming_span(trace):
     async with observe(trace, {"name": "gpt-4o-mini", "span_type": "llm"}) as span:
         stream = openai_client.chat.completions.create(
@@ -518,7 +518,7 @@ async def streaming_span(trace):
         return accumulated  # auto-saved as output`}
       />
 
-      <h2 id="observe-openai">observeOpenAI() — span + auto-parsed usage</h2>
+      <h2 id="observe-openai">observeOpenAI(), span + auto-parsed usage</h2>
       <p>
         Shorthand that wraps a single LLM call as a span, injects the trace headers so the proxy
         log can be linked to the span, and auto-parses <code>usage</code> from the response. Pass{' '}
@@ -558,11 +558,11 @@ res = observe_openai(trace, "greeting", lambda headers:
         <a href="#with-log-body"><code>withLogBody()</code></a> helper.
       </p>
 
-      <h2 id="observe-ollama">observeOllama() — self-hosted LLMs (v0.5.0+ / 0.4.0+)</h2>
+      <h2 id="observe-ollama">observeOllama(), self-hosted LLMs (v0.5.0+ / 0.4.0+)</h2>
       <p>
         Ollama runs on your own machine (or in your VPC) and exposes an OpenAI-compatible API at{' '}
         <code>http://localhost:11434/v1</code>. Because the Spanlens proxy is hosted, it can&rsquo;t
-        reach your local Ollama — but the SDK can. Wrap your Ollama call with{' '}
+        reach your local Ollama, but the SDK can. Wrap your Ollama call with{' '}
         <code>observeOllama()</code> and only the trace metadata (model, tokens, latency) flows to
         Spanlens. Your prompts and responses never leave your machine via Spanlens.
       </p>
@@ -637,7 +637,7 @@ with client.start_trace("local_chat") as trace:
       <p>
         If you use LangChain, LangGraph (v0.6.0+ / 0.5.0+), Vercel AI SDK, or LlamaIndex, plug in
         the matching integration instead of wiring callbacks manually. Each one records spans
-        automatically — tokens, latency, model name, and the full chain/tool/retriever topology —
+        automatically, tokens, latency, model name, and the full chain/tool/retriever topology ,
         without importing from the framework itself (duck-typed, version-agnostic).
       </p>
 
@@ -645,7 +645,7 @@ with client.start_trace("local_chat") as trace:
       <p>
         One callback handler works for plain LangChain chains, LCEL pipelines, and{' '}
         <strong>LangGraph compiled graphs</strong>. Spanlens captures LLM, chain, tool, and
-        retriever spans automatically — and uses LangChain&rsquo;s built-in{' '}
+        retriever spans automatically, and uses LangChain&rsquo;s built-in{' '}
         <code>runId</code> / <code>parentRunId</code> tracking to assemble the right span tree
         without any manual parent wiring.
       </p>
@@ -674,7 +674,7 @@ handler = SpanlensCallbackHandler(client=client)
 # Plain LangChain:
 chain.invoke({"input": "..."}, config={"callbacks": [handler]})
 
-# LangGraph — same handler:
+# LangGraph, same handler:
 graph = workflow.compile()
 result = graph.invoke(
     {"input": "plan a trip to Tokyo"},
@@ -728,7 +728,7 @@ result = graph.invoke(
           </tr>
           <tr>
             <td><code>trace</code></td>
-            <td>—</td>
+            <td>,</td>
             <td>Optional pre-existing trace to attach to. When given, the handler does <strong>not</strong> close the trace (caller owns the lifecycle).</td>
           </tr>
           <tr>
@@ -742,17 +742,17 @@ result = graph.invoke(
       <h4 id="langchain-notes">Notes</h4>
       <ul>
         <li>
-          <strong>Single handler, multiple runs</strong> — concurrent invocations are tracked by
+          <strong>Single handler, multiple runs</strong>, concurrent invocations are tracked by
           LangChain&rsquo;s per-run UUID, so one handler instance is safe to share across
           parallel graph executions.
         </li>
         <li>
-          <strong>Duck-typed</strong> — Spanlens does not import from{' '}
+          <strong>Duck-typed</strong>, Spanlens does not import from{' '}
           <code>@langchain/core</code> or <code>langchain-core</code>. Major-version bumps in
           LangChain itself don&rsquo;t require an SDK update.
         </li>
         <li>
-          <strong>Python optional dep</strong> — the handler falls back to a plain class when{' '}
+          <strong>Python optional dep</strong>, the handler falls back to a plain class when{' '}
           <code>langchain-core</code> isn&rsquo;t installed, so unit tests for your own code can
           drive it without LangChain being in the test environment.
         </li>
@@ -798,7 +798,7 @@ const unregister = registerSpanlensCallbacks(Settings, { client })
 await queryEngine.query({ query: 'What is RAG?' })
 
 unregister()  // remove callbacks when done (e.g. on process exit)`}
-        py={`# LlamaIndex Python integration — coming soon`}
+        py={`# LlamaIndex Python integration, coming soon`}
       />
 
       <h2 id="span-handle">Low-level: trace + span handles</h2>
@@ -836,10 +836,10 @@ with client.start_trace("multi-agent-workflow") as trace:
         span_b.end(output=result_b)`}
       />
 
-      <h2 id="flush">Graceful shutdown — <code>client.flush()</code></h2>
+      <h2 id="flush">Graceful shutdown, <code>client.flush()</code></h2>
       <p>
-        Ingest calls run in the background. In short-lived processes — scripts, one-shot jobs,
-        serverless cold starts — the process can exit before all POSTs complete. Call{' '}
+        Ingest calls run in the background. In short-lived processes, scripts, one-shot jobs,
+        serverless cold starts, the process can exit before all POSTs complete. Call{' '}
         <code>flush()</code> before exit to drain them:
       </p>
       <CodeBlock language="ts">{`const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
@@ -849,7 +849,7 @@ with client.start_trace("multi-agent-workflow") as trace:
 await client.flush()   // resolves when all in-flight ingest calls have settled
 process.exit(0)`}</CodeBlock>
       <p>
-        <code>flush()</code> uses <code>Promise.allSettled</code> internally — it resolves even if
+        <code>flush()</code> uses <code>Promise.allSettled</code> internally, it resolves even if
         some requests failed, so a network error won&apos;t hang the process. Failed writes are
         silently dropped (or forwarded to your <code>onError</code> hook if set). Transient
         failures are retried up to 3 times with exponential back-off (200 ms → 400 ms → 800 ms)
@@ -858,7 +858,7 @@ process.exit(0)`}</CodeBlock>
 
       <h2 id="non-blocking">Non-blocking by design</h2>
       <p>
-        Both SDKs do the actual ingest HTTP calls in the background — the TypeScript SDK uses the
+        Both SDKs do the actual ingest HTTP calls in the background, the TypeScript SDK uses the
         runtime&rsquo;s native promise queue, while Python uses a small daemon thread pool. Either
         way, your hot path (the LLM call itself) is never delayed by Spanlens, and a slow / down
         Spanlens server never crashes your app. Failures are swallowed by default; pass{' '}
@@ -881,7 +881,7 @@ process.exit(0)`}</CodeBlock>
 
       <h2 className="sr-only">Reference: original CodeBlock without tabs</h2>
       <p className="hidden">
-        {/* Keeps CodeBlock import from being marked unused — it stays available
+        {/* Keeps CodeBlock import from being marked unused, it stays available
             for any future single-language snippet. */}
       </p>
       <CodeBlock language="bash">{`# Quick links

--- a/apps/web/app/docs/self-host/page.tsx
+++ b/apps/web/app/docs/self-host/page.tsx
@@ -29,7 +29,7 @@ export default function SelfHostDocs() {
           <a href="https://supabase.com" target="_blank" rel="noopener noreferrer">
             supabase.com
           </a>{' '}
-          is enough to start. <strong>Plain Postgres is not supported</strong> — the server
+          is enough to start. <strong>Plain Postgres is not supported</strong>, the server
           uses <code>@supabase/supabase-js</code> directly.
         </li>
         <li>
@@ -49,7 +49,7 @@ export default function SelfHostDocs() {
 
       <h2 id="quickstart">Walkthrough</h2>
 
-      <h3>Option A — docker-compose (recommended)</h3>
+      <h3>Option A, docker-compose (recommended)</h3>
       <p>
         The easiest way to self-host. Pulls pre-built images from GHCR and runs both the{' '}
         <strong>dashboard (web)</strong> and the <strong>proxy / API server</strong> together.
@@ -82,10 +82,10 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
 SUPABASE_URL=https://<ref>.supabase.co
 SUPABASE_ANON_KEY=eyJ...
 SUPABASE_SERVICE_ROLE_KEY=eyJ...          # keep server-side only
-ENCRYPTION_KEY=$(openssl rand -base64 32) # back this up — see below
+ENCRYPTION_KEY=$(openssl rand -base64 32) # back this up, see below
 CRON_SECRET=$(openssl rand -hex 16)
 
-# ClickHouse — request logs are stored here, NOT Supabase
+# ClickHouse, request logs are stored here, NOT Supabase
 # The bundled docker-compose ships a clickhouse container; these defaults
 # match it. Point at ClickHouse Cloud (or any managed ClickHouse) for prod.
 CLICKHOUSE_URL=http://clickhouse:8123
@@ -93,7 +93,7 @@ CLICKHOUSE_USER=spanlens
 CLICKHOUSE_PASSWORD=$(openssl rand -hex 16)
 CLICKHOUSE_DB=spanlens
 
-# Optional — for invite emails
+# Optional, for invite emails
 # WEB_URL=https://your-domain.com
 # RESEND_API_KEY=re_...
 # RESEND_FROM=Spanlens <no-reply@your-domain.com>`}</CodeBlock>
@@ -110,7 +110,7 @@ docker compose up -d`}</CodeBlock>
         Three containers come up: <code>web</code>, <code>server</code>, and{' '}
         <code>clickhouse</code>. The server waits for ClickHouse&apos;s healthcheck before
         accepting traffic. The web container reads <code>NEXT_PUBLIC_*</code> from env at
-        startup and patches them into the pre-built bundle automatically — no rebuild needed.
+        startup and patches them into the pre-built bundle automatically, no rebuild needed.
       </p>
 
       <h4>4. Apply the ClickHouse schema</h4>
@@ -121,12 +121,12 @@ docker compose up -d`}</CodeBlock>
       <CodeBlock language="bash">{`# Clone or fetch the migrations folder
 curl -L https://github.com/spanlens/Spanlens/archive/main.tar.gz | tar xz --strip-components=1 spanlens-main/clickhouse
 
-# Apply (idempotent — re-running is safe)
+# Apply (idempotent, re-running is safe)
 CLICKHOUSE_URL=http://localhost:8123 \\
 CLICKHOUSE_USER=spanlens CLICKHOUSE_PASSWORD=<password> CLICKHOUSE_DB=spanlens \\
   npx -y tsx clickhouse/apply.ts`}</CodeBlock>
 
-      <h3>Option B — server only</h3>
+      <h3>Option B, server only</h3>
       <p>
         If you run the dashboard separately (at{' '}
         <a href="https://spanlens.io">spanlens.io</a> or your own Next.js deployment), you can
@@ -147,7 +147,7 @@ CLICKHOUSE_USER=spanlens CLICKHOUSE_PASSWORD=<password> CLICKHOUSE_DB=spanlens \
 
       <h4>2. Apply the schema</h4>
       <p>
-        Same as Option A step 1 — open <strong>SQL Editor → New query</strong>, paste{' '}
+        Same as Option A step 1, open <strong>SQL Editor → New query</strong>, paste{' '}
         <a
           href="https://raw.githubusercontent.com/spanlens/Spanlens/main/supabase/init.sql"
           target="_blank"
@@ -164,14 +164,14 @@ CLICKHOUSE_USER=spanlens CLICKHOUSE_PASSWORD=<password> CLICKHOUSE_DB=spanlens \
       </p>
       <ul>
         <li>
-          <strong>ClickHouse Cloud</strong> (recommended for production) — sign up at{' '}
+          <strong>ClickHouse Cloud</strong> (recommended for production), sign up at{' '}
           <a href="https://clickhouse.cloud" target="_blank" rel="noopener noreferrer">
             clickhouse.cloud
           </a>
           , create a service, copy the HTTPS endpoint + credentials.
         </li>
         <li>
-          <strong>Self-hosted ClickHouse</strong> — run{' '}
+          <strong>Self-hosted ClickHouse</strong>, run{' '}
           <code>clickhouse/clickhouse-server:24.10-alpine</code> with persistent volumes (see
           the bundled <code>docker-compose.yml</code> for the canonical setup).
         </li>
@@ -201,7 +201,7 @@ CLICKHOUSE_USER=default CLICKHOUSE_PASSWORD=<password> CLICKHOUSE_DB=spanlens \\
 
       <h4>4. Point your SDK at the self-hosted proxy</h4>
       <p>
-        <strong>Option 1 — CLI wizard</strong> (automates the step below):
+        <strong>Option 1, CLI wizard</strong> (automates the step below):
       </p>
       <CodeBlock language="bash">{`npx @spanlens/cli@latest init --server-url https://spanlens.yourcompany.com`}</CodeBlock>
       <p className="text-sm text-muted-foreground">
@@ -210,7 +210,7 @@ CLICKHOUSE_USER=default CLICKHOUSE_PASSWORD=<password> CLICKHOUSE_DB=spanlens \\
         <code>SPANLENS_BASE_URL</code> to <code>.env.local</code> automatically.
       </p>
       <p>
-        <strong>Option 2 — manual</strong>:
+        <strong>Option 2, manual</strong>:
       </p>
       <CodeBlock language="ts">{`import { createOpenAI } from '@spanlens/sdk/openai'
 
@@ -236,12 +236,12 @@ const openai = createOpenAI({
           <tr>
             <td><code>SUPABASE_SERVICE_ROLE_KEY</code></td>
             <td>Yes</td>
-            <td>Service role key — used by the server to write to Supabase past RLS (orgs, projects, traces, etc.)</td>
+            <td>Service role key, used by the server to write to Supabase past RLS (orgs, projects, traces, etc.)</td>
           </tr>
           <tr>
             <td><code>SUPABASE_ANON_KEY</code></td>
             <td>Yes</td>
-            <td>Anon key — used for RLS-protected reads from dashboard queries</td>
+            <td>Anon key, used for RLS-protected reads from dashboard queries</td>
           </tr>
           <tr>
             <td><code>CLICKHOUSE_URL</code></td>
@@ -275,12 +275,12 @@ const openai = createOpenAI({
           <tr>
             <td><code>NEXT_PUBLIC_SUPABASE_URL</code></td>
             <td>Yes (web only)</td>
-            <td>Same as <code>SUPABASE_URL</code> — exposed to the browser for Supabase Auth</td>
+            <td>Same as <code>SUPABASE_URL</code>, exposed to the browser for Supabase Auth</td>
           </tr>
           <tr>
             <td><code>NEXT_PUBLIC_SUPABASE_ANON_KEY</code></td>
             <td>Yes (web only)</td>
-            <td>Same as <code>SUPABASE_ANON_KEY</code> — exposed to the browser for Supabase Auth</td>
+            <td>Same as <code>SUPABASE_ANON_KEY</code>, exposed to the browser for Supabase Auth</td>
           </tr>
           <tr>
             <td><code>WEB_URL</code></td>
@@ -288,7 +288,7 @@ const openai = createOpenAI({
             <td>
               Base URL of your dashboard (e.g. <code>https://spanlens.example.com</code>).
               Used to build the accept link in invitation emails. Falls back to{' '}
-              <code>http://localhost:3000</code> if unset — fine for local dev,
+              <code>http://localhost:3000</code> if unset, fine for local dev,
               broken in production.
             </td>
           </tr>
@@ -322,7 +322,7 @@ const openai = createOpenAI({
 docker compose pull && docker compose up -d
 
 # If a new release added migrations, re-run init.sql in SQL Editor
-# (all statements use CREATE IF NOT EXISTS / ALTER IF NOT EXISTS — safe to re-run)`}</CodeBlock>
+# (all statements use CREATE IF NOT EXISTS / ALTER IF NOT EXISTS, safe to re-run)`}</CodeBlock>
       <p>
         We ship semver tags (<code>ghcr.io/spanlens/spanlens-server:0.3.0</code>,{' '}
         <code>ghcr.io/spanlens/spanlens-web:0.3.0</code>). Pin a tag in production and upgrade
@@ -331,7 +331,7 @@ docker compose pull && docker compose up -d
       <p>
         <strong>Supported architectures.</strong> Both images are published as
         multi-arch manifests for <code>linux/amd64</code> and <code>linux/arm64</code>{' '}
-        — Docker pulls the right variant for your host automatically. M1 / M2 / M3
+       , Docker pulls the right variant for your host automatically. M1 / M2 / M3
         Macs and AWS Graviton instances run the native ARM binary; x86 hosts run
         the amd64 binary. No platform flag needed.
       </p>
@@ -339,7 +339,7 @@ docker compose pull && docker compose up -d
       <h2 id="dashboard">Dashboard options</h2>
       <ul>
         <li>
-          <strong>docker-compose (recommended)</strong> — pulls{' '}
+          <strong>docker-compose (recommended)</strong>, pulls{' '}
           <code>ghcr.io/spanlens/spanlens-web:latest</code> alongside the server. Full
           self-hosting with no source required. See <a href="#quickstart">Option A</a> above.
         </li>
@@ -349,7 +349,7 @@ docker compose pull && docker compose up -d
           <a href="/settings">Settings</a>.
         </li>
         <li>
-          <strong>Build from source</strong> — clone the repo and{' '}
+          <strong>Build from source</strong>, clone the repo and{' '}
           <code>docker compose up -d --build</code> to build both images locally.
         </li>
       </ul>
@@ -360,30 +360,30 @@ docker compose pull && docker compose up -d
       </p>
       <ul>
         <li>
-          <strong>Supabase Postgres</strong> — holds the transactional crown jewels (orgs,
+          <strong>Supabase Postgres</strong>, holds the transactional crown jewels (orgs,
           projects, provider keys, subscriptions, prompts, evals, traces). Standard{' '}
           <code>pg_dump</code> against your Supabase DB covers you. Catastrophic if lost.
         </li>
         <li>
-          <strong>ClickHouse</strong> — holds request logs only. Append-only telemetry. Options
+          <strong>ClickHouse</strong>, holds request logs only. Append-only telemetry. Options
           in order of effort:
           <ol>
             <li>
-              <strong>ClickHouse Cloud automatic backups</strong> (1-day RPO, same region) — set
+              <strong>ClickHouse Cloud automatic backups</strong> (1-day RPO, same region), set
               and forget.
             </li>
             <li>
-              <strong>BACKUP TO S3</strong> on a schedule — <code>BACKUP TABLE requests TO
+              <strong>BACKUP TO S3</strong> on a schedule, <code>BACKUP TABLE requests TO
               S3(&apos;s3://bucket/path&apos;)</code>.
             </li>
             <li>
-              <strong>Accept the loss</strong> — historical logs are observability, not
+              <strong>Accept the loss</strong>, historical logs are observability, not
               source-of-truth. Loss costs you the past N days of dashboards, not customer trust.
             </li>
           </ol>
         </li>
         <li>
-          <strong>ENCRYPTION_KEY</strong> (outside any DB) — back this up in your secret
+          <strong>ENCRYPTION_KEY</strong> (outside any DB), back this up in your secret
           manager (AWS Secrets Manager, GCP Secret Manager, HashiCorp Vault). Without it,
           encrypted provider keys are unrecoverable.
         </li>
@@ -399,7 +399,7 @@ docker compose pull && docker compose up -d
         <li>
           <strong>ClickHouse is required.</strong> The server&apos;s logger and analytics
           helpers all assume a reachable ClickHouse instance. A Postgres-only mode is not
-          provided — the dual-store architecture is intentional (OLAP workload, columnar
+          provided, the dual-store architecture is intentional (OLAP workload, columnar
           storage, faster aggregates).
         </li>
         <li>

--- a/apps/web/app/dpa/page.tsx
+++ b/apps/web/app/dpa/page.tsx
@@ -65,7 +65,7 @@ export default function DPAPage() {
           <li>
             <strong>&ldquo;Customer Personal Data&rdquo;</strong> means Personal Data that
             the Customer or its end users submit to the Service or that the Service
-            generates on the Customer&apos;s behalf — including LLM request and response
+            generates on the Customer&apos;s behalf, including LLM request and response
             bodies, end-user identifiers, account profile data, and telemetry metadata.
           </li>
           <li>
@@ -252,10 +252,10 @@ export default function DPAPage() {
         <h2 id="assistance-art-32-36">10. Assistance with Arts. 32–36</h2>
         <p>
           Spanlens assists the Customer in ensuring compliance with the obligations
-          pursuant to Articles 32 to 36 of the GDPR — including security of processing,
+          pursuant to Articles 32 to 36 of the GDPR, including security of processing,
           notification of personal data breaches, communication of personal data breaches
           to the data subject, data protection impact assessments, and prior consultation
-          — taking into account the nature of processing and the information available
+         , taking into account the nature of processing and the information available
           to Spanlens.
         </p>
 
@@ -391,7 +391,7 @@ export default function DPAPage() {
           the SCCs as completed in Annex A.
         </p>
 
-        <h2 id="annex-a">Annex A — Completion of the Standard Contractual Clauses</h2>
+        <h2 id="annex-a">Annex A, Completion of the Standard Contractual Clauses</h2>
         <p className="text-sm text-muted-foreground">
           The following completions apply where the SCCs are incorporated under
           Section 14 of this DPA.
@@ -404,7 +404,7 @@ export default function DPAPage() {
             <strong>Docking clause (Clause 7):</strong> not used.
           </li>
           <li>
-            <strong>Sub-processors (Clause 9):</strong> Option 2 — general written
+            <strong>Sub-processors (Clause 9):</strong> Option 2, general written
             authorisation; notice period of 30 days as set out in Section 8 of this DPA.
           </li>
           <li>
@@ -420,7 +420,7 @@ export default function DPAPage() {
             resolution mechanism is not used.
           </li>
           <li>
-            <strong>Governing law of the SCCs (Clause 17):</strong> Option 1 — the law
+            <strong>Governing law of the SCCs (Clause 17):</strong> Option 1, the law
             of the Republic of Ireland.
           </li>
           <li>

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -48,7 +48,7 @@ export default function LoginPage() {
   return (
     <div className="min-h-screen bg-bg-elev grid grid-cols-2">
 
-      {/* ── Left pane — product proof ─────────────────────────────── */}
+      {/* ── Left pane, product proof ─────────────────────────────── */}
       <div className="bg-bg border-r border-border p-10 flex flex-col justify-between">
         <div>
           <LogoMark />
@@ -70,7 +70,7 @@ export default function LoginPage() {
         </div>
       </div>
 
-      {/* ── Right pane — form ────────────────────────────────────────── */}
+      {/* ── Right pane, form ────────────────────────────────────────── */}
       <div className="flex items-center justify-center p-10">
         <div className="w-[360px] max-w-full">
           <div className="mb-[22px]">

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -220,7 +220,7 @@ export default function OnboardingPage() {
           <div>
             <h1 className="text-[22px] font-medium tracking-[-0.4px] mb-1.5">Tell us about your project</h1>
             <p className="text-[13px] text-text-muted mb-5 leading-relaxed">
-              Helps us prioritize what to build. Both questions are optional — feel free to skip.
+              Helps us prioritize what to build. Both questions are optional, feel free to skip.
             </p>
 
             <div className="space-y-5">

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -6,12 +6,12 @@ import { CopyInstallButton } from '@/components/landing/copy-install-button'
 export const metadata = { title: 'Spanlens · LLM Observability' }
 
 const FEATURES = [
-  { kicker: '01', title: 'Request log', body: 'Every call — model, tokens, cost, latency, full body. Filter, group, export.', accent: '$0.0021' },
+  { kicker: '01', title: 'Request log', body: 'Every call with model, tokens, cost, latency, and full body. Filter, group, export.', accent: '$0.0021' },
   { kicker: '02', title: 'Cost tracking', body: 'Per-request breakdown, daily rollups, budget alerts before you blow the month.', accent: '−38%' },
   { kicker: '03', title: 'Agent tracing', body: 'Multi-step workflows as waterfall span trees. Find the one step that took 18s.', accent: '12 spans' },
   { kicker: '04', title: 'Anomaly detection', body: '3σ deviations in latency or cost vs. your 7-day baseline, flagged on arrival.', accent: '3.1σ' },
   { kicker: '05', title: 'PII + injection scan', body: 'Regex detection on request bodies at log time. API keys auto-masked before storage; PII patterns flagged for review.', accent: 'SSN · email' },
-  { kicker: '06', title: 'Model recommender', body: '"Your gpt-4o calls look like classification — try gpt-4o-mini." With numbers.', accent: '−$412/mo' },
+  { kicker: '06', title: 'Model recommender', body: '"Your gpt-4o calls look like classification, try gpt-4o-mini." With numbers.', accent: '−$412/mo' },
 ]
 
 const SURFACES = [
@@ -59,10 +59,10 @@ const PLANS = [
 ]
 
 const FAQS: [string, string][] = [
-  ['How does instrumentation work?', 'Swap the provider SDK for our drop-in. Same surface, same types. We record the full request and response on the wire — no extra round-trip, no sampling by default.'],
-  ['What about latency overhead?', 'p99 overhead is under 3ms. Ingestion happens async in a worker. If we ever fail, your request completes anyway — Spanlens never sits on the critical path.'],
-  ['How do you handle PII?', 'PII detectors (SSN, credit card, email, IBAN, passport, etc.) run at log time and flag matches for review in the Security dashboard — without blocking the request. API keys that slip into prompts are auto-masked before the row lands on disk. For workloads where prompt bodies must not be stored at all, opt out per-call with X-Spanlens-Log-Body: meta.'],
-  ['Do you support OpenTelemetry?', 'Yes — OTLP/HTTP ingest and export. Your existing OTel tracing flows into the same span store; LLM spans get LLM-specific attributes on top.'],
+  ['How does instrumentation work?', 'Swap the provider SDK for our drop-in. Same surface, same types. We record the full request and response on the wire, with no extra round-trip and no sampling by default.'],
+  ['What about latency overhead?', 'p99 overhead is under 3ms. Ingestion happens async in a worker. If we ever fail, your request completes anyway. Spanlens never sits on the critical path.'],
+  ['How do you handle PII?', 'PII detectors (SSN, credit card, email, IBAN, passport, etc.) run at log time and flag matches for review in the Security dashboard, without blocking the request. API keys that slip into prompts are auto-masked before the row lands on disk. For workloads where prompt bodies must not be stored at all, opt out per-call with X-Spanlens-Log-Body: meta.'],
+  ['Do you support OpenTelemetry?', 'Yes. OTLP/HTTP ingest and export. Your existing OTel tracing flows into the same span store; LLM spans get LLM-specific attributes on top.'],
   ['What\'s the data retention?', 'Free is 14 days. Pro is 90 days, Team is 365 days. Enterprise & self-hosted are configurable, including unlimited.'],
   ['Can I export my data?', 'Anytime. JSON, CSV, Parquet. Or pipe the raw stream to S3, BigQuery, or your warehouse via our sink connectors.'],
 ]
@@ -97,7 +97,7 @@ export default function LandingPage() {
         {/* Version badge */}
         <div className="inline-flex flex-wrap items-center gap-x-2 gap-y-1 px-2 py-[5px] rounded-full border border-accent-border bg-accent-bg text-accent font-mono text-[12px] tracking-[0.03em] mb-7 max-w-full">
           <span className="bg-accent text-bg px-[7px] py-[2px] rounded-full text-[10px] font-semibold tracking-[0.05em] shrink-0">NEW</span>
-          <span>SDK v0.3.0 — LangChain, Vercel AI SDK, LlamaIndex integrations</span>
+          <span>SDK v0.3.0 with LangChain, Vercel AI SDK, and LlamaIndex integrations</span>
           <code className="font-mono hidden sm:inline">· npm install @spanlens/sdk</code>
         </div>
 
@@ -107,12 +107,12 @@ export default function LandingPage() {
         </h1>
 
         <p className="text-[16px] sm:text-[18px] lg:text-[20px] leading-relaxed text-text-muted max-w-[640px] mb-10 [text-wrap:pretty]">
-          Record every OpenAI, Anthropic, and Gemini call — cost, latency, tokens, full
+          Record every OpenAI, Anthropic, and Gemini call with cost, latency, tokens, full
           request/response. Then surface anomalies, PII, and cheaper-model
           suggestions automatically.
         </p>
 
-        {/* Install block — stacked on mobile, inline on sm+ */}
+        {/* Install block: stacked on mobile, inline on sm+ */}
         <div className="flex flex-col sm:flex-row sm:items-center gap-2 mb-[18px]">
           <div className="flex items-center bg-bg-elev border border-border rounded-lg p-1 shadow-[0_1px_0_var(--border)] w-full sm:w-auto">
             <div className="px-[14px] py-2 font-mono text-[14px] flex-1 sm:flex-none">
@@ -185,7 +185,7 @@ export default function LandingPage() {
                 )
               })}
             </div>
-            {/* Table — horizontally scrollable on mobile */}
+            {/* Table: horizontally scrollable on mobile */}
             <div className="overflow-x-auto">
               <div className="min-w-[640px]">
                 {/* Table header */}
@@ -310,7 +310,7 @@ export default function LandingPage() {
             </h2>
             <p className="text-[15px] leading-[1.6] text-text-muted mb-5">
               Multi-step agents as waterfall trees. Critical path, cost attribution,
-              and latency outliers — highlighted automatically.
+              and latency outliers, highlighted automatically.
             </p>
             <div className="flex flex-col gap-2 font-mono text-[12px] text-text-muted">
               <div><span className="text-accent">●</span> critical path · 78% of wall-clock in 1 span</div>
@@ -435,7 +435,7 @@ export default function LandingPage() {
         <div className="font-mono text-[12px] text-accent tracking-[0.06em] uppercase mb-3">Pricing</div>
         <h2 className="text-[28px] sm:text-[36px] lg:text-[44px] font-medium tracking-[-1.2px] mb-2">Simple. Flat monthly.</h2>
         <p className="text-[15px] text-text-muted mb-8 max-w-[560px]">
-          Free while you&apos;re small. Flat monthly fee — not per seat. Self-host is free forever.
+          Free while you&apos;re small. Flat monthly fee, not per seat. Self-host is free forever.
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
           {PLANS.map((p) => (
@@ -460,7 +460,7 @@ export default function LandingPage() {
               <div className="flex flex-col gap-[7px] mb-[18px]">
                 {p.bullets.map((b) => (
                   <div key={b} className="flex gap-2 text-[13px] text-text-muted items-start">
-                    <span className="font-mono text-[11px] text-text-faint pt-px">—</span>
+                    <span className="font-mono text-[11px] text-text-faint pt-px">·</span>
                     <span>{b}</span>
                   </div>
                 ))}
@@ -501,7 +501,7 @@ export default function LandingPage() {
           See what your app is saying.
         </h2>
         <p className="text-[16px] sm:text-[17px] text-text-muted max-w-[540px] mx-auto leading-relaxed mb-8">
-          30-second setup. Your first 50,000 requests are on us. Cancel anytime — there&apos;s nothing to cancel.
+          30-second setup. Your first 50,000 requests are on us. Cancel anytime. There&apos;s nothing to cancel.
         </p>
         <div className="inline-flex flex-wrap justify-center gap-2.5">
           <Link href="/signup" className="font-mono text-[13px] text-bg bg-text px-[18px] py-[10px] rounded-[7px] font-medium hover:opacity-90 transition-opacity">

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -197,23 +197,23 @@ export default function PricingPage() {
           </p>
           <ul className="text-[13px] text-text-muted space-y-2 mb-4">
             <li>
-              <strong className="text-text">Soft limit</strong> — your plan&apos;s included quota (100K on Pro,
+              <strong className="text-text">Soft limit</strong>, your plan&apos;s included quota (100K on Pro,
               1M on Team). Extra requests pass through and accumulate.
             </li>
             <li>
-              <strong className="text-text">Overage billing</strong> — Pro $8 / Team $5 per 100K extra
+              <strong className="text-text">Overage billing</strong>, Pro $8 / Team $5 per 100K extra
               requests, charged immediately at the end of your billing period (not deferred to next month).
             </li>
             <li>
-              <strong className="text-text">Hard cap</strong> — default 5× the soft limit. Past this,
+              <strong className="text-text">Hard cap</strong>, default 5× the soft limit. Past this,
               requests return 429 even with overage enabled. Adjustable 1–100× in settings.
             </li>
             <li>
-              <strong className="text-text">Cost certainty mode</strong> — flip overage off in settings to
+              <strong className="text-text">Cost certainty mode</strong>, flip overage off in settings to
               hard-block at your quota instead.
             </li>
             <li>
-              <strong className="text-text">Free plan</strong> — proxy keeps working past 50K, but logging
+              <strong className="text-text">Free plan</strong>, proxy keeps working past 50K, but logging
               pauses (we don&apos;t want to break your app). Upgrade to Pro to resume logging plus overage.
             </li>
           </ul>

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -39,7 +39,7 @@ export default function PrivacyPage() {
           <li><strong>E-commerce Registration Number:</strong> 2025-경기광주-2133</li>
           <li><strong>Jurisdiction:</strong> Republic of Korea</li>
           <li>
-            <strong>Privacy Officer (개인정보보호책임자):</strong> Jeon Haesung —{' '}
+            <strong>Privacy Officer (개인정보보호책임자):</strong> Jeon Haesung ,{' '}
             <a href="mailto:support@spanlens.io">support@spanlens.io</a>
           </li>
         </ul>
@@ -57,7 +57,7 @@ export default function PrivacyPage() {
         <h3>Service telemetry (LLM requests routed through our proxy)</h3>
         <ul>
           <li>
-            Request and response bodies, <strong>truncated to a 10 KB preview</strong> — these
+            Request and response bodies, <strong>truncated to a 10 KB preview</strong>, these
             may contain whatever you or your end users submitted to the LLM, including prompts,
             file contents, user messages, and retrieved context.
           </li>
@@ -75,7 +75,7 @@ export default function PrivacyPage() {
           </li>
           <li>
             Security flags (PII patterns, prompt-injection patterns) detected in the request
-            body, stored as <strong>masked samples</strong> of 6 characters — never the raw
+            body, stored as <strong>masked samples</strong> of 6 characters, never the raw
             matched text.
           </li>
           <li>
@@ -122,19 +122,19 @@ export default function PrivacyPage() {
         <p>For EU users, we process data on the following legal bases (GDPR Art. 6):</p>
         <ul>
           <li>
-            <strong>Performance of a contract</strong> (Art. 6(1)(b)) — most service operation
+            <strong>Performance of a contract</strong> (Art. 6(1)(b)), most service operation
             falls here, because we process data to fulfill our service obligations to you.
           </li>
           <li>
-            <strong>Legitimate interests</strong> (Art. 6(1)(f)) — security monitoring, fraud
+            <strong>Legitimate interests</strong> (Art. 6(1)(f)), security monitoring, fraud
             prevention, and service improvement.
           </li>
           <li>
-            <strong>Legal obligation</strong> (Art. 6(1)(c)) — tax record retention and legal
+            <strong>Legal obligation</strong> (Art. 6(1)(c)), tax record retention and legal
             requests from Korean authorities.
           </li>
           <li>
-            <strong>Consent</strong> (Art. 6(1)(a)) — used for optional features; you may
+            <strong>Consent</strong> (Art. 6(1)(a)), used for optional features; you may
             withdraw consent at any time.
           </li>
         </ul>
@@ -143,17 +143,17 @@ export default function PrivacyPage() {
         <p>
           We engage third-party companies (&ldquo;sub-processors&rdquo;) to operate Spanlens.
           Each processes your data only as needed to provide their service, under contractual
-          confidentiality obligations. A current, authoritative list — with processing
-          locations, data categories, and transfer mechanisms — is maintained at{' '}
+          confidentiality obligations. A current, authoritative list, with processing
+          locations, data categories, and transfer mechanisms, is maintained at{' '}
           <Link href="/subprocessors">spanlens.io/subprocessors</Link>.
         </p>
         <p>
           As of the effective date of this Policy, our infrastructure sub-processors are
-          Vercel Inc. (USA — compute), Supabase Inc. (Republic of Korea — Postgres,
-          authentication), ClickHouse, Inc. (USA — LLM request log store), Upstash, Inc.
-          (USA — rate-limit counters), and Paddle.com Market Ltd. (Ireland — Merchant of
-          Record). Our communications sub-processors are Resend, Inc. (USA — transactional
-          email) and Functional Software, Inc. / Sentry (USA — error monitoring). For B2B
+          Vercel Inc. (USA, compute), Supabase Inc. (Republic of Korea, Postgres,
+          authentication), ClickHouse, Inc. (USA, LLM request log store), Upstash, Inc.
+          (USA, rate-limit counters), and Paddle.com Market Ltd. (Ireland, Merchant of
+          Record). Our communications sub-processors are Resend, Inc. (USA, transactional
+          email) and Functional Software, Inc. / Sentry (USA, error monitoring). For B2B
           customers, the full set of contractual safeguards applicable to these sub-processors
           is set out in our <Link href="/dpa">Data Processing Addendum</Link>.
         </p>
@@ -236,7 +236,7 @@ export default function PrivacyPage() {
           <li>Rectification (Art. 16)</li>
           <li>Erasure / &ldquo;right to be forgotten&rdquo; (Art. 17)</li>
           <li>Restriction of processing (Art. 18)</li>
-          <li>Data portability — export in machine-readable format (Art. 20)</li>
+          <li>Data portability, export in machine-readable format (Art. 20)</li>
           <li>Objection to processing based on legitimate interests (Art. 21)</li>
           <li>Lodging a complaint with your national Data Protection Authority</li>
         </ul>

--- a/apps/web/app/refund/page.tsx
+++ b/apps/web/app/refund/page.tsx
@@ -5,7 +5,7 @@ import { MarketingNav } from '@/components/layout/marketing-nav'
 export const metadata = {
   title: 'Refund Policy · Spanlens',
   description:
-    'Spanlens refund policy — 14-day money-back guarantee, EU statutory withdrawal rights, and how to request a refund.',
+    'Spanlens refund policy, 14-day money-back guarantee, EU statutory withdrawal rights, and how to request a refund.',
 }
 
 const EFFECTIVE_DATE = '2026-05-17'
@@ -84,7 +84,7 @@ export default function RefundPage() {
         <p>
           You may cancel your subscription at any time from the{' '}
           <Link href="/billing">Billing page</Link> in your dashboard. Cancellation stops future
-          renewals but does not by itself trigger a refund — your plan remains active through the
+          renewals but does not by itself trigger a refund, your plan remains active through the
           end of the current billing period.
         </p>
 

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -162,7 +162,7 @@ function SignupPageInner() {
   return (
     <div className="min-h-screen bg-bg-elev grid grid-cols-2">
 
-      {/* ── Left pane — product proof ─────────────────────────────── */}
+      {/* ── Left pane, product proof ─────────────────────────────── */}
       <div className="bg-bg border-r border-border p-10 flex flex-col justify-between">
         <div>
           <LogoMark />
@@ -173,7 +173,7 @@ function SignupPageInner() {
               are on us.
             </h2>
             <p className="text-[14px] text-text-muted leading-[1.55] mt-4">
-              No credit card. Self-host forever-free. Cancel anytime — there is nothing to cancel.
+              No credit card. Self-host forever-free. Cancel anytime, there is nothing to cancel.
             </p>
           </div>
         </div>
@@ -185,7 +185,7 @@ function SignupPageInner() {
         </div>
       </div>
 
-      {/* ── Right pane — form ────────────────────────────────────────── */}
+      {/* ── Right pane, form ────────────────────────────────────────── */}
       <div className="flex items-center justify-center p-10">
         <div className="w-[360px] max-w-full">
           {sent ? (

--- a/apps/web/app/subprocessors/page.tsx
+++ b/apps/web/app/subprocessors/page.tsx
@@ -163,7 +163,7 @@ export default function SubprocessorsPage() {
                 chargeback handling.
               </td>
               <td>
-                Customer name, billing address, card / IBAN (held by Paddle — not by
+                Customer name, billing address, card / IBAN (held by Paddle, not by
                 Spanlens), Paddle customer and subscription identifiers.
               </td>
               <td>
@@ -236,8 +236,8 @@ export default function SubprocessorsPage() {
         <h2 id="upstream-providers">Upstream LLM providers</h2>
         <p>
           Spanlens is a proxy. When you send a request to the Spanlens proxy targeting an
-          upstream LLM provider, we forward that request — including any prompt content
-          you submit — to the provider you chose, using API credentials you supplied.
+          upstream LLM provider, we forward that request, including any prompt content
+          you submit, to the provider you chose, using API credentials you supplied.
         </p>
         <p>
           The upstream providers are <strong>independent controllers</strong> with respect

--- a/apps/web/app/terms/page.tsx
+++ b/apps/web/app/terms/page.tsx
@@ -136,7 +136,7 @@ export default function TermsPage() {
         </p>
         <p>
           You may <strong>cancel your subscription at any time</strong> from the{' '}
-          <Link href="/billing">Billing page</Link> in your dashboard — cancellation stops
+          <Link href="/billing">Billing page</Link> in your dashboard, cancellation stops
           future renewals but does not by itself trigger a refund. Your plan remains active
           through the end of the current billing period.
         </p>
@@ -178,7 +178,7 @@ export default function TermsPage() {
         <ul>
           <li>Accepting and complying with those providers&apos; terms of service.</li>
           <li>Keeping your own provider API keys secure and authorized for the use cases you put through our proxy.</li>
-          <li>Any charges those providers bill you directly (Spanlens does not bill you for provider API usage — that&apos;s your account with OpenAI/Anthropic/Google).</li>
+          <li>Any charges those providers bill you directly (Spanlens does not bill you for provider API usage, that&apos;s your account with OpenAI/Anthropic/Google).</li>
         </ul>
 
         <h2 id="ip">8. Intellectual property</h2>
@@ -211,8 +211,8 @@ export default function TermsPage() {
         <h2 id="liability">10. Limitation of liability</h2>
         <p>
           To the maximum extent permitted by law, Oceancode&apos;s total aggregate liability
-          arising out of or relating to the service — whether in contract, tort, or any other
-          theory — is limited to the <strong>amount you paid to Spanlens in the 12 months
+          arising out of or relating to the service, whether in contract, tort, or any other
+          theory, is limited to the <strong>amount you paid to Spanlens in the 12 months
           preceding the event giving rise to liability</strong>.
         </p>
         <p>

--- a/apps/web/components/dashboard/kpi-card.tsx
+++ b/apps/web/components/dashboard/kpi-card.tsx
@@ -72,7 +72,7 @@ export function KpiCard({
         )}
       </div>
 
-      {/* Sparkline — fills full card width, fixed 44px tall */}
+      {/* Sparkline, fills full card width, fixed 44px tall */}
       <div className="w-full" style={{ height: VH }}>
         {path ? (
           <svg

--- a/apps/web/components/dashboard/quota-banner.tsx
+++ b/apps/web/components/dashboard/quota-banner.tsx
@@ -49,11 +49,11 @@ export function QuotaBanner() {
     // Three sub-cases: free_limit, overage_disabled, hard_cap
     if (quota.plan === 'free') {
       title = 'Free plan quota reached'
-      detail = `${formattedUsed} of ${formattedLimit} requests. New requests return 429 — upgrade to continue.`
+      detail = `${formattedUsed} of ${formattedLimit} requests. New requests return 429, upgrade to continue.`
       cta = 'Upgrade plan →'
     } else if (!quota.allowOverage) {
       title = 'Monthly quota exceeded'
-      detail = `${formattedUsed} of ${formattedLimit} on the ${quota.plan} plan. Overage billing is disabled — requests return 429.`
+      detail = `${formattedUsed} of ${formattedLimit} on the ${quota.plan} plan. Overage billing is disabled, requests return 429.`
       cta = 'Enable overage →'
       ctaHref = '/settings'
     } else {
@@ -65,7 +65,7 @@ export function QuotaBanner() {
   } else if (overageActive) {
     const overageRequests = quota.usedThisMonth - quota.limit
     title = 'Overage billing active'
-    detail = `${formattedUsed} of ${formattedLimit} included — ${overageRequests.toLocaleString()} extra requests will be billed on your next invoice. Hard cap at ${formattedCap}.`
+    detail = `${formattedUsed} of ${formattedLimit} included, ${overageRequests.toLocaleString()} extra requests will be billed on your next invoice. Hard cap at ${formattedCap}.`
     cta = 'Manage settings →'
     ctaHref = '/settings'
   } else {

--- a/apps/web/components/dashboard/welcome-banner.tsx
+++ b/apps/web/components/dashboard/welcome-banner.tsx
@@ -94,11 +94,11 @@ export function WelcomeBanner() {
           </button>
         </div>
 
-        {/* Step 1 — copy the key */}
+        {/* Step 1, copy the key */}
         <div className="mb-4">
           <div className="text-[12px] font-medium text-text mb-2">
             <span className="font-mono text-[10px] text-accent mr-1.5">1.</span>
-            Copy this key — it won&apos;t be shown again
+            Copy this key, it won&apos;t be shown again
           </div>
           <div className="flex items-center gap-2 bg-bg border border-border rounded-md px-3 py-2">
             <span className="font-mono text-[10px] text-text-faint uppercase tracking-[0.05em] shrink-0">
@@ -119,11 +119,11 @@ export function WelcomeBanner() {
             <code className="font-mono bg-bg border border-border px-1 rounded text-[10.5px]">
               .env.local
             </code>{' '}
-            (or your deployment&apos;s env settings — Vercel, Railway, etc.).
+            (or your deployment&apos;s env settings, Vercel, Railway, etc.).
           </p>
         </div>
 
-        {/* Step 2 — register a provider key */}
+        {/* Step 2, register a provider key */}
         <div className="mb-4">
           <div className="text-[12px] font-medium text-text mb-2">
             <span className="font-mono text-[10px] text-accent mr-1.5">2.</span>
@@ -139,11 +139,11 @@ export function WelcomeBanner() {
             </Link>
             , find your Spanlens key, click <em>+ Add provider key</em>, and paste your AI
             provider&apos;s API key. Spanlens stores it encrypted and uses it on your
-            behalf — your app never sees it again.
+            behalf, your app never sees it again.
           </p>
         </div>
 
-        {/* Step 3 — paste the snippet */}
+        {/* Step 3, paste the snippet */}
         <div>
           <div className="text-[12px] font-medium text-text mb-2">
             <span className="font-mono text-[10px] text-accent mr-1.5">3.</span>

--- a/apps/web/components/layout/footer.tsx
+++ b/apps/web/components/layout/footer.tsx
@@ -13,7 +13,7 @@ export function Footer() {
   return (
     <footer className="border-t border-border px-4 sm:px-6 lg:px-10 pt-10 pb-[60px] text-text-muted text-[13px]">
       <div className="max-w-[1200px] mx-auto flex flex-col sm:flex-row sm:justify-between sm:items-end gap-8 sm:gap-0">
-        {/* Left — logo + tagline */}
+        {/* Left: logo + tagline */}
         <div>
           <Link href="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
             <LogoMark size={20} className="rounded-[5px]" />
@@ -30,14 +30,24 @@ export function Footer() {
           </div>
         </div>
 
-        {/* Right — 3-col link groups */}
-        <div className="flex gap-8 sm:gap-12 font-mono text-[12px]">
+        {/* Right: 4-col link groups */}
+        <div className="flex flex-wrap gap-8 sm:gap-12 font-mono text-[12px]">
           <div>
             <div className="text-text-faint mb-2 tracking-[0.05em] uppercase text-[10px]">Product</div>
             <div className="flex flex-col gap-1.5">
               <Link href="/docs" className="hover:text-text transition-colors">Docs</Link>
               <Link href="/pricing" className="hover:text-text transition-colors">Pricing</Link>
               <Link href="/docs/quick-start" className="hover:text-text transition-colors">Quick start</Link>
+            </div>
+          </div>
+          <div>
+            <div className="text-text-faint mb-2 tracking-[0.05em] uppercase text-[10px]">Compare</div>
+            <div className="flex flex-col gap-1.5">
+              <Link href="/compare/langfuse" className="hover:text-text transition-colors">Langfuse</Link>
+              <Link href="/compare/helicone" className="hover:text-text transition-colors">Helicone</Link>
+              <Link href="/compare/langsmith" className="hover:text-text transition-colors">LangSmith</Link>
+              <Link href="/compare/braintrust" className="hover:text-text transition-colors">Braintrust</Link>
+              <Link href="/compare/arize-phoenix" className="hover:text-text transition-colors">Arize Phoenix</Link>
             </div>
           </div>
           <div>

--- a/apps/web/components/layout/marketing-nav.tsx
+++ b/apps/web/components/layout/marketing-nav.tsx
@@ -28,7 +28,7 @@ export function MarketingNav({ signupLabel = 'Start free →', subtitle }: Marke
           )}
         </Link>
 
-        {/* Links — hidden on mobile */}
+        {/* Links, hidden on mobile */}
         <div className="hidden sm:flex items-center gap-5 lg:gap-7 font-mono text-[13px] text-text-muted tracking-[0.015em]">
           <Link href="/#product" className="hover:text-text transition-colors">Product</Link>
           <Link href="/docs" className="hover:text-text transition-colors">Docs</Link>

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -108,8 +108,8 @@ function WorkspaceSwitcher() {
           className="absolute left-0 right-0 mt-1 z-20 rounded-[6px] border border-border-strong bg-bg-elev shadow-lg overflow-hidden"
           role="menu"
         >
-          {/* Workspaces section: always renders the list — even with a
-              single workspace — so the user sees "I am here" instead of an
+          {/* Workspaces section: always renders the list, even with a
+              single workspace, so the user sees "I am here" instead of an
               empty list with just a "+ New workspace" button (which used to
               read as "my workspace disappeared"). The current workspace
               shows a check mark; switching is a no-op when only one exists. */}
@@ -428,7 +428,7 @@ export function Sidebar() {
                     : String(quota.data.limit)
                   : '∞'
               } requests`
-            : '— / — requests'}
+            : ', /, requests'}
         </div>
         <div className="h-1 rounded-full bg-bg overflow-hidden">
           <div

--- a/apps/web/components/layout/topbar.tsx
+++ b/apps/web/components/layout/topbar.tsx
@@ -29,7 +29,7 @@ export function Topbar({ crumbs, right, className }: TopbarProps) {
         className,
       )}
     >
-      {/* Hamburger — mobile only */}
+      {/* Hamburger, mobile only */}
       <button
         type="button"
         onClick={toggle}
@@ -67,7 +67,7 @@ export function Topbar({ crumbs, right, className }: TopbarProps) {
       </nav>
 
       <div className="flex-1" />
-      {/* Search pill — hidden on mobile to make room for right-slot actions */}
+      {/* Search pill, hidden on mobile to make room for right-slot actions */}
       <CmdKPill className="hidden md:inline-flex" />
       {right}
     </div>

--- a/apps/web/components/marketing/compare-template.tsx
+++ b/apps/web/components/marketing/compare-template.tsx
@@ -1,0 +1,215 @@
+import Link from 'next/link'
+import { Check, Minus, X } from 'lucide-react'
+import { Footer } from '@/components/layout/footer'
+import { MarketingNav } from '@/components/layout/marketing-nav'
+import { cn } from '@/lib/utils'
+
+export type Verdict = 'yes' | 'no' | 'partial'
+
+export interface CompareRow {
+  feature: string
+  spanlens: Verdict | string
+  competitor: Verdict | string
+  /** Optional note rendered under the row */
+  note?: string
+}
+
+export interface CompareGroup {
+  title: string
+  rows: CompareRow[]
+}
+
+export interface ComparePoint {
+  title: string
+  body: string
+}
+
+export interface CompareTemplateProps {
+  competitor: string
+  /** Short headline shown under the title, e.g. "Drop-in proxy with eval built in" */
+  tagline: string
+  /** One-paragraph honest TL;DR */
+  tldr: string
+  /** Spanlens strengths against this specific competitor */
+  whySpanlens: ComparePoint[]
+  /** Cases where the competitor is the better fit — honesty earns trust */
+  whyCompetitor: ComparePoint[]
+  /** Detailed feature-by-feature comparison */
+  groups: CompareGroup[]
+  /** Short closing line above the CTA */
+  closing?: string
+}
+
+function VerdictCell({ value }: { value: Verdict | string }) {
+  if (value === 'yes') {
+    return <Check className="h-4 w-4 text-good" aria-label="Yes" />
+  }
+  if (value === 'no') {
+    return <X className="h-4 w-4 text-text-faint" aria-label="No" />
+  }
+  if (value === 'partial') {
+    return <Minus className="h-4 w-4 text-text-muted" aria-label="Partial" />
+  }
+  return <span className="font-mono text-[12px] text-text-muted">{value}</span>
+}
+
+export function CompareTemplate({
+  competitor,
+  tagline,
+  tldr,
+  whySpanlens,
+  whyCompetitor,
+  groups,
+  closing,
+}: CompareTemplateProps) {
+  return (
+    <div className="min-h-screen bg-bg">
+      <MarketingNav />
+
+      {/* Hero */}
+      <section className="max-w-[1000px] mx-auto px-6 pt-20 pb-12">
+        <Link
+          href="/compare"
+          className="font-mono text-[12px] text-text-faint hover:text-text-muted transition-colors"
+        >
+          ← All comparisons
+        </Link>
+        <h1 className="mt-4 text-[40px] sm:text-[48px] font-semibold tracking-[-0.8px] text-text leading-[1.05]">
+          Spanlens <span className="text-text-faint">vs</span> {competitor}
+        </h1>
+        <p className="mt-4 text-[18px] text-text-muted leading-relaxed">{tagline}</p>
+
+        <div className="mt-8 rounded-xl border border-border bg-bg-elev p-6">
+          <div className="font-mono text-[11px] uppercase tracking-[0.06em] text-text-faint mb-2">Summary</div>
+          <p className="text-[14px] text-text-muted leading-relaxed">{tldr}</p>
+        </div>
+      </section>
+
+      {/* Why Spanlens */}
+      <section className="max-w-[1000px] mx-auto px-6 py-12">
+        <h2 className="text-[24px] font-semibold tracking-[-0.4px] text-text mb-6">
+          Why teams pick Spanlens over {competitor}
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {whySpanlens.map((p) => (
+            <div key={p.title} className="rounded-xl border border-border bg-bg-elev p-5">
+              <h3 className="text-[15px] font-semibold text-text mb-2">{p.title}</h3>
+              <p className="text-[13px] text-text-muted leading-relaxed">{p.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Feature comparison table */}
+      <section className="max-w-[1000px] mx-auto px-6 py-12">
+        <h2 className="text-[24px] font-semibold tracking-[-0.4px] text-text mb-6">
+          Feature-by-feature
+        </h2>
+        <div className="rounded-xl border border-border overflow-hidden">
+          {groups.map((group, gi) => (
+            <div key={group.title} className={cn(gi > 0 && 'border-t border-border')}>
+              <div className="bg-bg-elev px-5 py-2.5 font-mono text-[11px] uppercase tracking-[0.06em] text-text-faint">
+                {group.title}
+              </div>
+              <div className="grid grid-cols-[1fr_120px_120px] text-[13px]">
+                <div className="px-5 py-2.5 border-b border-border bg-bg font-mono text-[11px] uppercase tracking-[0.06em] text-text-faint">
+                  Feature
+                </div>
+                <div className="px-3 py-2.5 border-b border-border bg-bg font-mono text-[11px] uppercase tracking-[0.06em] text-text-faint text-center">
+                  Spanlens
+                </div>
+                <div className="px-3 py-2.5 border-b border-border bg-bg font-mono text-[11px] uppercase tracking-[0.06em] text-text-faint text-center">
+                  {competitor}
+                </div>
+                {group.rows.map((row, ri) => (
+                  <div key={row.feature} className="contents">
+                    <div
+                      className={cn(
+                        'px-5 py-3 text-text',
+                        ri < group.rows.length - 1 && 'border-b border-border',
+                      )}
+                    >
+                      {row.feature}
+                      {row.note && (
+                        <div className="mt-1 text-[11px] text-text-faint leading-relaxed">{row.note}</div>
+                      )}
+                    </div>
+                    <div
+                      className={cn(
+                        'px-3 py-3 flex items-center justify-center',
+                        ri < group.rows.length - 1 && 'border-b border-border',
+                      )}
+                    >
+                      <VerdictCell value={row.spanlens} />
+                    </div>
+                    <div
+                      className={cn(
+                        'px-3 py-3 flex items-center justify-center',
+                        ri < group.rows.length - 1 && 'border-b border-border',
+                      )}
+                    >
+                      <VerdictCell value={row.competitor} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+        <p className="mt-3 font-mono text-[11px] text-text-faint">
+          Last updated {new Date().toISOString().slice(0, 10)} · Spot something inaccurate?{' '}
+          <a href="mailto:support@spanlens.io" className="underline hover:text-text-muted">
+            Let us know
+          </a>
+          .
+        </p>
+      </section>
+
+      {/* When competitor is better */}
+      <section className="max-w-[1000px] mx-auto px-6 py-12">
+        <h2 className="text-[24px] font-semibold tracking-[-0.4px] text-text mb-2">
+          When {competitor} might be the better fit
+        </h2>
+        <p className="text-[13px] text-text-muted mb-6">
+          We don&apos;t think every team should pick us. Here&apos;s where {competitor} legitimately wins.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {whyCompetitor.map((p) => (
+            <div key={p.title} className="rounded-xl border border-border bg-bg p-5">
+              <h3 className="text-[15px] font-semibold text-text mb-2">{p.title}</h3>
+              <p className="text-[13px] text-text-muted leading-relaxed">{p.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="max-w-[1000px] mx-auto px-6 py-16">
+        <div className="rounded-xl border border-border bg-bg-elev p-8 text-center">
+          {closing && (
+            <p className="text-[15px] text-text-muted mb-5 max-w-[640px] mx-auto leading-relaxed">{closing}</p>
+          )}
+          <div className="flex flex-col sm:flex-row gap-3 justify-center items-center">
+            <Link
+              href="/signup"
+              className="h-10 px-5 rounded-[6px] bg-accent text-bg text-[14px] font-medium leading-10 hover:opacity-90 transition-opacity"
+            >
+              Start free →
+            </Link>
+            <Link
+              href="/docs/quick-start"
+              className="h-10 px-5 rounded-[6px] border border-border text-text text-[14px] font-medium leading-10 hover:bg-bg-elev transition-colors"
+            >
+              Read the docs
+            </Link>
+          </div>
+          <p className="mt-4 font-mono text-[11px] text-text-faint">
+            Free tier · No credit card · Self-host with Docker
+          </p>
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  )
+}

--- a/apps/web/components/traces/gantt.tsx
+++ b/apps/web/components/traces/gantt.tsx
@@ -109,14 +109,14 @@ function computePositions(
 }
 
 function formatMs(ms: number | null): string {
-  if (ms == null) return '—'
+  if (ms == null) return ','
   if (ms < 1) return '<1ms'
   if (ms < 1000) return `${Math.round(ms)}ms`
   return `${(ms / 1000).toFixed(2)}s`
 }
 
 function formatCost(n: number | null): string {
-  if (n == null || n <= 0) return '—'
+  if (n == null || n <= 0) return ','
   if (n < 0.001) return `$${n.toFixed(5)}`
   if (n < 0.01) return `$${n.toFixed(4)}`
   return `$${n.toFixed(3)}`

--- a/apps/web/components/traces/trace-panel.tsx
+++ b/apps/web/components/traces/trace-panel.tsx
@@ -9,7 +9,7 @@ import type { SpanRow, SpanType } from '@/lib/queries/types'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 export function fmtMs(ms: number | null): string {
-  if (ms == null) return '—'
+  if (ms == null) return ','
   if (ms < 1) return '<1ms'
   if (ms < 1000) return `${Math.round(ms)}ms`
   return `${(ms / 1000).toFixed(2)}s`
@@ -22,7 +22,7 @@ export function fmtTimestamp(iso: string): string {
 }
 
 export function fmtCost(n: number | null): string {
-  if (n == null || n === 0) return '—'
+  if (n == null || n === 0) return ','
   return n < 0.001 ? '$' + n.toFixed(5) : '$' + n.toFixed(4)
 }
 
@@ -405,7 +405,7 @@ function SpanDrawer({ span, onClose, onPrev, onNext, hasPrev, hasNext, position,
           { label: 'Cost', value: fmtCost(span.cost_usd) },
           {
             label: 'Tokens',
-            value: span.total_tokens > 0 ? span.total_tokens.toLocaleString() : '—',
+            value: span.total_tokens > 0 ? span.total_tokens.toLocaleString() : ',',
             sub: span.total_tokens > 0 ? `${span.prompt_tokens} in / ${span.completion_tokens} out` : '',
           },
         ].map((s, i) => (
@@ -441,7 +441,7 @@ function SpanDrawer({ span, onClose, onPrev, onNext, hasPrev, hasNext, position,
         ))}
       </div>
 
-      {/* BOTTLENECK section — sticky at bottom when this span is the critical path */}
+      {/* BOTTLENECK section, sticky at bottom when this span is the critical path */}
       {isCritical && (
         <div className="px-5 py-4 border-t border-accent-border bg-accent-bg shrink-0">
           <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-accent mb-2">
@@ -600,7 +600,7 @@ function TracePanelInner({ traceId }: TracePanelProps) {
     <div className="flex h-full overflow-hidden border-l border-border bg-bg">
       <div className="flex flex-col flex-1 overflow-hidden">
 
-        {/* Live indicator — only when trace is still running */}
+        {/* Live indicator, only when trace is still running */}
         {trace.status === 'running' && (
           <div className="flex items-center gap-2 px-[22px] py-[5px] border-b border-accent-border/50 bg-accent-bg shrink-0">
             <span className="w-1.5 h-1.5 rounded-full bg-accent animate-pulse inline-block shrink-0" />
@@ -637,7 +637,7 @@ function TracePanelInner({ traceId }: TracePanelProps) {
               { label: 'Cost', value: fmtCost(trace.total_cost_usd) },
               {
                 label: 'Longest Span',
-                value: bottleneck ? `${bottleneckPct}% · ${bottleneck.name}` : '—',
+                value: bottleneck ? `${bottleneckPct}% · ${bottleneck.name}` : ',',
                 accent: !!bottleneck,
               },
             ].map((s) => (

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -27,7 +27,7 @@ export class ApiError extends Error {
   }
 }
 
-const SESSION_TTL_MS = 10_000 // 10s — well under the default 1h access-token lifetime
+const SESSION_TTL_MS = 10_000 // 10s, well under the default 1h access-token lifetime
 
 interface CachedSession {
   token: string | null

--- a/apps/web/lib/demo-data.ts
+++ b/apps/web/lib/demo-data.ts
@@ -972,7 +972,7 @@ const REASONS_GOOD = [
   'Concise and respects the user\'s time.',
 ]
 const REASONS_BAD = [
-  'Response is vague — no concrete next step suggested.',
+  'Response is vague, no concrete next step suggested.',
   'Generic apology, doesn\'t actually answer the question.',
   'Tone is too formal for the casual customer message.',
   'Response is overly long with redundant context.',
@@ -1072,7 +1072,7 @@ const SUPPORT_ITEMS: DatasetItem[] = [
     organization_id: DEMO_ORG_ID,
     dataset_id: 'ds-001',
     input: { messages: [{ role: 'user', content: 'I was charged twice for the same order #ORD-4521.' }] },
-    expected_output: 'I see two charges for order #ORD-4521. I\'ve refunded the duplicate charge — it should appear in 3–5 business days. Sorry for the inconvenience!',
+    expected_output: 'I see two charges for order #ORD-4521. I\'ve refunded the duplicate charge, it should appear in 3–5 business days. Sorry for the inconvenience!',
     source_request_id: 'req-1042',
     created_at: day(14),
   },
@@ -1238,7 +1238,7 @@ export const DEMO_EXPERIMENT_RESULTS: Record<string, ExperimentResult[]> = {
         ? 'I\'m sorry to hear that. Please contact billing@acme.com with your order number and we\'ll look into the duplicate charge.'
         : `[v6 response to "${item.input.messages?.[0]?.content?.slice(0, 40)}…"]`,
       output_b: i === 0
-        ? 'I see two charges for order #ORD-4521 on your account. I\'ve initiated a refund for the duplicate charge — it should appear in 3-5 business days. Anything else I can help with?'
+        ? 'I see two charges for order #ORD-4521 on your account. I\'ve initiated a refund for the duplicate charge, it should appear in 3-5 business days. Anything else I can help with?'
         : `[v7 response to "${item.input.messages?.[0]?.content?.slice(0, 40)}…"]`,
       cost_a_usd: 0.0015,
       cost_b_usd: 0.0019,
@@ -1268,7 +1268,7 @@ const QUEUE_BASE_REQUESTS = [
     prompt_version: 7,
     model: 'claude-sonnet-4-5',
     user_msg: 'Hi, I\'ve been charged twice for the same subscription this month. Can you help?',
-    response: 'I see two charges on your account from yesterday. I\'ve refunded the duplicate — it should reflect in your bank within 3-5 business days. Sorry for the trouble!',
+    response: 'I see two charges on your account from yesterday. I\'ve refunded the duplicate, it should reflect in your bank within 3-5 business days. Sorry for the trouble!',
     llm_judge_score: 0.92,
     human_score: 0.75,
     human_raw: 4,
@@ -1300,7 +1300,7 @@ const QUEUE_BASE_REQUESTS = [
     llm_judge_score: 0.42,
     human_score: 0.0,
     human_raw: 1,
-    human_comment: 'Has markdown fences — instructions were "return only valid JSON, no explanation". Fence breaks downstream parsers.',
+    human_comment: 'Has markdown fences, instructions were "return only valid JSON, no explanation". Fence breaks downstream parsers.',
     age_min: 45,
   },
   {
@@ -1309,7 +1309,7 @@ const QUEUE_BASE_REQUESTS = [
     prompt_name: 'email-classifier',
     prompt_version: 2,
     model: 'gpt-4o-mini',
-    user_msg: 'Subject: 50% OFF EVERYTHING — Last chance!',
+    user_msg: 'Subject: 50% OFF EVERYTHING, Last chance!',
     response: '{"category": "spam", "confidence": 0.94, "reasoning": "Promotional language + urgency"}',
     llm_judge_score: 0.95,
     human_score: 1.0,
@@ -1342,7 +1342,7 @@ const QUEUE_BASE_REQUESTS = [
     llm_judge_score: 0.35,
     human_score: 0.75,
     human_raw: 4,
-    human_comment: 'Actually correct behavior — "approximately" is vague. Judge undervalued this.',
+    human_comment: 'Actually correct behavior, "approximately" is vague. Judge undervalued this.',
     age_min: 240,
   },
 ]

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -12,7 +12,7 @@ export function cn(...inputs: ClassValue[]) {
 // React #418 hydration mismatch. The dashboard UI is English, so en-US is
 // consistent with the surrounding copy ("Renews on May 18, 2026").
 export function formatDate(iso: string | null): string {
-  if (!iso) return '—'
+  if (!iso) return ','
   return new Date(iso).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'short',
@@ -26,7 +26,7 @@ export function formatDate(iso: string | null): string {
  * Example: "May 18, 2026, 11:24 PM"
  */
 export function formatDateTime(iso: string | null): string {
-  if (!iso) return '—'
+  if (!iso) return ','
   return new Date(iso).toLocaleString('en-US', {
     year: 'numeric',
     month: 'short',
@@ -42,7 +42,7 @@ export function formatDateTime(iso: string | null): string {
  * where date is implied by context. Same #418 protection as formatDateTime.
  */
 export function formatTime(iso: string | null): string {
-  if (!iso) return '—'
+  if (!iso) return ','
   return new Date(iso).toLocaleTimeString('en-US', {
     hour: '2-digit',
     minute: '2-digit',


### PR DESCRIPTION
## Summary

- Add a `/compare` hub with five SEO-targeted, fair comparison pages: Langfuse, Helicone, LangSmith, Braintrust, and Arize Phoenix. Each page has a short summary, "Why teams pick Spanlens", a feature-by-feature table, and a "When the competitor wins" section to keep the tone honest.
- Add a Compare column to the marketing footer with plain brand names (no `vs ` prefix).
- Replace em-dashes with natural sentence flow across landing, pricing, docs, dashboard, and demo pages so the prose reads more conversationally.

## Notes on accuracy

- Removed unverifiable claims (Helicone acquisition language) and locale-specific notes.
- Softened verdicts where competitors do have a partial implementation (judge-to-human correlation in Langfuse, Vercel AI SDK in LangSmith).
- Consolidated same-kind rows (SDKs, provider proxies, security scanning) so the tables scan faster without losing detail (moved to the `note` field).
- Changed the summary box label from `TL;DR` to `Summary` for a more polished tone.

## Test plan

- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint`
- [x] Verified `/compare`, `/compare/langfuse`, `/compare/helicone`, `/compare/langsmith`, `/compare/braintrust`, `/compare/arize-phoenix` render with status 200
- [x] Confirmed zero em-dashes in the rendered HTML of `/`, `/pricing`, `/docs`, `/terms`, `/privacy`, `/compare`, and all comparison pages
- [x] Footer Compare column links route to the right pages
- [ ] Reviewer: sanity-check each comparison page for tone and factual accuracy