### PR TITLE
feat: dynamic models + Gemini judge + dataset upload + eval dataset fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ npm-debug.log*
 
 # Internal planning documents — never commit to public repo
 *.pdf
+*.pptx

--- a/apps/server/src/api/datasets.ts
+++ b/apps/server/src/api/datasets.ts
@@ -184,6 +184,95 @@ datasetsRouter.post('/:id/items', async (c) => {
   return c.json({ success: true, data }, 201)
 })
 
+// POST /api/v1/datasets/:id/items/bulk — bulk INSERT of items uploaded
+// from a client-side parsed file (JSON / CSV). Treats each row as an
+// independent item; partial-failure surfaced with per-row status so the UI
+// can show "8/10 inserted, 2 skipped (missing input)".
+datasetsRouter.post('/:id/items/bulk', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const datasetId = c.req.param('id')
+
+  // Verify ownership (same pattern as POST /items)
+  const { data: ds } = await supabaseAdmin
+    .from('datasets')
+    .select('id')
+    .eq('id', datasetId)
+    .eq('organization_id', orgId)
+    .is('archived_at', null)
+    .maybeSingle()
+  if (!ds) return c.json({ error: 'Dataset not found' }, 404)
+
+  let body: { items?: unknown }
+  try {
+    body = (await c.req.json()) as typeof body
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400)
+  }
+
+  if (!Array.isArray(body.items)) {
+    return c.json({ error: 'items must be an array' }, 400)
+  }
+  if (body.items.length === 0) {
+    return c.json({ error: 'items array is empty' }, 400)
+  }
+  // Cap per-request size to keep payload + memory bounded. Most uploads
+  // are <1000 rows in practice.
+  if (body.items.length > 5000) {
+    return c.json({ error: 'items array too large (max 5000)' }, 400)
+  }
+
+  // Normalize each row to the schema enforced by single-item POST:
+  // input must be an object containing `variables` or `messages`.
+  const rows: { organization_id: string; dataset_id: string; input: Record<string, unknown>; expected_output: string | null }[] = []
+  const skipped: { index: number; reason: string }[] = []
+
+  for (let i = 0; i < body.items.length; i++) {
+    const raw = body.items[i] as Record<string, unknown> | undefined
+    if (!raw || typeof raw !== 'object') {
+      skipped.push({ index: i, reason: 'not an object' })
+      continue
+    }
+
+    const rawInput = raw['input']
+    let input: Record<string, unknown> | null = null
+
+    if (typeof rawInput === 'string') {
+      // Plain-text input → wrap as a single user message so it fits the
+      // schema. Most common shape for CSV uploads.
+      input = { messages: [{ role: 'user', content: rawInput }] }
+    } else if (rawInput && typeof rawInput === 'object' && !Array.isArray(rawInput)) {
+      const obj = rawInput as Record<string, unknown>
+      const hasVars = obj['variables'] && typeof obj['variables'] === 'object'
+      const hasMsgs = Array.isArray(obj['messages'])
+      if (hasVars || hasMsgs) input = obj
+    }
+
+    if (!input) {
+      skipped.push({ index: i, reason: 'input missing or invalid shape' })
+      continue
+    }
+
+    const expected = raw['expected_output'] ?? raw['expectedOutput']
+    rows.push({
+      organization_id: orgId,
+      dataset_id: datasetId,
+      input,
+      expected_output: typeof expected === 'string' ? expected : null,
+    })
+  }
+
+  if (rows.length === 0) {
+    return c.json({ error: 'No valid items in upload', skipped }, 400)
+  }
+
+  const { error } = await supabaseAdmin.from('dataset_items').insert(rows)
+  if (error) return c.json({ error: error.message }, 500)
+
+  return c.json({ success: true, data: { inserted: rows.length, skipped } }, 201)
+})
+
 // POST /api/v1/datasets/:id/items/import-requests — bulk import from production
 datasetsRouter.post('/:id/items/import-requests', async (c) => {
   const orgId = c.get('orgId')

--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -48,8 +48,8 @@ evalsRouter.post('/evaluators', async (c) => {
   const scaleMax = typeof config.scale_max === 'number' ? config.scale_max : 1
 
   if (!criterion) return c.json({ error: 'config.criterion is required' }, 400)
-  if (judgeProvider !== 'openai' && judgeProvider !== 'anthropic') {
-    return c.json({ error: 'config.judge_provider must be "openai" or "anthropic"' }, 400)
+  if (judgeProvider !== 'openai' && judgeProvider !== 'anthropic' && judgeProvider !== 'gemini') {
+    return c.json({ error: 'config.judge_provider must be "openai", "anthropic", or "gemini"' }, 400)
   }
   if (!judgeModel) return c.json({ error: 'config.judge_model is required' }, 400)
   if (!(scaleMax > scaleMin)) {
@@ -136,6 +136,8 @@ evalsRouter.post('/eval-runs', async (c) => {
     sampleSize?: unknown
     sampleFrom?: unknown
     sampleTo?: unknown
+    runProvider?: unknown
+    runModel?: unknown
   }
   try {
     body = (await c.req.json()) as typeof body
@@ -158,6 +160,18 @@ evalsRouter.post('/eval-runs', async (c) => {
   }
   if (source === 'dataset' && !datasetId) {
     return c.json({ error: 'datasetId is required when source = dataset' }, 400)
+  }
+
+  // Dataset evals run the prompt against each item's input before judging.
+  // The picker can only emit our three supported provider strings.
+  const runProvider: 'openai' | 'anthropic' | 'gemini' | null =
+    body.runProvider === 'openai' || body.runProvider === 'anthropic' || body.runProvider === 'gemini'
+      ? body.runProvider
+      : null
+  const runModel = typeof body.runModel === 'string' ? body.runModel.trim() : null
+  if (source === 'dataset') {
+    if (!runProvider) return c.json({ error: 'runProvider is required when source = dataset' }, 400)
+    if (!runModel) return c.json({ error: 'runModel is required when source = dataset' }, 400)
   }
 
   // Verify both belong to org
@@ -222,6 +236,8 @@ evalsRouter.post('/eval-runs', async (c) => {
     sampleSize,
     sampleFrom,
     sampleTo,
+    runProvider,
+    runModel,
   }))
 
   return c.json({ success: true, data: run }, 202)

--- a/apps/server/src/api/experiments.ts
+++ b/apps/server/src/api/experiments.ts
@@ -37,7 +37,10 @@ experimentsRouter.post('/', async (c) => {
   const datasetId = typeof body.datasetId === 'string' ? body.datasetId.trim() : ''
   const evaluatorId = typeof body.evaluatorId === 'string' && body.evaluatorId.trim()
     ? body.evaluatorId.trim() : null
-  const runProvider = body.runProvider === 'anthropic' ? 'anthropic' : 'openai'
+  const runProvider: 'openai' | 'anthropic' | 'gemini' =
+    body.runProvider === 'anthropic' ? 'anthropic'
+    : body.runProvider === 'gemini' ? 'gemini'
+    : 'openai'
   const runModel = typeof body.runModel === 'string' ? body.runModel.trim() : ''
 
   if (!name) return c.json({ error: 'name is required' }, 400)

--- a/apps/server/src/api/models.ts
+++ b/apps/server/src/api/models.ts
@@ -1,0 +1,96 @@
+import { Hono } from 'hono'
+import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { supabaseAdmin } from '../lib/db.js'
+
+/**
+ * GET /api/v1/models — list of all priced models, grouped by provider.
+ *
+ * Why this exists:
+ *   The Prompts → Playground tab used to hardcode a 12-entry list of model
+ *   strings. After we expanded model_prices to 82 rows in PR #146, that
+ *   list went stale and users couldn't pick GPT-5.x / Claude Opus 4.7 /
+ *   Gemini 3.x. This endpoint reads model_prices directly so the UI stays
+ *   in sync with whatever's been seeded.
+ *
+ * Filtering:
+ *   - Skips models that look like dated snapshots when an alias exists for
+ *     the same family (heuristic: ends in -YYYYMMDD or -YYYY-MM-DD). Dated
+ *     variants stay billable but the picker shows the friendly alias.
+ *     Customers can still hit them by passing the dated name in the
+ *     request body — Playground UX just doesn't surface every snapshot.
+ *
+ * Auth: JWT (any signed-in user). Pricing is global — no org scoping.
+ */
+export const modelsRouter = new Hono<JwtContext>()
+
+modelsRouter.use('*', authJwt)
+
+interface ModelEntry {
+  model: string
+  promptPricePer1m: number
+  completionPricePer1m: number
+  cacheReadPricePer1m: number | null
+  cacheWritePricePer1m: number | null
+  /** Set when the model has a tiered long-context price. */
+  longContextThresholdTokens: number | null
+}
+
+interface ModelsResponse {
+  openai: ModelEntry[]
+  anthropic: ModelEntry[]
+  gemini: ModelEntry[]
+}
+
+const DATED_SUFFIX = /-\d{8}$|-\d{4}-\d{2}-\d{2}$/
+
+function isDatedSnapshot(model: string): boolean {
+  return DATED_SUFFIX.test(model)
+}
+
+modelsRouter.get('/', async (c) => {
+  const { data, error } = await supabaseAdmin
+    .from('model_prices')
+    .select(
+      'provider, model, prompt_price_per_1m, completion_price_per_1m,' +
+      ' cache_read_price_per_1m, cache_write_price_per_1m,' +
+      ' long_context_threshold_tokens',
+    )
+    .order('model', { ascending: true })
+
+  if (error) {
+    return c.json({ error: 'Failed to load models', detail: error.message }, 500)
+  }
+
+  const groups: ModelsResponse = { openai: [], anthropic: [], gemini: [] }
+
+  for (const row of data ?? []) {
+    const r = row as unknown as Record<string, unknown>
+    const provider = r['provider'] as 'openai' | 'anthropic' | 'gemini'
+    if (!groups[provider]) continue
+    const model = r['model'] as string
+    // Skip dated variants when an alias already exists — keeps the picker
+    // readable while the row stays billable for direct API calls.
+    if (isDatedSnapshot(model)) {
+      const alias = model.replace(DATED_SUFFIX, '')
+      const hasAlias = (data ?? []).some(
+        (other) => (other as unknown as Record<string, unknown>)['model'] === alias,
+      )
+      if (hasAlias) continue
+    }
+    groups[provider].push({
+      model,
+      promptPricePer1m: Number(r['prompt_price_per_1m']),
+      completionPricePer1m: Number(r['completion_price_per_1m']),
+      cacheReadPricePer1m:
+        r['cache_read_price_per_1m'] != null ? Number(r['cache_read_price_per_1m']) : null,
+      cacheWritePricePer1m:
+        r['cache_write_price_per_1m'] != null ? Number(r['cache_write_price_per_1m']) : null,
+      longContextThresholdTokens:
+        r['long_context_threshold_tokens'] != null
+          ? Number(r['long_context_threshold_tokens'])
+          : null,
+    })
+  }
+
+  return c.json({ success: true, data: groups })
+})

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -45,6 +45,7 @@ import { openapiRouter }       from './api/openapi.js'
 import { providerKeysRouter }  from './api/providerKeys.js'
 import { meRouter }            from './api/me.js'
 import { meRoleRouter }        from './api/meRole.js'
+import { modelsRouter }        from './api/models.js'
 import { systemRouter }       from './api/system.js'
 import { adminModelPricesRouter } from './api/admin/modelPrices.js'
 import { adminModelRecommendationsRouter } from './api/admin/modelRecommendations.js'
@@ -170,6 +171,7 @@ app.route('/api/v1/dismissals',     dismissalsRouter)
 app.route('/api/v1/me/profile',     userProfilesRouter)
 app.route('/api/v1/me/consent',     userConsentRouter)
 app.route('/api/v1/me/role',        meRoleRouter)    // JWT-auth — current user's org role (sidebar uses this)
+app.route('/api/v1/models',         modelsRouter)    // JWT-auth — model catalog (grouped by provider) for Playground
 app.route('/api/v1/me',             meRouter)        // sl_live_* introspection (CLI), registered AFTER other /me/* prefixes
 app.route('/api/v1/webhooks',       webhooksRouter)
 app.route('/api/v1/exports',        exportsRouter)

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -21,7 +21,7 @@ const MAX_RESPONSE_CHARS = 4000 // truncate long responses fed to judge
 
 interface JudgeConfig {
   criterion: string
-  judge_provider: 'openai' | 'anthropic'
+  judge_provider: 'openai' | 'anthropic' | 'gemini'
   judge_model: string
   scale_min: number
   scale_max: number
@@ -66,6 +66,105 @@ function extractResponseText(body: unknown): string | null {
   }
 
   return null
+}
+
+/**
+ * Generate a response for a dataset item by running the supplied prompt
+ * content + the item's input through the chosen provider. Mirrors the
+ * runPrompt() helper in experiment-runner.ts (intentionally inlined here
+ * to avoid the runner-to-runner import cycle).
+ *
+ * Returns the assistant text on success, null on any failure (network,
+ * 4xx/5xx, empty output). Callers should filter nulls.
+ */
+async function generateForItem(
+  promptContent: string,
+  itemInput: Record<string, unknown>,
+  provider: 'openai' | 'anthropic' | 'gemini',
+  model: string,
+  apiKey: string,
+): Promise<string | null> {
+  // The dataset-item shape allows either `variables` (template substitution)
+  // or `messages` (already-formatted chat). Translate to a single user
+  // message string for the LLM call.
+  let userContent: string
+  if (itemInput['variables'] && typeof itemInput['variables'] === 'object') {
+    // Variables are substituted into the prompt content. The judge sees
+    // the response, not the substituted prompt — so this branch produces a
+    // response based on the variable values + the prompt's template.
+    const vars = itemInput['variables'] as Record<string, string>
+    userContent = Object.entries(vars).map(([k, v]) => `${k}: ${v}`).join('\n')
+  } else if (Array.isArray(itemInput['messages'])) {
+    const msgs = itemInput['messages'] as Array<{ role: string; content: string }>
+    const lastUser = [...msgs].reverse().find((m) => m.role === 'user')
+    userContent = lastUser?.content ?? ''
+  } else {
+    return null
+  }
+  if (!userContent) return null
+
+  try {
+    if (provider === 'openai') {
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
+        body: JSON.stringify({
+          model,
+          messages: [
+            { role: 'system', content: promptContent },
+            { role: 'user', content: userContent },
+          ],
+          temperature: 0.7,
+          max_tokens: 1024,
+        }),
+      })
+      if (!res.ok) return null
+      const json = await res.json() as { choices: Array<{ message: { content: string } }> }
+      return json.choices?.[0]?.message?.content ?? null
+    }
+
+    if (provider === 'anthropic') {
+      const res = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: 1024,
+          temperature: 0.7,
+          system: promptContent,
+          messages: [{ role: 'user', content: userContent }],
+        }),
+      })
+      if (!res.ok) return null
+      const json = await res.json() as { content: Array<{ type: string; text: string }> }
+      return json.content?.find((b) => b.type === 'text')?.text ?? null
+    }
+
+    // Gemini
+    const res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          systemInstruction: { parts: [{ text: promptContent }] },
+          contents: [{ role: 'user', parts: [{ text: userContent }] }],
+          generationConfig: { temperature: 0.7, maxOutputTokens: 1024 },
+        }),
+      },
+    )
+    if (!res.ok) return null
+    const json = await res.json() as {
+      candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
+    }
+    return json.candidates?.[0]?.content?.parts?.[0]?.text ?? null
+  } catch {
+    return null
+  }
 }
 
 /** Builds the judge prompt asking it to score `responseText` against `criterion`. */
