### PR TITLE
fix(server): detect service_tier on Anthropic + recognize 'standard'

### DIFF
--- a/apps/server/src/lib/cost.ts
+++ b/apps/server/src/lib/cost.ts
@@ -54,6 +54,7 @@ export interface Usage {
  */
 const TIER_MULTIPLIERS: Record<ServiceTier, number> = {
   default: 1.0,
+  standard: 1.0,  // Gemini + Anthropic report this name for the Standard tier
   auto: 1.0,
   scale: 1.0,
   batch: 0.5,

--- a/apps/server/src/parsers/anthropic.ts
+++ b/apps/server/src/parsers/anthropic.ts
@@ -1,4 +1,14 @@
-import type { ParsedUsage } from './openai.js'
+import type { ParsedUsage, ServiceTier } from './openai.js'
+
+const KNOWN_TIERS: ReadonlySet<ServiceTier> = new Set([
+  'default', 'standard', 'auto', 'flex', 'priority', 'scale', 'batch',
+])
+
+/** Anthropic exposes the served tier at `usage.service_tier`. Same shape as OpenAI. */
+function coerceServiceTier(value: unknown): ServiceTier | undefined {
+  if (typeof value !== 'string') return undefined
+  return KNOWN_TIERS.has(value as ServiceTier) ? (value as ServiceTier) : undefined
+}
 
 /**
  * Anthropic 응답에서 usage를 추출합니다.
@@ -9,13 +19,20 @@ import type { ParsedUsage } from './openai.js'
  * 세 필드를 합산해서 promptTokens에 넣고, 캐시 부분은 별도 필드로도 노출합니다.
  *
  * (참고: streaming은 message_start에서 input_tokens + cache_*가 함께 옴 — 동일하게 합산)
+ *
+ * service_tier는 Anthropic이 `usage.service_tier`로 노출 (OpenAI/Gemini와 유사).
+ * 초기 가정 ("Anthropic은 tier를 응답에 안 줌")이 틀렸음 — 응답 body의 usage 객체
+ * 안에 있다.
  */
-function buildAnthropicUsage(usage: Record<string, number>, model: string): ParsedUsage {
-  const inputTokens = usage.input_tokens ?? 0
-  const cacheRead = usage.cache_read_input_tokens ?? 0
-  const cacheWrite = usage.cache_creation_input_tokens ?? 0
+function buildAnthropicUsage(
+  usage: Record<string, unknown>,
+  model: string,
+): ParsedUsage {
+  const inputTokens = (usage.input_tokens as number) ?? 0
+  const cacheRead = (usage.cache_read_input_tokens as number) ?? 0
+  const cacheWrite = (usage.cache_creation_input_tokens as number) ?? 0
   const promptTokens = inputTokens + cacheRead + cacheWrite
-  const completionTokens = usage.output_tokens ?? 0
+  const completionTokens = (usage.output_tokens as number) ?? 0
   return {
     promptTokens,
     completionTokens,
@@ -23,11 +40,12 @@ function buildAnthropicUsage(usage: Record<string, number>, model: string): Pars
     model,
     cacheReadTokens: cacheRead,
     cacheWriteTokens: cacheWrite,
+    serviceTier: coerceServiceTier(usage.service_tier),
   }
 }
 
 export function parseAnthropicResponse(body: Record<string, unknown>): ParsedUsage | null {
-  const usage = body.usage as Record<string, number> | undefined
+  const usage = body.usage as Record<string, unknown> | undefined
   if (!usage) return null
   return buildAnthropicUsage(usage, (body.model as string) ?? '')
 }
@@ -72,16 +90,17 @@ export function parseAnthropicStreamStart(line: string): Partial<ParsedUsage> | 
     const json = JSON.parse(data) as Record<string, unknown>
     if (json.type !== 'message_start') return null
     const message = json.message as Record<string, unknown> | undefined
-    const usage = message?.usage as Record<string, number> | undefined
+    const usage = message?.usage as Record<string, unknown> | undefined
     if (!usage) return null
-    const inputTokens = usage.input_tokens ?? 0
-    const cacheRead = usage.cache_read_input_tokens ?? 0
-    const cacheWrite = usage.cache_creation_input_tokens ?? 0
+    const inputTokens = (usage.input_tokens as number) ?? 0
+    const cacheRead = (usage.cache_read_input_tokens as number) ?? 0
+    const cacheWrite = (usage.cache_creation_input_tokens as number) ?? 0
     return {
       promptTokens: inputTokens + cacheRead + cacheWrite,
       cacheReadTokens: cacheRead,
       cacheWriteTokens: cacheWrite,
       model: (message?.model as string) ?? '',
+      serviceTier: coerceServiceTier(usage.service_tier),
     }
   } catch {
     return null

--- a/apps/server/src/parsers/gemini.ts
+++ b/apps/server/src/parsers/gemini.ts
@@ -1,7 +1,7 @@
 import type { ParsedUsage, ServiceTier } from './openai.js'
 
 const KNOWN_TIERS: ReadonlySet<ServiceTier> = new Set([
-  'default', 'auto', 'flex', 'priority', 'scale', 'batch',
+  'default', 'standard', 'auto', 'flex', 'priority', 'scale', 'batch',
 ])
 
 /**

--- a/apps/server/src/parsers/openai.ts
+++ b/apps/server/src/parsers/openai.ts
@@ -8,7 +8,7 @@
  *     for the most part; 'default' = Standard, 'flex', 'priority', 'batch'.
  *   Unknown / missing → undefined; caller logs '' (empty string).
  */
-export type ServiceTier = 'default' | 'auto' | 'flex' | 'priority' | 'scale' | 'batch'
+export type ServiceTier = 'default' | 'standard' | 'auto' | 'flex' | 'priority' | 'scale' | 'batch'
 
 export interface ParsedUsage {
   /**
@@ -45,7 +45,7 @@ export interface ParsedUsage {
 }
 
 const KNOWN_TIERS: ReadonlySet<ServiceTier> = new Set([
-  'default', 'auto', 'flex', 'priority', 'scale', 'batch',
+  'default', 'standard', 'auto', 'flex', 'priority', 'scale', 'batch',
 ])
 
 /** Narrow an unknown string to ServiceTier, dropping anything we don't recognize. */

--- a/apps/server/src/proxy/anthropic.ts
+++ b/apps/server/src/proxy/anthropic.ts
@@ -170,6 +170,7 @@ anthropicProxy.all('/*', async (c) => {
   let cacheReadTokens = 0
   let cacheWriteTokens = 0
   let resolvedModel = model
+  let serviceTier: import('../parsers/openai.js').ServiceTier | undefined
 
   if (upstreamRes.ok && resBodyJson) {
     try {
@@ -181,12 +182,13 @@ anthropicProxy.all('/*', async (c) => {
         totalTokens = parsed.totalTokens
         cacheReadTokens = parsed.cacheReadTokens ?? 0
         cacheWriteTokens = parsed.cacheWriteTokens ?? 0
+        serviceTier = parsed.serviceTier
       }
     } catch { /* ignore */ }
   }
 
   const cost = calculateCost('anthropic', resolvedModel, {
-    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens,
+    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
   })
 
   fireAndForget(c, logRequestAsync({
@@ -194,6 +196,7 @@ anthropicProxy.all('/*', async (c) => {
     model: resolvedModel,
     promptTokens, completionTokens, totalTokens,
     cacheReadTokens, cacheWriteTokens,
+    serviceTier: serviceTier ?? null,
     costUsd: cost?.totalCost ?? null,
     responseBody: resBodyJson,
     errorMessage: upstreamRes.ok ? null : resBodyText.slice(0, 1000),

--- a/apps/server/src/proxy/stream-logger.ts
+++ b/apps/server/src/proxy/stream-logger.ts
@@ -142,6 +142,7 @@ export async function logAnthropicStream(
   let completionTokens = 0
   let cacheReadTokens = 0
   let cacheWriteTokens = 0
+  let serviceTier: ServiceTier | undefined
 
   for (const line of lines) {
     const start = parseAnthropicStreamStart(line)
@@ -150,6 +151,7 @@ export async function logAnthropicStream(
       if (start.cacheReadTokens) cacheReadTokens = start.cacheReadTokens
       if (start.cacheWriteTokens) cacheWriteTokens = start.cacheWriteTokens
       if (start.model) model = start.model
+      if (start.serviceTier) serviceTier = start.serviceTier
       continue
     }
     const delta = parseAnthropicStreamChunk(line)
@@ -158,7 +160,7 @@ export async function logAnthropicStream(
 
   const totalTokens = promptTokens + completionTokens
   const cost = calculateCost('anthropic' as Provider, model, {
-    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens,
+    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
   })
 
   // Reconstruct upstream-shape usage so the dashboard preserves the raw
@@ -193,6 +195,7 @@ export async function logAnthropicStream(
     totalTokens,
     cacheReadTokens,
     cacheWriteTokens,
+    serviceTier: serviceTier ?? null,
     costUsd: cost?.totalCost ?? null,
     responseBody,
     truncated: ctx.truncated ?? false,

--- a/scripts/setup-smoke-test.mjs
+++ b/scripts/setup-smoke-test.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Inserts org/project/api_key/provider_keys into the local Supabase DB so the
+ * proxy can be exercised end-to-end without the web signup flow.
+ *
+ * Uses raw fetch to PostgREST so we don't need supabase-js installed at the
+ * scripts/ root.
+ *
+ * Throwaway: smoke test session 2026-05-22.
+ */
+
+const ENCRYPTION_KEY = process.env.ENCRYPTION_KEY
+const SUPABASE_URL = process.env.SUPABASE_URL ?? 'http://127.0.0.1:54321'
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY
+const OPENAI_KEY = process.env.SMOKE_OPENAI_KEY
+const GEMINI_KEY = process.env.SMOKE_GEMINI_KEY
+const ANTHROPIC_KEY = process.env.SMOKE_ANTHROPIC_KEY
+
+if (!ENCRYPTION_KEY || !SUPABASE_SERVICE_ROLE_KEY) {
+  console.error('Set ENCRYPTION_KEY and SUPABASE_SERVICE_ROLE_KEY')
+  process.exit(1)
+}
+if (!OPENAI_KEY || !GEMINI_KEY || !ANTHROPIC_KEY) {
+  console.error('Set SMOKE_OPENAI_KEY, SMOKE_GEMINI_KEY, SMOKE_ANTHROPIC_KEY')
+  process.exit(1)
+}
+
+// ── crypto helpers (mirrored from apps/server/src/lib/crypto.ts) ────────────
+const ALGORITHM = 'AES-GCM'
+const IV_LENGTH = 12
+const TAG_LENGTH = 16
+
+function base64ToBytes(b64) {
+  return Uint8Array.from(Buffer.from(b64, 'base64'))
+}
+function bytesToBase64(bytes) {
+  return Buffer.from(bytes).toString('base64')
+}
+
+async function getKey() {
+  const keyBytes = base64ToBytes(ENCRYPTION_KEY)
+  if (keyBytes.length !== 32) throw new Error('ENCRYPTION_KEY must decode to 32 bytes')
+  return crypto.subtle.importKey('raw', keyBytes, { name: ALGORITHM }, false, ['encrypt'])
+}
+
+async function aes256Encrypt(plaintext) {
+  const key = await getKey()
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH))
+  const encoded = new TextEncoder().encode(plaintext)
+  const encrypted = new Uint8Array(
+    await crypto.subtle.encrypt({ name: ALGORITHM, iv }, key, encoded),
+  )
+  const cipherOnly = encrypted.subarray(0, encrypted.length - TAG_LENGTH)
+  const tag = encrypted.subarray(encrypted.length - TAG_LENGTH)
+  const result = new Uint8Array(IV_LENGTH + TAG_LENGTH + cipherOnly.length)
+  result.set(iv, 0)
+  result.set(tag, IV_LENGTH)
+  result.set(cipherOnly, IV_LENGTH + TAG_LENGTH)
+  return bytesToBase64(result)
+}
+
+function randomHex(bytes) {
+  return Array.from(crypto.getRandomValues(new Uint8Array(bytes)), (b) =>
+    b.toString(16).padStart(2, '0'),
+  ).join('')
+}
+
+async function sha256Hex(text) {
+  const data = new TextEncoder().encode(text)
+  const buf = await crypto.subtle.digest('SHA-256', data)
+  return Array.from(new Uint8Array(buf), (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+// ── PostgREST helper ────────────────────────────────────────────────────────
+async function pgInsert(table, body) {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${table}`, {
+    method: 'POST',
+    headers: {
+      'apikey': SUPABASE_SERVICE_ROLE_KEY,
+      'Authorization': `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+      'Content-Type': 'application/json',
+      'Prefer': 'return=representation',
+    },
+    body: JSON.stringify(body),
+  })
+  const text = await res.text()
+  if (!res.ok) {
+    throw new Error(`${table} INSERT failed (${res.status}): ${text}`)
+  }
+  return JSON.parse(text)
+}
+
+// ── set up DB rows ──────────────────────────────────────────────────────────
+console.log('1. Creating auth user (owner)...')
+const userRes = await fetch(`${SUPABASE_URL}/auth/v1/admin/users`, {
+  method: 'POST',
+  headers: {
+    'apikey': SUPABASE_SERVICE_ROLE_KEY,
+    'Authorization': `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    email: `smoke-${Date.now()}@example.com`,
+    password: 'smoke-test-' + randomHex(8),
+    email_confirm: true,
+  }),
+})
+const userData = await userRes.json()
+if (!userRes.ok) {
+  console.error('auth user create failed:', userData)
+  process.exit(1)
+}
+const ownerId = userData.id
+console.log('   owner_id =', ownerId)
+
+console.log('2. Creating organization...')
+const [org] = await pgInsert('organizations', {
+  name: 'Smoke Test Org',
+  plan: 'team',
+  owner_id: ownerId,
+})
+console.log('   org_id =', org.id)
+
+console.log('3. Creating project...')
+const [project] = await pgInsert('projects', {
+  organization_id: org.id,
+  name: 'smoke-test',
+})
+console.log('   project_id =', project.id)
+
+console.log('4. Generating Spanlens key...')
+const rawKey = 'sl_live_' + randomHex(24)
+const keyHash = await sha256Hex(rawKey)
+const keyPrefix = rawKey.slice(0, 12)
+const [apiKey] = await pgInsert('api_keys', {
+  project_id: project.id,
+  name: 'smoke-test-key',
+  key_hash: keyHash,
+  key_prefix: keyPrefix,
+})
+console.log('   api_key_id =', apiKey.id)
+
+console.log('5. Encrypting + inserting provider keys...')
+const providers = [
+  { provider: 'openai',    plain: OPENAI_KEY,    name: 'smoke-openai' },
+  { provider: 'gemini',    plain: GEMINI_KEY,    name: 'smoke-gemini' },
+  { provider: 'anthropic', plain: ANTHROPIC_KEY, name: 'smoke-anthropic' },
+]
+for (const p of providers) {
+  const encrypted = await aes256Encrypt(p.plain)
+  await pgInsert('provider_keys', {
+    organization_id: org.id,
+    api_key_id: apiKey.id,
+    provider: p.provider,
+    name: p.name,
+    encrypted_key: encrypted,
+  })
+  console.log(`   ${p.provider}: stored (encrypted ${encrypted.length}b)`)
+}
+
+console.log('\n── READY ────────────────────────────────────────────────────')
+console.log('export SPANLENS_KEY=' + rawKey)
+console.log('export ORG_ID=' + org.id)
+console.log('export PROJECT_ID=' + project.id)
+console.log('─────────────────────────────────────────────────────────────')


### PR DESCRIPTION
## Summary

Smoke-tested PR #146 with real OpenAI, Gemini, and Anthropic keys and found two wrong assumptions:

### Bug 1: Anthropic DOES expose service_tier
The PR #146 note said "Anthropic surfaces tier only at the account level, not in the response." Live response proves otherwise — it ships `usage.service_tier` (value: `standard` in our test) right next to the token counts. Wired the parser, the messages proxy, and the streaming logger so the field flows through to ClickHouse.

### Bug 2: Gemini/Anthropic report 'standard', not 'default'
Our `KNOWN_TIERS` set only included the OpenAI names. When Gemini/Anthropic returned `standard`, `coerceServiceTier()` rejected it and the column stayed empty. Added `standard` to the type, both KNOWN_TIERS sets, and TIER_MULTIPLIERS as a 1.0× synonym for `default`.

Also bundled the smoke-test setup script (`scripts/setup-smoke-test.mjs`) — reusable for future end-to-end tests.

## Verified

| Provider | Tier sent | Tier in CH | Cost |
|---|---|---|---|
| OpenAI gpt-4o-mini | default | `default` | $0.000003 (baseline) |
| OpenAI gpt-4o-mini | priority | `priority` | $0.0000054 (baseline × 1.8) ✓ |
| Gemini gemini-2.5-flash | (auto) | `standard` | normal |
| Anthropic claude-haiku-4-5-20251001 | (auto) | `standard` | normal |

Priority multiplier is verified end-to-end against a real OpenAI response — math matches exactly.

## Test plan
- [x] `pnpm --filter server test` → 554 pass
- [x] Smoke test: hit all 3 providers via local proxy + verify CH rows
- [ ] Post-merge: monitor production for ~1h to confirm service_tier populates