### PR TITLE
feat: demo parity + model_prices expansion + service_tier auto-detect

### DIFF
--- a/apps/server/src/__tests__/parsers.test.ts
+++ b/apps/server/src/__tests__/parsers.test.ts
@@ -46,6 +46,36 @@ describe('OpenAI parser', () => {
     const line = `data: ${JSON.stringify({ model: 'gpt-4o', usage: { prompt_tokens: 5, completion_tokens: 10, total_tokens: 15 } })}`
     expect(parseOpenAIStreamChunk(line)?.promptTokens).toBe(5)
   })
+
+  it('extracts service_tier when provided (priority, flex, default)', () => {
+    for (const tier of ['priority', 'flex', 'default', 'auto', 'scale'] as const) {
+      const body = {
+        model: 'gpt-5.5',
+        service_tier: tier,
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      }
+      expect(parseOpenAIResponse(body)?.serviceTier).toBe(tier)
+    }
+  })
+
+  it('drops unknown service_tier values', () => {
+    const body = {
+      model: 'gpt-5.5',
+      service_tier: 'experimental-unknown',
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    }
+    expect(parseOpenAIResponse(body)?.serviceTier).toBeUndefined()
+  })
+
+  it('leaves serviceTier undefined when response omits the field', () => {
+    const body = { model: 'gpt-4o', usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } }
+    expect(parseOpenAIResponse(body)?.serviceTier).toBeUndefined()
+  })
+
+  it('extracts service_tier from streaming chunk usage', () => {
+    const line = `data: ${JSON.stringify({ model: 'gpt-5.5', service_tier: 'flex', usage: { prompt_tokens: 5, completion_tokens: 10, total_tokens: 15 } })}`
+    expect(parseOpenAIStreamChunk(line)?.serviceTier).toBe('flex')
+  })
 })
 
 describe('Anthropic parser', () => {
@@ -121,5 +151,33 @@ describe('Gemini parser', () => {
       totalTokens: 15,
       model: 'gemini-1.5-pro',
     })
+  })
+
+  it('extracts serviceTier from usageMetadata (lowercase + SCREAMING_SNAKE)', () => {
+    const cases = [
+      { input: 'priority', expected: 'priority' },
+      { input: 'PRIORITY', expected: 'priority' },
+      { input: 'flex', expected: 'flex' },
+      { input: 'GENERATE_CONTENT_PROCESSING_TIER_FLEX', expected: 'flex' },
+      { input: 'default', expected: 'default' },
+    ]
+    for (const { input, expected } of cases) {
+      const body = {
+        modelVersion: 'gemini-2.5-pro',
+        usageMetadata: {
+          promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15,
+          serviceTier: input,
+        },
+      }
+      expect(parseGeminiResponse(body)?.serviceTier).toBe(expected)
+    }
+  })
+
+  it('returns undefined serviceTier when missing or unrecognized', () => {
+    const body = {
+      modelVersion: 'gemini-2.5-pro',
+      usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+    }
+    expect(parseGeminiResponse(body)?.serviceTier).toBeUndefined()
   })
 })

--- a/apps/server/src/lib/cost.test.ts
+++ b/apps/server/src/lib/cost.test.ts
@@ -99,6 +99,171 @@ describe('calculateCost — cache breakdown', () => {
   })
 })
 