@@ -156,41 +255,94 @@ async function callJudge(
     }
   }
 
-  // Anthropic
-  const res = await fetch('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': apiKey,
-      'anthropic-version': '2023-06-01',
-    },
-    body: JSON.stringify({
-      model: config.judge_model,
-      max_tokens: 200,
-      temperature: 0,
-      messages: [{ role: 'user', content: prompt }],
-    }),
-  })
-  if (!res.ok) return null
-  const json = await res.json() as {
-    content: Array<{ type: string; text: string }>
-    usage: { input_tokens: number; output_tokens: number }
-    model: string
+  if (config.judge_provider === 'anthropic') {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: config.judge_model,
+        max_tokens: 200,
+        temperature: 0,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    })
+    if (!res.ok) return null
+    const json = await res.json() as {
+      content: Array<{ type: string; text: string }>
+      usage: { input_tokens: number; output_tokens: number }
+      model: string
+    }
+    const text = json.content?.find((b) => b.type === 'text')?.text ?? ''
+    const parsed = parseJudgeReply(text, config.scale_min, config.scale_max)
+    if (!parsed) return null
+    const tokens = (json.usage?.input_tokens ?? 0) + (json.usage?.output_tokens ?? 0)
+    const cost = calculateCost('anthropic', json.model ?? config.judge_model, {
+      promptTokens: json.usage?.input_tokens ?? 0,
+      completionTokens: json.usage?.output_tokens ?? 0,
+    })?.totalCost ?? 0
+    const range = config.scale_max - config.scale_min || 1
+    return {
+      score: (parsed.score - config.scale_min) / range,
+      reasoning: parsed.reasoning,
+      cost,
+      tokens,
+    }
   }
-  const text = json.content?.find((b) => b.type === 'text')?.text ?? ''
-  const parsed = parseJudgeReply(text, config.scale_min, config.scale_max)
-  if (!parsed) return null
-  const tokens = (json.usage?.input_tokens ?? 0) + (json.usage?.output_tokens ?? 0)
-  const cost = calculateCost('anthropic', json.model ?? config.judge_model, {
-    promptTokens: json.usage?.input_tokens ?? 0,
-    completionTokens: json.usage?.output_tokens ?? 0,
+
+  // Gemini — JSON output enforced via responseMimeType + responseSchema. This
+  // matches OpenAI's `response_format: json_object` strictness so the judge
+  // reply is always parseable. We hit `generateContent` directly (not our
+  // /proxy) because eval-runner runs on the server — calls to api.openai.com
+  // and generativelanguage.googleapis.com bypass our own proxy on purpose.
+  const geminiRes = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${config.judge_model}:generateContent?key=${apiKey}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ role: 'user', parts: [{ text: prompt }] }],
+        generationConfig: {
+          temperature: 0,
+          maxOutputTokens: 200,
+          responseMimeType: 'application/json',
+          responseSchema: {
+            type: 'object',
+            properties: {
+              score: { type: 'number' },
+              reasoning: { type: 'string' },
+            },
+            required: ['score', 'reasoning'],
+          },
+        },
+      }),
+    },
+  )
+  if (!geminiRes.ok) return null
+  const geminiJson = await geminiRes.json() as {
+    candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
+    usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number }
+    modelVersion?: string
+  }
+  const geminiText = geminiJson.candidates?.[0]?.content?.parts?.[0]?.text ?? ''
+  const geminiParsed = parseJudgeReply(geminiText, config.scale_min, config.scale_max)
+  if (!geminiParsed) return null
+  const geminiTokens =
+    (geminiJson.usageMetadata?.promptTokenCount ?? 0) +
+    (geminiJson.usageMetadata?.candidatesTokenCount ?? 0)
+  const geminiCost = calculateCost('gemini', geminiJson.modelVersion ?? config.judge_model, {
+    promptTokens: geminiJson.usageMetadata?.promptTokenCount ?? 0,
+    completionTokens: geminiJson.usageMetadata?.candidatesTokenCount ?? 0,
   })?.totalCost ?? 0
-  const range = config.scale_max - config.scale_min || 1
+  const geminiRange = config.scale_max - config.scale_min || 1
   return {
-    score: (parsed.score - config.scale_min) / range,
-    reasoning: parsed.reasoning,
-    cost,
-    tokens,
+    score: (geminiParsed.score - config.scale_min) / geminiRange,
+    reasoning: geminiParsed.reasoning,
+    cost: geminiCost,
+    tokens: geminiTokens,
   }
 }
 
@@ -225,6 +377,15 @@ interface RunInput {
   sampleSize: number
   sampleFrom?: string | null
   sampleTo?: string | null
+  /**
+   * When source = 'dataset', the prompt content must be executed against each
+   * item's input to produce a response — THEN that response is judged.
+   * (Scoring `expected_output` directly was the previous bug: it measured the
+   *  curated golden answer, not whatever the prompt actually generates.)
+   * These fields are required for dataset runs; ignored for production.
+   */
+  runProvider?: 'openai' | 'anthropic' | 'gemini' | null
+  runModel?: string | null
 }
 
 /** Result of one sample's scoring, shared between production and dataset paths. */
