### PR TITLE
docs: refresh /docs/features/evals and /docs/features/datasets

### DIFF
--- a/apps/web/app/docs/features/datasets/page.tsx
+++ b/apps/web/app/docs/features/datasets/page.tsx
@@ -52,17 +52,20 @@ export default function DatasetsDocs() {
           <code>input</code> (jsonb), two shapes are accepted:
           <CodeBlock language="json">{`{ "variables": { "company_name": "Acme", "customer_name": "Alice" } }
 { "messages": [{ "role": "user", "content": "..." }] }`}</CodeBlock>
+          Bulk upload also accepts a plain string for <code>input</code>; the server wraps it as a
+          single user message automatically.
         </li>
         <li>
-          <code>expected_output</code>, reference answer text (optional). Used as the scoring
-          target when running Evals in dataset mode. Items without a value are skipped.
+          <code>expected_output</code>, reference answer text (optional). Stored alongside the
+          item but not consumed by the eval runner in this release. The runner generates a fresh
+          response per item and scores that, so prompt quality is what gets measured.
         </li>
         <li>
           <code>source_request_id</code>, set when the item was imported from a production request.
         </li>
       </ul>
 
-      <h2>Three ways to add items</h2>
+      <h2>Four ways to add items</h2>
 
       <h3>1. Manual entry (dashboard)</h3>
       <p>
@@ -93,16 +96,54 @@ export default function DatasetsDocs() {
     "expectedOutput": "Hello Alice, how can I help?"
   }'`}</CodeBlock>
 
-      <h2>Connection to Evals (replay mode)</h2>
+      <h3>4. File upload from the Eval Run dialog</h3>
       <p>
-        When running an Eval, select <strong>Source: Dataset</strong> to score the dataset&apos;s{' '}
-        <code>expected_output</code> values instead of live production responses. Items without an{' '}
-        <code>expected_output</code> are skipped.
+        On the Eval Run dialog, switch <strong>Sample source</strong> to <strong>Dataset</strong>,
+        click the <strong>Plus Upload</strong> button next to the picker, and choose a JSON or
+        CSV file. The file is parsed in the browser (no external deps), a fresh dataset with an
+        auto generated name is created (for example <code>upload-2026-05-22-2245</code>), every
+        valid row is inserted in one bulk call, and the new dataset is pre selected so you can
+        click Run immediately.
+      </p>
+      <p>Accepted file shapes:</p>
+      <ul>
+        <li>
+          <strong>JSON</strong>, an array of <code>{`{ input, expected_output? }`}</code> objects.{' '}
+          <code>input</code> can be a plain string (wrapped as a one message conversation),{' '}
+          <code>{`{ messages: [...] }`}</code>, or <code>{`{ variables: {...} }`}</code>.
+        </li>
+        <li>
+          <strong>CSV</strong>, header row with <code>input</code> (required) and{' '}
+          <code>expected_output</code> (optional). Quoted fields are supported.
+        </li>
+      </ul>
+      <p>
+        The dataset stays in <a href="/datasets">/datasets</a> for later reuse. Rename it (so you
+        can find it months later), keep it as is, or delete it after the run.
+      </p>
+      <p>Behind the scenes the upload calls:</p>
+      <CodeBlock language="bash">{`curl https://spanlens-server.vercel.app/api/v1/datasets/<dataset-id>/items/bulk \\
+  -H "Authorization: Bearer $SPANLENS_JWT" \\
+  -H "Content-Type: application/json" \\
+  -d '{ "items": [ { "input": "..." }, ... ] }'`}</CodeBlock>
+      <p>
+        Max 5000 items per request. Rows the server cannot normalize (missing or wrong shape){' '}
+        come back in a <code>skipped</code> array with per row reasons instead of failing the
+        whole batch.
+      </p>
+
+      <h2>Connection to Evals</h2>
+      <p>
+        When running an Eval, select <strong>Source: Dataset</strong>, then pick a{' '}
+        <strong>Run provider</strong> and <strong>Run model</strong>. The eval runner does this
+        per item: take the dataset <code>input</code>, run it through the chosen prompt version
+        with that run model, then send the generated response to the judge for scoring.
       </p>
       <p>
-        This is called &quot;replay mode&quot;, scoring already-generated outputs.{' '}
-        <em>Fresh run mode</em> (run the prompt against each dataset input and then score the new
-        outputs) is handled by <a href="/docs/features/experiments">Experiments</a>.
+        Older releases scored the dataset&apos;s <code>expected_output</code> text directly. That
+        measured how friendly the curated reference text was, not how the prompt actually
+        behaves, so it was replaced. <code>expected_output</code> is stored but unused by the
+        runner in the current release.
       </p>
 
       <h2>API</h2>
@@ -139,6 +180,10 @@ export default function DatasetsDocs() {
             <td>Bulk import from request IDs (max 200)</td>
           </tr>
           <tr>
+            <td><code>POST /api/v1/datasets/:id/items/bulk</code></td>
+            <td>Bulk insert pre parsed items (max 5000). Used by the Eval Run dialog file upload.</td>
+          </tr>
+          <tr>
             <td><code>DELETE /api/v1/datasets/:id/items/:itemId</code></td>
             <td>Delete a single item</td>
           </tr>
@@ -148,16 +193,17 @@ export default function DatasetsDocs() {
       <h2>Limitations</h2>
       <ul>
         <li>
-          <strong>No CSV upload.</strong> Items must be added via the dashboard form or the API.
-          CSV import is planned for a later release.
-        </li>
-        <li>
-          <strong>Evals dataset source is replay mode only.</strong> Fresh-run evaluation
-          (running the prompt live against dataset inputs) is handled by Experiments.
-        </li>
-        <li>
           <strong>No item edit UI.</strong> To correct a wrongly entered item, delete it and
           add a new one.
+        </li>
+        <li>
+          <strong>Bulk upload limit is 5000 items.</strong> Larger sets must be split across
+          multiple calls.
+        </li>
+        <li>
+          <strong><code>expected_output</code> is reference only.</strong> The eval runner does
+          not currently feed it to the judge as a target. A future release may add a similarity
+          mode that uses it.
         </li>
       </ul>
 

--- a/apps/web/app/docs/features/evals/page.tsx
+++ b/apps/web/app/docs/features/evals/page.tsx
@@ -39,8 +39,17 @@ export default function EvalsDocs() {
           <code>config</code>:
           <ul>
             <li><code>criterion</code>, scoring criterion sentence</li>
-            <li><code>judge_provider</code>, <code>openai</code> / <code>anthropic</code></li>
-            <li><code>judge_model</code>, e.g. <code>gpt-4o-mini</code></li>
+            <li>
+              <code>judge_provider</code>, <code>openai</code>, <code>anthropic</code>, or{' '}
+              <code>gemini</code>. Gemini uses <code>responseMimeType: application/json</code> with{' '}
+              <code>responseSchema</code> for strict JSON output (matches OpenAI&apos;s{' '}
+              <code>response_format: json_object</code> strictness).
+            </li>
+            <li>
+              <code>judge_model</code>, any model in <code>model_prices</code> for that provider.
+              The Evals UI picker reads from <code>/api/v1/models</code> so newly seeded models
+              appear automatically.
+            </li>
             <li><code>scale_min</code>, <code>scale_max</code>, score range (normalized to 0..1 on save)</li>
           </ul>
         </li>
@@ -67,8 +76,29 @@ export default function EvalsDocs() {
       </p>
       <p>
         To use a <strong>Dataset</strong> as the sample source instead, see the{' '}
-        <a href="/docs/features/datasets">Datasets</a> page. The dataset&apos;s{' '}
-        <code>expected_output</code> field becomes the scoring target.
+        <a href="/docs/features/datasets">Datasets</a> page. In dataset mode the runner does
+        two things back to back:
+      </p>
+      <ol>
+        <li>
+          For each item, run the chosen prompt version against its <code>input</code> using{' '}
+          <code>runProvider</code> + <code>runModel</code> (an active provider key of that
+          provider must exist on the workspace). This produces a fresh response.
+        </li>
+        <li>Send the fresh response to the judge, which scores it against the criterion.</li>
+      </ol>
+      <p>
+        That means dataset mode measures how the prompt actually performs on the curated inputs,
+        not how friendly the static <code>expected_output</code> text is. The{' '}
+        <code>expected_output</code> field is reference only in this release; a later release may
+        feed it to the judge as a target for similarity checks.
+      </p>
+      <p>
+        On the Eval Run dialog, switching the Sample source toggle to <strong>Dataset</strong>{' '}
+        exposes a <strong>Plus Upload</strong> button next to the dataset picker. Picking a JSON
+        or CSV file creates a fresh dataset with an auto generated name (for example{' '}
+        <code>upload-2026-05-22-2245</code>), bulk inserts every parsed item, and pre selects it.
+        Rename or delete the dataset from <a href="/datasets">/datasets</a> later.
       </p>
 
       <h2>How Evals differs from A/B</h2>
@@ -216,6 +246,21 @@ curl https://spanlens-server.vercel.app/api/v1/eval-runs \\
     "source": "production",
     "sampleSize": 50,
     "sampleFrom": "2026-05-06T00:00:00Z"
+  }'
+
+# 2b. Dataset mode also accepts runProvider + runModel.
+#     The runner generates a response per item before scoring.
+curl https://spanlens-server.vercel.app/api/v1/eval-runs \\
+  -H "Authorization: Bearer $SPANLENS_JWT" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "evaluatorId": "<evaluator-id>",
+    "promptVersionId": "<v2-id>",
+    "source": "dataset",
+    "datasetId": "<dataset-id>",
+    "sampleSize": 50,
+    "runProvider": "openai",
+    "runModel": "gpt-4o-mini"
   }'
 
 # 3. Poll for results (status: pending → running → completed)


### PR DESCRIPTION
## Summary

Brings the two evaluation related docs in line with the workflow shipped in PR #149.

### evals
- judge_provider section lists Gemini as a third option and notes the responseSchema based JSON enforcement.
- judge_model section points at the dynamic /api/v1/models catalog.
- New explanation that dataset mode generates a fresh response per item (with runProvider + runModel) before the judge scores it. The older 'expected_output text is the scoring target' behavior is gone.
- New curl example block for dataset mode showing runProvider + runModel.
- Mentions the Plus Upload button on the Eval Run dialog.

### datasets
- dataset_items shape mentions the plain string input shorthand bulk upload now accepts.
- 'Three ways' becomes 'Four ways', the new fourth covers the JSON or CSV file upload from the Eval Run dialog plus the underlying POST /api/v1/datasets/:id/items/bulk endpoint.
- 'Connection to Evals' rewritten: not replay mode anymore.
- Limitations list refreshed: 'No CSV upload' and 'replay mode only' removed; 5000 item bulk cap and expected_output reference only added.
- API table gains the bulk endpoint row.

Prose avoids em dashes per the user's style preference.

## Test plan
- [x] pnpm --filter web typecheck clean
- [x] pnpm --filter web lint clean