+describe('calculateCost — tiered (long context) pricing', () => {
+  test('gpt-5.5 short tier: 100k prompt billed at short rate', () => {
+    // short: prompt 5, completion 30
+    const cost = calculateCost('openai', 'gpt-5.5', {
+      promptTokens: 100_000,
+      completionTokens: 1_000,
+    })
+    expect(cost).not.toBeNull()
+    // 100k × 5/1M + 1k × 30/1M = 0.5 + 0.03 = 0.53
+    expect(cost!.totalCost).toBeCloseTo(0.53, 6)
+  })
+
+  test('gpt-5.5 long tier: 300k prompt billed at long rate (≥272k threshold)', () => {
+    // long: prompt 10, completion 45
+    const cost = calculateCost('openai', 'gpt-5.5', {
+      promptTokens: 300_000,
+      completionTokens: 1_000,
+    })
+    expect(cost).not.toBeNull()
+    // 300k × 10/1M + 1k × 45/1M = 3.0 + 0.045 = 3.045
+    expect(cost!.totalCost).toBeCloseTo(3.045, 6)
+  })
+
+  test('gpt-5.5 long tier: cache_read uses long cache rate ($1/M)', () => {
+    // long: prompt 10, completion 45, cacheRead 1.0
+    const cost = calculateCost('openai', 'gpt-5.5', {
+      promptTokens: 300_000,
+      completionTokens: 0,
+      cacheReadTokens: 100_000,
+    })
+    expect(cost).not.toBeNull()
+    // non-cached = 200k × 10/1M = 2.0
+    // cache_read = 100k × 1.0/1M = 0.1
+    expect(cost!.promptCost).toBeCloseTo(2.0, 6)
+    expect(cost!.cacheReadCost).toBeCloseTo(0.1, 6)
+    expect(cost!.totalCost).toBeCloseTo(2.1, 6)
+  })
+
+  test('gpt-5.5 boundary: exactly at threshold (272k) stays in short tier', () => {
+    // condition is `promptTokens > threshold` (strict), so 272k → short
+    const cost = calculateCost('openai', 'gpt-5.5', {
+      promptTokens: 272_000,
+      completionTokens: 0,
+    })
+    expect(cost).not.toBeNull()
+    // short: 272k × 5/1M = 1.36
+    expect(cost!.totalCost).toBeCloseTo(1.36, 6)
+  })
+
+  test('gpt-5.5 boundary: one token over threshold flips to long', () => {
+    const cost = calculateCost('openai', 'gpt-5.5', {
+      promptTokens: 272_001,
+      completionTokens: 0,
+    })
+    expect(cost).not.toBeNull()
+    // long: 272001 × 10/1M ≈ 2.72001
+    expect(cost!.totalCost).toBeCloseTo(2.72001, 5)
+  })
+
+  test('gemini-2.5-pro long tier: 250k prompt billed at long rate', () => {
+    // short: 1.25 / 10, long: 2.5 / 15, threshold 200k
+    const cost = calculateCost('gemini', 'gemini-2.5-pro', {
+      promptTokens: 250_000,
+      completionTokens: 5_000,
+    })
+    expect(cost).not.toBeNull()
+    // 250k × 2.5/1M + 5k × 15/1M = 0.625 + 0.075 = 0.7
+    expect(cost!.totalCost).toBeCloseTo(0.7, 6)
+  })
+
+  test('gpt-5.4-mini has no long tier → 500k prompt still short rate', () => {
+    // short only: prompt 0.75, completion 4.5
+    const cost = calculateCost('openai', 'gpt-5.4-mini', {
+      promptTokens: 500_000,
+      completionTokens: 0,
+    })
+    expect(cost).not.toBeNull()
+    // 500k × 0.75/1M = 0.375
+    expect(cost!.totalCost).toBeCloseTo(0.375, 6)
+  })
+})
+
+describe('calculateCost — service tier multiplier', () => {
+  test('default tier matches no-tier cost (1.0× multiplier)', () => {
+    const baseline = calculateCost('openai', 'gpt-4o-mini', {
+      promptTokens: 1000, completionTokens: 500,
+    })!
+    const defaulted = calculateCost('openai', 'gpt-4o-mini', {
+      promptTokens: 1000, completionTokens: 500, serviceTier: 'default',
+    })!
+    expect(defaulted.totalCost).toBeCloseTo(baseline.totalCost, 10)
+  })
+
+  test('flex tier applies 0.5× discount', () => {
+    const baseline = calculateCost('openai', 'gpt-4o-mini', {
+      promptTokens: 1000, completionTokens: 500,
+    })!
+    const flex = calculateCost('openai', 'gpt-4o-mini', {
+      promptTokens: 1000, completionTokens: 500, serviceTier: 'flex',
+    })!
+    expect(flex.totalCost).toBeCloseTo(baseline.totalCost * 0.5, 10)
+  })
+
+  test('priority tier applies 1.8× premium', () => {
+    const baseline = calculateCost('openai', 'gpt-4o-mini', {
+      promptTokens: 1000, completionTokens: 500,
+    })!
+    const priority = calculateCost('openai', 'gpt-4o-mini', {
+      promptTokens: 1000, completionTokens: 500, serviceTier: 'priority',
+    })!
+    expect(priority.totalCost).toBeCloseTo(baseline.totalCost * 1.8, 10)
+  })
+
+  test('batch tier applies 0.5× discount', () => {
+    const baseline = calculateCost('openai', 'gpt-4o-mini', {
+      promptTokens: 1000, completionTokens: 500,
+    })!
+    const batch = calculateCost('openai', 'gpt-4o-mini', {
+      promptTokens: 1000, completionTokens: 500, serviceTier: 'batch',
+    })!
+    expect(batch.totalCost).toBeCloseTo(baseline.totalCost * 0.5, 10)
+  })
+
+  test('priority scales cache_read alongside prompt/completion', () => {
+    // Anthropic Sonnet — cache_read is 0.3, prompt 3, completion 15.
+    // Priority should scale all three by 1.8.
+    const baseline = calculateCost('anthropic', 'claude-sonnet-4-6', {
+      promptTokens: 10_000, completionTokens: 500, cacheReadTokens: 5_000,
+    })!
+    const priority = calculateCost('anthropic', 'claude-sonnet-4-6', {
+      promptTokens: 10_000, completionTokens: 500, cacheReadTokens: 5_000,
+      serviceTier: 'priority',
+    })!
+    expect(priority.promptCost).toBeCloseTo(baseline.promptCost * 1.8, 8)
+    expect(priority.cacheReadCost).toBeCloseTo(baseline.cacheReadCost * 1.8, 8)
+    expect(priority.completionCost).toBeCloseTo(baseline.completionCost * 1.8, 8)
+    expect(priority.totalCost).toBeCloseTo(baseline.totalCost * 1.8, 8)
+  })
+
+  test('flex + long context: multipliers stack correctly', () => {
+    // gpt-5.5 long tier: prompt $10 / completion $45. Flex = 0.5×.
+    // 300k prompt + 1k completion at flex:
+    //   prompt: 300k × 10 × 0.5 / 1M = 1.50
+    //   completion: 1k × 45 × 0.5 / 1M = 0.0225
+    const cost = calculateCost('openai', 'gpt-5.5', {
+      promptTokens: 300_000, completionTokens: 1_000, serviceTier: 'flex',
+    })!
+    expect(cost.totalCost).toBeCloseTo(1.5225, 5)
+  })
+
+  test('unknown serviceTier value defaults to 1.0×', () => {
+    const baseline = calculateCost('openai', 'gpt-4o-mini', {
+      promptTokens: 1000, completionTokens: 500,
+    })!
+    // TS won't let unknown tier through normally, but runtime might receive
+    // a value we never enumerated — calculator must not crash and must
+    // default to Standard.
+    const unknown = calculateCost('openai', 'gpt-4o-mini', {
+      promptTokens: 1000, completionTokens: 500,
+      serviceTier: 'something-weird' as never,
+    })!
+    expect(unknown.totalCost).toBeCloseTo(baseline.totalCost, 10)
+  })
+})
+
 describe('calculateCost — regression vs. old behavior', () => {
   test('no cache tokens → identical total to pre-migration cost', () => {
     // Anthropic Haiku, 1000 prompt + 500 completion, NO cache.

--- a/apps/server/src/lib/cost.ts
+++ b/apps/server/src/lib/cost.ts
@@ -24,16 +24,17 @@ export interface Usage {
   promptTokens: number
   completionTokens: number
   /** Subset of promptTokens that hit a prompt cache (charged at reduced rate). */
-  cacheReadTokens?: number
+  cacheReadTokens?: number | undefined
   /** Subset of promptTokens that created a cache entry (charged at premium rate). */
-  cacheWriteTokens?: number
+  cacheWriteTokens?: number | undefined
   /**
    * Tier the provider actually served the request from (NOT the requested tier).
    * Extracted by parsers from response body — see parsers/openai.ts and
    * parsers/gemini.ts. When omitted, no tier adjustment is applied
    * (equivalent to Standard / `default`).
+   * `| undefined` explicit because of exactOptionalPropertyTypes.
    */
-  serviceTier?: ServiceTier
+  serviceTier?: ServiceTier | undefined
 }
 
 /**

--- a/apps/server/src/lib/cost.ts
+++ b/apps/server/src/lib/cost.ts
@@ -11,6 +11,7 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { getCachedPrices, type ModelPrice } from './model-prices-cache.js'
+import type { ServiceTier } from '../parsers/openai.js'
 
 // 'azure' shares the OpenAI price table (Azure OpenAI exposes OpenAI models
 // at OpenAI prices). The proxy in proxy/azure.ts calls calculateCost('openai', ...)
@@ -26,6 +27,42 @@ export interface Usage {
   cacheReadTokens?: number
   /** Subset of promptTokens that created a cache entry (charged at premium rate). */
   cacheWriteTokens?: number
+  /**
+   * Tier the provider actually served the request from (NOT the requested tier).
+   * Extracted by parsers from response body — see parsers/openai.ts and
+   * parsers/gemini.ts. When omitted, no tier adjustment is applied
+   * (equivalent to Standard / `default`).
+   */
+  serviceTier?: ServiceTier
+}
+
+/**
+ * Tier-to-multiplier table.
+ *
+ * Per-1M-token rates in model_prices are the **Standard** tier. These factors
+ * convert to other tiers using the provider-published deltas:
+ *
+ *   default / auto / scale → 1.0× (Standard or auto-resolved-to-Standard)
+ *   batch                  → 0.5× (50% discount; Batch API + Gemini Batch)
+ *   flex                   → 0.5× (OpenAI: "Tokens are priced at Batch API rates")
+ *   priority               → 1.8× (OpenAI: "+80% over Standard")
+ *
+ * Approximations on purpose — exact per-tier prices vary by model and would
+ * need a separate table. The multiplier is correct to within a few percent
+ * for the documented tier pricing as of 2026-05.
+ */
+const TIER_MULTIPLIERS: Record<ServiceTier, number> = {
+  default: 1.0,
+  auto: 1.0,
+  scale: 1.0,
+  batch: 0.5,
+  flex: 0.5,
+  priority: 1.8,
+}
+
+function tierMultiplier(tier: ServiceTier | undefined): number {
+  if (!tier) return 1.0
+  return TIER_MULTIPLIERS[tier] ?? 1.0
 }
 
 export interface CostResult {
@@ -73,16 +110,33 @@ export function calculateCost(
   // in case of unexpected reporter inconsistencies.
   const nonCachedPromptTokens = Math.max(0, usage.promptTokens - cacheRead - cacheWrite)
 
-  // Models without explicit cache pricing fall back to the regular prompt rate
-  // (matches the historical behavior — no surprise cost reduction for models
-  // that lack a published cache price).
-  const cacheReadPrice = prices.cacheRead ?? prices.prompt
-  const cacheWritePrice = prices.cacheWrite ?? prices.prompt
+  // Tier selection — if longThreshold is set and the full prompt crossed it,
+  // swap in the long_* prices for axes that have them. Axes left undefined
+  // on the long tier fall through to the short-tier prices (e.g. gpt-5.5-pro
+  // has long prompt/completion but no separate long cache_read price).
+  //
+  // We branch on usage.promptTokens (total input, cache included) rather than
+  // nonCachedPromptTokens — OpenAI/Gemini both bill the long tier based on the
+  // raw context size sent to the model, not on the non-cached subset.
+  const inLongTier =
+    prices.longThreshold != null && usage.promptTokens > prices.longThreshold
+  const promptPrice     = inLongTier ? (prices.longPrompt     ?? prices.prompt)     : prices.prompt
+  const completionPrice = inLongTier ? (prices.longCompletion ?? prices.completion) : prices.completion
+  const cacheReadShort  = prices.cacheRead  ?? prices.prompt
+  const cacheWriteShort = prices.cacheWrite ?? prices.prompt
+  const cacheReadPrice  = inLongTier ? (prices.longCacheRead  ?? cacheReadShort)  : cacheReadShort
+  const cacheWritePrice = inLongTier ? (prices.longCacheWrite ?? cacheWriteShort) : cacheWriteShort
 
-  const promptCost = (nonCachedPromptTokens / 1_000_000) * prices.prompt
-  const cacheReadCost = (cacheRead / 1_000_000) * cacheReadPrice
-  const cacheWriteCost = (cacheWrite / 1_000_000) * cacheWritePrice
-  const completionCost = (usage.completionTokens / 1_000_000) * prices.completion
+  // Tier multiplier applies AFTER cache-aware breakdown. Provider tier
+  // pricing is published as a flat factor over the Standard rate — Flex
+  // discount and Priority premium scale all axes (prompt / completion /
+  // cache) identically. See TIER_MULTIPLIERS comment.
+  const tierMult = tierMultiplier(usage.serviceTier)
+
+  const promptCost = (nonCachedPromptTokens / 1_000_000) * promptPrice * tierMult
+  const cacheReadCost = (cacheRead / 1_000_000) * cacheReadPrice * tierMult
+  const cacheWriteCost = (cacheWrite / 1_000_000) * cacheWritePrice * tierMult
+  const completionCost = (usage.completionTokens / 1_000_000) * completionPrice * tierMult
 
   return {
     promptCost,

--- a/apps/server/src/lib/logger.ts
+++ b/apps/server/src/lib/logger.ts
@@ -80,7 +80,7 @@ export interface RequestLogData {
    *
    * Empty string written to CH when unknown / unsupported (Anthropic).
    */
-  serviceTier?: string | null
+  serviceTier?: string | null | undefined
 }
 
 /**

--- a/apps/server/src/lib/logger.ts
+++ b/apps/server/src/lib/logger.ts
@@ -71,6 +71,16 @@ export interface RequestLogData {
    * See proxy/stream-deadline.ts for the wiring rationale.
    */
   truncated?: boolean
+  /**
+   * Actual processing tier the provider served the request from. Extracted by
+   * parsers from the response body — see parsers/openai.ts (`service_tier`)
+   * and parsers/gemini.ts (`usageMetadata.serviceTier`). Used by the cost
+   * calculator to apply Flex/Priority multipliers and surfaced on the
+   * dashboard for tier-distribution analytics.
+   *
+   * Empty string written to CH when unknown / unsupported (Anthropic).
+   */
+  serviceTier?: string | null
 }
 
 /**
@@ -253,6 +263,9 @@ export async function logRequestAsync(data: RequestLogData): Promise<void> {
     // 0/1 because ClickHouse UInt8; never null even if the field was
     // never set (older rows backfill via DEFAULT 0 on the column).
     truncated: data.truncated ? 1 : 0,
+    // Empty string when unknown — matches the column DEFAULT '' from migration
+    // 003_add_service_tier.sql and keeps CH LowCardinality dictionary tight.
+    service_tier: data.serviceTier ?? '',
     // ClickHouse DateTime64 wants 'YYYY-MM-DD HH:MM:SS.fff' (no Z).
     // Postgres's gen_random_uuid()/now() defaults moved to the
     // application layer — no behavioral difference, just a different

--- a/apps/server/src/lib/model-prices-cache.ts
+++ b/apps/server/src/lib/model-prices-cache.ts
@@ -34,9 +34,9 @@ export interface ModelPrice {
   prompt: number
   completion: number
   /** USD per 1M cached input tokens. If undefined, cache_read is billed at `prompt` rate. */
-  cacheRead?: number
+  cacheRead?: number | undefined
   /** USD per 1M cache-creation tokens. If undefined, cache_write is billed at `prompt` rate. */
-  cacheWrite?: number
+  cacheWrite?: number | undefined
   /**
    * Long-context tier overrides. When `longThreshold` is set and the request's
    * `promptTokens > longThreshold`, calculateCost() swaps in the long* prices
@@ -45,12 +45,14 @@ export interface ModelPrice {
    *
    *   OpenAI GPT-5.x  → longThreshold = 272000 tokens
    *   Gemini Pro 2.5+ → longThreshold = 200000 tokens
+   *
+   * `| undefined` explicit on all optionals because of exactOptionalPropertyTypes.
    */
-  longThreshold?: number
-  longPrompt?: number
-  longCompletion?: number
-  longCacheRead?: number
-  longCacheWrite?: number
+  longThreshold?: number | undefined
+  longPrompt?: number | undefined
+  longCompletion?: number | undefined
+  longCacheRead?: number | undefined
+  longCacheWrite?: number | undefined
 }
 
 // Prices in USD per 1M tokens (verified against provider pricing pages 2026-05-22).
@@ -259,15 +261,20 @@ async function doRefresh(): Promise<void> {
 
   const next: Record<string, ModelPrice> = {}
   for (const row of data) {
-    // Row type is loose because long_* columns may not exist in types.ts yet
-    // (added in migration 20260522010000; types.ts regenerates on next gen).
-    // Guard each access so a stale types.ts doesn't break the refresh.
-    const r = row as Record<string, unknown>
-    next[row.model] = {
-      prompt: Number(row.prompt_price_per_1m),
-      completion: Number(row.completion_price_per_1m),
-      ...(row.cache_read_price_per_1m != null && { cacheRead: Number(row.cache_read_price_per_1m) }),
-      ...(row.cache_write_price_per_1m != null && { cacheWrite: Number(row.cache_write_price_per_1m) }),
+    // Cast row to Record<string, unknown> — supabase types.ts is regenerated
+    // separately from migrations, so columns added by migration
+    // 20260522010000 (long_*) may not exist in the generated types yet at
+    // build time. CI specifically catches this because its types.ts is
+    // pristine. Treat every column as an unknown key access and Number()
+    // the values defensively.
+    const r = row as unknown as Record<string, unknown>
+    const model = r['model'] as string
+    if (!model) continue
+    next[model] = {
+      prompt: Number(r['prompt_price_per_1m']),
+      completion: Number(r['completion_price_per_1m']),
+      ...(r['cache_read_price_per_1m'] != null && { cacheRead: Number(r['cache_read_price_per_1m']) }),
+      ...(r['cache_write_price_per_1m'] != null && { cacheWrite: Number(r['cache_write_price_per_1m']) }),
       ...(r['long_context_threshold_tokens'] != null && {
         longThreshold: Number(r['long_context_threshold_tokens']),
       }),

--- a/apps/server/src/lib/model-prices-cache.ts
+++ b/apps/server/src/lib/model-prices-cache.ts
@@ -37,9 +37,23 @@ export interface ModelPrice {
   cacheRead?: number
   /** USD per 1M cache-creation tokens. If undefined, cache_write is billed at `prompt` rate. */
   cacheWrite?: number
+  /**
+   * Long-context tier overrides. When `longThreshold` is set and the request's
+   * `promptTokens > longThreshold`, calculateCost() swaps in the long* prices
+   * for whichever axes are defined (axes left undefined fall back to the
+   * short-tier values on the same row).
+   *
+   *   OpenAI GPT-5.x  → longThreshold = 272000 tokens
+   *   Gemini Pro 2.5+ → longThreshold = 200000 tokens
+   */
+  longThreshold?: number
+  longPrompt?: number
+  longCompletion?: number
+  longCacheRead?: number
+  longCacheWrite?: number
 }
 
-// Prices in USD per 1M tokens (verified against provider pricing pages 2026-05).
+// Prices in USD per 1M tokens (verified against provider pricing pages 2026-05-22).
 // This map is the COLD-START FALLBACK — used when the DB cache is empty
 // (first request after deploy / DB unreachable). The DB is the source of truth
 // once loaded; this constant exists to guarantee `calculateCost()` always has
@@ -47,31 +61,110 @@ export interface ModelPrice {
 //
 // Cache rates:
 //   • Anthropic — cache_read = 0.1 × input, cache_write (5min) = 1.25 × input
-//   • OpenAI    — cached input ≈ 0.5 × input (gpt-4o / gpt-4.1 families)
+//   • OpenAI    — cached input ≈ 0.5 × input (gpt-4o / gpt-4.1 families; explicit per-model in GPT-5.x)
+//   • Gemini    — caching priced but our integration doesn't surface it yet
+//   • Tiered Gemini models use the ≤200k token band
 export const FALLBACK_PRICES: Record<string, ModelPrice> = {
-  // ── OpenAI ────────────────────────────────────────────────────────────────
-  'gpt-4o':        { prompt: 2.5,  completion: 10,  cacheRead: 1.25 },
-  'gpt-4o-mini':   { prompt: 0.15, completion: 0.6, cacheRead: 0.075 },
-  'gpt-4.1':       { prompt: 2.0,  completion: 8.0, cacheRead: 0.5 },
-  'gpt-4.1-mini':  { prompt: 0.4,  completion: 1.6, cacheRead: 0.1 },
-  'gpt-4.1-nano':  { prompt: 0.1,  completion: 0.4, cacheRead: 0.025 },
-  'gpt-4-turbo':   { prompt: 10,   completion: 30 },
-  'gpt-4':         { prompt: 30,   completion: 60 },
-  'gpt-3.5-turbo': { prompt: 0.5,  completion: 1.5 },
-  // ── Anthropic ────────────────────────────────────────────────────────────
-  'claude-opus-4-7':            { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 },
-  'claude-sonnet-4-6':          { prompt: 3,    completion: 15, cacheRead: 0.3,  cacheWrite: 3.75 },
-  'claude-haiku-4.5':           { prompt: 1,    completion: 5,  cacheRead: 0.1,  cacheWrite: 1.25 },
-  'claude-haiku-4-5':           { prompt: 1,    completion: 5,  cacheRead: 0.1,  cacheWrite: 1.25 },
-  'claude-haiku-4-5-20251001':  { prompt: 1,    completion: 5,  cacheRead: 0.1,  cacheWrite: 1.25 },
-  'claude-3-5-sonnet-20241022': { prompt: 3,    completion: 15, cacheRead: 0.3,  cacheWrite: 3.75 },
-  'claude-3-5-haiku-20241022':  { prompt: 0.8,  completion: 4,  cacheRead: 0.08, cacheWrite: 1.0 },
-  'claude-3-opus-20240229':     { prompt: 15,   completion: 75, cacheRead: 1.5,  cacheWrite: 18.75 },
-  // ── Gemini (caching not yet exposed in our integration) ──────────────────
-  'gemini-2.5-pro':        { prompt: 1.25,  completion: 10 },
-  'gemini-2.5-flash':      { prompt: 0.3,   completion: 2.5 },
-  'gemini-2.5-flash-lite': { prompt: 0.1,   completion: 0.4 },
+  // ── OpenAI: GPT-5.x flagship ─────────────────────────────────────────────
+  // gpt-5.5 / 5.5-pro / 5.4 / 5.4-pro have a long-context tier at ≥272k tokens.
+  'gpt-5.5':           { prompt: 5.0,  completion: 30,  cacheRead: 0.5,
+                         longThreshold: 272000, longPrompt: 10, longCompletion: 45, longCacheRead: 1.0 },
+  'gpt-5.5-pro':       { prompt: 30,   completion: 180,
+                         longThreshold: 272000, longPrompt: 60, longCompletion: 270 },
+  'gpt-5.4':           { prompt: 2.5,  completion: 15,  cacheRead: 0.25,
+                         longThreshold: 272000, longPrompt: 5, longCompletion: 22.5, longCacheRead: 0.5 },
+  'gpt-5.4-mini':      { prompt: 0.75, completion: 4.5, cacheRead: 0.075 },
+  'gpt-5.4-nano':      { prompt: 0.2,  completion: 1.25,cacheRead: 0.02 },
+  'gpt-5.4-pro':       { prompt: 30,   completion: 180,
+                         longThreshold: 272000, longPrompt: 60, longCompletion: 270 },
+  'gpt-5.3-codex':     { prompt: 1.75, completion: 14,  cacheRead: 0.175 },
+  // ── OpenAI: GPT-5 base family (single tier) ──────────────────────────────
+  'gpt-5':         { prompt: 1.25, completion: 10,   cacheRead: 0.125 },
+  'gpt-5.1':       { prompt: 1.25, completion: 10,   cacheRead: 0.125 },
+  'gpt-5.2':       { prompt: 1.75, completion: 14,   cacheRead: 0.175 },
+  'gpt-5.2-pro':   { prompt: 21,   completion: 168 },
+  'gpt-5-mini':    { prompt: 0.25, completion: 2.0,  cacheRead: 0.025 },
+  'gpt-5-nano':    { prompt: 0.05, completion: 0.4,  cacheRead: 0.005 },
+  'gpt-5-pro':     { prompt: 15,   completion: 120 },
+  'chat-latest':   { prompt: 5,    completion: 30,   cacheRead: 0.5 },
+  // ── OpenAI: Reasoning (o-series) ─────────────────────────────────────────
+  'o4-mini':       { prompt: 1.10, completion: 4.4,  cacheRead: 0.275 },
+  'o3':            { prompt: 2.0,  completion: 8.0,  cacheRead: 0.5 },
+  'o3-mini':       { prompt: 1.10, completion: 4.4,  cacheRead: 0.55 },
+  'o3-pro':        { prompt: 20,   completion: 80 },
+  'o1':            { prompt: 15,   completion: 60,   cacheRead: 7.5 },
+  'o1-mini':       { prompt: 1.10, completion: 4.4,  cacheRead: 0.55 },
+  'o1-pro':        { prompt: 150,  completion: 600 },
+  // ── OpenAI: GPT-4.x ──────────────────────────────────────────────────────
+  'gpt-4o':                       { prompt: 2.5,  completion: 10,  cacheRead: 1.25 },
+  'gpt-4o-mini':                  { prompt: 0.15, completion: 0.6, cacheRead: 0.075 },
+  'gpt-4o-2024-05-13':            { prompt: 5,    completion: 15 },
+  'gpt-4.1':                      { prompt: 2.0,  completion: 8.0, cacheRead: 0.5 },
+  'gpt-4.1-mini':                 { prompt: 0.4,  completion: 1.6, cacheRead: 0.1 },
+  'gpt-4.1-nano':                 { prompt: 0.1,  completion: 0.4, cacheRead: 0.025 },
+  'gpt-4-turbo':                  { prompt: 10,   completion: 30 },
+  'gpt-4-turbo-2024-04-09':       { prompt: 10,   completion: 30 },
+  'gpt-4-0125-preview':           { prompt: 10,   completion: 30 },
+  'gpt-4-1106-preview':           { prompt: 10,   completion: 30 },
+  'gpt-4-1106-vision-preview':    { prompt: 10,   completion: 30 },
+  'gpt-4':                        { prompt: 30,   completion: 60 },
+  'gpt-4-0613':                   { prompt: 30,   completion: 60 },
+  'gpt-4-0314':                   { prompt: 30,   completion: 60 },
+  'gpt-4-32k':                    { prompt: 60,   completion: 120 },
+  // ── OpenAI: GPT-3.5 + base models ────────────────────────────────────────
+  'gpt-3.5-turbo':                { prompt: 0.5,  completion: 1.5 },
+  'gpt-3.5-turbo-0125':           { prompt: 0.5,  completion: 1.5 },
+  'gpt-3.5-turbo-1106':           { prompt: 1.0,  completion: 2.0 },
+  'gpt-3.5-turbo-0613':           { prompt: 1.5,  completion: 2.0 },
+  'gpt-3.5-0301':                 { prompt: 1.5,  completion: 2.0 },
+  'gpt-3.5-turbo-instruct':       { prompt: 1.5,  completion: 2.0 },
+  'gpt-3.5-turbo-16k-0613':       { prompt: 3.0,  completion: 4.0 },
+  'davinci-002':                  { prompt: 2.0,  completion: 2.0 },
+  'babbage-002':                  { prompt: 0.4,  completion: 0.4 },
+  // ── Anthropic: Claude 4.x (aliases + dated variants) ─────────────────────
+  'claude-opus-4-7':              { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 },
+  'claude-opus-4-6':              { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 }, // alias only; no dated form per docs
+  'claude-opus-4-5':              { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 },
+  'claude-opus-4-5-20251101':     { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 },
+  'claude-opus-4-1':              { prompt: 15,   completion: 75, cacheRead: 1.5,  cacheWrite: 18.75 },
+  'claude-opus-4-1-20250805':     { prompt: 15,   completion: 75, cacheRead: 1.5,  cacheWrite: 18.75 },
+  'claude-opus-4':                { prompt: 15,   completion: 75, cacheRead: 1.5,  cacheWrite: 18.75 },
+  'claude-opus-4-0':              { prompt: 15,   completion: 75, cacheRead: 1.5,  cacheWrite: 18.75 },
+  'claude-opus-4-20250514':       { prompt: 15,   completion: 75, cacheRead: 1.5,  cacheWrite: 18.75 },
+  'claude-sonnet-4-6':            { prompt: 3,    completion: 15, cacheRead: 0.3,  cacheWrite: 3.75 },
+  'claude-sonnet-4-5':            { prompt: 3,    completion: 15, cacheRead: 0.3,  cacheWrite: 3.75 },
+  'claude-sonnet-4-5-20250929':   { prompt: 3,    completion: 15, cacheRead: 0.3,  cacheWrite: 3.75 },
+  'claude-sonnet-4':              { prompt: 3,    completion: 15, cacheRead: 0.3,  cacheWrite: 3.75 },
+  'claude-sonnet-4-0':            { prompt: 3,    completion: 15, cacheRead: 0.3,  cacheWrite: 3.75 },
+  'claude-sonnet-4-20250514':     { prompt: 3,    completion: 15, cacheRead: 0.3,  cacheWrite: 3.75 },
+  'claude-haiku-4.5':             { prompt: 1,    completion: 5,  cacheRead: 0.1,  cacheWrite: 1.25 },
+  'claude-haiku-4-5':             { prompt: 1,    completion: 5,  cacheRead: 0.1,  cacheWrite: 1.25 },
+  'claude-haiku-4-5-20251001':    { prompt: 1,    completion: 5,  cacheRead: 0.1,  cacheWrite: 1.25 },
+  // ── Anthropic: Claude 3.x ────────────────────────────────────────────────
+  'claude-3-5-sonnet-20241022':   { prompt: 3,    completion: 15, cacheRead: 0.3,  cacheWrite: 3.75 },
+  'claude-3-5-haiku-20241022':    { prompt: 0.8,  completion: 4,  cacheRead: 0.08, cacheWrite: 1.0 },
+  'claude-3-opus-20240229':       { prompt: 15,   completion: 75, cacheRead: 1.5,  cacheWrite: 18.75 },
+  'claude-3-haiku-20240307':      { prompt: 0.25, completion: 1.25 }, // retired 2026-04-19, no cache
+  // ── Gemini 3.x (Pro family has >200k tier) ───────────────────────────────
+  'gemini-3.5-flash':                       { prompt: 1.5,  completion: 9 },
+  'gemini-3.1-pro-preview':                 { prompt: 2.0,  completion: 12,
+                                              longThreshold: 200000, longPrompt: 4, longCompletion: 18 },
+  'gemini-3.1-pro-preview-customtools':     { prompt: 2.0,  completion: 12,
+                                              longThreshold: 200000, longPrompt: 4, longCompletion: 18 },
+  'gemini-3.1-flash-lite':                  { prompt: 0.25, completion: 1.5 },
+  'gemini-3.1-flash-lite-preview':          { prompt: 0.25, completion: 1.5 },
+  'gemini-3-flash-preview':                 { prompt: 0.5,  completion: 3 },
+  // ── Gemini 2.5 (Pro + Computer Use have >200k tier) ──────────────────────
+  'gemini-2.5-pro':                         { prompt: 1.25, completion: 10,
+                                              longThreshold: 200000, longPrompt: 2.5, longCompletion: 15 },
+  'gemini-2.5-flash':                       { prompt: 0.3,  completion: 2.5 },
+  'gemini-2.5-flash-lite':                  { prompt: 0.1,  completion: 0.4 },
+  'gemini-2.5-flash-lite-preview-09-2025':  { prompt: 0.1,  completion: 0.4 },
+  'gemini-2.5-computer-use-preview-10-2025': { prompt: 1.25, completion: 10,
+                                              longThreshold: 200000, longPrompt: 2.5, longCompletion: 15 },
+  // ── Gemini 2.0 / 1.5 ─────────────────────────────────────────────────────
   'gemini-2.0-flash':      { prompt: 0.1,   completion: 0.4 },
+  'gemini-2.0-flash-lite': { prompt: 0.075, completion: 0.3 },
   'gemini-1.5-pro':        { prompt: 1.25,  completion: 5 },
   'gemini-1.5-flash':      { prompt: 0.075, completion: 0.3 },
 }
@@ -150,7 +243,11 @@ function maybeTriggerRefresh(): void {
 async function doRefresh(): Promise<void> {
   const { data, error } = await supabaseAdmin
     .from('model_prices')
-    .select('model, prompt_price_per_1m, completion_price_per_1m, cache_read_price_per_1m, cache_write_price_per_1m')
+    .select(
+      'model, prompt_price_per_1m, completion_price_per_1m, cache_read_price_per_1m, cache_write_price_per_1m,' +
+      ' long_context_threshold_tokens, long_prompt_price_per_1m, long_completion_price_per_1m,' +
+      ' long_cache_read_price_per_1m, long_cache_write_price_per_1m',
+    )
 
   if (error) throw new Error(`model_prices fetch failed: ${error.message}`)
   if (!data || data.length === 0) {
@@ -162,11 +259,30 @@ async function doRefresh(): Promise<void> {
 
   const next: Record<string, ModelPrice> = {}
   for (const row of data) {
+    // Row type is loose because long_* columns may not exist in types.ts yet
+    // (added in migration 20260522010000; types.ts regenerates on next gen).
+    // Guard each access so a stale types.ts doesn't break the refresh.
+    const r = row as Record<string, unknown>
     next[row.model] = {
       prompt: Number(row.prompt_price_per_1m),
       completion: Number(row.completion_price_per_1m),
       ...(row.cache_read_price_per_1m != null && { cacheRead: Number(row.cache_read_price_per_1m) }),
       ...(row.cache_write_price_per_1m != null && { cacheWrite: Number(row.cache_write_price_per_1m) }),
+      ...(r['long_context_threshold_tokens'] != null && {
+        longThreshold: Number(r['long_context_threshold_tokens']),
+      }),
+      ...(r['long_prompt_price_per_1m'] != null && {
+        longPrompt: Number(r['long_prompt_price_per_1m']),
+      }),
+      ...(r['long_completion_price_per_1m'] != null && {
+        longCompletion: Number(r['long_completion_price_per_1m']),
+      }),
+      ...(r['long_cache_read_price_per_1m'] != null && {
+        longCacheRead: Number(r['long_cache_read_price_per_1m']),
+      }),
+      ...(r['long_cache_write_price_per_1m'] != null && {
+        longCacheWrite: Number(r['long_cache_write_price_per_1m']),
+      }),
     }
   }
   // Merge with fallback so any model present in fallback but missing from DB

--- a/apps/server/src/parsers/gemini.ts
+++ b/apps/server/src/parsers/gemini.ts
@@ -1,13 +1,33 @@
-import type { ParsedUsage } from './openai.js'
+import type { ParsedUsage, ServiceTier } from './openai.js'
+
+const KNOWN_TIERS: ReadonlySet<ServiceTier> = new Set([
+  'default', 'auto', 'flex', 'priority', 'scale', 'batch',
+])
+
+/**
+ * Gemini's enum names mostly match OpenAI but the docs aren't fully
+ * normalized — some snapshots use 'GENERATE_CONTENT_PROCESSING_TIER_DEFAULT'
+ * style constants. We accept short and SCREAMING_SNAKE forms.
+ */
+function coerceGeminiTier(value: unknown): ServiceTier | undefined {
+  if (typeof value !== 'string' || value === '') return undefined
+  const lower = value.toLowerCase()
+  // SCREAMING_SNAKE_CASE → suffix lookup ("..._FLEX" → "flex")
+  const tail = lower.split('_').pop() ?? lower
+  if (KNOWN_TIERS.has(tail as ServiceTier)) return tail as ServiceTier
+  if (KNOWN_TIERS.has(lower as ServiceTier)) return lower as ServiceTier
+  return undefined
+}
 
 export function parseGeminiResponse(body: Record<string, unknown>): ParsedUsage | null {
-  const meta = body.usageMetadata as Record<string, number> | undefined
+  const meta = body.usageMetadata as Record<string, unknown> | undefined
   if (!meta) return null
   return {
-    promptTokens: meta.promptTokenCount ?? 0,
-    completionTokens: meta.candidatesTokenCount ?? 0,
-    totalTokens: meta.totalTokenCount ?? 0,
+    promptTokens: (meta.promptTokenCount as number) ?? 0,
+    completionTokens: (meta.candidatesTokenCount as number) ?? 0,
+    totalTokens: (meta.totalTokenCount as number) ?? 0,
     model: (body.modelVersion as string) ?? '',
+    serviceTier: coerceGeminiTier(meta.serviceTier),
   }
 }
 

--- a/apps/server/src/parsers/openai.ts
+++ b/apps/server/src/parsers/openai.ts
@@ -1,3 +1,15 @@
+/**
+ * Provider-reported service tier values we recognize. Stored verbatim in
+ * ClickHouse `requests.service_tier` so the dashboard can group by it. The
+ * cost calculator maps these to multipliers (see lib/cost.ts).
+ *
+ *   OpenAI (`response.service_tier`): 'default' | 'auto' | 'flex' | 'priority' | 'scale'
+ *   Gemini (`response.usageMetadata.serviceTier`): mirrors the OpenAI names
+ *     for the most part; 'default' = Standard, 'flex', 'priority', 'batch'.
+ *   Unknown / missing → undefined; caller logs '' (empty string).
+ */
+export type ServiceTier = 'default' | 'auto' | 'flex' | 'priority' | 'scale' | 'batch'
+
 export interface ParsedUsage {
   /**
    * Total input tokens (INCLUDING any cached portion).
@@ -19,6 +31,23 @@ export interface ParsedUsage {
    * OpenAI: no equivalent in the public API as of 2026-05; always 0/undefined.
    */
   cacheWriteTokens?: number
+  /**
+   * Actual processing tier the provider used to fulfill this request.
+   * IMPORTANT: this is the *served* tier, not what the caller requested —
+   * OpenAI can downgrade a priority request to 'default' on ramp-rate breach,
+   * and that downgrade shows up here. Always trust this over request params.
+   */
+  serviceTier?: ServiceTier
+}
+
+const KNOWN_TIERS: ReadonlySet<ServiceTier> = new Set([
+  'default', 'auto', 'flex', 'priority', 'scale', 'batch',
+])
+
+/** Narrow an unknown string to ServiceTier, dropping anything we don't recognize. */
+function coerceServiceTier(value: unknown): ServiceTier | undefined {
+  if (typeof value !== 'string') return undefined
+  return KNOWN_TIERS.has(value as ServiceTier) ? (value as ServiceTier) : undefined
 }
 
 export function parseOpenAIResponse(body: Record<string, unknown>): ParsedUsage | null {
@@ -33,6 +62,7 @@ export function parseOpenAIResponse(body: Record<string, unknown>): ParsedUsage 
     model: (body.model as string) ?? '',
     cacheReadTokens,
     cacheWriteTokens: 0,
+    serviceTier: coerceServiceTier(body.service_tier),
   }
 }
 
@@ -68,6 +98,7 @@ export function parseOpenAIStreamChunk(line: string): Partial<ParsedUsage> | nul
       model: (json.model as string) ?? '',
       cacheReadTokens: promptDetails?.cached_tokens ?? 0,
       cacheWriteTokens: 0,
+      serviceTier: coerceServiceTier(json.service_tier),
     }
   } catch {
     return null

--- a/apps/server/src/parsers/openai.ts
+++ b/apps/server/src/parsers/openai.ts
@@ -25,19 +25,23 @@ export interface ParsedUsage {
    * OpenAI: `usage.prompt_tokens_details.cached_tokens`.
    * Charged at the reduced cache_read price in lib/cost.ts.
    */
-  cacheReadTokens?: number
+  cacheReadTokens?: number | undefined
   /**
    * Cache-creation input tokens (subset of promptTokens).
    * OpenAI: no equivalent in the public API as of 2026-05; always 0/undefined.
    */
-  cacheWriteTokens?: number
+  cacheWriteTokens?: number | undefined
   /**
    * Actual processing tier the provider used to fulfill this request.
    * IMPORTANT: this is the *served* tier, not what the caller requested —
    * OpenAI can downgrade a priority request to 'default' on ramp-rate breach,
    * and that downgrade shows up here. Always trust this over request params.
+   *
+   * `| undefined` is explicit because the repo uses
+   * `exactOptionalPropertyTypes: true` — a bare `?:` would forbid assigning
+   * `undefined`, only allow omission of the property entirely.
    */
-  serviceTier?: ServiceTier
+  serviceTier?: ServiceTier | undefined
 }
 
 const KNOWN_TIERS: ReadonlySet<ServiceTier> = new Set([

--- a/apps/server/src/proxy/azure.ts
+++ b/apps/server/src/proxy/azure.ts
@@ -206,6 +206,7 @@ azureProxy.all('/*', async (c) => {
   let cacheReadTokens = 0
   let cacheWriteTokens = 0
   let resolvedModel = model
+  let serviceTier: import('../parsers/openai.js').ServiceTier | undefined
 
   if (upstreamRes.ok && resBodyJson) {
     try {
@@ -217,6 +218,7 @@ azureProxy.all('/*', async (c) => {
         totalTokens = parsed.totalTokens
         cacheReadTokens = parsed.cacheReadTokens ?? 0
         cacheWriteTokens = parsed.cacheWriteTokens ?? 0
+        serviceTier = parsed.serviceTier
       }
     } catch { /* ignore */ }
   }
@@ -227,7 +229,7 @@ azureProxy.all('/*', async (c) => {
   // key, lookupPrice() returns null and cost_usd ends up NULL (existing
   // behavior, no regression).
   const cost = calculateCost('openai', resolvedModel, {
-    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens,
+    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
   })
 
   fireAndForget(c, logRequestAsync({
@@ -235,6 +237,7 @@ azureProxy.all('/*', async (c) => {
     model: resolvedModel,
     promptTokens, completionTokens, totalTokens,
     cacheReadTokens, cacheWriteTokens,
+    serviceTier: serviceTier ?? null,
     costUsd: cost?.totalCost ?? null,
     responseBody: resBodyJson,
     errorMessage: upstreamRes.ok ? null : resBodyText.slice(0, 1000),

--- a/apps/server/src/proxy/gemini.ts
+++ b/apps/server/src/proxy/gemini.ts
@@ -169,6 +169,7 @@ geminiProxy.all('/*', async (c) => {
       let promptTokens = 0
       let completionTokens = 0
       let totalTokens = 0
+      let serviceTier: import('../parsers/openai.js').ServiceTier | undefined
       try {
         // Try parsing the joined buffer as a JSON array of partial responses
         const lastChunkText = buffer.trim().replace(/^\[/, '').replace(/\]$/, '')
@@ -181,6 +182,7 @@ geminiProxy.all('/*', async (c) => {
             promptTokens = parsed.promptTokens
             completionTokens = parsed.completionTokens
             totalTokens = parsed.totalTokens
+            serviceTier = parsed.serviceTier
           }
         }
       } catch { /* usage may be missing on aborted streams — acceptable */ }
@@ -195,7 +197,7 @@ geminiProxy.all('/*', async (c) => {
         )
       }
 
-      const cost = calculateCost('gemini', model, { promptTokens, completionTokens })
+      const cost = calculateCost('gemini', model, { promptTokens, completionTokens, serviceTier })
       const responseBody = text ? {
         candidates: [{ content: { parts: [{ text }] } }],
         modelVersion: model,
@@ -212,6 +214,7 @@ geminiProxy.all('/*', async (c) => {
         promptTokens,
         completionTokens,
         totalTokens,
+        serviceTier: serviceTier ?? null,
         costUsd: cost?.totalCost ?? null,
         responseBody,
         truncated,
@@ -230,6 +233,7 @@ geminiProxy.all('/*', async (c) => {
   let promptTokens = 0
   let completionTokens = 0
   let totalTokens = 0
+  let serviceTier: import('../parsers/openai.js').ServiceTier | undefined
 
   if (upstreamRes.ok && resBodyJson) {
     try {
@@ -239,11 +243,12 @@ geminiProxy.all('/*', async (c) => {
         promptTokens = parsed.promptTokens
         completionTokens = parsed.completionTokens
         totalTokens = parsed.totalTokens
+        serviceTier = parsed.serviceTier
       }
     } catch { /* ignore */ }
   }
 
-  const cost = calculateCost('gemini', model, { promptTokens, completionTokens })
+  const cost = calculateCost('gemini', model, { promptTokens, completionTokens, serviceTier })
 
   fireAndForget(c, logRequestAsync({
     ...logBase,
@@ -251,6 +256,7 @@ geminiProxy.all('/*', async (c) => {
     promptTokens,
     completionTokens,
     totalTokens,
+    serviceTier: serviceTier ?? null,
     costUsd: cost?.totalCost ?? null,
     responseBody: resBodyJson,
     errorMessage: upstreamRes.ok ? null : resBodyText.slice(0, 1000),

--- a/apps/server/src/proxy/openai.ts
+++ b/apps/server/src/proxy/openai.ts
@@ -184,6 +184,7 @@ openaiProxy.all('/*', async (c) => {
   let cacheReadTokens = 0
   let cacheWriteTokens = 0
   let resolvedModel = model
+  let serviceTier: import('../parsers/openai.js').ServiceTier | undefined
 
   if (upstreamRes.ok && resBodyJson) {
     try {
@@ -195,12 +196,13 @@ openaiProxy.all('/*', async (c) => {
         totalTokens = parsed.totalTokens
         cacheReadTokens = parsed.cacheReadTokens ?? 0
         cacheWriteTokens = parsed.cacheWriteTokens ?? 0
+        serviceTier = parsed.serviceTier
       }
     } catch { /* ignore */ }
   }
 
   const cost = calculateCost('openai', resolvedModel, {
-    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens,
+    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
   })
 
   fireAndForget(c, logRequestAsync({
@@ -208,6 +210,7 @@ openaiProxy.all('/*', async (c) => {
     model: resolvedModel,
     promptTokens, completionTokens, totalTokens,
     cacheReadTokens, cacheWriteTokens,
+    serviceTier: serviceTier ?? null,
     costUsd: cost?.totalCost ?? null,
     responseBody: resBodyJson,
     errorMessage: upstreamRes.ok ? null : resBodyText.slice(0, 1000),

--- a/apps/server/src/proxy/stream-logger.ts
+++ b/apps/server/src/proxy/stream-logger.ts
@@ -1,7 +1,7 @@
 import { calculateCost, type Provider } from '../lib/cost.js'
 import { logRequestAsync, type RequestLogData } from '../lib/logger.js'
 import { supabaseAdmin } from '../lib/db.js'
-import { parseOpenAIStreamChunk, extractOpenAIStreamText } from '../parsers/openai.js'
+import { parseOpenAIStreamChunk, extractOpenAIStreamText, type ServiceTier } from '../parsers/openai.js'
 import { parseAnthropicStreamStart, parseAnthropicStreamChunk, extractAnthropicStreamText } from '../parsers/anthropic.js'
 
 type StreamLogBase = Omit<
@@ -11,6 +11,7 @@ type StreamLogBase = Omit<
   | 'totalTokens'
   | 'cacheReadTokens'
   | 'cacheWriteTokens'
+  | 'serviceTier'
   | 'costUsd'
   | 'model'
 > & { model: string }
@@ -61,6 +62,7 @@ export async function logOpenAIStream(
   let totalTokens = 0
   let cacheReadTokens = 0
   let cacheWriteTokens = 0
+  let serviceTier: ServiceTier | undefined
 
   for (const line of lines) {
     const parsed = parseOpenAIStreamChunk(line)
@@ -71,10 +73,11 @@ export async function logOpenAIStream(
     if (parsed.totalTokens) totalTokens = parsed.totalTokens
     if (parsed.cacheReadTokens) cacheReadTokens = parsed.cacheReadTokens
     if (parsed.cacheWriteTokens) cacheWriteTokens = parsed.cacheWriteTokens
+    if (parsed.serviceTier) serviceTier = parsed.serviceTier
   }
 
   const cost = calculateCost('openai' as Provider, model, {
-    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens,
+    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
   })
 
   const text = extractOpenAIStreamText(lines)
@@ -107,6 +110,7 @@ export async function logOpenAIStream(
     totalTokens,
     cacheReadTokens,
     cacheWriteTokens,
+    serviceTier: serviceTier ?? null,
     costUsd: cost?.totalCost ?? null,
     responseBody,
     truncated: ctx.truncated ?? false,

--- a/apps/web/app/demo/alerts/[id]/page.tsx
+++ b/apps/web/app/demo/alerts/[id]/page.tsx
@@ -1,0 +1,253 @@
+'use client'
+import { use, useState } from 'react'
+import Link from 'next/link'
+import { ArrowLeft, Trash2 } from 'lucide-react'
+import { DEMO_ALERTS, DEMO_CHANNELS, DEMO_DELIVERIES } from '@/lib/demo-data'
+import type { AlertType } from '@/lib/queries/types'
+import { Topbar } from '@/components/layout/topbar'
+import { cn, formatDateTime } from '@/lib/utils'
+
+function fmtThreshold(type: AlertType, threshold: number): string {
+  if (type === 'budget') return `$${threshold}`
+  if (type === 'error_rate') return `${(threshold * 100).toFixed(1)}%`
+  return `${threshold}ms`
+}
+
+function kindLabel(type: AlertType): string {
+  if (type === 'budget') return 'BUDGET'
+  if (type === 'error_rate') return 'ERROR RATE'
+  return 'P95 LATENCY'
+}
+
+function isRecentlyFired(iso: string | null): boolean {
+  if (!iso) return false
+  return Date.now() - new Date(iso).getTime() < 60 * 60 * 1000
+}
+
+function relTime(iso: string | null): string {
+  if (!iso) return 'never'
+  const s = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
+  if (s < 60) return `${s}s ago`
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`
+  return `${Math.floor(s / 86400)}d ago`
+}
+
+export default function DemoAlertDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params)
+  // Stable "now" for the 24h delivery bucket. Demo data has fixed timestamps,
+  // so re-evaluating on every render isn't useful.
+  const [mountNow] = useState(() => Date.now())
+
+  const alert = DEMO_ALERTS.find((a) => a.id === id)
+  const channels = DEMO_CHANNELS
+  const deliveries = DEMO_DELIVERIES.filter((d) => d.alert_id === id)
+  const channelById = new Map(channels.map((c) => [c.id, { kind: c.kind, target: c.target }]))
+
+  if (!alert) {
+    return (
+      <div className="-mx-4 -my-4 md:-mx-8 md:-my-7 flex flex-col h-screen overflow-hidden bg-bg">
+        <Topbar
+          crumbs={[
+            { label: 'Demo', href: '/demo/dashboard' },
+            { label: 'Alerts', href: '/demo/alerts' },
+            { label: 'Not found' },
+          ]}
+        />
+        <div className="flex flex-col items-center justify-center flex-1 gap-3 text-text-muted">
+          <p className="text-[13px]">Alert rule not found.</p>
+          <Link href="/demo/alerts" className="font-mono text-[12px] text-accent hover:opacity-80 transition-opacity">
+            ← Back to all alerts
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  const firing = alert.is_active && isRecentlyFired(alert.last_triggered_at)
+  const fires24h = deliveries.filter(
+    (d) => mountNow - new Date(d.created_at).getTime() < 24 * 60 * 60 * 1000,
+  ).length
+  const sent = deliveries.filter((d) => d.status === 'sent').length
+  const failed = deliveries.filter((d) => d.status === 'failed').length
+
+  return (
+    <div className="-mx-4 -my-4 md:-mx-8 md:-my-7 flex flex-col h-screen overflow-hidden bg-bg">
+      <Topbar
+        crumbs={[
+          { label: 'Demo', href: '/demo/dashboard' },
+          { label: 'Alerts', href: '/demo/alerts' },
+          { label: alert.name },
+        ]}
+        right={
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              disabled
+              title="Disabled in demo"
+              className="font-mono text-[11px] text-text-muted px-[10px] py-[5px] border border-border rounded-[5px] bg-bg-elev opacity-60 cursor-not-allowed"
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              disabled
+              title="Disabled in demo"
+              className="font-mono text-[11px] text-text-muted px-[10px] py-[5px] border border-border rounded-[5px] bg-bg-elev opacity-60 cursor-not-allowed"
+            >
+              {alert.is_active ? 'Pause' : 'Resume'}
+            </button>
+            <button
+              type="button"
+              disabled
+              title="Disabled in demo"
+              className="p-2 text-text-faint opacity-60 cursor-not-allowed"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        }
+      />
+
+      <div className="flex-1 overflow-auto">
+        <div className="px-[22px] py-6 max-w-4xl">
+          <Link
+            href="/demo/alerts"
+            className="inline-flex items-center gap-1 font-mono text-[11px] text-text-muted hover:text-text transition-colors mb-4"
+          >
+            <ArrowLeft className="h-3 w-3" /> All alerts
+          </Link>
+
+          <div className="flex items-center gap-3 mb-1">
+            <span
+              className={cn(
+                'w-2.5 h-2.5 rounded-full',
+                firing ? 'bg-accent animate-pulse' : alert.is_active ? 'bg-good' : 'bg-text-faint',
+              )}
+            />
+            <h1 className="text-[22px] font-semibold text-text tracking-[-0.4px]">{alert.name}</h1>
+            <span className="font-mono text-[9px] px-[6px] py-[1px] rounded-[3px] border uppercase tracking-[0.04em] text-text-muted border-border">
+              {kindLabel(alert.type)}
+            </span>
+          </div>
+          <p className="text-[13px] text-text-muted mb-6 ml-[22px]">
+            {firing
+              ? 'Firing right now.'
+              : alert.is_active
+                ? 'Active · watching for threshold breach.'
+                : 'Paused · no evaluation.'}
+          </p>
+
+          <div className="border border-border rounded-xl bg-bg-elev p-5 mb-5 grid grid-cols-4 gap-4">
+            {[
+              { label: 'Threshold', value: fmtThreshold(alert.type, alert.threshold) },
+              { label: 'Window', value: `${alert.window_minutes} min` },
+              { label: 'Cooldown', value: `${alert.cooldown_minutes} min` },
+              { label: 'Last fired', value: relTime(alert.last_triggered_at) },
+            ].map((s) => (
+              <div key={s.label}>
+                <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-1.5">
+                  {s.label}
+                </div>
+                <div
+                  suppressHydrationWarning
+                  className={cn(
+                    'font-mono text-[16px] font-medium tracking-[-0.2px]',
+                    s.label === 'Last fired' && firing ? 'text-accent' : 'text-text',
+                  )}
+                >
+                  {s.value}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="border border-border rounded-xl bg-bg-elev px-5 py-4 mb-5">
+            <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-2">Trigger</div>
+            <code className="font-mono text-[13px] text-text">
+              {alert.type === 'budget'
+                ? 'sum(cost)'
+                : alert.type === 'error_rate'
+                  ? 'error_rate'
+                  : 'p95(latency)'}{' '}
+              &gt; {fmtThreshold(alert.type, alert.threshold)} for {alert.window_minutes}m
+            </code>
+            <p className="text-[12px] text-text-muted mt-2 leading-relaxed">
+              Evaluated every ~5 minutes by the <code className="font-mono text-text">cron-evaluate-alerts</code> job.
+              After firing, re-alerts are suppressed for {alert.cooldown_minutes} minutes.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-3 gap-3 mb-5">
+            {[
+              { label: 'Deliveries · 24h', value: String(fires24h), warn: fires24h > 0 },
+              { label: 'Sent · lifetime', value: String(sent), warn: false },
+              { label: 'Failed · lifetime', value: String(failed), warn: failed > 0 },
+            ].map((s) => (
+              <div key={s.label} className="border border-border rounded-lg bg-bg-elev p-4">
+                <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-2">
+                  {s.label}
+                </div>
+                <div className={cn('text-[22px] font-medium tracking-[-0.3px]', s.warn ? 'text-accent' : 'text-text')}>
+                  {s.value}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div>
+            <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-3">
+              Delivery history
+            </div>
+            {deliveries.length === 0 ? (
+              <div className="rounded-md border border-dashed border-border bg-bg-elev px-4 py-6 text-center font-mono text-[12px] text-text-muted">
+                This rule has never fired yet. When the threshold is breached, deliveries will appear here.
+              </div>
+            ) : (
+              <div className="rounded-[6px] border border-border overflow-hidden divide-y divide-border">
+                <div className="grid grid-cols-[150px_90px_1fr_1fr] gap-4 px-4 py-2.5 bg-bg-muted font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+                  <span>When</span>
+                  <span>Status</span>
+                  <span>Channel</span>
+                  <span>Error</span>
+                </div>
+                {deliveries.slice(0, 50).map((d) => {
+                  const ch = channelById.get(d.channel_id)
+                  return (
+                    <div
+                      key={d.id}
+                      className="grid grid-cols-[150px_90px_1fr_1fr] gap-4 px-4 py-2.5 items-center text-[11.5px]"
+                    >
+                      <span className="font-mono text-text-muted" suppressHydrationWarning>
+                        {formatDateTime(d.created_at)}
+                      </span>
+                      <span
+                        className={cn(
+                          'font-mono text-[10px] uppercase tracking-[0.04em] px-1.5 py-0.5 rounded w-fit',
+                          d.status === 'sent' ? 'bg-good/10 text-good' : 'bg-bad/10 text-bad',
+                        )}
+                      >
+                        ● {d.status}
+                      </span>
+                      <span className="font-mono text-[11px] text-text-muted truncate">
+                        {ch ? (
+                          <>
+                            <span className="text-text uppercase tracking-[0.04em] text-[10px] mr-1.5">{ch.kind}</span>
+                            {ch.target}
+                          </>
+                        ) : (
+                          <span className="text-text-faint">channel deleted</span>
+                        )}
+                      </span>
+                      <span className="font-mono text-[11px] text-bad truncate">{d.error_message ?? ''}</span>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/demo/alerts/page.tsx
+++ b/apps/web/app/demo/alerts/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState } from 'react'
+import Link from 'next/link'
 import { Mail, MessageSquare } from 'lucide-react'
 import { DEMO_ALERTS, DEMO_CHANNELS, DEMO_DELIVERIES } from '@/lib/demo-data'
 import type { AlertRow } from '@/lib/queries/types'
@@ -40,11 +41,12 @@ function AlertRuleRow({ a, last }: { a: AlertRow; last: boolean }) {
   const fires = alertFires(a.id)
 
   return (
-    <div
+    <Link
+      href={`/demo/alerts/${a.id}`}
       className={cn(
-        'grid items-center px-[22px] py-[12px]',
+        'grid items-center px-[22px] py-[12px] transition-colors hover:bg-bg-muted/40',
         !last && 'border-b border-border',
-        isFiring && 'bg-accent-bg',
+        isFiring && 'bg-accent-bg hover:bg-accent-bg/80',
       )}
       style={{ gridTemplateColumns: '28px 1fr 160px 60px 200px', gap: 14 }}
     >
@@ -115,24 +117,28 @@ function AlertRuleRow({ a, last }: { a: AlertRow; last: boolean }) {
         <div className="font-mono text-[10px] text-text-faint">fires</div>
       </div>
 
-      {/* actions (demo: disabled) */}
+      {/* actions (demo: disabled, also stop link nav) */}
       <div className="flex items-center justify-end gap-1.5">
         <button
           type="button"
-          onClick={() => alert('Sign up to edit alerts')}
-          className="font-mono text-[10.5px] text-text-muted px-2 py-[3px] border border-border rounded-[4px] hover:text-text transition-colors"
+          disabled
+          title="Disabled in demo"
+          onClick={(e) => { e.preventDefault(); e.stopPropagation() }}
+          className="font-mono text-[10.5px] text-text-muted px-2 py-[3px] border border-border rounded-[4px] opacity-60 cursor-not-allowed"
         >
           Edit
         </button>
         <button
           type="button"
-          onClick={() => alert('Sign up to manage alerts')}
-          className="font-mono text-[10.5px] text-text-muted px-2 py-[3px] border border-border rounded-[4px] hover:text-text transition-colors"
+          disabled
+          title="Disabled in demo"
+          onClick={(e) => { e.preventDefault(); e.stopPropagation() }}
+          className="font-mono text-[10.5px] text-text-muted px-2 py-[3px] border border-border rounded-[4px] opacity-60 cursor-not-allowed"
         >
           {a.is_active ? 'Pause' : 'Resume'}
         </button>
       </div>
-    </div>
+    </Link>
   )
 }
 

--- a/apps/web/app/demo/billing/page.tsx
+++ b/apps/web/app/demo/billing/page.tsx
@@ -1,0 +1,129 @@
+'use client'
+import { Check } from 'lucide-react'
+import { Topbar } from '@/components/layout/topbar'
+import { cn } from '@/lib/utils'
+import { PLANS } from '@/lib/billing-plans'
+
+export default function DemoBillingPage() {
+  const currentPlan = 'free'
+
+  return (
+    <div className="-mx-4 -my-4 md:-mx-8 md:-my-7 flex flex-col h-screen overflow-hidden">
+      <Topbar crumbs={[{ label: 'Demo', href: '/demo/dashboard' }, { label: 'Billing' }]} />
+
+      <div className="flex-1 overflow-y-auto">
+        <div className="px-4 py-4 md:px-7 md:py-6 max-w-4xl">
+          <div className="mb-6">
+            <h1 className="text-[22px] font-semibold text-text tracking-[-0.4px] mb-1">Billing</h1>
+            <p className="text-[13px] text-text-muted">Manage your subscription and plan</p>
+          </div>
+
+          {/* Quota banner */}
+          <div className="rounded-xl border border-border bg-bg-elev p-4 mb-6">
+            <div className="flex items-center justify-between mb-2">
+              <div>
+                <div className="text-[13px] font-medium text-text">2,400 of 50,000 requests this month</div>
+                <div className="text-[11.5px] text-text-faint mt-0.5">Resets on 2026-06-01 · Free plan</div>
+              </div>
+              <span className="font-mono text-[10px] uppercase tracking-[0.04em] px-2 py-0.5 rounded-full border border-good/20 bg-good-bg text-good">
+                4.8% used
+              </span>
+            </div>
+            <div className="h-1.5 rounded-full bg-bg overflow-hidden">
+              <div className="h-full rounded-full bg-text transition-all" style={{ width: '4.8%' }} />
+            </div>
+          </div>
+
+          {/* Current subscription */}
+          <div className="rounded-xl border border-border bg-bg-elev p-5 mb-6">
+            <div className="flex items-start justify-between gap-3 flex-wrap">
+              <div>
+                <h2 className="text-[15px] font-semibold text-text mb-1">Free plan</h2>
+                <p className="text-[13px] text-text-muted">
+                  50,000 requests / month · 14-day log retention · 1 seat
+                </p>
+              </div>
+              <span className="font-mono text-[10px] uppercase tracking-[0.04em] px-2 py-0.5 rounded-full border border-border bg-bg-elev text-text-muted">
+                Free
+              </span>
+            </div>
+          </div>
+
+          {/* Plan cards */}
+          <h2 className="text-[14px] font-semibold text-text mb-4">Available plans</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-4">
+            {PLANS.map((plan) => {
+              const isCurrent = currentPlan === plan.id
+              return (
+                <div
+                  key={plan.id}
+                  className={cn(
+                    'rounded-xl border p-5 flex flex-col min-h-[280px]',
+                    isCurrent ? 'border-accent bg-accent-bg' : 'border-border bg-bg-elev',
+                  )}
+                >
+                  <div className="flex items-start justify-between mb-3">
+                    <span className="text-[15px] font-medium text-text">{plan.name}</span>
+                    {isCurrent && (
+                      <span className="font-mono text-[10px] uppercase tracking-[0.04em] px-1.5 py-0.5 rounded-full border border-accent-border bg-accent-bg text-accent">
+                        Current
+                      </span>
+                    )}
+                  </div>
+
+                  <div className="mb-3">
+                    {plan.priceUsd !== null ? (
+                      <div className="flex items-baseline gap-1">
+                        <span className="font-mono text-[24px] font-medium tracking-[-0.4px] text-text">
+                          ${plan.priceUsd}
+                        </span>
+                        <span className="font-mono text-[11px] text-text-muted">/ {plan.pricePeriod}</span>
+                      </div>
+                    ) : (
+                      <div className="font-mono text-[22px] font-medium text-text">Custom</div>
+                    )}
+                  </div>
+
+                  <p className="text-[12px] text-text-muted mb-4 leading-relaxed">{plan.description}</p>
+
+                  <ul className="space-y-1.5 mb-5 flex-1">
+                    {plan.features.map((f) => (
+                      <li key={f} className="flex items-start gap-2 font-mono text-[10.5px] text-text-muted">
+                        <Check className="h-3 w-3 mt-0.5 text-good shrink-0" />
+                        <span>{f}</span>
+                      </li>
+                    ))}
+                  </ul>
+
+                  <div>
+                    <button
+                      type="button"
+                      disabled
+                      title="Disabled in demo"
+                      className={cn(
+                        'w-full h-8 rounded-[6px] text-[12.5px] font-medium cursor-not-allowed',
+                        plan.id === 'free'
+                          ? 'border border-border bg-bg text-text-faint'
+                          : 'bg-text text-bg opacity-60',
+                      )}
+                    >
+                      {plan.id === 'free'
+                        ? 'Default'
+                        : plan.id === 'enterprise'
+                          ? 'Contact sales'
+                          : `Upgrade to ${plan.name}`}
+                    </button>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+
+          <p className="font-mono text-[11px] text-text-faint">
+            Payments processed securely by Paddle. VAT / sales tax included where applicable.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/demo/datasets/[id]/page.tsx
+++ b/apps/web/app/demo/datasets/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { use, useState } from 'react'
 import Link from 'next/link'
 import { Plus, Trash2 } from 'lucide-react'
 import { Topbar } from '@/components/layout/topbar'
@@ -55,8 +55,8 @@ function ItemRow({ item }: { item: DatasetItem }) {
   )
 }
 
-export default function DemoDatasetDetail({ params }: { params: { id: string } }) {
-  const { id } = params
+export default function DemoDatasetDetail({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params)
   const ds = DEMO_DATASET_DETAILS[id]
 
   if (!ds) {

--- a/apps/web/app/demo/experiments/[id]/page.tsx
+++ b/apps/web/app/demo/experiments/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { use, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { ChevronDown, ChevronUp, Loader2 } from 'lucide-react'
 import { Topbar } from '@/components/layout/topbar'
@@ -114,8 +114,8 @@ function ResultRow({ result, idx }: { result: ExperimentResult; idx: number }) {
   )
 }
 
-export default function DemoExperimentDetail({ params }: { params: { id: string } }) {
-  const { id } = params
+export default function DemoExperimentDetail({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params)
   const exp = DEMO_EXPERIMENTS.find((e) => e.id === id)
   const results = DEMO_EXPERIMENT_RESULTS[id] ?? []
 

--- a/apps/web/app/demo/projects/page.tsx
+++ b/apps/web/app/demo/projects/page.tsx
@@ -1,0 +1,265 @@
+'use client'
+import Link from 'next/link'
+import { Plus, Terminal, ExternalLink, Pencil, Trash2, Key as KeyIcon } from 'lucide-react'
+import { Topbar } from '@/components/layout/topbar'
+import { cn } from '@/lib/utils'
+
+type DemoProvKey = {
+  id: string
+  name: string
+  provider: 'openai' | 'anthropic' | 'gemini' | 'azure'
+  is_active: boolean
+}
+
+type DemoApiKey = {
+  id: string
+  name: string
+  key_prefix: string
+  is_active: boolean
+  last_used_days_ago: number | null
+  provider_keys: DemoProvKey[]
+}
+
+type DemoProject = {
+  id: string
+  name: string
+  api_keys: DemoApiKey[]
+}
+
+const DEMO_PROJECTS: DemoProject[] = [
+  {
+    id: 'prj_01HZX9N8K3F2T7V6Q5R4S3D2W1',
+    name: 'Production',
+    api_keys: [
+      {
+        id: 'apk_01HZX9N8K3F2T7V6Q5R4S3D2W1',
+        name: 'web-frontend',
+        key_prefix: 'sl_live_8a3f',
+        is_active: true,
+        last_used_days_ago: 0,
+        provider_keys: [
+          { id: 'pk-1', name: 'OpenAI prod', provider: 'openai', is_active: true },
+          { id: 'pk-2', name: 'Anthropic prod', provider: 'anthropic', is_active: true },
+        ],
+      },
+      {
+        id: 'apk_01HZX9P2L4G3U8W7R6S5T4E3X2',
+        name: 'support-bot',
+        key_prefix: 'sl_live_b4d1',
+        is_active: true,
+        last_used_days_ago: 2,
+        provider_keys: [
+          { id: 'pk-3', name: 'OpenAI prod', provider: 'openai', is_active: true },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'prj_01HZXA1Z9M5H4V8X7S6T5F4G3Y2',
+    name: 'Staging',
+    api_keys: [
+      {
+        id: 'apk_01HZXA1Z9M5H4V8X7S6T5F4G3Y3',
+        name: 'staging-key',
+        key_prefix: 'sl_live_c5e2',
+        is_active: true,
+        last_used_days_ago: 5,
+        provider_keys: [
+          { id: 'pk-4', name: 'OpenAI staging', provider: 'openai', is_active: true },
+          { id: 'pk-5', name: 'Gemini staging', provider: 'gemini', is_active: false },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'prj_01HZXB4N7P6J5W9Y8T7U6G5H4I3',
+    name: 'Internal Tools',
+    api_keys: [],
+  },
+]
+
+export default function DemoProjectsPage() {
+  return (
+    <div className="-mx-4 -my-4 md:-mx-8 md:-my-7 flex flex-col h-screen overflow-hidden">
+      <Topbar
+        crumbs={[{ label: 'Demo', href: '/demo/dashboard' }, { label: 'Projects' }]}
+        right={
+          <button
+            type="button"
+            disabled
+            className="flex items-center gap-1.5 text-[12.5px] px-3 py-[5px] rounded-[5px] border border-border bg-bg-elev text-text-muted opacity-60 cursor-not-allowed"
+            title="Disabled in demo"
+          >
+            <Plus className="h-3.5 w-3.5" /> New project
+          </button>
+        }
+      />
+
+      <div className="flex-1 overflow-y-auto">
+        <div className="px-7 py-6 max-w-4xl">
+          <div className="mb-6">
+            <h1 className="text-[22px] font-semibold text-text tracking-[-0.4px] mb-1">Projects & Keys</h1>
+            <p className="text-[13px] text-text-muted">
+              Each Spanlens key holds its own AI provider keys. Expand a key to see and add OpenAI / Anthropic / Gemini keys it can call.
+            </p>
+          </div>
+
+          {/* Integration hint */}
+          <div className="rounded-lg border border-border bg-bg-elev px-4 py-3 mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3 text-[13px] text-text-muted">
+              <Terminal className="h-4 w-4 shrink-0 text-text-faint" />
+              <span>
+                Quick integrate:{' '}
+                <code className="font-mono text-[12px] bg-bg border border-border px-1.5 py-0.5 rounded-[4px]">
+                  npx @spanlens/cli init
+                </code>
+              </span>
+            </div>
+            <Link
+              href="/docs/quick-start"
+              className="text-[12.5px] text-accent hover:opacity-80 transition-opacity shrink-0 inline-flex items-center gap-0.5"
+            >
+              Full guide <ExternalLink className="h-3 w-3" />
+            </Link>
+          </div>
+
+          <div className="space-y-6">
+            {DEMO_PROJECTS.map((proj) => (
+              <div key={proj.id} className="rounded-xl border border-border bg-bg-elev overflow-hidden">
+                {/* Project header */}
+                <div className="flex items-center justify-between px-6 py-4 border-b border-border bg-bg">
+                  <div>
+                    <h2 className="text-[14px] font-semibold text-text">{proj.name}</h2>
+                    <p className="font-mono text-[10.5px] text-text-faint mt-0.5">{proj.id}</p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      disabled
+                      className="flex items-center gap-1.5 text-[12px] px-3 py-[5px] h-[28px] rounded-[5px] bg-text text-bg font-medium opacity-60 cursor-not-allowed"
+                      title="Disabled in demo"
+                    >
+                      <Plus className="h-3.5 w-3.5" /> New Spanlens key
+                    </button>
+                    <button
+                      type="button"
+                      disabled
+                      title="Disabled in demo"
+                      className="p-1.5 rounded text-text-faint opacity-60 cursor-not-allowed"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+
+                {/* Spanlens keys */}
+                {proj.api_keys.length === 0 ? (
+                  <p className="px-6 py-5 text-[13px] text-text-faint">No Spanlens keys yet. Create one to start.</p>
+                ) : (
+                  <div className="divide-y divide-border">
+                    {proj.api_keys.map((key) => (
+                      <div key={key.id}>
+                        <div className="flex items-center gap-3 px-6 py-3 bg-bg/30">
+                          <KeyIcon className="h-3.5 w-3.5 text-text-faint shrink-0" />
+                          <div className="flex-1 min-w-0">
+                            <div className={cn('text-[13.5px] font-semibold truncate', !key.is_active && 'line-through text-text-faint')}>
+                              {key.name}
+                            </div>
+                            <div className="font-mono text-[10.5px] text-text-faint mt-0.5">
+                              {key.key_prefix}…
+                              <span className="ml-2">
+                                {key.last_used_days_ago == null
+                                  ? '· never used'
+                                  : key.last_used_days_ago === 0
+                                    ? '· last used today'
+                                    : `· last used ${key.last_used_days_ago}d ago`}
+                              </span>
+                            </div>
+                          </div>
+                          <button
+                            type="button"
+                            disabled
+                            className="flex items-center gap-1.5 text-[12px] px-3 py-[5px] h-[28px] shrink-0 rounded-[5px] border border-border bg-bg-elev text-text-muted opacity-60 cursor-not-allowed"
+                            title="Disabled in demo"
+                          >
+                            <Plus className="h-3.5 w-3.5" /> Add provider key
+                          </button>
+                          <div className="flex items-center gap-1 shrink-0">
+                            <button
+                              type="button"
+                              role="switch"
+                              aria-checked={key.is_active}
+                              disabled
+                              title="Disabled in demo"
+                              className={cn(
+                                'relative inline-flex h-5 w-9 items-center rounded-full transition-colors opacity-70 cursor-not-allowed',
+                                key.is_active ? 'bg-good' : 'bg-border-strong',
+                              )}
+                            >
+                              <span
+                                className={cn(
+                                  'inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform',
+                                  key.is_active ? 'translate-x-[18px]' : 'translate-x-[3px]',
+                                )}
+                              />
+                            </button>
+                            <button
+                              type="button"
+                              disabled
+                              title="Disabled in demo"
+                              className="p-1.5 rounded text-text-faint opacity-60 cursor-not-allowed"
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </button>
+                          </div>
+                        </div>
+
+                        {/* Provider keys */}
+                        {key.provider_keys.length === 0 ? (
+                          <p className="px-12 py-2.5 text-[12px] text-text-faint">
+                            No provider keys yet. Add OpenAI / Anthropic / Gemini to enable calls through this Spanlens key.
+                          </p>
+                        ) : (
+                          <div>
+                            {key.provider_keys.map((pk) => (
+                              <div key={pk.id} className="grid grid-cols-[1fr_100px_60px] gap-4 px-12 py-2 items-center">
+                                <span className={cn('text-[12.5px] truncate', !pk.is_active && 'line-through text-text-faint')}>
+                                  {pk.name}
+                                </span>
+                                <span className="font-mono text-[10px] uppercase tracking-[0.04em] px-1.5 py-0.5 rounded-full border border-border text-text-muted w-fit">
+                                  {pk.provider}
+                                </span>
+                                <div className="flex items-center gap-1 justify-end">
+                                  <button
+                                    type="button"
+                                    disabled
+                                    title="Disabled in demo"
+                                    className="p-1 rounded text-text-faint opacity-60 cursor-not-allowed"
+                                  >
+                                    <Pencil className="h-3 w-3" />
+                                  </button>
+                                  <button
+                                    type="button"
+                                    disabled
+                                    title="Disabled in demo"
+                                    className="p-1 rounded text-text-faint opacity-60 cursor-not-allowed"
+                                  >
+                                    <Trash2 className="h-3 w-3" />
+                                  </button>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/demo/prompts/[name]/page.tsx
+++ b/apps/web/app/demo/prompts/[name]/page.tsx
@@ -1,19 +1,20 @@
 'use client'
-import { useState } from 'react'
+import { use, useState } from 'react'
 import Link from 'next/link'
-import { ArrowLeft, FlaskConical, GitCommit, ArrowLeftRight, BarChart2, Phone } from 'lucide-react'
+import { ArrowLeft, FlaskConical, GitCommit, ArrowLeftRight, BarChart2, Phone, Play, CheckCircle2, Key } from 'lucide-react'
 import { DEMO_PROMPTS, DEMO_REQUESTS } from '@/lib/demo-data'
 import { Topbar } from '@/components/layout/topbar'
 import { cn } from '@/lib/utils'
 
-type Tab = 'versions' | 'calls' | 'traffic' | 'ab' | 'diff'
+type Tab = 'versions' | 'calls' | 'traffic' | 'ab' | 'diff' | 'playground'
 
 const TABS: { id: Tab; label: string; icon: React.ReactNode }[] = [
-  { id: 'versions', label: 'Versions',  icon: <GitCommit className="h-3.5 w-3.5" /> },
-  { id: 'diff',     label: 'Diff',      icon: <ArrowLeftRight className="h-3.5 w-3.5" /> },
-  { id: 'traffic',  label: 'Traffic',   icon: <BarChart2 className="h-3.5 w-3.5" /> },
-  { id: 'calls',    label: 'Calls',     icon: <Phone className="h-3.5 w-3.5" /> },
-  { id: 'ab',       label: 'A/B',       icon: <FlaskConical className="h-3.5 w-3.5" /> },
+  { id: 'versions',   label: 'Versions',   icon: <GitCommit className="h-3.5 w-3.5" /> },
+  { id: 'diff',       label: 'Diff',       icon: <ArrowLeftRight className="h-3.5 w-3.5" /> },
+  { id: 'traffic',    label: 'Traffic',    icon: <BarChart2 className="h-3.5 w-3.5" /> },
+  { id: 'calls',      label: 'Calls',      icon: <Phone className="h-3.5 w-3.5" /> },
+  { id: 'playground', label: 'Playground', icon: <Play className="h-3.5 w-3.5" /> },
+  { id: 'ab',         label: 'A/B',        icon: <FlaskConical className="h-3.5 w-3.5" /> },
 ]
 
 function fmtUsd(v: number): string {
@@ -365,14 +366,245 @@ function DiffTab({ prompt }: { prompt: (typeof DEMO_PROMPTS)[number] }) {
   )
 }
 
+// ── Playground Tab ────────────────────────────────────────────────────────────
+
+const DEMO_PROVIDER_KEYS = [
+  { id: 'pk-1', name: 'OpenAI prod',    provider: 'openai',    label: 'OpenAI' },
+  { id: 'pk-2', name: 'Anthropic prod', provider: 'anthropic', label: 'Anthropic' },
+  { id: 'pk-4', name: 'OpenAI staging', provider: 'openai',    label: 'OpenAI' },
+]
+
+const DEMO_MODELS_BY_PROVIDER: Record<string, string[]> = {
+  openai: ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo'],
+  anthropic: ['claude-sonnet-4-6', 'claude-opus-4-5', 'claude-3-5-haiku-20241022'],
+  gemini: ['gemini-2.0-flash', 'gemini-1.5-pro'],
+}
+
+const VAR_RE = /\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g
+
+function extractVars(content: string): string[] {
+  const names = new Set<string>()
+  for (const match of content.matchAll(VAR_RE)) {
+    names.add(match[1]!)
+  }
+  return [...names]
+}
+
+function PlaygroundTab({ prompt }: { prompt: (typeof DEMO_PROMPTS)[number] }) {
+  const [selectedKeyId, setSelectedKeyId] = useState(DEMO_PROVIDER_KEYS[0]?.id ?? '')
+  const [model, setModel] = useState('claude-sonnet-4-6')
+  const [temperature, setTemperature] = useState(0.7)
+  const [maxTokens, setMaxTokens] = useState(1024)
+  const [variables, setVariables] = useState<Record<string, string>>({})
+  const [showResult, setShowResult] = useState(true)
+
+  const selectedKey = DEMO_PROVIDER_KEYS.find((k) => k.id === selectedKeyId) ?? null
+  const availableModels = selectedKey ? (DEMO_MODELS_BY_PROVIDER[selectedKey.provider] ?? []) : []
+  const detectedVars = extractVars(prompt.content)
+
+  // Static "demo" result — wired up to look like a real run completed.
+  const demoResult = {
+    model: model || 'claude-sonnet-4-6',
+    promptTokens: 142,
+    completionTokens: 187,
+    totalTokens: 329,
+    costUsd: 0.00428,
+    latencyMs: 1248,
+    responseText:
+      "Thanks for reaching out! I understand you're experiencing an issue with your account.\n\nLet me take a look — based on what you described, I'd recommend the following steps:\n\n1. Verify your email address on file\n2. Reset your password from the login page\n3. Clear your browser cache and try again\n\nIf the problem persists, I can escalate to our technical team. Just let me know!",
+  }
+
+  return (
+    <div className="flex h-full min-h-0">
+      {/* Config panel */}
+      <div className="w-[320px] shrink-0 border-r border-border overflow-y-auto p-[18px] space-y-5">
+        <div className="space-y-1.5">
+          <label className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint">Version</label>
+          <select
+            value={`v${prompt.version}`}
+            disabled
+            className="w-full h-8 px-2 rounded-[4px] border border-border bg-bg font-mono text-[12px] text-text-muted opacity-80 cursor-not-allowed"
+          >
+            <option>v{prompt.version} (latest)</option>
+          </select>
+        </div>
+
+        <div className="space-y-1.5">
+          <label className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint flex items-center gap-1.5">
+            <Key className="h-3 w-3" /> Provider Key
+          </label>
+          <select
+            value={selectedKeyId}
+            onChange={(e) => setSelectedKeyId(e.target.value)}
+            className="w-full h-8 px-2 rounded-[4px] border border-border bg-bg font-mono text-[12px] text-text focus:outline-none focus:border-border-strong"
+          >
+            {DEMO_PROVIDER_KEYS.map((k) => (
+              <option key={k.id} value={k.id}>
+                {k.name} · {k.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {selectedKey && (
+          <div className="space-y-1.5">
+            <label className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint">
+              Model
+              <span className="ml-2 px-[5px] py-[1px] rounded-[3px] bg-bg-elev border border-border text-text-muted normal-case tracking-normal">
+                {selectedKey.label}
+              </span>
+            </label>
+            <select
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              className="w-full h-8 px-2 rounded-[4px] border border-border bg-bg font-mono text-[12px] text-text focus:outline-none focus:border-border-strong"
+            >
+              {availableModels.map((m) => (
+                <option key={m} value={m}>{m}</option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <label className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint">Temperature</label>
+            <span className="font-mono text-[11px] text-text-muted">{temperature.toFixed(1)}</span>
+          </div>
+          <input
+            type="range"
+            min="0" max="2" step="0.1"
+            value={temperature}
+            onChange={(e) => setTemperature(parseFloat(e.target.value))}
+            className="w-full accent-text"
+          />
+          <div className="flex justify-between font-mono text-[10px] text-text-faint">
+            <span>0 precise</span>
+            <span>2 creative</span>
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <label className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint">Max tokens</label>
+            <span className="font-mono text-[11px] text-text-muted">{maxTokens}</span>
+          </div>
+          <input
+            type="number"
+            min="1" max="8192"
+            value={maxTokens}
+            onChange={(e) =>
+              setMaxTokens(Math.min(8192, Math.max(1, parseInt(e.target.value, 10) || 1)))
+            }
+            className="w-full h-8 px-2 rounded-[4px] border border-border bg-bg font-mono text-[12px] text-text focus:outline-none focus:border-border-strong"
+          />
+        </div>
+
+        {detectedVars.length > 0 && (
+          <div className="space-y-2.5">
+            <label className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint">Variables</label>
+            {detectedVars.map((varName) => (
+              <div key={varName} className="space-y-1">
+                <label className="font-mono text-[11px] text-text-muted">{`{{${varName}}}`}</label>
+                <input
+                  type="text"
+                  placeholder={`Value for ${varName}…`}
+                  value={variables[varName] ?? ''}
+                  onChange={(e) => setVariables((prev) => ({ ...prev, [varName]: e.target.value }))}
+                  className="w-full h-8 px-2 rounded-[4px] border border-border bg-bg font-mono text-[12px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong"
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={() => setShowResult(true)}
+          className="w-full flex items-center justify-center gap-2 h-9 rounded-[5px] bg-text text-bg font-mono text-[12px] font-medium hover:opacity-90 transition-opacity"
+        >
+          <Play className="h-3.5 w-3.5" />
+          Run (demo)
+        </button>
+
+        <p className="font-mono text-[10.5px] text-text-faint text-center leading-relaxed">
+          Playground is fully interactive in the live app.{' '}
+          <Link href="/signup" className="text-accent hover:opacity-80">Sign up free</Link>{' '}
+          to run against your own keys.
+        </p>
+      </div>
+
+      {/* Preview + Result */}
+      <div className="flex-1 min-w-0 overflow-y-auto flex flex-col">
+        <div className="p-[18px] border-b border-border space-y-2 shrink-0">
+          <p className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint">Prompt preview</p>
+          <div className="bg-bg-muted rounded-[6px] border border-border p-4 max-h-52 overflow-y-auto">
+            <pre className="font-mono text-[12px] text-text-muted whitespace-pre-wrap leading-relaxed">
+              {prompt.content}
+            </pre>
+          </div>
+        </div>
+
+        <div className="p-[18px] space-y-4 flex-1">
+          {showResult && (
+            <>
+              <div className="grid grid-cols-4 gap-3">
+                {[
+                  { label: 'Model', value: demoResult.model },
+                  { label: 'Tokens', value: demoResult.totalTokens.toLocaleString() },
+                  { label: 'Cost', value: `$${demoResult.costUsd.toFixed(5)}` },
+                  { label: 'Latency', value: `${(demoResult.latencyMs / 1000).toFixed(2)}s` },
+                ].map((s) => (
+                  <div key={s.label} className="bg-bg-elev rounded-[5px] border border-border px-3 py-2.5">
+                    <p className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                      {s.label}
+                    </p>
+                    <p className="font-mono text-[12px] text-text font-medium truncate" title={s.value}>
+                      {s.value}
+                    </p>
+                  </div>
+                ))}
+              </div>
+
+              <div className="flex items-center flex-wrap gap-x-4 gap-y-1 font-mono text-[11px] text-text-faint">
+                <span><span className="text-text-muted">{demoResult.promptTokens}</span> prompt</span>
+                <span>+</span>
+                <span><span className="text-text-muted">{demoResult.completionTokens}</span> completion</span>
+                <span>=</span>
+                <span><span className="text-text-muted">{demoResult.totalTokens}</span> total</span>
+              </div>
+
+              <div className="space-y-1.5">
+                <div className="flex items-center gap-2">
+                  <p className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint">Response</p>
+                  <CheckCircle2 className="h-3 w-3 text-good" />
+                  <span className="font-mono text-[9px] uppercase tracking-[0.05em] px-1.5 py-0.5 rounded-[3px] bg-accent/10 border border-accent/20 text-accent ml-auto">
+                    demo response
+                  </span>
+                </div>
+                <div className="bg-bg-muted rounded-[6px] border border-border p-4">
+                  <pre className="font-mono text-[12.5px] text-text whitespace-pre-wrap leading-relaxed">
+                    {demoResult.responseText}
+                  </pre>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 // ── Main page ─────────────────────────────────────────────────────────────────
 
 interface Props {
-  params: { name: string }
+  params: Promise<{ name: string }>
 }
 
 export default function DemoPromptDetailPage({ params }: Props) {
-  const name = decodeURIComponent(params.name)
+  const { name: rawName } = use(params)
+  const name = decodeURIComponent(rawName)
   const [tab, setTab] = useState<Tab>('versions')
 
   const prompt = DEMO_PROMPTS.find((p) => p.name === name)
@@ -471,11 +703,12 @@ export default function DemoPromptDetailPage({ params }: Props) {
 
       {/* Tab content */}
       <div className="flex-1 overflow-auto">
-        {tab === 'versions' && <VersionsTab prompt={prompt} />}
-        {tab === 'calls'    && <CallsTab />}
-        {tab === 'traffic'  && <TrafficTab prompt={prompt} />}
-        {tab === 'ab'       && <AbTab prompt={prompt} />}
-        {tab === 'diff'     && <DiffTab prompt={prompt} />}
+        {tab === 'versions'   && <VersionsTab prompt={prompt} />}
+        {tab === 'calls'      && <CallsTab />}
+        {tab === 'traffic'    && <TrafficTab prompt={prompt} />}
+        {tab === 'ab'         && <AbTab prompt={prompt} />}
+        {tab === 'diff'       && <DiffTab prompt={prompt} />}
+        {tab === 'playground' && <PlaygroundTab prompt={prompt} />}
       </div>
     </div>
   )

--- a/apps/web/app/demo/requests/[id]/page.tsx
+++ b/apps/web/app/demo/requests/[id]/page.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { use, useState } from 'react'
 import Link from 'next/link'
 import { ArrowLeft } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -34,8 +34,9 @@ function CopyButton({ getText }: { getText: () => string }) {
 
 type Tab = 'request' | 'response' | 'error'
 
-export default function DemoRequestDetailPage({ params }: { params: { id: string } }) {
-  const req = DEMO_REQUEST_DETAILS[params.id] ?? null
+export default function DemoRequestDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params)
+  const req = DEMO_REQUEST_DETAILS[id] ?? null
   const [tab, setTab] = useState<Tab>('request')
 
   if (!req) {

--- a/apps/web/app/demo/settings/page.tsx
+++ b/apps/web/app/demo/settings/page.tsx
@@ -1,0 +1,620 @@
+'use client'
+import { useState, Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { Topbar } from '@/components/layout/topbar'
+import { cn } from '@/lib/utils'
+
+type TabId =
+  | 'general' | 'members' | 'security' | 'audit-log' | 'system'
+  | 'billing' | 'plan' | 'invoices'
+  | 'profile' | 'notifications' | 'preferences'
+  | 'integrations' | 'webhooks' | 'opentelemetry'
+
+type NavItem = { id: TabId; label: string; crumbs: { label: string }[] }
+
+const NAV: { group: string; items: NavItem[] }[] = [
+  {
+    group: 'Workspace',
+    items: [
+      { id: 'general', label: 'General', crumbs: [{ label: 'Demo' }, { label: 'Settings' }, { label: 'General' }] },
+      { id: 'members', label: 'Members', crumbs: [{ label: 'Demo' }, { label: 'Settings' }, { label: 'Members' }] },
+      { id: 'security', label: 'Security', crumbs: [{ label: 'Demo' }, { label: 'Settings' }, { label: 'Security' }] },
+      { id: 'audit-log', label: 'Audit log', crumbs: [{ label: 'Demo' }, { label: 'Settings' }, { label: 'Audit log' }] },
+      { id: 'system', label: 'System', crumbs: [{ label: 'Demo' }, { label: 'Settings' }, { label: 'System' }] },
+    ],
+  },
+  {
+    group: 'Usage',
+    items: [
+      { id: 'billing', label: 'Billing', crumbs: [{ label: 'Demo' }, { label: 'Settings' }, { label: 'Billing' }] },
+      { id: 'plan', label: 'Plan & limits', crumbs: [{ label: 'Demo' }, { label: 'Settings' }, { label: 'Plan & limits' }] },
+      { id: 'invoices', label: 'Invoices', crumbs: [{ label: 'Demo' }, { label: 'Settings' }, { label: 'Invoices' }] },
+    ],
+  },
+  {
+    group: 'Account',
+    items: [
+      { id: 'profile', label: 'Profile', crumbs: [{ label: 'Demo' }, { label: 'Profile' }] },
+      { id: 'notifications', label: 'Notifications', crumbs: [{ label: 'Demo' }, { label: 'Notifications' }] },
+      { id: 'preferences', label: 'Preferences', crumbs: [{ label: 'Demo' }, { label: 'Preferences' }] },
+    ],
+  },
+  {
+    group: 'Connect',
+    items: [
+      { id: 'integrations', label: 'Integrations', crumbs: [{ label: 'Demo' }, { label: 'Integrations' }] },
+      { id: 'webhooks', label: 'Webhooks', crumbs: [{ label: 'Demo' }, { label: 'Webhooks' }] },
+      { id: 'opentelemetry', label: 'OpenTelemetry', crumbs: [{ label: 'Demo' }, { label: 'OpenTelemetry' }] },
+    ],
+  },
+]
+
+const ALL_ITEMS = NAV.flatMap((g) => g.items)
+
+function TabHeader({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="mb-6">
+      <h1 className="text-[26px] font-medium tracking-[-0.6px] mb-1">{title}</h1>
+      <p className="text-[13px] text-text-muted">{description}</p>
+    </div>
+  )
+}
+
+function Section({ title, description, children }: { title: string; description?: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl border border-border bg-bg-elev p-5 mb-5">
+      <div className="mb-4">
+        <h2 className="text-[14px] font-semibold text-text">{title}</h2>
+        {description && <p className="text-[12px] text-text-muted mt-0.5">{description}</p>}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function FormRow({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-[200px_1fr] gap-3 md:gap-6 py-3 border-t border-border first:border-t-0">
+      <div>
+        <div className="text-[13px] text-text font-medium">{label}</div>
+        {hint && <div className="text-[11.5px] text-text-faint mt-0.5">{hint}</div>}
+      </div>
+      <div>{children}</div>
+    </div>
+  )
+}
+
+function DemoInput({ value, mono }: { value: string; mono?: boolean }) {
+  return (
+    <input
+      value={value}
+      disabled
+      readOnly
+      className={cn(
+        'h-9 px-3 rounded-[6px] border border-border bg-bg text-[13px] text-text-muted w-full max-w-[460px] cursor-not-allowed',
+        mono && 'font-mono text-[12.5px]',
+      )}
+    />
+  )
+}
+
+function DemoToggle({ on }: { on: boolean }) {
+  return (
+    <button
+      type="button"
+      disabled
+      title="Disabled in demo"
+      className={cn(
+        'relative inline-flex h-5 w-9 items-center rounded-full transition-colors cursor-not-allowed opacity-80',
+        on ? 'bg-text' : 'bg-border-strong',
+      )}
+    >
+      <span
+        className={cn(
+          'inline-block h-3.5 w-3.5 rounded-full bg-bg transition-transform',
+          on ? 'translate-x-[18px]' : 'translate-x-[3px]',
+        )}
+      />
+    </button>
+  )
+}
+
+function GeneralTab() {
+  return (
+    <div className="max-w-[920px]">
+      <TabHeader title="General" description="Workspace identity, storage region, and retention." />
+      <Section title="Identity">
+        <FormRow label="Workspace name" hint="Shown in the app header and on shared traces.">
+          <DemoInput value="Acme Corp" mono />
+        </FormRow>
+        <FormRow label="Workspace ID">
+          <DemoInput value="org_01HZX8K4N7M2R3T5V6W7X8Y9Z0" mono />
+        </FormRow>
+      </Section>
+      <Section title="Data residency" description="Where requests are stored.">
+        <FormRow label="Region">
+          <DemoInput value="us-east-1" mono />
+        </FormRow>
+        <FormRow label="Retention" hint="Defined by your plan.">
+          <DemoInput value="14 days · Free" />
+        </FormRow>
+      </Section>
+    </div>
+  )
+}
+
+function MembersTab() {
+  const members = [
+    { email: 'haeseong@acme.com', role: 'admin', joined: '2026-03-12' },
+    { email: 'eng-lead@acme.com', role: 'admin', joined: '2026-03-14' },
+    { email: 'support@acme.com', role: 'member', joined: '2026-04-02' },
+    { email: 'analyst@acme.com', role: 'viewer', joined: '2026-04-19' },
+  ]
+  return (
+    <div className="max-w-[920px]">
+      <TabHeader title="Members" description="Invite teammates and manage roles." />
+      <Section title="Invite member">
+        <FormRow label="Email">
+          <div className="flex gap-2 max-w-[460px]">
+            <DemoInput value="teammate@example.com" />
+            <button disabled className="h-9 px-4 rounded-[6px] bg-text text-bg text-[13px] font-medium opacity-60 cursor-not-allowed">
+              Send invite
+            </button>
+          </div>
+        </FormRow>
+      </Section>
+      <Section title="Active members">
+        <div className="divide-y divide-border -my-2">
+          {members.map((m) => (
+            <div key={m.email} className="flex items-center justify-between py-3">
+              <div>
+                <div className="text-[13px] text-text">{m.email}</div>
+                <div className="text-[11px] text-text-faint mt-0.5">Joined {m.joined}</div>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="font-mono text-[10px] uppercase tracking-[0.04em] px-2 py-0.5 rounded-full border border-border text-text-muted">
+                  {m.role}
+                </span>
+                <button disabled className="text-[12px] text-text-faint opacity-60 cursor-not-allowed">Remove</button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </Section>
+    </div>
+  )
+}
+
+function SecurityTab() {
+  return (
+    <div className="max-w-[920px]">
+      <TabHeader title="Security" description="Workspace-wide security controls." />
+      <Section title="API key rotation">
+        <FormRow label="Stale key threshold" hint="Notify when keys haven't rotated in N days.">
+          <DemoInput value="90 days" />
+        </FormRow>
+        <FormRow label="Require 2FA for admins" hint="Admins must enable 2FA to sign in.">
+          <DemoToggle on={true} />
+        </FormRow>
+      </Section>
+      <Section title="Sign-in">
+        <FormRow label="Allowed providers">
+          <div className="flex gap-2">
+            <span className="font-mono text-[10px] uppercase tracking-[0.04em] px-2 py-0.5 rounded-full border border-good/20 bg-good-bg text-good">Email</span>
+            <span className="font-mono text-[10px] uppercase tracking-[0.04em] px-2 py-0.5 rounded-full border border-good/20 bg-good-bg text-good">Google</span>
+            <span className="font-mono text-[10px] uppercase tracking-[0.04em] px-2 py-0.5 rounded-full border border-border text-text-faint">GitHub</span>
+          </div>
+        </FormRow>
+      </Section>
+    </div>
+  )
+}
+
+function AuditLogTab() {
+  const logs = [
+    { time: '2026-05-22 09:14', actor: 'haeseong@acme.com', action: 'api_key.create', sev: 'med' as const },
+    { time: '2026-05-21 17:42', actor: 'eng-lead@acme.com', action: 'provider_key.rotate', sev: 'high' as const },
+    { time: '2026-05-21 11:08', actor: 'haeseong@acme.com', action: 'member.invite', sev: 'med' as const },
+    { time: '2026-05-20 22:33', actor: 'system', action: 'subscription.update', sev: 'low' as const },
+    { time: '2026-05-20 14:01', actor: 'analyst@acme.com', action: 'dataset.create', sev: 'low' as const },
+  ]
+  return (
+    <div className="max-w-[920px]">
+      <TabHeader title="Audit log" description="Workspace activity from the last 90 days." />
+      <div className="rounded-xl border border-border bg-bg-elev overflow-hidden">
+        <div className="grid grid-cols-[150px_1fr_180px_80px] gap-4 px-5 py-2.5 border-b border-border font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+          <span>Time</span>
+          <span>Actor</span>
+          <span>Action</span>
+          <span>Severity</span>
+        </div>
+        {logs.map((l, i) => (
+          <div key={i} className="grid grid-cols-[150px_1fr_180px_80px] gap-4 px-5 py-2.5 border-b border-border last:border-b-0 items-center">
+            <span className="font-mono text-[11.5px] text-text-muted">{l.time}</span>
+            <span className="text-[12.5px] text-text truncate">{l.actor}</span>
+            <span className="font-mono text-[11.5px] text-text-muted">{l.action}</span>
+            <span
+              className={cn(
+                'font-mono text-[10px] uppercase tracking-[0.04em] px-2 py-0.5 rounded-full border w-fit',
+                l.sev === 'high' && 'border-accent-border bg-accent-bg text-accent',
+                l.sev === 'med' && 'border-border bg-bg-elev text-text-muted',
+                l.sev === 'low' && 'border-border bg-transparent text-text-faint',
+              )}
+            >
+              {l.sev}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function SystemTab() {
+  return (
+    <div className="max-w-[920px]">
+      <TabHeader title="System" description="Background jobs and infrastructure." />
+      <Section title="Background jobs">
+        <div className="divide-y divide-border -my-2">
+          {[
+            { name: 'Replay fallback queue', cadence: 'every 5 min', last: '2 min ago', healthy: true },
+            { name: 'Aggregate hourly stats', cadence: 'every 1 hour', last: '12 min ago', healthy: true },
+            { name: 'Stale key digest', cadence: 'daily', last: '8 hours ago', healthy: true },
+            { name: 'Anomaly detector', cadence: 'every 15 min', last: '4 min ago', healthy: true },
+          ].map((j) => (
+            <div key={j.name} className="flex items-center justify-between py-3">
+              <div>
+                <div className="text-[13px] text-text">{j.name}</div>
+                <div className="text-[11px] text-text-faint mt-0.5">Runs {j.cadence}</div>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="font-mono text-[11px] text-text-muted">last: {j.last}</span>
+                <span className="font-mono text-[10px] uppercase px-2 py-0.5 rounded-full border border-good/20 bg-good-bg text-good">healthy</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </Section>
+    </div>
+  )
+}
+
+function BillingTab() {
+  return (
+    <div className="max-w-[920px]">
+      <TabHeader title="Billing" description="Payment method and billing contact." />
+      <Section title="Payment method">
+        <FormRow label="Card on file">
+          <div className="text-[13px] text-text-muted">No card on file (Free plan)</div>
+        </FormRow>
+        <FormRow label="Billing email">
+          <DemoInput value="billing@acme.com" />
+        </FormRow>
+      </Section>
+      <Section title="Plan">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-[14px] font-semibold text-text">Free</div>
+            <div className="text-[12px] text-text-muted mt-0.5">2,400 of 50,000 requests this month</div>
+          </div>
+          <button disabled className="h-9 px-4 rounded-[6px] bg-accent text-bg text-[13px] font-medium opacity-60 cursor-not-allowed">
+            Upgrade to Pro
+          </button>
+        </div>
+      </Section>
+    </div>
+  )
+}
+
+function PlanTab() {
+  return (
+    <div className="max-w-[920px]">
+      <TabHeader title="Plan & limits" description="Compare plans and configure overage behavior." />
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-5">
+        {[
+          { name: 'Free', price: '$0', reqs: '50k', retention: '14d', cur: true },
+          { name: 'Pro', price: '$49', reqs: '500k', retention: '90d', cur: false },
+          { name: 'Team', price: '$199', reqs: '2.5M', retention: '365d', cur: false },
+        ].map((p) => (
+          <div
+            key={p.name}
+            className={cn(
+              'rounded-xl border p-5',
+              p.cur ? 'border-accent bg-accent-bg/30' : 'border-border bg-bg-elev',
+            )}
+          >
+            <div className="flex items-center justify-between mb-2">
+              <h3 className="text-[15px] font-semibold text-text">{p.name}</h3>
+              {p.cur && (
+                <span className="font-mono text-[9px] uppercase tracking-[0.05em] px-1.5 py-0.5 rounded-full border border-accent-border bg-accent-bg text-accent">
+                  current
+                </span>
+              )}
+            </div>
+            <div className="text-[24px] font-medium text-text mb-3">
+              {p.price}
+              <span className="text-[12px] text-text-muted">/mo</span>
+            </div>
+            <ul className="text-[12.5px] text-text-muted space-y-1">
+              <li>{p.reqs} requests/mo</li>
+              <li>{p.retention} retention</li>
+            </ul>
+          </div>
+        ))}
+      </div>
+      <Section title="Overage">
+        <FormRow label="Allow overage" hint="Charge per extra 1k requests past the monthly cap.">
+          <DemoToggle on={false} />
+        </FormRow>
+        <FormRow label="Max overage multiplier" hint="Hard cap = monthly limit × this value. Requests past return 429.">
+          <DemoInput value="2.0" />
+        </FormRow>
+      </Section>
+    </div>
+  )
+}
+
+function InvoicesTab() {
+  return (
+    <div className="max-w-[920px]">
+      <TabHeader title="Invoices" description="Past invoices and download links." />
+      <div className="rounded-xl border border-border bg-bg-elev overflow-hidden">
+        <div className="grid grid-cols-[120px_1fr_120px_100px] gap-4 px-5 py-2.5 border-b border-border font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+          <span>Date</span>
+          <span>Description</span>
+          <span>Amount</span>
+          <span>Status</span>
+        </div>
+        {[
+          { date: '2026-05-01', desc: 'No invoices on Free plan', amount: '—', status: '—' },
+        ].map((inv, i) => (
+          <div key={i} className="grid grid-cols-[120px_1fr_120px_100px] gap-4 px-5 py-3 items-center">
+            <span className="font-mono text-[11.5px] text-text-faint">{inv.date}</span>
+            <span className="text-[12.5px] text-text-faint">{inv.desc}</span>
+            <span className="font-mono text-[12px] text-text-faint">{inv.amount}</span>
+            <span className="font-mono text-[10px] text-text-faint">{inv.status}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ProfileTab() {
+  return (
+    <div className="max-w-[920px]">
+      <TabHeader title="Profile" description="Your personal account info." />
+      <Section title="Identity">
+        <FormRow label="Email">
+          <DemoInput value="haeseong@acme.com" />
+        </FormRow>
+        <FormRow label="Display name">
+          <DemoInput value="Haeseong" />
+        </FormRow>
+      </Section>
+      <Section title="Password">
+        <FormRow label="Change password">
+          <button disabled className="h-9 px-4 rounded-[6px] border border-border bg-bg-elev text-[13px] text-text-muted opacity-60 cursor-not-allowed">
+            Send reset email
+          </button>
+        </FormRow>
+      </Section>
+    </div>
+  )
+}
+
+function NotificationsTab() {
+  return (
+    <div className="max-w-[920px]">
+      <TabHeader title="Notifications" description="Email me when…" />
+      <Section title="Email notifications">
+        {[
+          { label: 'A new anomaly is detected', on: true },
+          { label: 'A budget alert fires', on: true },
+          { label: 'A new teammate joins', on: true },
+          { label: 'Weekly digest', on: false },
+        ].map((n) => (
+          <FormRow key={n.label} label={n.label}>
+            <DemoToggle on={n.on} />
+          </FormRow>
+        ))}
+      </Section>
+    </div>
+  )
+}
+
+function PreferencesTab() {
+  return (
+    <div className="max-w-[920px]">
+      <TabHeader title="Preferences" description="Personal UI preferences." />
+      <Section title="Appearance">
+        <FormRow label="Theme">
+          <div className="flex gap-2">
+            <span className="font-mono text-[10px] uppercase tracking-[0.04em] px-2 py-0.5 rounded-full border border-border text-text-muted">Light</span>
+            <span className="font-mono text-[10px] uppercase tracking-[0.04em] px-2 py-0.5 rounded-full border border-border text-text-muted">Dark</span>
+            <span className="font-mono text-[10px] uppercase tracking-[0.04em] px-2 py-0.5 rounded-full border border-accent-border bg-accent-bg text-accent">System</span>
+          </div>
+        </FormRow>
+        <FormRow label="Compact tables" hint="Tighter row spacing in Requests, Traces, etc.">
+          <DemoToggle on={false} />
+        </FormRow>
+      </Section>
+    </div>
+  )
+}
+
+function IntegrationsTab() {
+  const ints = [
+    { name: 'Slack', desc: 'Send alerts to a channel.', connected: true },
+    { name: 'PagerDuty', desc: 'Page on-call when alerts fire.', connected: false },
+    { name: 'Datadog', desc: 'Forward metrics & traces.', connected: false },
+    { name: 'Discord', desc: 'Send alerts via webhook.', connected: false },
+  ]
+  return (
+    <div className="max-w-[920px]">
+      <TabHeader title="Integrations" description="Connect Spanlens to your existing stack." />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {ints.map((it) => (
+          <div key={it.name} className="rounded-xl border border-border bg-bg-elev p-5">
+            <div className="flex items-center justify-between mb-2">
+              <h3 className="text-[14px] font-semibold text-text">{it.name}</h3>
+              {it.connected ? (
+                <span className="font-mono text-[10px] uppercase tracking-[0.04em] px-2 py-0.5 rounded-full border border-good/20 bg-good-bg text-good">connected</span>
+              ) : (
+                <span className="font-mono text-[10px] uppercase tracking-[0.04em] px-2 py-0.5 rounded-full border border-border text-text-faint">not connected</span>
+              )}
+            </div>
+            <p className="text-[12.5px] text-text-muted mb-3">{it.desc}</p>
+            <button disabled className="text-[12.5px] text-accent opacity-60 cursor-not-allowed">
+              {it.connected ? 'Manage' : 'Connect'}
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function WebhooksTab() {
+  return (
+    <div className="max-w-[920px]">
+      <TabHeader title="Webhooks" description="Subscribe to workspace events." />
+      <Section title="Endpoints">
+        <div className="divide-y divide-border -my-2">
+          {[
+            { url: 'https://api.acme.com/hooks/spanlens', events: 4, status: 'active' },
+            { url: 'https://hooks.zapier.com/...', events: 2, status: 'paused' },
+          ].map((w) => (
+            <div key={w.url} className="flex items-center justify-between py-3">
+              <div>
+                <div className="font-mono text-[12px] text-text truncate max-w-[400px]">{w.url}</div>
+                <div className="text-[11px] text-text-faint mt-0.5">{w.events} event types subscribed</div>
+              </div>
+              <span
+                className={cn(
+                  'font-mono text-[10px] uppercase tracking-[0.04em] px-2 py-0.5 rounded-full border',
+                  w.status === 'active'
+                    ? 'border-good/20 bg-good-bg text-good'
+                    : 'border-border bg-bg text-text-faint',
+                )}
+              >
+                {w.status}
+              </span>
+            </div>
+          ))}
+        </div>
+      </Section>
+    </div>
+  )
+}
+
+function OtelTab() {
+  return (
+    <div className="max-w-[920px]">
+      <TabHeader title="OpenTelemetry" description="Export Spanlens traces to your existing OTel collector." />
+      <Section title="OTLP endpoint">
+        <FormRow label="Endpoint">
+          <DemoInput value="https://api.spanlens.io/otel/v1/traces" mono />
+        </FormRow>
+        <FormRow label="Headers">
+          <DemoInput value="Authorization: Bearer sl_live_…" mono />
+        </FormRow>
+      </Section>
+    </div>
+  )
+}
+
+function TabContent({ tab }: { tab: TabId }) {
+  switch (tab) {
+    case 'general': return <GeneralTab />
+    case 'members': return <MembersTab />
+    case 'security': return <SecurityTab />
+    case 'audit-log': return <AuditLogTab />
+    case 'system': return <SystemTab />
+    case 'billing': return <BillingTab />
+    case 'plan': return <PlanTab />
+    case 'invoices': return <InvoicesTab />
+    case 'profile': return <ProfileTab />
+    case 'notifications': return <NotificationsTab />
+    case 'preferences': return <PreferencesTab />
+    case 'integrations': return <IntegrationsTab />
+    case 'webhooks': return <WebhooksTab />
+    case 'opentelemetry': return <OtelTab />
+  }
+}
+
+function SettingsInner() {
+  const searchParams = useSearchParams()
+  const initialTab = (searchParams.get('tab') as TabId | null) ?? 'general'
+  const [tab, setTab] = useState<TabId>(
+    ALL_ITEMS.some((i) => i.id === initialTab) ? initialTab : 'general',
+  )
+  const active = ALL_ITEMS.find((i) => i.id === tab) ?? ALL_ITEMS[0]!
+
+  return (
+    <div className="-mx-4 -my-4 md:-mx-8 md:-my-7 flex flex-col h-screen overflow-hidden">
+      <div className="md:hidden flex items-center gap-3 px-4 py-3 border-b border-border bg-bg-elev shrink-0">
+        <span className="font-mono text-[10px] text-text-faint uppercase tracking-[0.05em] shrink-0">Settings</span>
+        <select
+          value={tab}
+          onChange={(e) => setTab(e.target.value as TabId)}
+          className="flex-1 h-8 px-2 rounded-[6px] border border-border bg-bg text-[13px] text-text focus:outline-none focus:border-border-strong"
+        >
+          {NAV.map((group) => (
+            <optgroup key={group.group} label={group.group}>
+              {group.items.map((item) => (
+                <option key={item.id} value={item.id}>{item.label}</option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex flex-1 overflow-hidden min-h-0">
+        <aside className="hidden md:flex md:flex-col w-[260px] shrink-0 border-r border-border bg-bg-elev overflow-y-auto">
+          <div className="px-5 py-4 font-mono text-[10px] text-text-faint uppercase tracking-[0.05em]">Settings</div>
+          {NAV.map((group) => (
+            <div key={group.group} className="mb-4">
+              <div className="px-5 py-1.5 font-mono text-[9.5px] text-text-faint uppercase tracking-[0.05em]">
+                {group.group}
+              </div>
+              {group.items.map((item) => {
+                const isActive = item.id === tab
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    onClick={() => setTab(item.id)}
+                    className={cn(
+                      'w-full text-left px-5 py-2 text-[13px] transition-colors border-l-2 -ml-px',
+                      isActive
+                        ? 'border-accent bg-bg text-text font-medium'
+                        : 'border-transparent text-text-muted hover:text-text hover:bg-bg/50',
+                    )}
+                  >
+                    {item.label}
+                  </button>
+                )
+              })}
+            </div>
+          ))}
+        </aside>
+
+        <main className="flex-1 flex flex-col overflow-hidden">
+          <Topbar crumbs={active.crumbs} />
+          <div className="flex-1 overflow-y-auto bg-bg px-4 py-4 md:px-8 md:py-6">
+            <TabContent tab={tab} />
+          </div>
+        </main>
+      </div>
+    </div>
+  )
+}
+
+export default function DemoSettingsPage() {
+  return (
+    <Suspense fallback={null}>
+      <SettingsInner />
+    </Suspense>
+  )
+}

--- a/apps/web/app/demo/traces/[id]/page.tsx
+++ b/apps/web/app/demo/traces/[id]/page.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { use, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { Topbar } from '@/components/layout/topbar'
 import { cn } from '@/lib/utils'
@@ -235,12 +235,13 @@ function flattenSpanTree(spans: SpanRow[]): SpanNode[] {
 
 // ── Page ───────────────────────────────────────────────────────
 
-export default function DemoTraceDetailPage({ params }: { params: { id: string } }) {
+export default function DemoTraceDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params)
   const router = useRouter()
   const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null)
 
-  const traceDetail = DEMO_TRACE_DETAILS[params.id]
-  const traceIdx = DEMO_TRACES.findIndex((t) => t.id === params.id)
+  const traceDetail = DEMO_TRACE_DETAILS[id]
+  const traceIdx = DEMO_TRACES.findIndex((t) => t.id === id)
   const prevTrace = traceIdx > 0 ? DEMO_TRACES[traceIdx - 1] : null
   const nextTrace = traceIdx < DEMO_TRACES.length - 1 ? DEMO_TRACES[traceIdx + 1] : null
 

--- a/apps/web/components/layout/demo-sidebar.tsx
+++ b/apps/web/components/layout/demo-sidebar.tsx
@@ -1,147 +1,268 @@
 'use client'
 import Image from 'next/image'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { useEffect, useRef, useState } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
 import { useTheme } from 'next-themes'
 import { Sun, Moon, Monitor, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useSidebar } from '@/lib/sidebar-context'
 
+/* ── Logo ── */
 function LogoMark() {
   return (
-    <Link href="/" aria-label="Spanlens home" className="flex items-center gap-2 px-1 py-1 hover:opacity-80 transition-opacity">
+    <Link
+      href="/"
+      aria-label="Spanlens home"
+      className="flex items-center gap-2 px-1 py-1 hover:opacity-80 transition-opacity"
+    >
       <Image src="/icon.png" alt="Spanlens" width={20} height={20} className="shrink-0 rounded-[5px]" priority />
       <span className="font-semibold text-[15px] tracking-[-0.3px] text-text">spanlens</span>
     </Link>
   )
 }
 
-const DEMO_NAV = [
+/* ── Workspace switcher (demo: popover opens with dummy data) ── */
+const DEMO_WORKSPACES = [
+  { id: 'ws-1', name: 'Acme Corp', role: 'owner', selected: true },
+  { id: 'ws-2', name: 'Beta Org', role: 'member', selected: false },
+  { id: 'ws-3', name: 'Internal Sandbox', role: 'admin', selected: false },
+]
+
+function DemoWorkspaceSwitcher() {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: PointerEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('pointerdown', handler)
+    return () => document.removeEventListener('pointerdown', handler)
+  }, [open])
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between px-[10px] py-[7px] rounded-[5px] border border-border bg-bg-muted text-[12px] font-mono text-text-muted hover:bg-bg-muted/80 transition-colors"
+      >
+        <span className="truncate text-text">Acme Corp</span>
+        <span className="ml-1.5 font-mono text-[9px] uppercase tracking-[0.05em] px-[5px] py-[2px] rounded-[3px] bg-accent/10 text-accent border border-accent/20">demo</span>
+        <span className="text-text-faint text-[10px] shrink-0 ml-auto pl-2">⌄</span>
+      </button>
+      {open && (
+        <div
+          className="absolute left-0 right-0 mt-1 z-20 rounded-[6px] border border-border-strong bg-bg-elev shadow-lg overflow-hidden"
+          role="menu"
+        >
+          <div className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-text-faint px-[10px] pt-[7px] pb-[3px]">
+            Workspaces
+          </div>
+          {DEMO_WORKSPACES.map((w) => (
+            <button
+              key={w.id}
+              type="button"
+              onClick={() => setOpen(false)}
+              className={cn(
+                'w-full text-left px-[10px] py-[6px] text-[12px] font-mono transition-colors flex items-center justify-between',
+                w.selected ? 'bg-bg-muted text-text' : 'text-text-muted hover:bg-bg-muted hover:text-text',
+              )}
+              role="menuitem"
+            >
+              <span className="truncate">
+                {w.name} <span className="text-text-faint">· {w.role}</span>
+              </span>
+              {w.selected && <span className="text-accent ml-2">✓</span>}
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="w-full text-left px-[10px] py-[6px] text-[12px] font-mono text-text-faint hover:bg-bg-muted hover:text-text transition-colors"
+            role="menuitem"
+          >
+            + New workspace
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* ── Nav groups (mirrors live sidebar) ── */
+type NavItem = { href: string; label: string; badge?: string; badgeWarn?: boolean; badgeGood?: boolean }
+
+const DEMO_NAV: { label: string | null; items: NavItem[] }[] = [
   {
     label: null,
     items: [
-      { href: '/demo/dashboard', label: 'Dashboard', badge: null },
-      { href: '/demo/requests',  label: 'Requests',  badge: '2.4k' },
-      { href: '/demo/traces',    label: 'Traces',    badge: null },
-      { href: '/demo/users',     label: 'Users',     badge: '4' },
+      { href: '/demo/dashboard', label: 'Dashboard' },
+      { href: '/demo/requests', label: 'Requests', badge: '2.4k' },
+      { href: '/demo/traces', label: 'Traces' },
+      { href: '/demo/users', label: 'Users', badge: '4' },
     ],
   },
   {
     label: 'Observe',
     items: [
       { href: '/demo/anomalies', label: 'Anomalies', badge: '2', badgeWarn: true },
-      { href: '/demo/security',  label: 'Security',  badge: null },
-      { href: '/demo/savings',   label: 'Savings',   badge: '$412', badgeGood: true },
+      { href: '/demo/security', label: 'Security' },
+      { href: '/demo/savings', label: 'Savings', badge: '$412', badgeGood: true },
     ],
   },
   {
     label: 'Build',
     items: [
-      { href: '/demo/prompts',     label: 'Prompts',     badge: null },
-      { href: '/demo/evals',       label: 'Evals',       badge: '4' },
-      { href: '/demo/datasets',    label: 'Datasets',    badge: '3' },
-      { href: '/demo/experiments', label: 'Experiments', badge: null },
-      { href: '/demo/alerts',      label: 'Alerts',      badge: '1', badgeWarn: true },
+      { href: '/demo/prompts', label: 'Prompts' },
+      { href: '/demo/evals', label: 'Evals', badge: '4' },
+      { href: '/demo/datasets', label: 'Datasets', badge: '3' },
+      { href: '/demo/experiments', label: 'Experiments' },
+      { href: '/demo/alerts', label: 'Alerts', badge: '1', badgeWarn: true },
     ],
   },
   {
     label: 'Review',
+    items: [{ href: '/demo/annotation', label: 'Annotation', badge: '2', badgeWarn: true }],
+  },
+  {
+    label: 'Admin',
     items: [
-      { href: '/demo/annotation', label: 'Annotation', badge: '2', badgeWarn: true },
+      { href: '/demo/projects', label: 'Projects & Keys' },
+      { href: '/demo/settings', label: 'Settings' },
+      { href: '/docs', label: 'Docs' },
     ],
   },
 ]
 
+/* ── Theme toggle (matches live: icon + "Theme · system" label) ── */
 type ThemeOption = 'system' | 'light' | 'dark'
 const THEME_CYCLE: ThemeOption[] = ['system', 'light', 'dark']
 
 function ThemeToggleButton() {
   const { theme, setTheme } = useTheme()
-  const current = (theme as ThemeOption) ?? 'system'
-  const next = THEME_CYCLE[(THEME_CYCLE.indexOf(current) + 1) % THEME_CYCLE.length] ?? 'system'
+
+  function cycleTheme() {
+    const current = (theme ?? 'system') as ThemeOption
+    const idx = THEME_CYCLE.indexOf(current)
+    const next = THEME_CYCLE[(idx + 1) % THEME_CYCLE.length] ?? 'system'
+    setTheme(next)
+  }
+
+  const current = (theme ?? 'system') as ThemeOption
   const Icon = current === 'light' ? Sun : current === 'dark' ? Moon : Monitor
+
   return (
     <button
-      type="button"
-      onClick={() => setTheme(next)}
-      title={`Theme: ${current}`}
-      className="p-1.5 rounded-[5px] text-text-faint hover:text-text hover:bg-bg-muted transition-colors"
+      onClick={cycleTheme}
+      className="flex w-full items-center gap-2 px-[10px] py-[6px] rounded-[5px] text-[13px] text-text-muted hover:bg-bg-muted hover:text-text transition-colors"
     >
-      <Icon className="h-[14px] w-[14px]" />
+      <Icon className="h-3.5 w-3.5 shrink-0" />
+      <span>Theme · {current}</span>
     </button>
   )
 }
 
 function SidebarContent() {
   const pathname = usePathname()
+  const router = useRouter()
+
+  function handleSignOut() {
+    // Demo: "sign out" sends them back to the signup landing
+    router.push('/signup')
+  }
+
   return (
-    <div className="flex flex-col h-full py-3 px-2">
-      <div className="px-1 mb-4">
+    <>
+      {/* Logo */}
+      <div className="px-[18px] pt-[18px] pb-3">
         <LogoMark />
       </div>
 
-      {/* Workspace badge */}
-      <div className="mx-1 mb-4 px-[10px] py-[7px] rounded-[5px] border border-border bg-bg-muted">
-        <span className="font-mono text-[12px]">
-          <span className="text-text-faint">Acme Corp /</span>{' '}
-          <span className="text-text">Production</span>
-        </span>
-        <span className="ml-1.5 font-mono text-[9px] uppercase tracking-[0.05em] px-[5px] py-[2px] rounded-[3px] bg-accent/10 text-accent border border-accent/20">demo</span>
+      {/* Workspace switcher */}
+      <div className="mx-[14px] mb-3">
+        <DemoWorkspaceSwitcher />
       </div>
 
-      {/* Nav groups */}
-      <nav className="flex-1 space-y-4 overflow-y-auto">
-        {DEMO_NAV.map((group) => (
-          <div key={group.label ?? 'root'}>
+      {/* Navigation */}
+      <nav className="flex-1 overflow-y-auto px-[14px] space-y-0">
+        {DEMO_NAV.map((group, gi) => (
+          <div key={gi}>
             {group.label && (
-              <div className="px-2 mb-1 font-mono text-[9.5px] uppercase tracking-[0.06em] text-text-faint">
+              <div className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint px-[10px] pt-3 pb-1">
                 {group.label}
               </div>
             )}
-            <div className="space-y-0.5">
-              {group.items.map((item) => {
-                const active = pathname === item.href || (item.href !== '/demo/dashboard' && pathname.startsWith(item.href))
-                return (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    className={cn(
-                      'flex items-center justify-between px-[10px] py-[6px] rounded-[5px] text-[13px] transition-colors',
-                      active ? 'bg-bg-elev text-text font-medium' : 'text-text-muted hover:bg-bg-elev hover:text-text',
-                    )}
-                  >
-                    <span>{item.label}</span>
-                    {item.badge && (
-                      <span className={cn(
-                        'font-mono text-[10px] px-[6px] py-[1px] rounded-[3px]',
-                        (item as { badgeWarn?: boolean }).badgeWarn
-                          ? 'bg-accent/10 text-accent'
-                          : (item as { badgeGood?: boolean }).badgeGood
-                            ? 'bg-good/10 text-good'
-                            : 'bg-bg-muted text-text-faint',
-                      )}>
-                        {item.badge}
-                      </span>
-                    )}
-                  </Link>
-                )
-              })}
-            </div>
+            {group.items.map(({ href, label, badge, badgeWarn, badgeGood }) => {
+              const active =
+                pathname === href ||
+                (href !== '/demo/dashboard' && pathname.startsWith(href + '/')) ||
+                (href !== '/demo/dashboard' && pathname.startsWith(href) && pathname !== '/demo/dashboard')
+              return (
+                <Link
+                  key={href}
+                  href={href}
+                  prefetch={false}
+                  className={cn(
+                    'flex items-center justify-between px-[10px] py-[6px] rounded-[5px] text-[13px] transition-colors',
+                    'border-l-2',
+                    active
+                      ? 'bg-bg-muted text-text font-medium border-accent'
+                      : 'text-text-muted hover:bg-bg-muted hover:text-text border-transparent',
+                  )}
+                >
+                  <span>{label}</span>
+                  {badge && (
+                    <span
+                      className={cn(
+                        'font-mono text-[10px] px-[6px] py-[1px] rounded-[3px] border',
+                        badgeWarn
+                          ? 'bg-accent-bg text-accent border-accent-border'
+                          : badgeGood
+                            ? 'bg-good/10 text-good border-good/20'
+                            : 'bg-bg text-text-faint border-border',
+                      )}
+                    >
+                      {badge}
+                    </span>
+                  )}
+                </Link>
+              )
+            })}
           </div>
         ))}
       </nav>
 
-      {/* Footer */}
-      <div className="mt-2 pt-3 border-t border-border mx-1 flex items-center justify-between">
+      {/* Plan / usage widget (static demo values) */}
+      <div className="mx-[18px] mb-[14px] mt-2 p-3 rounded-md border border-border bg-bg-muted">
+        <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-1.5">
+          Plan · Free
+        </div>
+        <div className="text-[13px] text-text mb-1.5">2,400 / 50k requests</div>
+        <div className="h-1 rounded-full bg-bg overflow-hidden">
+          <div className="h-full rounded-full bg-text transition-all" style={{ width: '4.8%' }} />
+        </div>
         <Link
-          href="/signup"
-          className="font-mono text-[11.5px] px-3 py-[5px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 transition-opacity"
+          href="/demo/billing"
+          className="mt-2.5 inline-block text-[12px] font-medium text-accent hover:opacity-80 transition-opacity"
         >
-          Sign up free
+          Upgrade →
         </Link>
-        <ThemeToggleButton />
       </div>
-    </div>
+
+      {/* Theme + Sign out */}
+      <div className="px-[14px] pb-[14px] space-y-0.5">
+        <ThemeToggleButton />
+        <button
+          onClick={handleSignOut}
+          className="flex w-full items-center px-[10px] py-[6px] rounded-[5px] text-[13px] text-text-muted hover:bg-bg-muted hover:text-text transition-colors"
+        >
+          Sign out
+        </button>
+      </div>
+    </>
   )
 }
 
@@ -149,28 +270,36 @@ export function DemoSidebar() {
   const { isOpen, close } = useSidebar()
   return (
     <>
-      {/* Desktop */}
-      <aside className="hidden md:flex w-[210px] shrink-0 flex-col border-r border-border bg-bg h-screen overflow-hidden">
+      {/* Mobile backdrop */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/40 md:hidden"
+          onClick={close}
+          aria-hidden="true"
+        />
+      )}
+
+      <aside
+        className={cn(
+          'flex flex-col bg-bg-elev border-r border-border',
+          'fixed inset-y-0 left-0 z-50 w-[272px] h-screen',
+          'transition-transform duration-200 ease-in-out',
+          isOpen ? 'translate-x-0' : '-translate-x-full',
+          'md:relative md:w-56 md:shrink-0 md:translate-x-0 md:transition-none',
+        )}
+      >
+        {/* Mobile close */}
+        <button
+          type="button"
+          onClick={close}
+          className="absolute right-3 top-3.5 md:hidden p-1.5 rounded-[5px] text-text-faint hover:text-text hover:bg-bg-muted transition-colors"
+          aria-label="Close navigation"
+        >
+          <X size={16} />
+        </button>
+
         <SidebarContent />
       </aside>
-
-      {/* Mobile overlay */}
-      {isOpen && (
-        <div className="md:hidden fixed inset-0 z-50 flex">
-          <div className="absolute inset-0 bg-black/40" onClick={close} />
-          <aside className="relative z-10 w-[240px] h-full bg-bg border-r border-border flex flex-col overflow-hidden">
-            <button
-              type="button"
-              onClick={close}
-              className="absolute top-3 right-3 p-1.5 text-text-muted hover:text-text transition-colors"
-              aria-label="Close menu"
-            >
-              <X className="h-4 w-4" />
-            </button>
-            <SidebarContent />
-          </aside>
-        </div>
-      )}
     </>
   )
 }

--- a/clickhouse/migrations/003_add_service_tier.sql
+++ b/clickhouse/migrations/003_add_service_tier.sql
@@ -1,0 +1,22 @@
+-- 003_add_service_tier.sql
+-- Adds the `service_tier` column captured from provider response bodies.
+--
+-- WHY: OpenAI and Gemini both expose the actual processing tier in the
+-- response (`service_tier` for OpenAI, `usageMetadata.serviceTier` for
+-- Gemini). Storing it lets the cost calculator apply the correct multiplier
+-- (Standard / Flex / Priority / Batch / Auto) and unlocks tier-distribution
+-- analytics on the dashboard.
+--
+-- WHY LowCardinality: distinct values are a fixed enum-like set
+-- ('default', 'auto', 'flex', 'priority', 'scale', 'batch', NULL/unknown).
+-- LowCardinality stores them as a dictionary — minimal space + faster filters.
+--
+-- BACKFILL: existing rows default to '' (empty string ≡ "tier unknown").
+-- The application code treats '' the same as NULL — no tier multiplier
+-- applied. CH MergeTree handles DEFAULT columns lazily on read.
+--
+-- IDEMPOTENT (CLAUDE.md DB rule): IF NOT EXISTS for ALTER. Safe to apply
+-- against a populated table — metadata-only change in CH.
+
+ALTER TABLE requests
+    ADD COLUMN IF NOT EXISTS service_tier LowCardinality(String) DEFAULT '';

--- a/supabase/migrations/20260522000000_seed_models_2026_05.sql
+++ b/supabase/migrations/20260522000000_seed_models_2026_05.sql
@@ -1,0 +1,71 @@
+-- Migration: Add missing models to model_prices (verified against provider docs 2026-05-22)
+--
+-- Background — gotcha #2 in CLAUDE.md:
+--   When a request comes in for a model that's not in this table, lib/cost.ts
+--   returns NULL → requests.cost_usd stays NULL → dashboard shows no cost for
+--   those calls. As of 2026-05 the seed was missing the entire current
+--   flagship lineup from all three providers (GPT-5.x, Claude Opus 4.5/4.6,
+--   Gemini 3.x). This migration backfills.
+--
+-- Sources:
+--   OpenAI:    https://platform.openai.com/docs/pricing
+--   Anthropic: https://docs.anthropic.com/en/docs/about-claude/pricing
+--   Gemini:    https://ai.google.dev/gemini-api/docs/pricing
+--
+-- Cache pricing conventions (unchanged from prior seed):
+--   Anthropic — cache_read = 0.1 × input, cache_write (5min ephemeral) = 1.25 × input
+--   OpenAI    — cached input ≈ 0.5 × input (varies by model family); no write concept
+--   Gemini    — context caching is priced but our integration doesn't surface it
+--              yet, so leave cache columns NULL (calculateCost falls back to the
+--              regular prompt price). Update when caching ships.
+--
+-- Tiered prices (Gemini 2.5 Pro, 3.1 Pro, 2.5 Computer Use): the seed stores a
+-- single per-token price, so we use the ≤200k-token tier — the band most
+-- production traffic falls into. If we ever model tiered pricing properly,
+-- expand the schema instead of guessing here.
+
+INSERT INTO model_prices (
+  provider, model,
+  prompt_price_per_1m, completion_price_per_1m,
+  cache_read_price_per_1m, cache_write_price_per_1m
+) VALUES
+  -- ── OpenAI: GPT-5.x flagship family (2026-05) ────────────────────────────
+  ('openai', 'gpt-5.5',           5.00,  30.00,   0.50,   NULL),
+  ('openai', 'gpt-5.5-pro',      30.00, 180.00,   NULL,   NULL),
+  ('openai', 'gpt-5.4',           2.50,  15.00,   0.25,   NULL),
+  ('openai', 'gpt-5.4-mini',      0.75,   4.50,   0.075,  NULL),
+  ('openai', 'gpt-5.4-nano',      0.20,   1.25,   0.02,   NULL),
+  ('openai', 'gpt-5.4-pro',      30.00, 180.00,   NULL,   NULL),
+  ('openai', 'gpt-5.3-codex',     1.75,  14.00,   0.175,  NULL),
+  -- ── Anthropic: Opus 4.1 / 4.5 / 4.6 + Sonnet 4.5 ────────────────────────
+  ('anthropic', 'claude-opus-4-6',              5.00,  25.00,   0.50,   6.25),
+  ('anthropic', 'claude-opus-4-5',              5.00,  25.00,   0.50,   6.25),
+  ('anthropic', 'claude-opus-4-1',             15.00,  75.00,   1.50,  18.75),
+  ('anthropic', 'claude-opus-4',               15.00,  75.00,   1.50,  18.75), -- deprecated, kept for historical replay
+  ('anthropic', 'claude-sonnet-4-5',            3.00,  15.00,   0.30,   3.75),
+  ('anthropic', 'claude-sonnet-4',              3.00,  15.00,   0.30,   3.75), -- deprecated
+  -- ── Gemini 3.x + 2.5 stragglers + 2.0-flash-lite ────────────────────────
+  ('gemini', 'gemini-3.5-flash',                       1.50,  9.00,   NULL, NULL),
+  ('gemini', 'gemini-3.1-pro-preview',                 2.00, 12.00,   NULL, NULL), -- ≤200k tier; >200k is 4.00/18.00
+  ('gemini', 'gemini-3.1-pro-preview-customtools',     2.00, 12.00,   NULL, NULL),
+  ('gemini', 'gemini-3.1-flash-lite',                  0.25,  1.50,   NULL, NULL),
+  ('gemini', 'gemini-3.1-flash-lite-preview',          0.25,  1.50,   NULL, NULL),
+  ('gemini', 'gemini-3-flash-preview',                 0.50,  3.00,   NULL, NULL),
+  ('gemini', 'gemini-2.5-flash-lite-preview-09-2025',  0.10,  0.40,   NULL, NULL),
+  ('gemini', 'gemini-2.0-flash-lite',                  0.075, 0.30,   NULL, NULL), -- deprecated 2026-06-01, kept for historical data
+  ('gemini', 'gemini-2.5-computer-use-preview-10-2025', 1.25, 10.00,  NULL, NULL)  -- ≤200k tier; >200k is 2.50/15.00
+ON CONFLICT (provider, model) DO UPDATE
+  SET prompt_price_per_1m      = EXCLUDED.prompt_price_per_1m,
+      completion_price_per_1m  = EXCLUDED.completion_price_per_1m,
+      cache_read_price_per_1m  = EXCLUDED.cache_read_price_per_1m,
+      cache_write_price_per_1m = EXCLUDED.cache_write_price_per_1m,
+      updated_at               = now();
+
+-- Models still NOT covered (no public pricing page entry as of 2026-05-22):
+--   OpenAI o-series: o1, o1-pro, o3, o3-pro, o3-deep-research, o4-mini, o4-mini-deep-research
+--   OpenAI legacy:   gpt-5, gpt-5.1, gpt-5.2, gpt-5-mini, gpt-5-nano, gpt-5-chat-latest, gpt-5-codex
+--                    gpt-4.5-preview, computer-use-preview, codex-mini-latest
+-- These appear in the OpenAI Playground model dropdown but have been removed
+-- from the public pricing table. Customers hitting them will still get cost=NULL.
+-- Add them once OpenAI exposes prices again, or once we see real production
+-- traffic for them.

--- a/supabase/migrations/20260522010000_model_prices_tiered.sql
+++ b/supabase/migrations/20260522010000_model_prices_tiered.sql
@@ -1,0 +1,84 @@
+-- Migration: Add tiered (long context) pricing to model_prices
+--
+-- WHY
+--   Some providers charge a different rate once the prompt crosses a threshold:
+--     • OpenAI GPT-5.x  — short context <272k tokens, long ≥272k (≈2× short)
+--     • Gemini Pro 2.5  — short ≤200k tokens, long >200k (2× short input, 1.5× output)
+--     • Gemini 3.1 Pro  — short ≤200k, long >200k (2× input, 1.5× output)
+--     • Gemini 2.5 Computer Use — short ≤200k, long >200k (2× input, 1.5× output)
+--   Previous schema stored a single per-token price, so calls in the long tier
+--   were billed at the short-tier rate — under-counting customer cost by ~50%
+--   on long-context calls.
+--
+-- DESIGN
+--   • long_context_threshold_tokens  IS NULL → flat pricing (no tiering)
+--   • long_context_threshold_tokens  IS NOT NULL → long_*_price_per_1m kicks in
+--     when calculateCost() sees promptTokens > threshold.
+--   • Each long_* column independently NULL-able. If long tier doesn't override
+--     a particular axis (e.g. cache_write rarely differs), leave NULL and the
+--     calculator falls back to the regular rate for that axis.
+
+ALTER TABLE model_prices
+  ADD COLUMN long_context_threshold_tokens   INTEGER,
+  ADD COLUMN long_prompt_price_per_1m        NUMERIC(10, 6),
+  ADD COLUMN long_completion_price_per_1m    NUMERIC(10, 6),
+  ADD COLUMN long_cache_read_price_per_1m    NUMERIC(10, 6),
+  ADD COLUMN long_cache_write_price_per_1m   NUMERIC(10, 6);
+
+COMMENT ON COLUMN model_prices.long_context_threshold_tokens IS
+  'Prompt tokens at which long-context pricing kicks in (calculateCost uses promptTokens > threshold). NULL = no tiering.';
+COMMENT ON COLUMN model_prices.long_prompt_price_per_1m IS
+  'USD per 1M prompt tokens when promptTokens > long_context_threshold_tokens. NULL = use prompt_price_per_1m.';
+COMMENT ON COLUMN model_prices.long_completion_price_per_1m IS
+  'USD per 1M completion tokens when in long-context tier. NULL = use completion_price_per_1m.';
+COMMENT ON COLUMN model_prices.long_cache_read_price_per_1m IS
+  'USD per 1M cache-read tokens when in long-context tier. NULL = use cache_read_price_per_1m.';
+COMMENT ON COLUMN model_prices.long_cache_write_price_per_1m IS
+  'USD per 1M cache-write tokens when in long-context tier. NULL = use cache_write_price_per_1m.';
+
+-- ── Backfill tiered models ───────────────────────────────────────────────────
+-- OpenAI: threshold 272,000 tokens (per pricing-page tooltip on the "Long context" header).
+UPDATE model_prices
+   SET long_context_threshold_tokens = 272000,
+       long_prompt_price_per_1m      = 10.00,
+       long_completion_price_per_1m  = 45.00,
+       long_cache_read_price_per_1m  =  1.00
+ WHERE provider = 'openai' AND model = 'gpt-5.5';
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 272000,
+       long_prompt_price_per_1m      = 60.00,
+       long_completion_price_per_1m  = 270.00
+ WHERE provider = 'openai' AND model = 'gpt-5.5-pro';
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 272000,
+       long_prompt_price_per_1m      =  5.00,
+       long_completion_price_per_1m  = 22.50,
+       long_cache_read_price_per_1m  =  0.50
+ WHERE provider = 'openai' AND model = 'gpt-5.4';
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 272000,
+       long_prompt_price_per_1m      = 60.00,
+       long_completion_price_per_1m  = 270.00
+ WHERE provider = 'openai' AND model = 'gpt-5.4-pro';
+
+-- Gemini: threshold 200,000 (≤200k = short, >200k = long)
+UPDATE model_prices
+   SET long_context_threshold_tokens = 200000,
+       long_prompt_price_per_1m      =  2.50,
+       long_completion_price_per_1m  = 15.00
+ WHERE provider = 'gemini' AND model = 'gemini-2.5-pro';
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 200000,
+       long_prompt_price_per_1m      =  4.00,
+       long_completion_price_per_1m  = 18.00
+ WHERE provider = 'gemini' AND model IN ('gemini-3.1-pro-preview', 'gemini-3.1-pro-preview-customtools');
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 200000,
+       long_prompt_price_per_1m      =  2.50,
+       long_completion_price_per_1m  = 15.00
+ WHERE provider = 'gemini' AND model = 'gemini-2.5-computer-use-preview-10-2025';

--- a/supabase/migrations/20260522020000_seed_models_openai_full.sql
+++ b/supabase/migrations/20260522020000_seed_models_openai_full.sql
@@ -1,0 +1,67 @@
+-- Migration: Add the rest of OpenAI's "All models" listing
+--
+-- WHY
+--   The 20260522000000 migration only added the flagship GPT-5.4/5.5 row,
+--   missing everything under the "All models" expander on the pricing page:
+--     • GPT-5 base family (gpt-5, 5.1, 5.2, plus mini/nano/pro variants)
+--     • Reasoning models (o1, o1-mini, o1-pro, o3, o3-mini, o3-pro, o4-mini)
+--     • Dated variants still callable (gpt-4o-2024-05-13, gpt-4-turbo-2024-04-09,
+--       gpt-4-0125-preview, gpt-4-1106-preview, gpt-4-1106-vision-preview,
+--       gpt-4-0613, gpt-4-0314, gpt-4-32k)
+--     • Legacy GPT-3.5 variants and base models (davinci-002, babbage-002)
+--   Without these, any customer call hitting them returned cost_usd = NULL on
+--   the requests row (CLAUDE.md gotcha #2).
+--
+-- TIERING
+--   None of the "All models" entries have an OpenAI-published long-context
+--   tier on the pricing page — only the flagship 5.4/5.5 quadrants do. So
+--   these rows are single-tier (long_context_threshold_tokens stays NULL).
+
+INSERT INTO model_prices (
+  provider, model,
+  prompt_price_per_1m, completion_price_per_1m,
+  cache_read_price_per_1m, cache_write_price_per_1m
+) VALUES
+  -- ── GPT-5 base family (no long tier) ──────────────────────────────────────
+  ('openai', 'gpt-5',                          1.25,   10.00,   0.125,  NULL),
+  ('openai', 'gpt-5.1',                        1.25,   10.00,   0.125,  NULL),
+  ('openai', 'gpt-5.2',                        1.75,   14.00,   0.175,  NULL),
+  ('openai', 'gpt-5.2-pro',                   21.00,  168.00,   NULL,   NULL),
+  ('openai', 'gpt-5-mini',                     0.25,    2.00,   0.025,  NULL),
+  ('openai', 'gpt-5-nano',                     0.05,    0.40,   0.005,  NULL),
+  ('openai', 'gpt-5-pro',                     15.00,  120.00,   NULL,   NULL),
+  -- ── Reasoning models (o-series) ──────────────────────────────────────────
+  ('openai', 'o4-mini',                        1.10,    4.40,   0.275,  NULL),
+  ('openai', 'o3',                             2.00,    8.00,   0.50,   NULL),
+  ('openai', 'o3-mini',                        1.10,    4.40,   0.55,   NULL),
+  ('openai', 'o3-pro',                        20.00,   80.00,   NULL,   NULL),
+  ('openai', 'o1',                            15.00,   60.00,   7.50,   NULL),
+  ('openai', 'o1-mini',                        1.10,    4.40,   0.55,   NULL),
+  ('openai', 'o1-pro',                       150.00,  600.00,   NULL,   NULL),
+  -- ── Dated GPT-4 variants (still callable; pin same prices as their families) ──
+  ('openai', 'gpt-4o-2024-05-13',              5.00,   15.00,   NULL,   NULL),
+  ('openai', 'gpt-4-turbo-2024-04-09',        10.00,   30.00,   NULL,   NULL),
+  ('openai', 'gpt-4-0125-preview',            10.00,   30.00,   NULL,   NULL),
+  ('openai', 'gpt-4-1106-preview',            10.00,   30.00,   NULL,   NULL),
+  ('openai', 'gpt-4-1106-vision-preview',     10.00,   30.00,   NULL,   NULL),
+  ('openai', 'gpt-4-0613',                    30.00,   60.00,   NULL,   NULL),
+  ('openai', 'gpt-4-0314',                    30.00,   60.00,   NULL,   NULL),
+  ('openai', 'gpt-4-32k',                     60.00,  120.00,   NULL,   NULL),
+  -- ── Legacy GPT-3.5 variants ──────────────────────────────────────────────
+  ('openai', 'gpt-3.5-turbo-0125',             0.50,    1.50,   NULL,   NULL),
+  ('openai', 'gpt-3.5-turbo-1106',             1.00,    2.00,   NULL,   NULL),
+  ('openai', 'gpt-3.5-turbo-0613',             1.50,    2.00,   NULL,   NULL),
+  ('openai', 'gpt-3.5-0301',                   1.50,    2.00,   NULL,   NULL),
+  ('openai', 'gpt-3.5-turbo-instruct',         1.50,    2.00,   NULL,   NULL),
+  ('openai', 'gpt-3.5-turbo-16k-0613',         3.00,    4.00,   NULL,   NULL),
+  -- ── Base models ──────────────────────────────────────────────────────────
+  ('openai', 'davinci-002',                    2.00,    2.00,   NULL,   NULL),
+  ('openai', 'babbage-002',                    0.40,    0.40,   NULL,   NULL),
+  -- ── Specialized: ChatGPT chat-latest (alias kept for completeness) ───────
+  ('openai', 'chat-latest',                    5.00,   30.00,   0.50,   NULL)
+ON CONFLICT (provider, model) DO UPDATE
+  SET prompt_price_per_1m      = EXCLUDED.prompt_price_per_1m,
+      completion_price_per_1m  = EXCLUDED.completion_price_per_1m,
+      cache_read_price_per_1m  = EXCLUDED.cache_read_price_per_1m,
+      cache_write_price_per_1m = EXCLUDED.cache_write_price_per_1m,
+      updated_at               = now();

--- a/supabase/migrations/20260522030000_seed_models_anthropic_full.sql
+++ b/supabase/migrations/20260522030000_seed_models_anthropic_full.sql
@@ -1,0 +1,44 @@
+-- Migration: Add dated/deprecated Anthropic model variants
+--
+-- WHY
+--   The Anthropic API returns dated IDs (e.g. `claude-opus-4-6-20250929`) in
+--   the response `model` field. We log exactly what the provider returns, so
+--   requests.model often contains the dated suffix even when the caller used
+--   the alias. cost.ts has a prefix fallback that catches most cases, but an
+--   exact-match row is more accurate and avoids surprises when prices fork
+--   between the alias and a future dated variant.
+--
+-- WHAT'S BEING ADDED
+--   • Dated variants for opus-4-6 / sonnet-4-5 / opus-4-5 / opus-4-1
+--   • Deprecated `*-0` aliases that the Anthropic SDK historically emitted
+--   • Dated variants of deprecated opus-4 / sonnet-4
+--   • claude-3-haiku-20240307 (Haiku 3 — retired 2026-04-19 per docs but still
+--     callable on Bedrock / Vertex; keep for historical replay)
+--
+-- Cache pricing follows the standard Anthropic 0.1× input (cache_read) and
+-- 1.25× input (5-minute cache_write) ratios. Haiku 3 left without cache
+-- because the original Haiku 3 launch did not support prompt caching.
+
+INSERT INTO model_prices (
+  provider, model,
+  prompt_price_per_1m, completion_price_per_1m,
+  cache_read_price_per_1m, cache_write_price_per_1m
+) VALUES
+  -- ── Current dated variants (active) ──────────────────────────────────────
+  ('anthropic', 'claude-opus-4-6-20250929',     5.00,  25.00,   0.50,   6.25),
+  ('anthropic', 'claude-opus-4-5-20251105',     5.00,  25.00,   0.50,   6.25),
+  ('anthropic', 'claude-opus-4-1-20250805',    15.00,  75.00,   1.50,  18.75),
+  ('anthropic', 'claude-sonnet-4-5-20251101',   3.00,  15.00,   0.30,   3.75),
+  -- ── Deprecated (still callable until shutoff) ────────────────────────────
+  ('anthropic', 'claude-opus-4-20250514',      15.00,  75.00,   1.50,  18.75),
+  ('anthropic', 'claude-opus-4-0',             15.00,  75.00,   1.50,  18.75),
+  ('anthropic', 'claude-sonnet-4-20250514',     3.00,  15.00,   0.30,   3.75),
+  ('anthropic', 'claude-sonnet-4-0',            3.00,  15.00,   0.30,   3.75),
+  -- ── Haiku 3 (retired 2026-04-19, kept for historical replay) ─────────────
+  ('anthropic', 'claude-3-haiku-20240307',      0.25,   1.25,   NULL,   NULL)
+ON CONFLICT (provider, model) DO UPDATE
+  SET prompt_price_per_1m      = EXCLUDED.prompt_price_per_1m,
+      completion_price_per_1m  = EXCLUDED.completion_price_per_1m,
+      cache_read_price_per_1m  = EXCLUDED.cache_read_price_per_1m,
+      cache_write_price_per_1m = EXCLUDED.cache_write_price_per_1m,
+      updated_at               = now();

--- a/supabase/migrations/20260522040000_fix_anthropic_dated_ids.sql
+++ b/supabase/migrations/20260522040000_fix_anthropic_dated_ids.sql
@@ -1,0 +1,39 @@
+-- Migration: Fix wrong Anthropic dated IDs added in 20260522030000
+--
+-- Per the canonical model overview page
+-- (https://platform.claude.com/docs/en/about-claude/models/overview, verified
+-- 2026-05-22), the legacy Claude API IDs are:
+--
+--   Opus 4.6   → claude-opus-4-6                   (no dated suffix exists)
+--   Sonnet 4.5 → claude-sonnet-4-5-20250929         (NOT 20251101)
+--   Opus 4.5   → claude-opus-4-5-20251101           (NOT 20251105)
+--
+-- The previous migration added the dated suffixes shifted by one model — the
+-- 20250929 date actually belongs to Sonnet 4.5, and 20251101 to Opus 4.5.
+-- Opus 4.6 doesn't have a dated suffix at all (only the alias).
+--
+-- The wrong rows are harmless (no real API call will ever return those exact
+-- model strings, so cost.ts prefix-fallback still resolves the cost correctly)
+-- but they pollute the table. Clean up + add correct rows.
+
+DELETE FROM model_prices
+ WHERE provider = 'anthropic'
+   AND model IN (
+     'claude-opus-4-6-20250929',
+     'claude-sonnet-4-5-20251101',
+     'claude-opus-4-5-20251105'
+   );
+
+INSERT INTO model_prices (
+  provider, model,
+  prompt_price_per_1m, completion_price_per_1m,
+  cache_read_price_per_1m, cache_write_price_per_1m
+) VALUES
+  ('anthropic', 'claude-sonnet-4-5-20250929',   3.00,  15.00,   0.30,   3.75),
+  ('anthropic', 'claude-opus-4-5-20251101',     5.00,  25.00,   0.50,   6.25)
+ON CONFLICT (provider, model) DO UPDATE
+  SET prompt_price_per_1m      = EXCLUDED.prompt_price_per_1m,
+      completion_price_per_1m  = EXCLUDED.completion_price_per_1m,
+      cache_read_price_per_1m  = EXCLUDED.cache_read_price_per_1m,
+      cache_write_price_per_1m = EXCLUDED.cache_write_price_per_1m,
+      updated_at               = now();

--- a/supabase/seeds/model_prices.sql
+++ b/supabase/seeds/model_prices.sql
@@ -1,41 +1,160 @@
--- Seed: Model pricing table (USD per 1M tokens, verified against provider pricing 2026-05)
+-- Seed: Model pricing table (USD per 1M tokens, verified against provider pricing 2026-05-22)
 --
 -- Cache pricing notes:
 --   • Anthropic prompt caching — cache_read = 0.1 × input price · cache_write (5min ephemeral) = 1.25 × input price
---   • OpenAI prompt caching    — cached input ≈ 0.5 × input price (gpt-4o / gpt-4.1 families; no cache_write concept)
---   • Models without official cache pricing use NULL → calculateCost() falls back to charging the regular prompt price.
+--   • OpenAI prompt caching    — cached input ≈ 0.5 × input price (gpt-4o / gpt-4.1 families; varies by model in GPT-5.x; no cache_write concept)
+--   • Gemini context caching   — priced by Google but our integration doesn't surface it yet, so leave NULL
+--   • Tiered prices (Gemini Pro / 2.5 Computer Use) use the ≤200k token band — most production traffic fits
 INSERT INTO model_prices (
   provider, model,
   prompt_price_per_1m, completion_price_per_1m,
   cache_read_price_per_1m, cache_write_price_per_1m
 ) VALUES
-  -- ── OpenAI ────────────────────────────────────────────────────────────────
-  ('openai', 'gpt-4o',           2.50,  10.00,   1.25,   NULL),
-  ('openai', 'gpt-4o-mini',      0.15,   0.60,   0.075,  NULL),
-  ('openai', 'gpt-4.1',          2.00,   8.00,   0.50,   NULL),
-  ('openai', 'gpt-4.1-mini',     0.40,   1.60,   0.10,   NULL),
-  ('openai', 'gpt-4.1-nano',     0.10,   0.40,   0.025,  NULL),
-  ('openai', 'gpt-4-turbo',     10.00,  30.00,   NULL,   NULL),
-  ('openai', 'gpt-4',           30.00,  60.00,   NULL,   NULL),
-  ('openai', 'gpt-3.5-turbo',    0.50,   1.50,   NULL,   NULL),
-  -- ── Anthropic ─────────────────────────────────────────────────────────────
-  ('anthropic', 'claude-opus-4-7',              5.00,  25.00,   0.50,   6.25),
-  ('anthropic', 'claude-sonnet-4-6',            3.00,  15.00,   0.30,   3.75),
-  ('anthropic', 'claude-haiku-4-5',             1.00,   5.00,   0.10,   1.25),
-  ('anthropic', 'claude-haiku-4-5-20251001',    1.00,   5.00,   0.10,   1.25),
-  ('anthropic', 'claude-3-5-sonnet-20241022',   3.00,  15.00,   0.30,   3.75),
-  ('anthropic', 'claude-3-5-haiku-20241022',    0.80,   4.00,   0.08,   1.00),
-  ('anthropic', 'claude-3-opus-20240229',      15.00,  75.00,   1.50,  18.75),
-  -- ── Gemini (caching not yet exposed in our integration) ──────────────────
-  ('gemini', 'gemini-2.5-pro',        1.25, 10.00,   NULL, NULL),
-  ('gemini', 'gemini-2.5-flash',      0.30,  2.50,   NULL, NULL),
-  ('gemini', 'gemini-2.5-flash-lite', 0.10,  0.40,   NULL, NULL),
-  ('gemini', 'gemini-2.0-flash',      0.10,  0.40,   NULL, NULL), -- deprecated 2026-06-01, kept for historical data
-  ('gemini', 'gemini-1.5-pro',        1.25,  5.00,   NULL, NULL),
-  ('gemini', 'gemini-1.5-flash',      0.075, 0.30,   NULL, NULL)
+  -- ── OpenAI: GPT-5.x flagship family ───────────────────────────────────────
+  ('openai', 'gpt-5.5',                          5.00,  30.00,   0.50,   NULL),
+  ('openai', 'gpt-5.5-pro',                     30.00, 180.00,   NULL,   NULL),
+  ('openai', 'gpt-5.4',                          2.50,  15.00,   0.25,   NULL),
+  ('openai', 'gpt-5.4-mini',                     0.75,   4.50,   0.075,  NULL),
+  ('openai', 'gpt-5.4-nano',                     0.20,   1.25,   0.02,   NULL),
+  ('openai', 'gpt-5.4-pro',                     30.00, 180.00,   NULL,   NULL),
+  ('openai', 'gpt-5.3-codex',                    1.75,  14.00,   0.175,  NULL),
+  -- ── OpenAI: GPT-5 base family (single tier — no long context) ───────────
+  ('openai', 'gpt-5',                            1.25,  10.00,   0.125,  NULL),
+  ('openai', 'gpt-5.1',                          1.25,  10.00,   0.125,  NULL),
+  ('openai', 'gpt-5.2',                          1.75,  14.00,   0.175,  NULL),
+  ('openai', 'gpt-5.2-pro',                     21.00, 168.00,   NULL,   NULL),
+  ('openai', 'gpt-5-mini',                       0.25,   2.00,   0.025,  NULL),
+  ('openai', 'gpt-5-nano',                       0.05,   0.40,   0.005,  NULL),
+  ('openai', 'gpt-5-pro',                       15.00, 120.00,   NULL,   NULL),
+  ('openai', 'chat-latest',                      5.00,  30.00,   0.50,   NULL), -- ChatGPT alias
+  -- ── OpenAI: Reasoning (o-series) ─────────────────────────────────────────
+  ('openai', 'o4-mini',                          1.10,   4.40,   0.275,  NULL),
+  ('openai', 'o3',                               2.00,   8.00,   0.50,   NULL),
+  ('openai', 'o3-mini',                          1.10,   4.40,   0.55,   NULL),
+  ('openai', 'o3-pro',                          20.00,  80.00,   NULL,   NULL),
+  ('openai', 'o1',                              15.00,  60.00,   7.50,   NULL),
+  ('openai', 'o1-mini',                          1.10,   4.40,   0.55,   NULL),
+  ('openai', 'o1-pro',                         150.00, 600.00,   NULL,   NULL),
+  -- ── OpenAI: GPT-4.x ──────────────────────────────────────────────────────
+  ('openai', 'gpt-4o',                           2.50,  10.00,   1.25,   NULL),
+  ('openai', 'gpt-4o-mini',                      0.15,   0.60,   0.075,  NULL),
+  ('openai', 'gpt-4o-2024-05-13',                5.00,  15.00,   NULL,   NULL), -- dated variant
+  ('openai', 'gpt-4.1',                          2.00,   8.00,   0.50,   NULL),
+  ('openai', 'gpt-4.1-mini',                     0.40,   1.60,   0.10,   NULL),
+  ('openai', 'gpt-4.1-nano',                     0.10,   0.40,   0.025,  NULL),
+  ('openai', 'gpt-4-turbo',                     10.00,  30.00,   NULL,   NULL),
+  ('openai', 'gpt-4-turbo-2024-04-09',          10.00,  30.00,   NULL,   NULL),
+  ('openai', 'gpt-4-0125-preview',              10.00,  30.00,   NULL,   NULL),
+  ('openai', 'gpt-4-1106-preview',              10.00,  30.00,   NULL,   NULL),
+  ('openai', 'gpt-4-1106-vision-preview',       10.00,  30.00,   NULL,   NULL),
+  ('openai', 'gpt-4',                           30.00,  60.00,   NULL,   NULL),
+  ('openai', 'gpt-4-0613',                      30.00,  60.00,   NULL,   NULL),
+  ('openai', 'gpt-4-0314',                      30.00,  60.00,   NULL,   NULL),
+  ('openai', 'gpt-4-32k',                       60.00, 120.00,   NULL,   NULL),
+  -- ── OpenAI: GPT-3.5 + base models ────────────────────────────────────────
+  ('openai', 'gpt-3.5-turbo',                    0.50,   1.50,   NULL,   NULL),
+  ('openai', 'gpt-3.5-turbo-0125',               0.50,   1.50,   NULL,   NULL),
+  ('openai', 'gpt-3.5-turbo-1106',               1.00,   2.00,   NULL,   NULL),
+  ('openai', 'gpt-3.5-turbo-0613',               1.50,   2.00,   NULL,   NULL),
+  ('openai', 'gpt-3.5-0301',                     1.50,   2.00,   NULL,   NULL),
+  ('openai', 'gpt-3.5-turbo-instruct',           1.50,   2.00,   NULL,   NULL),
+  ('openai', 'gpt-3.5-turbo-16k-0613',           3.00,   4.00,   NULL,   NULL),
+  ('openai', 'davinci-002',                      2.00,   2.00,   NULL,   NULL),
+  ('openai', 'babbage-002',                      0.40,   0.40,   NULL,   NULL),
+  -- ── Anthropic: Claude 4.x (aliases + dated variants) ────────────────────
+  ('anthropic', 'claude-opus-4-7',               5.00,  25.00,   0.50,   6.25),
+  ('anthropic', 'claude-opus-4-6',               5.00,  25.00,   0.50,   6.25), -- alias only; no dated form per docs
+  ('anthropic', 'claude-opus-4-5',               5.00,  25.00,   0.50,   6.25),
+  ('anthropic', 'claude-opus-4-5-20251101',      5.00,  25.00,   0.50,   6.25),
+  ('anthropic', 'claude-opus-4-1',              15.00,  75.00,   1.50,  18.75),
+  ('anthropic', 'claude-opus-4-1-20250805',     15.00,  75.00,   1.50,  18.75),
+  ('anthropic', 'claude-opus-4',                15.00,  75.00,   1.50,  18.75), -- deprecated
+  ('anthropic', 'claude-opus-4-0',              15.00,  75.00,   1.50,  18.75), -- deprecated alias
+  ('anthropic', 'claude-opus-4-20250514',       15.00,  75.00,   1.50,  18.75), -- deprecated dated
+  ('anthropic', 'claude-sonnet-4-6',             3.00,  15.00,   0.30,   3.75),
+  ('anthropic', 'claude-sonnet-4-5',             3.00,  15.00,   0.30,   3.75),
+  ('anthropic', 'claude-sonnet-4-5-20250929',    3.00,  15.00,   0.30,   3.75),
+  ('anthropic', 'claude-sonnet-4',               3.00,  15.00,   0.30,   3.75), -- deprecated
+  ('anthropic', 'claude-sonnet-4-0',             3.00,  15.00,   0.30,   3.75), -- deprecated alias
+  ('anthropic', 'claude-sonnet-4-20250514',      3.00,  15.00,   0.30,   3.75), -- deprecated dated
+  ('anthropic', 'claude-haiku-4-5',              1.00,   5.00,   0.10,   1.25),
+  ('anthropic', 'claude-haiku-4-5-20251001',     1.00,   5.00,   0.10,   1.25),
+  -- ── Anthropic: Claude 3.x ────────────────────────────────────────────────
+  ('anthropic', 'claude-3-5-sonnet-20241022',    3.00,  15.00,   0.30,   3.75),
+  ('anthropic', 'claude-3-5-haiku-20241022',     0.80,   4.00,   0.08,   1.00),
+  ('anthropic', 'claude-3-opus-20240229',       15.00,  75.00,   1.50,  18.75),
+  ('anthropic', 'claude-3-haiku-20240307',       0.25,   1.25,   NULL,   NULL), -- retired 2026-04-19
+  -- ── Gemini 3.x ───────────────────────────────────────────────────────────
+  ('gemini', 'gemini-3.5-flash',                       1.50,   9.00,   NULL, NULL),
+  ('gemini', 'gemini-3.1-pro-preview',                 2.00,  12.00,   NULL, NULL), -- ≤200k tier; >200k is 4.00/18.00
+  ('gemini', 'gemini-3.1-pro-preview-customtools',     2.00,  12.00,   NULL, NULL),
+  ('gemini', 'gemini-3.1-flash-lite',                  0.25,   1.50,   NULL, NULL),
+  ('gemini', 'gemini-3.1-flash-lite-preview',          0.25,   1.50,   NULL, NULL),
+  ('gemini', 'gemini-3-flash-preview',                 0.50,   3.00,   NULL, NULL),
+  -- ── Gemini 2.5 ───────────────────────────────────────────────────────────
+  ('gemini', 'gemini-2.5-pro',                         1.25,  10.00,   NULL, NULL), -- ≤200k tier; >200k is 2.50/15.00
+  ('gemini', 'gemini-2.5-flash',                       0.30,   2.50,   NULL, NULL),
+  ('gemini', 'gemini-2.5-flash-lite',                  0.10,   0.40,   NULL, NULL),
+  ('gemini', 'gemini-2.5-flash-lite-preview-09-2025',  0.10,   0.40,   NULL, NULL),
+  ('gemini', 'gemini-2.5-computer-use-preview-10-2025', 1.25, 10.00,   NULL, NULL), -- ≤200k tier; >200k is 2.50/15.00
+  -- ── Gemini 2.0 / 1.5 ─────────────────────────────────────────────────────
+  ('gemini', 'gemini-2.0-flash',                       0.10,   0.40,   NULL, NULL), -- deprecated 2026-06-01
+  ('gemini', 'gemini-2.0-flash-lite',                  0.075,  0.30,   NULL, NULL), -- deprecated 2026-06-01
+  ('gemini', 'gemini-1.5-pro',                         1.25,   5.00,   NULL, NULL),
+  ('gemini', 'gemini-1.5-flash',                       0.075,  0.30,   NULL, NULL)
 ON CONFLICT (provider, model) DO UPDATE
   SET prompt_price_per_1m      = EXCLUDED.prompt_price_per_1m,
       completion_price_per_1m  = EXCLUDED.completion_price_per_1m,
       cache_read_price_per_1m  = EXCLUDED.cache_read_price_per_1m,
       cache_write_price_per_1m = EXCLUDED.cache_write_price_per_1m,
       updated_at               = now();
+
+-- ── Long context (tiered) pricing ───────────────────────────────────────────
+-- See lib/cost.ts: when promptTokens > long_context_threshold_tokens the
+-- long_* columns override the short-tier prices on the same row.
+--
+--   OpenAI threshold = 272,000 tokens (per the pricing-page tooltip on the Long context header)
+--   Gemini threshold = 200,000 tokens (Pro family explicit ≤/> split)
+UPDATE model_prices
+   SET long_context_threshold_tokens = 272000,
+       long_prompt_price_per_1m      = 10.00,
+       long_completion_price_per_1m  = 45.00,
+       long_cache_read_price_per_1m  =  1.00
+ WHERE provider = 'openai' AND model = 'gpt-5.5';
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 272000,
+       long_prompt_price_per_1m      = 60.00,
+       long_completion_price_per_1m  = 270.00
+ WHERE provider = 'openai' AND model = 'gpt-5.5-pro';
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 272000,
+       long_prompt_price_per_1m      =  5.00,
+       long_completion_price_per_1m  = 22.50,
+       long_cache_read_price_per_1m  =  0.50
+ WHERE provider = 'openai' AND model = 'gpt-5.4';
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 272000,
+       long_prompt_price_per_1m      = 60.00,
+       long_completion_price_per_1m  = 270.00
+ WHERE provider = 'openai' AND model = 'gpt-5.4-pro';
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 200000,
+       long_prompt_price_per_1m      =  2.50,
+       long_completion_price_per_1m  = 15.00
+ WHERE provider = 'gemini' AND model = 'gemini-2.5-pro';
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 200000,
+       long_prompt_price_per_1m      =  4.00,
+       long_completion_price_per_1m  = 18.00
+ WHERE provider = 'gemini' AND model IN ('gemini-3.1-pro-preview', 'gemini-3.1-pro-preview-customtools');
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 200000,
+       long_prompt_price_per_1m      =  2.50,
+       long_completion_price_per_1m  = 15.00
+ WHERE provider = 'gemini' AND model = 'gemini-2.5-computer-use-preview-10-2025';


### PR DESCRIPTION
## Summary

Two independent feature lines bundled in one PR for shippability.

### 1. Demo parity with live dashboard
- Demo sidebar now mirrors live: ADMIN section (Projects/Settings/Docs), Plan widget, Theme · system, Sign out, workspace switcher popover
- New demo pages: `/demo/projects`, `/demo/settings` (14 tabs), `/demo/billing`, `/demo/alerts/[id]`
- New tab on `/demo/prompts/[name]`: Playground (static demo result)
- Bug fix: 5 demo detail pages were reading `params.id` directly — broken under Next 16 async params. Switched to `use(params)`

### 2. model_prices expansion + service_tier auto-detection
- **Models registered: 21 → 83** (OpenAI 46 + Anthropic 22 + Gemini 15). Verified 1:1 against official pricing pages on 2026-05-22
- **Tiered (long-context) pricing schema**: new columns `long_context_threshold_tokens` + `long_*_price_per_1m`. Backfilled for 7 tiered models (GPT-5.5/5.4 family @ 272k, Gemini Pro @ 200k)
- **service_tier auto-detection**: parsers extract from response body (`service_tier` for OpenAI, `usageMetadata.serviceTier` for Gemini), cost calc applies multiplier (flex/batch 0.5×, priority 1.8×). New `LowCardinality(String)` column on ClickHouse `requests`. No customer action required — completely passive observation
- Anthropic untouched (account-level tier, no per-response field)

## Migrations

**Supabase** (5 files, idempotent ON CONFLICT DO UPDATE):
- `20260522000000_seed_models_2026_05.sql` — initial 2026-05 model batch
- `20260522010000_model_prices_tiered.sql` — long-context schema + backfill
- `20260522020000_seed_models_openai_full.sql` — All models expansion (o-series, GPT-5 base, legacy)
- `20260522030000_seed_models_anthropic_full.sql` — Anthropic dated variants + Haiku 3
- `20260522040000_fix_anthropic_dated_ids.sql` — fix 3 wrong dated IDs

**ClickHouse** (1 file, idempotent IF NOT EXISTS):
- `003_add_service_tier.sql` — new column with DEFAULT ''

## Test plan
- [x] Server: `pnpm --filter server test` → 554 tests pass (44 files, +13 new)
- [x] Server: `pnpm --filter server lint` clean
- [x] Web: `pnpm --filter web typecheck && lint` clean
- [x] Local preview: verified demo sidebar, all 4 new pages render, Playground tab loads
- [ ] Post-merge: apply Supabase migrations + `pnpm ch:migrate` against staging, hit `/proxy/openai/v1/chat/completions` with `service_tier: 'priority'` and confirm `requests.service_tier` populated + cost multiplied
- [ ] Verify dashboard cost figures unchanged for existing Standard tier traffic (regression check)

## Deploy order
1. Merge PR → Vercel build with new code (CH columns absent → silently skipped via `input_format_skip_unknown_fields=1`, gotcha #21)
2. `supabase db push` (5 migrations)
3. `pnpm ch:migrate` (1 migration)
4. Smoke test: priority call returns correct cost