@@ -239,7 +400,19 @@ interface SampleOutcome extends JudgeOutcome {
  * caller gets an immediate 202 while work continues in the background.
  */
 export async function runEvalRun(input: RunInput): Promise<void> {
-  const { evalRunId, organizationId, evaluatorId, promptVersionId, source, datasetId, sampleSize, sampleFrom, sampleTo } = input
+  const {
+    evalRunId,
+    organizationId,
+    evaluatorId,
+    promptVersionId,
+    source,
+    datasetId,
+    sampleSize,
+    sampleFrom,
+    sampleTo,
+    runProvider,
+    runModel,
+  } = input
 
   // Mark running
   await supabaseAdmin
@@ -345,26 +518,72 @@ export async function runEvalRun(input: RunInput): Promise<void> {
         })
         .filter((s) => s.responseText.length > 0)
     } else {
-      // source === 'dataset'
+      // source === 'dataset' — run the prompt against each item's input,
+      // THEN score the generated response. expected_output is reference-only
+      // (a future enhancement could feed it into the judge prompt as a target).
       if (!datasetId) throw new Error('datasetId is required when source = dataset')
+      if (!runProvider || !runModel) {
+        throw new Error('runProvider and runModel are required when source = dataset')
+      }
 
+      // 1. Resolve the prompt version's content + the run provider key
+      const { data: pv, error: pvErr } = await supabaseAdmin
+        .from('prompt_versions')
+        .select('content')
+        .eq('id', promptVersionId)
+        .eq('organization_id', organizationId)
+        .maybeSingle()
+      if (pvErr || !pv) throw new Error(`Prompt version not found: ${pvErr?.message ?? promptVersionId}`)
+      const promptContent = pv.content as string
+
+      const { data: runKeyRow, error: runKeyErr } = await supabaseAdmin
+        .from('provider_keys')
+        .select('encrypted_key')
+        .eq('organization_id', organizationId)
+        .eq('provider', runProvider)
+        .eq('is_active', true)
+        .limit(1)
+        .maybeSingle()
+      if (runKeyErr || !runKeyRow) {
+        throw new Error(`No active ${runProvider} provider key found for prompt generation`)
+      }
+      const runApiKey = await aes256Decrypt(runKeyRow.encrypted_key as string)
+      if (!runApiKey) throw new Error('Failed to decrypt run provider key')
+
+      // 2. Fetch all items in the dataset (no expected_output filter — we
+      //    generate fresh responses, so items without a golden answer are
+      //    still scorable on the criterion alone)
       const { data: items, error: itemsErr } = await supabaseAdmin
         .from('dataset_items')
-        .select('id, expected_output')
+        .select('id, input')
         .eq('dataset_id', datasetId)
         .eq('organization_id', organizationId)
-        .not('expected_output', 'is', null)
         .order('created_at', { ascending: false })
         .limit(sampleSize)
-
       if (itemsErr) throw new Error(`Dataset items fetch failed: ${itemsErr.message}`)
 
-      preparedSamples = (items ?? [])
-        .filter((i) => typeof i.expected_output === 'string' && i.expected_output.length > 0)
-        .map((i) => ({
-          responseText: i.expected_output as string,
+      // 3. Generate a response for each item by running the prompt against
+      //    its input. Failures (network, model rejection) are dropped — the
+      //    eval still completes with whatever scored.
+      const generated = await Promise.all(
+        (items ?? []).map(async (i) => {
+          const out = await generateForItem(
+            promptContent,
+            i.input as Record<string, unknown>,
+            runProvider,
+            runModel,
+            runApiKey,
+          )
+          return out ? { responseText: out, datasetItemId: i.id as string } : null
+        }),
+      )
+
+      preparedSamples = generated
+        .filter((g): g is { responseText: string; datasetItemId: string } => g !== null && g.responseText.length > 0)
+        .map((g) => ({
+          responseText: g.responseText,
           requestId: null,
-          datasetItemId: i.id as string,
+          datasetItemId: g.datasetItemId,
         }))
     }
 

--- a/apps/server/src/lib/experiment-runner.ts
+++ b/apps/server/src/lib/experiment-runner.ts
@@ -23,7 +23,7 @@ const TEMPERATURE = 0.7
 // JudgeConfig kept in sync with eval-runner.ts. Inlined to avoid circular imports.
 interface JudgeConfig {
   criterion: string
-  judge_provider: 'openai' | 'anthropic'
+  judge_provider: 'openai' | 'anthropic' | 'gemini'
   judge_model: string
   scale_min: number
   scale_max: number
@@ -58,7 +58,7 @@ interface PromptVersionRow {
 async function runPrompt(
   content: string,
   item: DatasetItemRow,
-  provider: 'openai' | 'anthropic',
+  provider: 'openai' | 'anthropic' | 'gemini',
   model: string,
   apiKey: string,
 ): Promise<RunResult | { error: string }> {
@@ -110,36 +110,71 @@ async function runPrompt(
       return { output, cost, latencyMs, tokens: promptTokens + completionTokens }
     }
 
-    // Anthropic
-    const res = await fetch('https://api.anthropic.com/v1/messages', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': apiKey,
-        'anthropic-version': '2023-06-01',
+    if (provider === 'anthropic') {
+      const res = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: MAX_TOKENS,
+          temperature: TEMPERATURE,
+          system: content,
+          messages: [{ role: 'user', content: userContent }],
+        }),
+      })
+      const latencyMs = Date.now() - startMs
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        return { error: `Anthropic error (${res.status}): ${text.slice(0, 200)}` }
+      }
+      const json = await res.json() as {
+        content: Array<{ type: string; text: string }>
+        usage: { input_tokens: number; output_tokens: number }
+        model: string
+      }
+      const output = json.content?.find((b) => b.type === 'text')?.text ?? ''
+      const promptTokens = json.usage?.input_tokens ?? 0
+      const completionTokens = json.usage?.output_tokens ?? 0
+      const cost = calculateCost('anthropic', json.model ?? model, { promptTokens, completionTokens })?.totalCost ?? 0
+      return { output, cost, latencyMs, tokens: promptTokens + completionTokens }
+    }
+
+    // Gemini — `content` is the system prompt, `userContent` the data item.
+    // Gemini doesn't have a dedicated "system" message role; pass via
+    // systemInstruction so it gets the same treatment as Anthropic's `system`.
+    const res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          systemInstruction: { parts: [{ text: content }] },
+          contents: [{ role: 'user', parts: [{ text: userContent }] }],
+          generationConfig: {
+            temperature: TEMPERATURE,
+            maxOutputTokens: MAX_TOKENS,
+          },
+        }),
       },
-      body: JSON.stringify({
-        model,
-        max_tokens: MAX_TOKENS,
-        temperature: TEMPERATURE,
-        system: content,
-        messages: [{ role: 'user', content: userContent }],
-      }),
-    })
+    )
     const latencyMs = Date.now() - startMs
     if (!res.ok) {
       const text = await res.text().catch(() => '')
-      return { error: `Anthropic error (${res.status}): ${text.slice(0, 200)}` }
+      return { error: `Gemini error (${res.status}): ${text.slice(0, 200)}` }
     }
     const json = await res.json() as {
-      content: Array<{ type: string; text: string }>
-      usage: { input_tokens: number; output_tokens: number }
-      model: string
+      candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
+      usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number }
+      modelVersion?: string
     }
-    const output = json.content?.find((b) => b.type === 'text')?.text ?? ''
-    const promptTokens = json.usage?.input_tokens ?? 0
-    const completionTokens = json.usage?.output_tokens ?? 0
-    const cost = calculateCost('anthropic', json.model ?? model, { promptTokens, completionTokens })?.totalCost ?? 0
+    const output = json.candidates?.[0]?.content?.parts?.[0]?.text ?? ''
+    const promptTokens = json.usageMetadata?.promptTokenCount ?? 0
+    const completionTokens = json.usageMetadata?.candidatesTokenCount ?? 0
+    const cost = calculateCost('gemini', json.modelVersion ?? model, { promptTokens, completionTokens })?.totalCost ?? 0
     return { output, cost, latencyMs, tokens: promptTokens + completionTokens }
   } catch (err) {
     return { error: err instanceof Error ? err.message : 'Unknown error' }
@@ -224,40 +259,91 @@ async function callJudge(
       tokens,
     }
   }
-  const res = await fetch('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': apiKey,
-      'anthropic-version': '2023-06-01',
-    },
-    body: JSON.stringify({
-      model: config.judge_model,
-      max_tokens: 200,
-      temperature: 0,
-      messages: [{ role: 'user', content: prompt }],
-    }),
-  })
-  if (!res.ok) return null
-  const json = await res.json() as {
-    content: Array<{ type: string; text: string }>
-    usage: { input_tokens: number; output_tokens: number }
-    model: string
+  if (config.judge_provider === 'anthropic') {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: config.judge_model,
+        max_tokens: 200,
+        temperature: 0,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    })
+    if (!res.ok) return null
+    const json = await res.json() as {
+      content: Array<{ type: string; text: string }>
+      usage: { input_tokens: number; output_tokens: number }
+      model: string
+    }
+    const text = json.content?.find((b) => b.type === 'text')?.text ?? ''
+    const parsed = parseJudgeReply(text, config.scale_min, config.scale_max)
+    if (!parsed) return null
+    const tokens = (json.usage?.input_tokens ?? 0) + (json.usage?.output_tokens ?? 0)
+    const cost = calculateCost('anthropic', json.model ?? config.judge_model, {
+      promptTokens: json.usage?.input_tokens ?? 0,
+      completionTokens: json.usage?.output_tokens ?? 0,
+    })?.totalCost ?? 0
+    const range = config.scale_max - config.scale_min || 1
+    return {
+      score: (parsed.score - config.scale_min) / range,
+      reasoning: parsed.reasoning,
+      cost,
+      tokens,
+    }
   }
-  const text = json.content?.find((b) => b.type === 'text')?.text ?? ''
-  const parsed = parseJudgeReply(text, config.scale_min, config.scale_max)
-  if (!parsed) return null
-  const tokens = (json.usage?.input_tokens ?? 0) + (json.usage?.output_tokens ?? 0)
-  const cost = calculateCost('anthropic', json.model ?? config.judge_model, {
-    promptTokens: json.usage?.input_tokens ?? 0,
-    completionTokens: json.usage?.output_tokens ?? 0,
+
+  // Gemini judge — JSON output via responseMimeType + responseSchema
+  // (matches OpenAI's `response_format: json_object` strictness).
+  const geminiRes = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${config.judge_model}:generateContent?key=${apiKey}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ role: 'user', parts: [{ text: prompt }] }],
+        generationConfig: {
+          temperature: 0,
+          maxOutputTokens: 200,
+          responseMimeType: 'application/json',
+          responseSchema: {
+            type: 'object',
+            properties: {
+              score: { type: 'number' },
+              reasoning: { type: 'string' },
+            },
+            required: ['score', 'reasoning'],
+          },
+        },
+      }),
+    },
+  )
+  if (!geminiRes.ok) return null
+  const geminiJson = await geminiRes.json() as {
+    candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
+    usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number }
+    modelVersion?: string
+  }
+  const geminiText = geminiJson.candidates?.[0]?.content?.parts?.[0]?.text ?? ''
+  const geminiParsed = parseJudgeReply(geminiText, config.scale_min, config.scale_max)
+  if (!geminiParsed) return null
+  const geminiTokens =
+    (geminiJson.usageMetadata?.promptTokenCount ?? 0) +
+    (geminiJson.usageMetadata?.candidatesTokenCount ?? 0)
+  const geminiCost = calculateCost('gemini', geminiJson.modelVersion ?? config.judge_model, {
+    promptTokens: geminiJson.usageMetadata?.promptTokenCount ?? 0,
+    completionTokens: geminiJson.usageMetadata?.candidatesTokenCount ?? 0,
   })?.totalCost ?? 0
-  const range = config.scale_max - config.scale_min || 1
+  const geminiRange = config.scale_max - config.scale_min || 1
   return {
-    score: (parsed.score - config.scale_min) / range,
-    reasoning: parsed.reasoning,
-    cost,
-    tokens,
+    score: (geminiParsed.score - config.scale_min) / geminiRange,
+    reasoning: geminiParsed.reasoning,
+    cost: geminiCost,
+    tokens: geminiTokens,
   }
 }
 
@@ -291,7 +377,7 @@ interface RunInput {
   versionBId: string
   datasetId: string
   evaluatorId: string | null
-  runProvider: 'openai' | 'anthropic'
+  runProvider: 'openai' | 'anthropic' | 'gemini'
   runModel: string
 }
 

--- a/apps/web/app/(dashboard)/datasets/[id]/dataset-detail-client.tsx
+++ b/apps/web/app/(dashboard)/datasets/[id]/dataset-detail-client.tsx
@@ -174,10 +174,20 @@ function ItemRow({ item, datasetId }: { item: DatasetItem; datasetId: string }) 
 
   return (
     <div className="border-b border-border last:border-0">
-      <button
-        type="button"
+      {/* Outer container is a div (not <button>) so the inner Delete <button>
+          and source-request <Link> don't violate HTML's "no nested buttons"
+          rule. Keyboard activation preserved via role + Enter/Space. */}
+      <div
+        role="button"
+        tabIndex={0}
         onClick={() => setExpanded((v) => !v)}
-        className="w-full flex items-start gap-3 px-[16px] py-[11px] hover:bg-bg-muted transition-colors text-left"
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            setExpanded((v) => !v)
+          }
+        }}
+        className="w-full flex items-start gap-3 px-[16px] py-[11px] hover:bg-bg-muted transition-colors text-left cursor-pointer"
       >
         <div className="flex-1 min-w-0">
           <p className="font-mono text-[12px] text-text truncate">{inputPreview}</p>
@@ -196,7 +206,7 @@ function ItemRow({ item, datasetId }: { item: DatasetItem; datasetId: string }) 
           )}
           {item.source_request_id && (
             <Link
-              href={`/requests?id=${item.source_request_id}`}
+              href={`/requests/${item.source_request_id}`}
               onClick={(e) => e.stopPropagation()}
               className="text-text-faint hover:text-text"
               aria-label="View source request"
@@ -213,7 +223,7 @@ function ItemRow({ item, datasetId }: { item: DatasetItem; datasetId: string }) 
             <Trash2 className="h-3.5 w-3.5" />
           </button>
         </div>
-      </button>
+      </div>
       {expanded && (
         <div className="bg-bg-muted/50 px-[16px] py-[10px] border-t border-border space-y-2 font-mono text-[11.5px]">
           <div>

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Beaker, Play, Trash2, Plus, Loader2, AlertTriangle } from 'lucide-react'
 import { Topbar } from '@/components/layout/topbar'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
@@ -19,12 +19,22 @@ import {
 } from '@/lib/queries/use-evals'
 import { usePrompts, usePromptVersions } from '@/lib/queries/use-prompts'
 import type { PromptVersion } from '@/lib/queries/use-prompts'
-import { useDatasets } from '@/lib/queries/use-datasets'
+import {
+  useDatasets,
+  useCreateDataset,
+  useBulkAddDatasetItems,
+} from '@/lib/queries/use-datasets'
+import { parseUploadedFile, generateUploadName } from '@/lib/dataset-upload'
 import { useCorrelation, pearsonR } from '@/lib/queries/use-human-evals'
+import { useModels } from '@/lib/queries/use-models'
 
-const JUDGE_MODELS = {
-  openai: ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo'],
-  anthropic: ['claude-3-5-haiku-20241022', 'claude-3-5-sonnet-20241022'],
+// Fallback used only when /api/v1/models is still loading. Real list comes
+// from useModels(). Keep this minimal — just enough to render <select>
+// without an empty initial frame.
+const JUDGE_MODELS_FALLBACK = {
+  openai: ['gpt-4o-mini'],
+  anthropic: ['claude-haiku-4-5'],
+  gemini: ['gemini-2.5-flash-lite'],
 } as const
 
 function fmtUsd(n: number | null | undefined): string {
@@ -56,11 +66,23 @@ function StatusBadge({ status }: { status: EvalRunStatus }) {
 function NewEvaluatorDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
   const prompts = usePrompts()
   const createMutation = useCreateEvaluator()
+  const { data: modelsCatalog } = useModels()
+  // Map the catalog's full shape down to the openai/anthropic strings that
+  // this picker needs. Gemini is excluded — the eval API only supports
+  // OpenAI/Anthropic judges as of 2026-05.
+  const judgeModels: { openai: string[]; anthropic: string[]; gemini: string[] } = {
+    openai: (modelsCatalog?.openai ?? []).map((m) => m.model),
+    anthropic: (modelsCatalog?.anthropic ?? []).map((m) => m.model),
+    gemini: (modelsCatalog?.gemini ?? []).map((m) => m.model),
+  }
+  if (judgeModels.openai.length === 0) judgeModels.openai = [...JUDGE_MODELS_FALLBACK.openai]
+  if (judgeModels.anthropic.length === 0) judgeModels.anthropic = [...JUDGE_MODELS_FALLBACK.anthropic]
+  if (judgeModels.gemini.length === 0) judgeModels.gemini = [...JUDGE_MODELS_FALLBACK.gemini]
 
   const [promptName, setPromptName] = useState('')
   const [name, setName] = useState('')
   const [criterion, setCriterion] = useState('')
-  const [judgeProvider, setJudgeProvider] = useState<'openai' | 'anthropic'>('openai')
+  const [judgeProvider, setJudgeProvider] = useState<'openai' | 'anthropic' | 'gemini'>('openai')
   const [judgeModel, setJudgeModel] = useState('gpt-4o-mini')
   const [scaleMin] = useState(0)
   const [scaleMax] = useState(1)
@@ -155,14 +177,15 @@ function NewEvaluatorDialog({ open, onClose }: { open: boolean; onClose: () => v
               <select
                 value={judgeProvider}
                 onChange={(e) => {
-                  const p = e.target.value as 'openai' | 'anthropic'
+                  const p = e.target.value as 'openai' | 'anthropic' | 'gemini'
                   setJudgeProvider(p)
-                  setJudgeModel(JUDGE_MODELS[p][0])
+                  setJudgeModel(judgeModels[p][0] ?? '')
                 }}
                 className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text focus:outline-none focus:border-border-strong"
               >
                 <option value="openai">OpenAI</option>
                 <option value="anthropic">Anthropic</option>
+                <option value="gemini">Gemini</option>
               </select>
             </div>
             <div>
@@ -174,7 +197,7 @@ function NewEvaluatorDialog({ open, onClose }: { open: boolean; onClose: () => v
                 onChange={(e) => setJudgeModel(e.target.value)}
                 className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text focus:outline-none focus:border-border-strong"
               >
-                {JUDGE_MODELS[judgeProvider].map((m) => (
+                {judgeModels[judgeProvider].map((m) => (
                   <option key={m} value={m}>{m}</option>
                 ))}
               </select>
@@ -222,6 +245,8 @@ function RunEvaluatorDialog({
   const datasets = useDatasets()
   const createRun = useCreateEvalRun()
   const estimate = useEstimateEvalCost()
+  const createDataset = useCreateDataset()
+  const bulkAddItems = useBulkAddDatasetItems()
 
   const [versionIdRaw, setVersionId] = useState('')
   const [source, setSource] = useState<'production' | 'dataset'>('production')
@@ -229,6 +254,60 @@ function RunEvaluatorDialog({
   const [sampleSize, setSampleSize] = useState(50)
   const [days, setDays] = useState(7)
   const [error, setError] = useState('')
+  // For dataset mode: which provider+model runs the prompt before judging.
+  // Production mode doesn't need these — responses are already in CH.
+  const [runProvider, setRunProvider] = useState<'openai' | 'anthropic' | 'gemini'>('openai')
+  const [runModel, setRunModel] = useState('gpt-4o-mini')
+  const modelsCatalog = useModels()
+  const runModelOptions = (modelsCatalog.data?.[runProvider] ?? []).map((m) => m.model)
+  const [uploadingState, setUploadingState] = useState<'idle' | 'uploading' | 'done'>('idle')
+  const [uploadMsg, setUploadMsg] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  async function handleFileUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    // Reset the input so picking the same file twice still fires onChange.
+    if (e.target) e.target.value = ''
+    if (!file) return
+
+    setUploadMsg(null)
+    setUploadingState('uploading')
+    try {
+      // 1. Parse client-side. Failures here mean malformed file — no API call.
+      const { items, warnings } = await parseUploadedFile(file)
+      if (items.length === 0) {
+        setError('No valid items in file')
+        setUploadingState('idle')
+        return
+      }
+
+      // 2. Create a fresh dataset with an auto-generated name. User can
+      //    rename / delete from /datasets later if they want.
+      const created = await createDataset.mutateAsync({
+        name: generateUploadName(),
+        description: `Uploaded from ${file.name} (${items.length} items)`,
+      })
+
+      // 3. Bulk insert items. Server reports per-row skip reasons.
+      const result = await bulkAddItems.mutateAsync({
+        datasetId: created.id,
+        items,
+      })
+
+      setDatasetId(created.id)
+      setUploadingState('done')
+      const skippedNote = result.skipped.length > 0
+        ? `, ${result.skipped.length} skipped by server`
+        : ''
+      const warnNote = warnings.length > 0
+        ? `, ${warnings.length} warnings client-side`
+        : ''
+      setUploadMsg(`Uploaded ${result.inserted} items${skippedNote}${warnNote}.`)
+    } catch (err) {
+      setUploadingState('idle')
+      setError(err instanceof Error ? err.message : 'Upload failed')
+    }
+  }
 
   // Derive default selection from query data instead of syncing via an
   // effect. Once the user picks a value, `versionIdRaw` wins.
@@ -245,13 +324,14 @@ function RunEvaluatorDialog({
     setError('')
     if (!versionId) { setError('Select a version'); return }
     if (source === 'dataset' && !datasetId) { setError('Select a dataset'); return }
+    if (source === 'dataset' && !runModel) { setError('Select a model to run the prompt'); return }
     try {
       const run = await createRun.mutateAsync({
         evaluatorId: evaluator.id,
         promptVersionId: versionId,
         source,
         sampleSize,
-        ...(source === 'dataset' && datasetId && { datasetId }),
+        ...(source === 'dataset' && datasetId && { datasetId, runProvider, runModel }),
         ...(source === 'production' && {
           sampleFrom: new Date(Date.now() - days * 86400_000).toISOString(),
         }),
@@ -314,21 +394,88 @@ function RunEvaluatorDialog({
               <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
                 Dataset
               </label>
-              <select
-                value={datasetId}
-                onChange={(e) => setDatasetId(e.target.value)}
-                required
-                className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text"
-              >
-                <option value="">Select dataset…</option>
-                {(datasets.data ?? []).map((d) => (
-                  <option key={d.id} value={d.id}>
-                    {d.name} ({d.item_count ?? 0} items)
-                  </option>
-                ))}
-              </select>
+              <div className="flex gap-1.5">
+                <select
+                  value={datasetId}
+                  onChange={(e) => setDatasetId(e.target.value)}
+                  required
+                  className="flex-1 h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text"
+                >
+                  <option value="">Select dataset…</option>
+                  {(datasets.data ?? []).map((d) => (
+                    <option key={d.id} value={d.id}>
+                      {d.name} ({d.item_count ?? 0} items)
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={uploadingState === 'uploading'}
+                  className="font-mono text-[11px] px-3 py-1 rounded-[4px] border border-border bg-bg-elev hover:bg-bg-muted disabled:opacity-50 transition-colors whitespace-nowrap"
+                  title="Upload JSON or CSV. Saved as a new dataset with an auto-generated name; rename or delete from /datasets later."
+                >
+                  {uploadingState === 'uploading' ? 'Uploading…' : '+ Upload'}
+                </button>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".json,.csv,application/json,text/csv"
+                  onChange={(e) => void handleFileUpload(e)}
+                  className="hidden"
+                />
+              </div>
+              {uploadMsg && (
+                <p className="font-mono text-[10px] text-good mt-1">{uploadMsg}</p>
+              )}
               <p className="font-mono text-[10px] text-text-faint mt-1">
-                Only items with expected_output are scored.
+                JSON: array of <code>{`{ input, expected_output? }`}</code>.
+                CSV: header row <code>input,expected_output</code>. Uploads
+                are saved as datasets (auto-named) so you can re-run later.
+              </p>
+
+              {/* Generator picker — dataset items hold inputs only; we need
+                  a provider+model to actually run the prompt against each
+                  input before the judge can score the response. */}
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                <div>
+                  <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                    Run provider
+                  </label>
+                  <select
+                    value={runProvider}
+                    onChange={(e) => {
+                      const p = e.target.value as 'openai' | 'anthropic' | 'gemini'
+                      setRunProvider(p)
+                      const opts = (modelsCatalog.data?.[p] ?? []).map((m) => m.model)
+                      setRunModel(opts[0] ?? '')
+                    }}
+                    className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text"
+                  >
+                    <option value="openai">OpenAI</option>
+                    <option value="anthropic">Anthropic</option>
+                    <option value="gemini">Gemini</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                    Run model
+                  </label>
+                  <select
+                    value={runModel}
+                    onChange={(e) => setRunModel(e.target.value)}
+                    className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text"
+                  >
+                    {runModelOptions.length === 0 && <option value="">Loading…</option>}
+                    {runModelOptions.map((m) => (
+                      <option key={m} value={m}>{m}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <p className="font-mono text-[10px] text-text-faint mt-1">
+                Runs each dataset input through this model first, then the judge
+                scores the generated response.
               </p>
             </div>
           )}
@@ -404,6 +551,67 @@ function RunEvaluatorDialog({
 }
 
 // ── Run detail panel ─────────────────────────────────────────────────────────
+
+/**
+ * One row in "Lowest-scoring samples". Click to expand → shows full
+ * reasoning (no line clamp) + a link to the source request when this row
+ * came from production traffic. Dataset-source rows don't have a
+ * /requests/[id] target — they expand to reasoning only since the
+ * dataset item input isn't fetched here (would need a separate query).
+ */
+function LowestScoreRow({
+  res,
+}: {
+  res: { id: string; score: number; reasoning: string | null; judge_cost_usd: number; request_id: string | null; dataset_item_id: string | null }
+}) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => setOpen((v) => !v)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          setOpen((v) => !v)
+        }
+      }}
+      className="block p-2 rounded-[5px] border border-border hover:bg-bg-muted transition-colors cursor-pointer"
+    >
+      <div className="flex justify-between items-center mb-1">
+        <span className="font-mono text-[12px] text-text font-medium">
+          {fmtScore(res.score)}
+        </span>
+        <span className="font-mono text-[10px] text-text-faint">
+          {fmtUsd(res.judge_cost_usd)}
+        </span>
+      </div>
+      {res.reasoning && (
+        <p className={`font-mono text-[10.5px] text-text-muted ${open ? '' : 'line-clamp-2'}`}>
+          {res.reasoning}
+        </p>
+      )}
+      {open && res.request_id && (
+        <div className="mt-2 pt-2 border-t border-border">
+          <a
+            href={`/requests/${res.request_id}`}
+            onClick={(e) => e.stopPropagation()}
+            className="font-mono text-[10.5px] text-accent hover:underline"
+          >
+            → View source request
+          </a>
+        </div>
+      )}
+      {open && !res.request_id && res.dataset_item_id && (
+        <div className="mt-2 pt-2 border-t border-border">
+          <span className="font-mono text-[10.5px] text-text-faint">
+            Dataset item · {res.dataset_item_id.slice(0, 8)}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}
 
 function RunDetailPanel({ runId, onClose }: { runId: string; onClose: () => void }) {
   const run = useEvalRun(runId, { pollWhilePending: true })
@@ -501,38 +709,54 @@ function RunDetailPanel({ runId, onClose }: { runId: string; onClose: () => void
               </div>
             </div>
 
-            {/* Worst N */}
-            <div>
-              <p className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-2">
-                Lowest-scoring samples
-              </p>
-              <div className="space-y-2">
-                {results.data.slice(0, 5).map((res) => (
-                  <a
-                    key={res.id}
-                    href={res.request_id ? `/requests?id=${res.request_id}` : undefined}
-                    className="block p-2 rounded-[5px] border border-border hover:bg-bg-muted transition-colors"
-                  >
-                    <div className="flex justify-between items-center mb-1">
-                      <span className="font-mono text-[12px] text-text font-medium">
-                        {fmtScore(res.score)}
-                      </span>
-                      <span className="font-mono text-[10px] text-text-faint">
-                        {fmtUsd(res.judge_cost_usd)}
-                      </span>
-                    </div>
-                    {res.reasoning && (
-                      <p className="font-mono text-[10.5px] text-text-muted line-clamp-2">
-                        {res.reasoning}
-                      </p>
-                    )}
-                  </a>
-                ))}
-              </div>
-            </div>
+            {/* Samples — bottom-5 by default, toggle to see all 12 */}
+            <SampleList samples={results.data} />
           </>
         )}
       </div>
+    </div>
+  )
+}
+
+/**
+ * Eval results sorted ascending by score (server enforces, see
+ * apps/server/src/api/evals.ts). We show the worst 5 by default —
+ * that's where prompt-engineering effort pays off — with a toggle to
+ * reveal every scored sample for the curious. Avoids the confusion
+ * users hit when the visible 5 don't reconcile with the panel's
+ * average score (the hidden samples are higher and pull avg up).
+ */
+function SampleList({
+  samples,
+}: {
+  samples: Array<{ id: string; score: number; reasoning: string | null; judge_cost_usd: number; request_id: string | null; dataset_item_id: string | null }>
+}) {
+  const [showAll, setShowAll] = useState(false)
+  const visible = showAll ? samples : samples.slice(0, 5)
+  const total = samples.length
+  const moreCount = total - 5
+
+  return (
+    <div>
+      <p className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-2">
+        {showAll
+          ? `All samples · ${total}`
+          : `Lowest-scoring · ${Math.min(5, total)} of ${total}`}
+      </p>
+      <div className="space-y-2">
+        {visible.map((res) => (
+          <LowestScoreRow key={res.id} res={res} />
+        ))}
+      </div>
+      {moreCount > 0 && (
+        <button
+          type="button"
+          onClick={() => setShowAll((v) => !v)}
+          className="w-full mt-2 py-2 font-mono text-[10.5px] text-accent hover:bg-bg-muted rounded-[5px] border border-dashed border-border transition-colors"
+        >
+          {showAll ? 'show less' : 'show all'}
+        </button>
+      )}
     </div>
   )
 }
@@ -562,10 +786,20 @@ function EvaluatorRow({
 
   return (
     <div className="border-b border-border last:border-0">
-      <button
-        type="button"
+      {/* Outer container is a div, not a button: HTML forbids nested buttons,
+          and we need the Run/Delete buttons inside the same row. Keyboard
+          activation is preserved via role="button" + Enter/Space handlers. */}
+      <div
+        role="button"
+        tabIndex={0}
         onClick={() => setExpanded((v) => !v)}
-        className="w-full flex items-center px-[16px] py-[12px] hover:bg-bg-muted transition-colors text-left"
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            setExpanded((v) => !v)
+          }
+        }}
+        className="w-full flex items-center px-[16px] py-[12px] hover:bg-bg-muted transition-colors text-left cursor-pointer"
         style={{ gridTemplateColumns: '1fr 140px 100px 100px 120px' }}
       >
         <div className="flex-1 min-w-0">
@@ -597,7 +831,7 @@ function EvaluatorRow({
             <Trash2 className="h-3.5 w-3.5" />
           </button>
         </div>
-      </button>
+      </div>
 
       {expanded && (
         <div className="bg-bg-muted/50 px-[16px] py-[10px] border-t border-border">

--- a/apps/web/app/(dashboard)/experiments/experiments-client.tsx
+++ b/apps/web/app/(dashboard)/experiments/experiments-client.tsx
@@ -15,10 +15,13 @@ import {
 import { usePrompts, usePromptVersions } from '@/lib/queries/use-prompts'
 import { useDatasets } from '@/lib/queries/use-datasets'
 import { useEvaluators } from '@/lib/queries/use-evals'
+import { useModels } from '@/lib/queries/use-models'
 
-const RUN_MODELS = {
-  openai: ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo', 'gpt-3.5-turbo'],
-  anthropic: ['claude-3-5-haiku-20241022', 'claude-3-5-sonnet-20241022'],
+// Fallback for the first paint before useModels() resolves.
+const RUN_MODELS_FALLBACK = {
+  openai: ['gpt-4o-mini'],
+  anthropic: ['claude-haiku-4-5'],
+  gemini: ['gemini-2.5-flash-lite'],
 } as const
 
 function fmtUsd(n: number | null | undefined): string {
@@ -51,6 +54,15 @@ function NewExperimentDialog({ open, onClose }: { open: boolean; onClose: () => 
   const prompts = usePrompts()
   const datasets = useDatasets()
   const create = useCreateExperiment()
+  const { data: modelsCatalog } = useModels()
+  const runModels: { openai: string[]; anthropic: string[]; gemini: string[] } = {
+    openai: (modelsCatalog?.openai ?? []).map((m) => m.model),
+    anthropic: (modelsCatalog?.anthropic ?? []).map((m) => m.model),
+    gemini: (modelsCatalog?.gemini ?? []).map((m) => m.model),
+  }
+  if (runModels.openai.length === 0) runModels.openai = [...RUN_MODELS_FALLBACK.openai]
+  if (runModels.anthropic.length === 0) runModels.anthropic = [...RUN_MODELS_FALLBACK.anthropic]
+  if (runModels.gemini.length === 0) runModels.gemini = [...RUN_MODELS_FALLBACK.gemini]
 
   const [name, setName] = useState('')
   const [promptName, setPromptName] = useState('')
@@ -60,7 +72,7 @@ function NewExperimentDialog({ open, onClose }: { open: boolean; onClose: () => 
   const [versionBId, setVersionBId] = useState('')
   const [datasetId, setDatasetId] = useState('')
   const [evaluatorId, setEvaluatorId] = useState('')
-  const [runProvider, setRunProvider] = useState<'openai' | 'anthropic'>('openai')
+  const [runProvider, setRunProvider] = useState<'openai' | 'anthropic' | 'gemini'>('openai')
   const [runModel, setRunModel] = useState<string>('gpt-4o-mini')
   const [error, setError] = useState('')
 
@@ -219,14 +231,15 @@ function NewExperimentDialog({ open, onClose }: { open: boolean; onClose: () => 
               <select
                 value={runProvider}
                 onChange={(e) => {
-                  const p = e.target.value as 'openai' | 'anthropic'
+                  const p = e.target.value as 'openai' | 'anthropic' | 'gemini'
                   setRunProvider(p)
-                  setRunModel(RUN_MODELS[p][0])
+                  setRunModel(runModels[p][0] ?? '')
                 }}
                 className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text"
               >
                 <option value="openai">OpenAI</option>
                 <option value="anthropic">Anthropic</option>
+                <option value="gemini">Gemini</option>
               </select>
             </div>
             <div>
@@ -238,7 +251,7 @@ function NewExperimentDialog({ open, onClose }: { open: boolean; onClose: () => 
                 onChange={(e) => setRunModel(e.target.value)}
                 className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text"
               >
-                {RUN_MODELS[runProvider].map((m) => (
+                {runModels[runProvider].map((m) => (
                   <option key={m} value={m}>{m}</option>
                 ))}
               </select>

--- a/apps/web/app/(dashboard)/prompts/[name]/tabs/playground-tab.tsx
+++ b/apps/web/app/(dashboard)/prompts/[name]/tabs/playground-tab.tsx
@@ -3,6 +3,7 @@ import { useState, useMemo } from 'react'
 import { Play, Loader2, AlertTriangle, CheckCircle2, Key } from 'lucide-react'
 import { usePlaygroundRun, type PromptVersion, type PlaygroundResult } from '@/lib/queries/use-prompts'
 import { useProviderKeys } from '@/lib/queries/use-provider-keys'
+import { useModels, type ModelsByProvider } from '@/lib/queries/use-models'
 
 const VAR_RE = /\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g
 
@@ -14,22 +15,20 @@ function extractVars(content: string): string[] {
   return [...names]
 }
 
-const MODELS_BY_PROVIDER: Record<string, string[]> = {
-  openai: ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-3.5-turbo'],
-  anthropic: [
-    'claude-sonnet-4-6',
-    'claude-opus-4-5',
-    'claude-3-5-sonnet-20241022',
-    'claude-3-5-haiku-20241022',
-    'claude-3-opus-20240229',
-  ],
-  gemini: ['gemini-2.0-flash', 'gemini-1.5-pro', 'gemini-1.5-flash'],
-}
-
 const PROVIDER_LABELS: Record<string, string> = {
   openai: 'OpenAI',
   anthropic: 'Anthropic',
   gemini: 'Gemini',
+}
+
+/** Pick the model strings for a provider out of the catalog. */
+function modelsForProvider(
+  catalog: ModelsByProvider | undefined,
+  provider: string | undefined | null,
+): string[] {
+  if (!catalog || !provider) return []
+  const key = provider as keyof ModelsByProvider
+  return (catalog[key] ?? []).map((m) => m.model)
 }
 
 function fmtUsd(v: number): string {
@@ -51,6 +50,7 @@ export function PlaygroundTab({ versions }: Props) {
   const [result, setResult] = useState<PlaygroundResult | null>(null)
 
   const { data: allKeys, isLoading: keysLoading } = useProviderKeys()
+  const { data: modelsCatalog } = useModels()
   const runMutation = usePlaygroundRun()
 
   // Playground runs against a provider key directly — no Spanlens key here.
@@ -65,8 +65,8 @@ export function PlaygroundTab({ versions }: Props) {
   )
 
   const availableModels = useMemo(
-    () => (selectedKey?.provider ? (MODELS_BY_PROVIDER[selectedKey.provider] ?? []) : []),
-    [selectedKey],
+    () => modelsForProvider(modelsCatalog, selectedKey?.provider),
+    [modelsCatalog, selectedKey],
   )
 
   // Reset model when key changes
@@ -74,7 +74,7 @@ export function PlaygroundTab({ versions }: Props) {
     setSelectedKeyId(keyId)
     setResult(null)
     const key = activeKeys.find((k) => k.id === keyId)
-    const models = key?.provider ? (MODELS_BY_PROVIDER[key.provider] ?? []) : []
+    const models = modelsForProvider(modelsCatalog, key?.provider)
     setModel(models[0] ?? '')
   }
 

--- a/apps/web/app/(dashboard)/requests/[id]/request-detail-client.tsx
+++ b/apps/web/app/(dashboard)/requests/[id]/request-detail-client.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Check, Copy, Play, RotateCw } from 'lucide-react'
 import { Skeleton } from '@/components/ui/skeleton'
 import { cn, formatDateTime } from '@/lib/utils'
 import { useRequest, useReplayRequest, useRunReplay } from '@/lib/queries/use-requests'
+import { useModels, type ModelsByProvider } from '@/lib/queries/use-models'
 
 // TODO: re-add `usePostHog()` + `cache_breakdown_viewed` capture once the
 // PostHog provider lands on main (separate PR). The event payload is fully
@@ -224,31 +225,14 @@ export function RequestDetailClient({ id }: { id: string }) {
 
 // ── Replay button + dialog ─────────────────────────────────────────────
 
-const MODELS_BY_PROVIDER: Record<string, string[]> = {
-  openai: [
-    'gpt-4o',
-    'gpt-4o-mini',
-    'o1',
-    'o1-mini',
-    'o3-mini',
-    'gpt-4-turbo',
-    'gpt-3.5-turbo',
-  ],
-  anthropic: [
-    'claude-opus-4-5',
-    'claude-sonnet-4-5',
-    'claude-haiku-3-5',
-    'claude-3-5-sonnet-20241022',
-    'claude-3-5-haiku-20241022',
-    'claude-3-opus-20240229',
-  ],
-  gemini: [
-    'gemini-2.0-flash',
-    'gemini-2.0-flash-exp',
-    'gemini-1.5-pro',
-    'gemini-1.5-flash',
-    'gemini-1.5-flash-8b',
-  ],
+/** Pull provider model strings out of the live catalog. */
+function modelsForProvider(
+  catalog: ModelsByProvider | undefined,
+  provider: string,
+): string[] {
+  if (!catalog) return []
+  const key = provider as keyof ModelsByProvider
+  return (catalog[key] ?? []).map((m) => m.model)
 }
 
 function buildCurlSnippet(proxyPath: string, body: Record<string, unknown>): string {
@@ -274,12 +258,17 @@ function ReplayButton({ requestId, originalModel, provider }: ReplayButtonProps)
 
   const prepare = useReplayRequest()
   const run = useRunReplay()
+  const { data: modelsCatalog } = useModels()
 
-  // Model options: provider list + original if not already included
-  const providerModels = MODELS_BY_PROVIDER[provider] ?? []
-  const modelOptions = providerModels.includes(originalModel)
-    ? providerModels
-    : [originalModel, ...providerModels]
+  // Model options: provider list from the live catalog + original if not
+  // already included. Falls back to just the original while the catalog
+  // is loading so the dropdown isn't empty.
+  const providerModels = modelsForProvider(modelsCatalog, provider)
+  const modelOptions = providerModels.length === 0
+    ? [originalModel]
+    : providerModels.includes(originalModel)
+      ? providerModels
+      : [originalModel, ...providerModels]
 
   function reset(): void {
     setModel(originalModel)

--- a/apps/web/lib/dataset-upload.ts
+++ b/apps/web/lib/dataset-upload.ts
@@ -1,0 +1,154 @@
+/**
+ * Parses a user-uploaded file (JSON or CSV) into the dataset-item shape the
+ * server accepts. Used by the "+ Upload" button on the Eval Run dialog.
+ *
+ * Accepted shapes:
+ *
+ *   JSON: an array of objects. Each object must have `input` and an optional
+ *         `expected_output` (or `expectedOutput`). `input` can be:
+ *           - a plain string         → wrapped as { messages: [{role,user,content}] }
+ *           - an object with messages → passed through
+ *           - an object with variables → passed through
+ *
+ *   CSV:  first row = header, columns `input` and optional `expected_output`.
+ *         Values may be wrapped in double quotes; commas inside quotes are
+ *         preserved. Each row becomes one item with `input` as a string,
+ *         which the server then wraps into a single-message conversation.
+ *
+ * No external deps — keeps the web bundle small.
+ */
+
+export interface UploadedItem {
+  input: unknown
+  expected_output?: string | null
+}
+
+export interface ParseResult {
+  items: UploadedItem[]
+  warnings: string[]
+}
+
+/** Top-level entry — sniffs by file extension, falls back by content. */
+export async function parseUploadedFile(file: File): Promise<ParseResult> {
+  const text = await file.text()
+  const ext = file.name.toLowerCase().split('.').pop()
+
+  if (ext === 'json' || (ext !== 'csv' && text.trim().startsWith('['))) {
+    return parseJson(text)
+  }
+  return parseCsv(text)
+}
+
+function parseJson(text: string): ParseResult {
+  let raw: unknown
+  try {
+    raw = JSON.parse(text)
+  } catch (err) {
+    throw new Error(`Invalid JSON: ${err instanceof Error ? err.message : 'parse failed'}`)
+  }
+  if (!Array.isArray(raw)) {
+    throw new Error('JSON must be an array of objects, each with an `input` field.')
+  }
+  const items: UploadedItem[] = []
+  const warnings: string[] = []
+  for (let i = 0; i < raw.length; i++) {
+    const row = raw[i] as Record<string, unknown> | undefined
+    if (!row || typeof row !== 'object') {
+      warnings.push(`Row ${i + 1}: not an object — skipped`)
+      continue
+    }
+    if (!('input' in row)) {
+      warnings.push(`Row ${i + 1}: missing "input" — skipped`)
+      continue
+    }
+    const expected = row['expected_output'] ?? row['expectedOutput']
+    items.push({
+      input: row['input'],
+      expected_output: typeof expected === 'string' ? expected : null,
+    })
+  }
+  return { items, warnings }
+}
+
+/** Minimal CSV parser — handles quoted fields with embedded commas/newlines. */
+function parseCsv(text: string): ParseResult {
+  const rows = parseCsvRows(text)
+  if (rows.length === 0) throw new Error('CSV is empty.')
+
+  const header = rows[0]!.map((h) => h.trim().toLowerCase())
+  const inputIdx = header.indexOf('input')
+  if (inputIdx === -1) {
+    throw new Error('CSV header must include "input" (and optionally "expected_output").')
+  }
+  const expectedIdx = header.findIndex((h) => h === 'expected_output' || h === 'expectedoutput')
+
+  const items: UploadedItem[] = []
+  const warnings: string[] = []
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i]!
+    const input = row[inputIdx]?.trim() ?? ''
+    if (!input) {
+      warnings.push(`Row ${i + 1}: empty input — skipped`)
+      continue
+    }
+    items.push({
+      input,
+      expected_output: expectedIdx >= 0 ? (row[expectedIdx]?.trim() || null) : null,
+    })
+  }
+  return { items, warnings }
+}
+
+/**
+ * Tokenize CSV. We only support the basics — RFC 4180 quoted fields, comma
+ * delimiter, CRLF or LF rows. No escaped quotes (just doubled "" within
+ * quoted fields).
+ */
+function parseCsvRows(text: string): string[][] {
+  const rows: string[][] = []
+  let cur: string[] = []
+  let field = ''
+  let inQuotes = false
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') { field += '"'; i++ }
+        else inQuotes = false
+      } else {
+        field += ch
+      }
+      continue
+    }
+    if (ch === '"') { inQuotes = true; continue }
+    if (ch === ',') { cur.push(field); field = ''; continue }
+    if (ch === '\r') continue
+    if (ch === '\n') {
+      cur.push(field)
+      // Skip empty trailing lines from final newline
+      if (!(cur.length === 1 && cur[0] === '')) rows.push(cur)
+      cur = []
+      field = ''
+      continue
+    }
+    field += ch
+  }
+  // Final field if file doesn't end with newline
+  if (field.length > 0 || cur.length > 0) {
+    cur.push(field)
+    if (!(cur.length === 1 && cur[0] === '')) rows.push(cur)
+  }
+  return rows
+}
+
+/** Auto-generated name format for uploads. Keeps /datasets list tidy. */
+export function generateUploadName(now: Date = new Date()): string {
+  const pad = (n: number) => n.toString().padStart(2, '0')
+  return [
+    'upload',
+    now.getFullYear(),
+    pad(now.getMonth() + 1),
+    pad(now.getDate()),
+    `${pad(now.getHours())}${pad(now.getMinutes())}`,
+  ].join('-')
+}

--- a/apps/web/lib/queries/use-datasets.ts
+++ b/apps/web/lib/queries/use-datasets.ts
@@ -115,6 +115,31 @@ export function useAddDatasetItem() {
   })
 }
 
+/**
+ * Bulk-upload pre-parsed items into a dataset. Skips invalid rows server-side
+ * and reports counts back. Used by the file-upload flow on the Eval Run
+ * dialog — see `useUploadDatasetFromFile` below.
+ */
+export function useBulkAddDatasetItems() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: {
+      datasetId: string
+      items: Array<{ input: unknown; expected_output?: string | null }>
+    }) => {
+      const res = await apiPost<ApiEnvelope<{ inserted: number; skipped: Array<{ index: number; reason: string }> }>>(
+        `/api/v1/datasets/${input.datasetId}/items/bulk`,
+        { items: input.items },
+      )
+      return res.data
+    },
+    onSuccess: (_data, vars) => {
+      void qc.invalidateQueries({ queryKey: ['datasets', vars.datasetId] })
+      void qc.invalidateQueries({ queryKey: datasetsQueryKey() })
+    },
+  })
+}
+
 export function useImportRequestsToDataset() {
   const qc = useQueryClient()
   return useMutation({

--- a/apps/web/lib/queries/use-evals.ts
+++ b/apps/web/lib/queries/use-evals.ts
@@ -8,7 +8,7 @@ import type { ApiEnvelope } from './types'
 
 export interface JudgeConfig {
   criterion: string
-  judge_provider: 'openai' | 'anthropic'
+  judge_provider: 'openai' | 'anthropic' | 'gemini'
   judge_model: string
   scale_min: number
   scale_max: number
@@ -175,6 +175,10 @@ export interface CreateEvalRunInput {
   sampleSize: number
   sampleFrom?: string
   sampleTo?: string
+  /** Required when source = 'dataset' — used to generate the response that
+   *  then gets scored by the judge. */
+  runProvider?: 'openai' | 'anthropic' | 'gemini'
+  runModel?: string
 }
 
 export function useCreateEvalRun() {

--- a/apps/web/lib/queries/use-experiments.ts
+++ b/apps/web/lib/queries/use-experiments.ts
@@ -107,7 +107,7 @@ export interface CreateExperimentInput {
   versionBId: string
   datasetId: string
   evaluatorId?: string
-  runProvider: 'openai' | 'anthropic'
+  runProvider: 'openai' | 'anthropic' | 'gemini'
   runModel: string
 }
 

--- a/apps/web/lib/queries/use-models.ts
+++ b/apps/web/lib/queries/use-models.ts
@@ -1,0 +1,47 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+
+import { apiGet } from '@/lib/api'
+import type { ApiEnvelope } from './types'
+
+/**
+ * Catalog of priced models, grouped by provider. Backs the Playground tab
+ * selector so the picker auto-tracks whatever's in model_prices instead of
+ * the old hardcoded 12-entry list.
+ *
+ * Dated snapshots (e.g. gpt-4o-2024-05-13) are hidden by the API when an
+ * alias of the same family exists. Callers can still hit dated models
+ * directly via the API — just not via the picker UI.
+ */
+
+export interface ModelEntry {
+  model: string
+  promptPricePer1m: number
+  completionPricePer1m: number
+  cacheReadPricePer1m: number | null
+  cacheWritePricePer1m: number | null
+  longContextThresholdTokens: number | null
+}
+
+export interface ModelsByProvider {
+  openai: ModelEntry[]
+  anthropic: ModelEntry[]
+  gemini: ModelEntry[]
+}
+
+const EMPTY: ModelsByProvider = { openai: [], anthropic: [], gemini: [] }
+
+export function useModels() {
+  return useQuery({
+    queryKey: ['models'] as const,
+    queryFn: async () => {
+      const res = await apiGet<ApiEnvelope<ModelsByProvider>>('/api/v1/models')
+      return res.data ?? EMPTY
+    },
+    // Model catalog changes when an admin updates model_prices. That's
+    // rare (quarterly at most) so cache for a long time — switching tabs
+    // shouldn't re-fetch.
+    staleTime: 30 * 60_000,
+  })
+}

--- a/scripts/sample-eval-dataset.json
+++ b/scripts/sample-eval-dataset.json
@@ -1,0 +1,50 @@
+[
+  {
+    "input": "안녕하세요, Spanlens 가입한 지 얼마 안 됐는데 대시보드 너무 좋아요! 감사합니다 😊",
+    "expected_output": "Warm greeting that thanks the user for the kind feedback and offers help with anything else."
+  },
+  {
+    "input": "How do I export my request logs to CSV?",
+    "expected_output": "Clear step-by-step pointing to /requests → Export button, plus mention CSV/JSON formats."
+  },
+  {
+    "input": "WHY DOES YOUR API KEEP TIMING OUT??? This is the third time today!!!",
+    "expected_output": "Calm, empathetic apology + acknowledges frustration + asks for request_id or timestamp to investigate."
+  },
+  {
+    "input": "thanks",
+    "expected_output": "Brief friendly acknowledgement, offers to help with anything else."
+  },
+  {
+    "input": "내 결제가 두 번 청구된 것 같은데 환불 가능할까요?",
+    "expected_output": "Korean response, apologetic, explains how to verify the duplicate charge and the refund process."
+  },
+  {
+    "input": "Can you write me a haiku?",
+    "expected_output": "Polite redirect noting this is customer support but offers help with Spanlens-related questions."
+  },
+  {
+    "input": "My API key keeps getting rejected even though I just generated it.",
+    "expected_output": "Asks user to check key prefix sl_live_ vs sl_test_, confirm the project, then offer to escalate."
+  },
+  {
+    "input": "I want to cancel my subscription immediately.",
+    "expected_output": "Respects the decision without pressure, explains where to cancel in settings, confirms billing will stop at period end."
+  },
+  {
+    "input": "이건 쓰레기 서비스야 환불해줘",
+    "expected_output": "Korean response, calm and apologetic, asks what went wrong, explains refund process clearly."
+  },
+  {
+    "input": "Hi! Is it possible to integrate Spanlens with my LangChain Python app?",
+    "expected_output": "Helpful answer mentioning the @spanlens/sdk package, baseURL configuration, and link to /docs/quick-start."
+  },
+  {
+    "input": "Hello?",
+    "expected_output": "Warm greeting that invites the user to describe what they need help with."
+  },
+  {
+    "input": "What is the meaning of life?",
+    "expected_output": "Friendly off-topic acknowledgement that gently redirects to Spanlens-related help."
+  }
+]

--- a/scripts/smoke-all-providers.mjs
+++ b/scripts/smoke-all-providers.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Smoke test: hit one call per representative model on every provider, then
+ * verify each row landed in ClickHouse with the right cost/service_tier.
+ *
+ * Each call asks for tiny output (max 5-10 tokens) to keep total cost <$0.10.
+ * Reuses the Spanlens key from setup-smoke-test.mjs.
+ */
+
+const SPANLENS_KEY = process.env.SPANLENS_KEY
+if (!SPANLENS_KEY) {
+  console.error('Set SPANLENS_KEY (from setup-smoke-test.mjs output)')
+  process.exit(1)
+}
+
+const BASE = 'http://localhost:3001'
+
+const TESTS = [
+  // ── OpenAI ─────────────────────────────────────────────────────────────────
+  { id: 'oa-1', provider: 'openai', model: 'gpt-4o-mini',  desc: 'GPT-4o-mini baseline' },
+  { id: 'oa-2', provider: 'openai', model: 'gpt-4o',       desc: 'GPT-4o' },
+  { id: 'oa-3', provider: 'openai', model: 'gpt-5-mini',   desc: 'GPT-5 base mini' },
+  { id: 'oa-4', provider: 'openai', model: 'gpt-5.5',      desc: 'GPT-5.5 flagship (tier)', extra: { service_tier: 'priority' } },
+  // ── Anthropic ──────────────────────────────────────────────────────────────
+  { id: 'an-1', provider: 'anthropic', model: 'claude-haiku-4-5',  desc: 'Claude Haiku 4.5' },
+  { id: 'an-2', provider: 'anthropic', model: 'claude-sonnet-4-6', desc: 'Claude Sonnet 4.6' },
+  { id: 'an-3', provider: 'anthropic', model: 'claude-opus-4-7',   desc: 'Claude Opus 4.7 (flagship)' },
+  // ── Gemini ─────────────────────────────────────────────────────────────────
+  { id: 'gm-1', provider: 'gemini', model: 'gemini-2.5-flash-lite', desc: 'Gemini 2.5 Flash Lite' },
+  { id: 'gm-2', provider: 'gemini', model: 'gemini-2.5-flash',      desc: 'Gemini 2.5 Flash' },
+  { id: 'gm-3', provider: 'gemini', model: 'gemini-2.5-pro',        desc: 'Gemini 2.5 Pro (tier)' },
+]
+
+async function callOpenAI(t) {
+  const body = {
+    model: t.model,
+    messages: [{ role: 'user', content: `say ${t.id}` }],
+    max_tokens: 5,
+    ...t.extra,
+  }
+  const res = await fetch(`${BASE}/proxy/openai/v1/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${SPANLENS_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+  return { status: res.status, body: await res.json() }
+}
+
+async function callAnthropic(t) {
+  const body = {
+    model: t.model,
+    max_tokens: 10,
+    messages: [{ role: 'user', content: `say ${t.id}` }],
+  }
+  const res = await fetch(`${BASE}/proxy/anthropic/v1/messages`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${SPANLENS_KEY}`,
+      'Content-Type': 'application/json',
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify(body),
+  })
+  return { status: res.status, body: await res.json() }
+}
+
+async function callGemini(t) {
+  const body = {
+    contents: [{ parts: [{ text: `say ${t.id}` }] }],
+    generationConfig: { maxOutputTokens: 10 },
+  }
+  const res = await fetch(
+    `${BASE}/proxy/gemini/v1beta/models/${t.model}:generateContent`,
+    {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${SPANLENS_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    },
+  )
+  return { status: res.status, body: await res.json() }
+}
+
+const callers = {
+  openai: callOpenAI,
+  anthropic: callAnthropic,
+  gemini: callGemini,
+}
+
+console.log('── Running calls ─────────────────────────────────────────────')
+for (const t of TESTS) {
+  try {
+    const result = await callers[t.provider](t)
+    const ok = result.status === 200
+    const errMsg = ok ? '' : ` · ${JSON.stringify(result.body?.error ?? result.body).slice(0, 80)}`
+    console.log(`${ok ? '✓' : '✗'} ${t.id.padEnd(5)} ${t.provider.padEnd(10)} ${t.model.padEnd(40)} status=${result.status}${errMsg}`)
+  } catch (err) {
+    console.log(`✗ ${t.id.padEnd(5)} ${t.provider.padEnd(10)} ${t.model.padEnd(40)} EXCEPTION: ${err.message}`)
+  }
+  // Tiny pause so CH inserts don't pile up
+  await new Promise((r) => setTimeout(r, 200))
+}
+
+console.log('\nWaiting 3s for async log writes to ClickHouse…')
+await new Promise((r) => setTimeout(r, 3000))
+console.log('Done. Run the CH query in the report step.')

--- a/scripts/smoke-eval-setup.mjs
+++ b/scripts/smoke-eval-setup.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Sets up a prompt + 10 varied calls so /evals has data to score.
+ *
+ * Creates:
+ *   1. Prompt "customer-support-smoke" v1 — friendly customer support persona
+ *   2. 10 proxy calls with X-Spanlens-Prompt-Version header
+ *      Mix of "easy" and "harder" customer messages so the judge sees a
+ *      range of response qualities.
+ */
+
+const ENCRYPTION_KEY = process.env.ENCRYPTION_KEY
+const SUPABASE_URL = process.env.SUPABASE_URL ?? 'http://127.0.0.1:54321'
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY
+const SPANLENS_KEY = process.env.SPANLENS_KEY
+const ORG_ID = process.env.ORG_ID
+const PROJECT_ID = process.env.PROJECT_ID
+
+for (const [k, v] of Object.entries({
+  ENCRYPTION_KEY, SUPABASE_SERVICE_ROLE_KEY, SPANLENS_KEY, ORG_ID, PROJECT_ID,
+})) {
+  if (!v) { console.error(`Missing env: ${k}`); process.exit(1) }
+}
+
+async function pgInsert(table, body) {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${table}`, {
+    method: 'POST',
+    headers: {
+      'apikey': SUPABASE_SERVICE_ROLE_KEY,
+      'Authorization': `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+      'Content-Type': 'application/json',
+      'Prefer': 'return=representation',
+    },
+    body: JSON.stringify(body),
+  })
+  const text = await res.text()
+  if (!res.ok) throw new Error(`${table} INSERT failed (${res.status}): ${text}`)
+  return JSON.parse(text)
+}
+
+// ── 1. Create prompt version ────────────────────────────────────────────────
+const promptContent = `You are a helpful, friendly customer support agent for SpanLens, an LLM observability platform.
+
+Your goal: resolve customer issues efficiently and warmly. Always:
+- Greet the customer
+- Acknowledge their issue
+- Provide a clear answer or next step
+- End on a friendly note
+
+If you don't know the answer, say so politely and offer to escalate.`
+
+console.log('1. Creating prompt version...')
+const [promptVersion] = await pgInsert('prompt_versions', {
+  organization_id: ORG_ID,
+  project_id: PROJECT_ID,
+  name: 'customer-support-smoke',
+  version: 1,
+  content: promptContent,
+  variables: [],
+  metadata: { source: 'smoke-eval-setup' },
+})
+console.log(`   prompt_version_id = ${promptVersion.id}`)
+console.log(`   name = ${promptVersion.name}, version = ${promptVersion.version}`)
+
+// ── 2. Make 10 varied calls referencing this prompt version ────────────────
+const messages = [
+  'My subscription was charged twice this month, can you help?',
+  'How do I export my data?',
+  'WHY DOES YOUR APP CRASH ALL THE TIME???',  // angry user — tests if model stays friendly
+  'Can you tell me how to integrate Spanlens with my Python app?',
+  'thanks',  // very short — tests if model handles graceful close
+  '내 결제가 안 됐는데 어떻게 해야 하지?',  // Korean — tests if it acknowledges + answers
+  'I need to cancel my subscription immediately, this is urgent!',
+  'What is the meaning of life?',  // off-topic
+  'My API key keeps getting rejected, help',
+  'Hi! I just signed up and I love the dashboard 😊',  // happy user — easy win for friendliness
+]
+
+console.log(`\n2. Running ${messages.length} OpenAI calls with X-Spanlens-Prompt-Version...`)
+
+let success = 0
+let failed = 0
+for (let i = 0; i < messages.length; i++) {
+  const msg = messages[i]
+  try {
+    const res = await fetch('http://localhost:3001/proxy/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${SPANLENS_KEY}`,
+        'Content-Type': 'application/json',
+        // Linking the call to the prompt version so /evals can find it
+        'X-Spanlens-Prompt-Version': `${promptVersion.name}@${promptVersion.version}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: promptContent },
+          { role: 'user', content: msg },
+        ],
+        max_tokens: 150,
+      }),
+    })
+    if (res.ok) {
+      const json = await res.json()
+      const reply = json.choices?.[0]?.message?.content ?? ''
+      console.log(`   ${(i + 1).toString().padStart(2)}/10 ✓ "${msg.slice(0, 40)}..." → "${reply.slice(0, 60)}..."`)
+      success++
+    } else {
+      console.log(`   ${(i + 1).toString().padStart(2)}/10 ✗ status=${res.status}`)
+      failed++
+    }
+  } catch (err) {
+    console.log(`   ${(i + 1).toString().padStart(2)}/10 ✗ ${err.message}`)
+    failed++
+  }
+  await new Promise((r) => setTimeout(r, 300))
+}
+
+console.log(`\nResult: ${success} ok, ${failed} failed`)
+console.log('\n── Next steps in the browser ───────────────────────────────────')
+console.log(`Prompt name:    ${promptVersion.name}`)
+console.log(`Prompt version: v${promptVersion.version}`)
+console.log()
+console.log('1. /prompts → click "customer-support-smoke" to see version + calls')
+console.log('2. /evals  → "+ New evaluator"')
+console.log('     - Prompt: customer-support-smoke')
+console.log('     - Name: Friendliness')
+console.log('     - Criterion: Is the response friendly, polite, and clearly addresses the customer issue?')
+console.log('     - Judge provider: choose any (OpenAI / Anthropic / Gemini)')
+console.log('     - Judge model: e.g. gpt-4o-mini or gemini-2.5-flash-lite (cheap)')
+console.log('3. After saving → "Run" the evaluator → see scores roll in')
+console.log('─────────────────────────────────────────────────────────────────')

--- a/scripts/smoke-traces.mjs
+++ b/scripts/smoke-traces.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Smoke test agent tracing — create a trace + span via /ingest, then make a
+ * proxy call carrying X-Trace-Id / X-Span-Id headers. Verifies traces, spans,
+ * and ClickHouse requests all link together.
+ */
+
+const SPANLENS_KEY = process.env.SPANLENS_KEY
+if (!SPANLENS_KEY) {
+  console.error('Set SPANLENS_KEY')
+  process.exit(1)
+}
+
+const BASE = 'http://localhost:3001'
+
+async function jpost(path, body, extraHeaders = {}) {
+  const res = await fetch(`${BASE}${path}`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${SPANLENS_KEY}`,
+      'Content-Type': 'application/json',
+      ...extraHeaders,
+    },
+    body: JSON.stringify(body),
+  })
+  const text = await res.text()
+  let json
+  try { json = JSON.parse(text) } catch { json = text }
+  return { status: res.status, body: json }
+}
+
+console.log('── Trace + Span ingest flow ──────────────────────────────')
+
+// 1) Create trace
+console.log('\n1. POST /ingest/traces')
+const traceRes = await jpost('/ingest/traces', {
+  name: 'smoke-test-multi-provider',
+  metadata: { test: 'all-3-providers' },
+})
+console.log('  ', traceRes.status, traceRes.body)
+if (traceRes.status !== 201) process.exit(1)
+const traceId = traceRes.body.data.id
+
+// 2) Create span
+console.log('\n2. POST /ingest/traces/:id/spans')
+const spanRes = await jpost(`/ingest/traces/${traceId}/spans`, {
+  name: 'openai-call',
+  kind: 'llm',
+  started_at: new Date().toISOString(),
+})
+console.log('  ', spanRes.status, spanRes.body)
+if (spanRes.status !== 201) process.exit(1)
+const spanId = spanRes.body.data.id
+
+// 3) Wait for ingest INSERT to commit before proxy call references it
+// (gotcha #10 — _creationPromise chain handles it via SDK, but we're raw curl)
+await new Promise((r) => setTimeout(r, 500))
+
+// 4) Make a proxy call carrying the trace/span headers
+console.log('\n3. POST /proxy/openai with X-Trace-Id / X-Span-Id')
+const callRes = await jpost(
+  '/proxy/openai/v1/chat/completions',
+  {
+    model: 'gpt-4o-mini',
+    messages: [{ role: 'user', content: 'trace test' }],
+    max_tokens: 5,
+  },
+  {
+    'X-Trace-Id': traceId,
+    'X-Span-Id': spanId,
+  },
+)
+console.log('   status:', callRes.status, 'model:', callRes.body.model)
+
+// 5) Close the span
+console.log('\n4. PATCH /ingest/spans/:id (close)')
+const closeRes = await fetch(`${BASE}/ingest/spans/${spanId}`, {
+  method: 'PATCH',
+  headers: {
+    'Authorization': `Bearer ${SPANLENS_KEY}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    ended_at: new Date().toISOString(),
+    status: 'ok',
+  }),
+})
+console.log('  ', closeRes.status)
+
+// 6) Close the trace
+console.log('\n5. PATCH /ingest/traces/:id (close)')
+const traceCloseRes = await fetch(`${BASE}/ingest/traces/${traceId}`, {
+  method: 'PATCH',
+  headers: {
+    'Authorization': `Bearer ${SPANLENS_KEY}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    ended_at: new Date().toISOString(),
+    status: 'ok',
+  }),
+})
+console.log('  ', traceCloseRes.status)
+
+await new Promise((r) => setTimeout(r, 2000))
+
+console.log('\n── IDs to verify ──────────────────────────────────────────')
+console.log('TRACE_ID =', traceId)
+console.log('SPAN_ID =', spanId)
+console.log('───────────────────────────────────────────────────────────')


### PR DESCRIPTION
## Summary

Three layered improvements to the Evals workflow, smoke tested end to end against real OpenAI / Anthropic / Gemini keys.

### 1. Dynamic model catalog (`GET /api/v1/models`)
- New endpoint groups `model_prices` by provider and hides dated snapshots when an alias exists.
- `useModels()` hook with 30 min staleTime backs the Playground, Evals judge, Experiments run, and Requests Replay pickers.
- Old hardcoded lists (12 to 18 strings per file) gone. Adding a new model to `model_prices` now flows to every picker without a code change.

### 2. Gemini judge + Gemini experiment runner
- `judge_provider` and `runProvider` types widened to include `'gemini'`.
- New Gemini branches in `eval-runner` and `experiment-runner` use `responseMimeType: 'application/json'` + `responseSchema` for strict JSON output (matches OpenAI's `response_format: json_object` strictness, unlike Anthropic which relies on prompt engineering).
- UI selects gain a `Gemini` option.

### 3. Hybrid dataset upload + correct dataset eval mode
- Eval Run dialog now has a `Plus Upload` button next to the Dataset dropdown. JSON or CSV is parsed client side; the file becomes a fresh dataset with auto generated name (`upload-YYYY-MM-DD-HHMM`), items insert via the new `POST /api/v1/datasets/:id/items/bulk` endpoint, then pre selected. The dataset stays in `/datasets` for later reuse or deletion.
- `eval-runner` dataset mode rewrote: was scoring `expected_output` text directly (measured the curated golden answer, not the prompt). Now runs the prompt against each item's input with a `runProvider + runModel` (required), then sends the generated response to the judge.
- UX fixes that surfaced during smoke testing: nested `<button>` in `ItemRow` (same pattern as the PR #148 EvaluatorRow fix), wrong `/requests?id=` URLs replaced with `/requests/:id`, dead click on dataset mode lowest scoring rows fixed (rows now expand inline + link to source request when applicable), and a `Show all` toggle on the sample list so users can reconcile the avg score with visible rows.

## Smoke test evidence

Same 12 item dataset, before vs after the dataset mode fix:

| | Before (scored expected_output) | After (scored generated response) |
|---|---|---|
| Avg score | 68.3 | 74.2 |
| Cost | $0.00040 | $0.00067 (1.7x: generate + judge) |
| Reasoning quality | meta about our golden answer text | actual quote from generated text e.g. `'정말 기쁩니다' is inappropriate in context` |

The Korean phrase critique is the smoking gun: only possible if the judge actually read the LLM generated response, not the static `expected_output` we wrote in English.

## Files

Server: `api/models.ts` (new), `api/datasets.ts`, `api/evals.ts`, `api/experiments.ts`, `app.ts`, `lib/eval-runner.ts`, `lib/experiment-runner.ts`

Web: `lib/queries/use-models.ts` (new), `lib/queries/use-datasets.ts`, `lib/queries/use-evals.ts`, `lib/queries/use-experiments.ts`, `lib/dataset-upload.ts` (new), four picker pages + Evals Run dialog + Datasets detail page

Scripts: `scripts/sample-eval-dataset.json`, `scripts/smoke-all-providers.mjs`, `scripts/smoke-traces.mjs`, `scripts/smoke-eval-setup.mjs`

## Test plan
- [x] `pnpm --filter web typecheck && lint` clean
- [x] `pnpm --filter server test` 554 tests pass
- [x] Smoke test against real provider keys: 12 item dataset eval, OpenAI gpt-4o-mini as judge, avg 74.2, reasoning specific enough to call out Korean phrase awkwardness
- [ ] Post merge: production model_prices and prompt_versions tables drive the live pickers