### PR TITLE
feat(web): wire Google + GitHub OAuth login

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -4,3 +4,13 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=<supabase-anon-key>
 
 # Server API URL
 NEXT_PUBLIC_API_URL=http://localhost:3001
+
+# OAuth providers (local dev) — set these BEFORE `supabase start` so the
+# auth container picks them up. Production providers are configured via
+# Supabase Dashboard, not env vars. See docs/auth-oauth-setup.md.
+# Redirect URI to register in each provider's console:
+#   http://127.0.0.1:54321/auth/v1/callback
+SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=<google-oauth-client-id>
+SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET=<google-oauth-client-secret>
+SUPABASE_AUTH_EXTERNAL_GITHUB_CLIENT_ID=<github-oauth-client-id>
+SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET=<github-oauth-client-secret>

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -32,6 +32,13 @@ import { QuotaBanner } from '@/components/dashboard/quota-banner'
 import { useAuditLogs } from '@/lib/queries/use-audit-logs'
 import { useCurrentUser } from '@/lib/queries/use-current-user'
 import {
+  useIdentities,
+  useLinkIdentity,
+  useUnlinkIdentity,
+  type LinkableProvider,
+} from '@/lib/queries/use-identities'
+import type { UserIdentity } from '@supabase/supabase-js'
+import {
   useMembers,
   useInvitations,
   useInviteMember,
@@ -60,7 +67,7 @@ import { CronJobsPanel } from './cron-jobs-panel'
 type TabId =
   | 'general' | 'members' | 'security' | 'audit-log' | 'system'
   | 'billing' | 'plan' | 'invoices'
-  | 'profile' | 'notifications' | 'preferences'
+  | 'profile' | 'auth-methods' | 'notifications' | 'preferences'
   | 'integrations' | 'destinations' | 'webhooks' | 'opentelemetry'
 
 interface NavItem { id: TabId; label: string; crumbs: { label: string }[] }
@@ -89,9 +96,10 @@ const NAV: { group: string; items: NavItem[] }[] = [
   {
     group: 'Account',
     items: [
-      { id: 'profile',       label: 'Profile',       crumbs: [{ label: 'Account' }, { label: 'Profile' }] },
-      { id: 'notifications', label: 'Notifications', crumbs: [{ label: 'Account' }, { label: 'Notifications' }] },
-      { id: 'preferences',   label: 'Preferences',   crumbs: [{ label: 'Account' }, { label: 'Preferences' }] },
+      { id: 'profile',       label: 'Profile',          crumbs: [{ label: 'Account' }, { label: 'Profile' }] },
+      { id: 'auth-methods',  label: 'Sign-in methods',  crumbs: [{ label: 'Account' }, { label: 'Sign-in methods' }] },
+      { id: 'notifications', label: 'Notifications',    crumbs: [{ label: 'Account' }, { label: 'Notifications' }] },
+      { id: 'preferences',   label: 'Preferences',      crumbs: [{ label: 'Account' }, { label: 'Preferences' }] },
     ],
   },
   {
@@ -1052,6 +1060,144 @@ function ProfileTab() {
   )
 }
 
+// ─── SIGN-IN METHODS tab ──────────────────────────────────────────────────────
+
+interface ProviderConfig {
+  id: LinkableProvider
+  label: string
+  glyph: string
+}
+
+const SIGNIN_PROVIDERS: ProviderConfig[] = [
+  { id: 'google', label: 'Google', glyph: 'G' },
+  { id: 'github', label: 'GitHub', glyph: '⌥' },
+]
+
+function SignInMethodsTab() {
+  const { data: user, isLoading: userLoading } = useCurrentUser()
+  const { data: identities, isLoading: identitiesLoading, error: identitiesError } = useIdentities()
+  const linkMutation = useLinkIdentity()
+  const unlinkMutation = useUnlinkIdentity()
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  const identityList: UserIdentity[] = identities ?? []
+  const isLastIdentity = identityList.length <= 1
+  const isLoading = userLoading || identitiesLoading
+  const isBusy = linkMutation.isPending || unlinkMutation.isPending
+
+  function findIdentity(provider: LinkableProvider): UserIdentity | undefined {
+    return identityList.find((row) => row.provider === provider)
+  }
+
+  async function handleConnect(provider: LinkableProvider) {
+    setActionError(null)
+    try {
+      await linkMutation.mutateAsync({ provider })
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to start sign-in flow.')
+    }
+  }
+
+  async function handleDisconnect(identity: UserIdentity) {
+    setActionError(null)
+    try {
+      await unlinkMutation.mutateAsync(identity)
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to disconnect provider.')
+    }
+  }
+
+  return (
+    <div className="max-w-[920px]">
+      <TabHeader
+        title="Sign-in methods"
+        description="Manage how you sign in to Spanlens. Connect multiple providers to the same account, then sign in with any of them."
+      />
+
+      <Section title="Linked providers" className="mb-5">
+        {isLoading ? (
+          <div className="px-6 py-4 font-mono text-[12.5px] text-text-faint">Loading…</div>
+        ) : identitiesError ? (
+          <div className="px-6 py-4 font-mono text-[12.5px] text-bad">
+            Failed to load identities. Reload the page to try again.
+          </div>
+        ) : (
+          <>
+            <FormRow label="Email">
+              <div className="flex items-center justify-between gap-3">
+                <div className="font-mono text-[12.5px] text-text">{user?.email ?? '—'}</div>
+                <MonoPill variant="accent">Primary</MonoPill>
+              </div>
+            </FormRow>
+
+            {SIGNIN_PROVIDERS.map((provider) => {
+              const linked = findIdentity(provider.id)
+              const disconnectBlocked = Boolean(linked) && isLastIdentity
+              return (
+                <FormRow key={provider.id} label={provider.label}>
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="flex items-center gap-2.5 min-w-0">
+                      <span className="w-[18px] h-[18px] rounded-[4px] bg-bg-muted flex items-center justify-center font-mono text-[10px] text-text-muted font-bold shrink-0">
+                        {provider.glyph}
+                      </span>
+                      {linked ? (
+                        <MonoPill variant="good" dot>
+                          Connected
+                          {linked.last_sign_in_at
+                            ? ` · last used ${formatDate(linked.last_sign_in_at)}`
+                            : ''}
+                        </MonoPill>
+                      ) : (
+                        <MonoPill variant="faint" dot>Not connected</MonoPill>
+                      )}
+                    </div>
+                    {linked ? (
+                      <GhostBtn
+                        onClick={() => void handleDisconnect(linked)}
+                        disabled={isBusy || disconnectBlocked}
+                        title={disconnectBlocked ? 'Connect another sign-in method before removing this one.' : undefined}
+                      >
+                        Disconnect
+                      </GhostBtn>
+                    ) : (
+                      <PrimaryBtn
+                        onClick={() => void handleConnect(provider.id)}
+                        disabled={isBusy}
+                      >
+                        Connect
+                      </PrimaryBtn>
+                    )}
+                  </div>
+                </FormRow>
+              )
+            })}
+          </>
+        )}
+
+        {actionError && (
+          <div className="px-6 py-3 border-t border-border text-[12.5px] text-bad">
+            {actionError}
+          </div>
+        )}
+      </Section>
+
+      <Section title="Why connect multiple providers?" className="mb-5">
+        <div className="px-6 py-4 text-[13px] text-text-muted leading-relaxed space-y-2">
+          <p>
+            One account, multiple ways in. Connect Google or GitHub to sign in faster the
+            next time and keep email as a fallback if a provider is unavailable.
+          </p>
+          <p>
+            Spanlens never receives your provider password. Disconnecting a provider
+            removes its OAuth token from this account immediately and cannot be undone
+            from the provider&apos;s side.
+          </p>
+        </div>
+      </Section>
+    </div>
+  )
+}
+
 // ─── NOTIFICATIONS tab ────────────────────────────────────────────────────────
 
 function NotificationsTab() {
@@ -1714,6 +1860,7 @@ function TabContent({ tab }: { tab: TabId }) {
     case 'plan':          return <PlanLimitsTab />
     case 'invoices':      return <InvoicesTab />
     case 'profile':       return <ProfileTab />
+    case 'auth-methods':  return <SignInMethodsTab />
     case 'notifications': return <NotificationsTab />
     case 'preferences':   return <PreferencesTab />
     case 'integrations':  return <IntegrationsTab />

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -1073,12 +1073,50 @@ const SIGNIN_PROVIDERS: ProviderConfig[] = [
   { id: 'github', label: 'GitHub', glyph: '⌥' },
 ]
 
+/**
+ * Translates `?error=<code>` query left by /auth/callback after a failed
+ * linkIdentity flow into something the user can act on. Codes mirror
+ * `mapOAuthError` in apps/web/app/auth/callback/route.ts.
+ */
+const LINK_ERROR_MESSAGES: Record<string, string> = {
+  identity_already_linked:
+    'This provider is already connected to your account.',
+  identity_linked_to_other_user:
+    'This Google or GitHub account is already linked to a different Spanlens user. Use a different provider account, or sign in with that one instead.',
+  manual_linking_disabled:
+    'Account linking is currently disabled. Please contact support.',
+  provider_disabled:
+    'This sign-in method is currently unavailable.',
+  oauth_callback_failed: 'Connecting the provider failed. Please try again.',
+}
+
 function SignInMethodsTab() {
   const { data: user, isLoading: userLoading } = useCurrentUser()
   const { data: identities, isLoading: identitiesLoading, error: identitiesError } = useIdentities()
   const linkMutation = useLinkIdentity()
   const unlinkMutation = useUnlinkIdentity()
   const [actionError, setActionError] = useState<string | null>(null)
+
+  // Surface failures that happened in /auth/callback (linkIdentity flow
+  // round-trips through the provider, so a thrown mutation here can't
+  // catch them — the callback redirects back with `?error=<code>`).
+  // Same `window.location` pattern as the login page; runs once per
+  // mount so cascading-render concerns don't apply.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const params = new URLSearchParams(window.location.search)
+    const code = params.get('error')
+    if (!code) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setActionError(LINK_ERROR_MESSAGES[code] ?? 'Connecting the provider failed. Please try again.')
+    params.delete('error')
+    const next = params.toString()
+    window.history.replaceState(
+      null,
+      '',
+      `${window.location.pathname}${next ? `?${next}` : ''}`,
+    )
+  }, [])
 
   const identityList: UserIdentity[] = identities ?? []
   const isLastIdentity = identityList.length <= 1

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -24,22 +24,38 @@ import { recordOAuthConsentIfMissing } from '@/lib/oauth-consent'
  * out-of-band via fire-and-forget — the redirect must not wait on a
  * server round-trip. Helper is idempotent so re-logins do nothing.
  */
+const OAUTH_RETURN_COOKIE = 'sl_oauth_return'
+
 export async function GET(request: Request): Promise<NextResponse> {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get('code')
-  const next = searchParams.get('next') ?? '/dashboard'
 
   const forwardedHost = request.headers.get('x-forwarded-host')
   const isLocal = process.env.NODE_ENV === 'development'
   const redirectBase =
     isLocal || !forwardedHost ? origin : `https://${forwardedHost}`
 
+  // Priority order for the post-callback destination:
+  //   1. `?next=` query (legacy / magic-link)
+  //   2. `sl_oauth_return` cookie (linkIdentity flow — see use-identities.ts)
+  //   3. `/dashboard` default
+  // The cookie is cleared on the response regardless of success / failure
+  // so a stale value never persists into the next sign-in.
+  const cookieStore = await cookies()
+  const returnCookie = cookieStore.get(OAUTH_RETURN_COOKIE)?.value
+  const next =
+    searchParams.get('next') ??
+    (returnCookie ? decodeURIComponent(returnCookie) : null) ??
+    '/dashboard'
+
   if (!code) {
-    return NextResponse.redirect(`${redirectBase}${next}`)
+    const r = NextResponse.redirect(`${redirectBase}${next}`)
+    if (returnCookie) r.cookies.delete(OAUTH_RETURN_COOKIE)
+    return r
   }
 
   const response = NextResponse.redirect(`${redirectBase}${next}`)
-  const cookieStore = await cookies()
+  if (returnCookie) response.cookies.delete(OAUTH_RETURN_COOKIE)
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -61,9 +77,11 @@ export async function GET(request: Request): Promise<NextResponse> {
   const { data, error } = await supabase.auth.exchangeCodeForSession(code)
 
   if (error) {
-    return NextResponse.redirect(
+    const errResponse = NextResponse.redirect(
       buildErrorRedirect(redirectBase, next, mapOAuthError(error)),
     )
+    if (returnCookie) errResponse.cookies.delete(OAUTH_RETURN_COOKIE)
+    return errResponse
   }
 
   // Fire-and-forget. The redirect response is already prepared; we

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { recordOAuthConsentIfMissing } from '@/lib/oauth-consent'
 
 export async function GET(request: Request) {
   const url = new URL(request.url)
@@ -8,7 +9,21 @@ export async function GET(request: Request) {
 
   if (code) {
     const supabase = await createClient()
-    await supabase.auth.exchangeCodeForSession(code)
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code)
+
+    // OAuth signups skip the explicit Terms/Privacy checkbox shown to
+    // email signups. Record current-version acceptance here so legal
+    // audit history is consistent across both paths. Idempotent —
+    // re-logins for existing users will no-op after the first record.
+    if (!error && data.session?.access_token) {
+      try {
+        await recordOAuthConsentIfMissing(data.session.access_token, url.origin)
+      } catch (err) {
+        // Non-fatal — the consent endpoint is best-effort here, same
+        // policy as the email signup flow (signup/page.tsx:34).
+        console.error('[auth/callback] consent recording failed:', err)
+      }
+    }
   }
 
   return NextResponse.redirect(new URL(next, url.origin))

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -1,30 +1,83 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
 import { recordOAuthConsentIfMissing } from '@/lib/oauth-consent'
 
-export async function GET(request: Request) {
-  const url = new URL(request.url)
-  const code = url.searchParams.get('code')
-  const next = url.searchParams.get('next') ?? '/dashboard'
+/**
+ * OAuth + magic-link callback. Exchanges `?code=...` for a Supabase
+ * session and redirects to `next` (default `/dashboard`).
+ *
+ * Cookie handling follows the Supabase SSR official pattern: build the
+ * NextResponse first, then have the supabase client write its session
+ * cookies directly onto that response. The previous shape — set cookies
+ * via `cookies()` store, then return a fresh `NextResponse.redirect()` —
+ * worked inconsistently because Next.js does not always flush
+ * cookie-store mutations into a brand-new Response built later in the
+ * handler. Symptom: OAuth succeeded but the dashboard never saw the
+ * session and middleware bounced the user back to /login.
+ *
+ * `x-forwarded-host` is honored so Vercel preview / production URLs
+ * redirect to the user-facing host rather than the internal
+ * deployment URL.
+ *
+ * Terms + Privacy consent for first-time OAuth signups is recorded
+ * out-of-band via fire-and-forget — the redirect must not wait on a
+ * server round-trip. Helper is idempotent so re-logins do nothing.
+ */
+export async function GET(request: Request): Promise<NextResponse> {
+  const { searchParams, origin } = new URL(request.url)
+  const code = searchParams.get('code')
+  const next = searchParams.get('next') ?? '/dashboard'
 
-  if (code) {
-    const supabase = await createClient()
-    const { data, error } = await supabase.auth.exchangeCodeForSession(code)
+  const forwardedHost = request.headers.get('x-forwarded-host')
+  const isLocal = process.env.NODE_ENV === 'development'
+  const redirectBase =
+    isLocal || !forwardedHost ? origin : `https://${forwardedHost}`
 
-    // OAuth signups skip the explicit Terms/Privacy checkbox shown to
-    // email signups. Record current-version acceptance here so legal
-    // audit history is consistent across both paths. Idempotent —
-    // re-logins for existing users will no-op after the first record.
-    if (!error && data.session?.access_token) {
-      try {
-        await recordOAuthConsentIfMissing(data.session.access_token, url.origin)
-      } catch (err) {
-        // Non-fatal — the consent endpoint is best-effort here, same
-        // policy as the email signup flow (signup/page.tsx:34).
-        console.error('[auth/callback] consent recording failed:', err)
-      }
-    }
+  if (!code) {
+    return NextResponse.redirect(`${redirectBase}${next}`)
   }
 
-  return NextResponse.redirect(new URL(next, url.origin))
+  const response = NextResponse.redirect(`${redirectBase}${next}`)
+  const cookieStore = await cookies()
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            response.cookies.set(name, value, options)
+          })
+        },
+      },
+    },
+  )
+
+  const { data, error } = await supabase.auth.exchangeCodeForSession(code)
+
+  if (error) {
+    return NextResponse.redirect(
+      `${redirectBase}/login?error=${encodeURIComponent('oauth_callback_failed')}`,
+    )
+  }
+
+  // Fire-and-forget. The redirect response is already prepared; we
+  // don't want to block the user on an audit-log round-trip. apps/web
+  // runs under the Node.js runtime by default, so the function process
+  // stays alive long enough for this promise to settle. If it doesn't,
+  // the helper is idempotent — the next sign-in tries again.
+  if (data.session?.access_token) {
+    recordOAuthConsentIfMissing(data.session.access_token, redirectBase).catch(
+      (err: unknown) => {
+        console.error('[auth/callback] consent recording failed:', err)
+      },
+    )
+  }
+
+  return response
 }

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -62,7 +62,7 @@ export async function GET(request: Request): Promise<NextResponse> {
 
   if (error) {
     return NextResponse.redirect(
-      `${redirectBase}/login?error=${encodeURIComponent(mapOAuthError(error))}`,
+      buildErrorRedirect(redirectBase, next, mapOAuthError(error)),
     )
   }
 
@@ -91,14 +91,42 @@ export async function GET(request: Request): Promise<NextResponse> {
  */
 function mapOAuthError(error: { message?: string | null }): string {
   const msg = error.message?.toLowerCase() ?? ''
+  // Order matters: more specific patterns first. "linked to another user"
+  // and plain "already exists" both contain "exists"/"linked" so the
+  // cross-user case needs to be checked before the generic one.
+  if (
+    msg.includes('another user') ||
+    (msg.includes('linked') && msg.includes('another'))
+  ) {
+    return 'identity_linked_to_other_user'
+  }
   if (msg.includes('email') && (msg.includes('already') || msg.includes('exists'))) {
     return 'email_conflict'
   }
   if (msg.includes('identity') && msg.includes('exists')) {
     return 'identity_already_linked'
   }
+  if (msg.includes('manual linking') && msg.includes('disabled')) {
+    return 'manual_linking_disabled'
+  }
   if (msg.includes('provider') && msg.includes('disabled')) {
     return 'provider_disabled'
   }
   return 'oauth_callback_failed'
+}
+
+/**
+ * Pick the right page to land on after a failed callback. If the
+ * original `next` was a known authenticated route (settings), keep
+ * the user there so the error appears in context. Otherwise default
+ * to /login because the user almost certainly isn't authenticated.
+ *
+ * Stripping any existing `?` from `next` because the supabase
+ * exchangeCodeForSession call already consumed the URL and we want
+ * a clean target to append `?error=...` to.
+ */
+function buildErrorRedirect(base: string, next: string, code: string): string {
+  const safeNext = next.split('?')[0] ?? '/login'
+  const target = safeNext.startsWith('/settings') ? safeNext : '/login'
+  return `${base}${target}?error=${encodeURIComponent(code)}`
 }

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -62,7 +62,7 @@ export async function GET(request: Request): Promise<NextResponse> {
 
   if (error) {
     return NextResponse.redirect(
-      `${redirectBase}/login?error=${encodeURIComponent('oauth_callback_failed')}`,
+      `${redirectBase}/login?error=${encodeURIComponent(mapOAuthError(error))}`,
     )
   }
 
@@ -80,4 +80,25 @@ export async function GET(request: Request): Promise<NextResponse> {
   }
 
   return response
+}
+
+/**
+ * Translate a Supabase auth error into a stable query-string code that
+ * the login page can match without depending on Supabase's wording.
+ * Add new cases here as we observe them in production logs — Supabase
+ * error shapes change between SDK versions, so defaulting to a generic
+ * code is the safe path.
+ */
+function mapOAuthError(error: { message?: string | null }): string {
+  const msg = error.message?.toLowerCase() ?? ''
+  if (msg.includes('email') && (msg.includes('already') || msg.includes('exists'))) {
+    return 'email_conflict'
+  }
+  if (msg.includes('identity') && msg.includes('exists')) {
+    return 'identity_already_linked'
+  }
+  if (msg.includes('provider') && msg.includes('disabled')) {
+    return 'provider_disabled'
+  }
+  return 'oauth_callback_failed'
 }

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -90,7 +90,7 @@ export async function GET(request: Request): Promise<NextResponse> {
   // stays alive long enough for this promise to settle. If it doesn't,
   // the helper is idempotent — the next sign-in tries again.
   if (data.session?.access_token) {
-    recordOAuthConsentIfMissing(data.session.access_token, redirectBase).catch(
+    recordOAuthConsentIfMissing(data.session.access_token).catch(
       (err: unknown) => {
         console.error('[auth/callback] consent recording failed:', err)
       },

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,9 +1,24 @@
 'use client'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
+
+/**
+ * Maps the `?error=<code>` query (set by /auth/callback when OAuth
+ * exchange fails) to a user-facing English message. Keep keys aligned
+ * with `mapOAuthError` in apps/web/app/auth/callback/route.ts.
+ */
+const OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  email_conflict:
+    'An account with this email already exists. Sign in with your password, then connect Google or GitHub from Settings → Sign-in methods.',
+  identity_already_linked:
+    'This provider is already connected to your account.',
+  provider_disabled:
+    'This sign-in method is currently unavailable. Please use another provider or email.',
+  oauth_callback_failed: 'Sign-in failed. Please try again.',
+}
 
 function LogoMark() {
   return (
@@ -29,6 +44,27 @@ export default function LoginPage() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+
+  // Surface OAuth callback errors. Read once on mount and clean the
+  // query so the message disappears on a manual reload. `useSearchParams`
+  // would force a Suspense boundary refactor on this page; reading
+  // `window.location` keeps the change local. The setState happens
+  // exactly once per mount, so the cascading-render concern the lint
+  // rule guards against does not apply here.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const errorCode = params.get('error')
+    if (!errorCode) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setError(OAUTH_ERROR_MESSAGES[errorCode] ?? 'Sign-in failed. Please try again.')
+    params.delete('error')
+    const next = params.toString()
+    window.history.replaceState(
+      null,
+      '',
+      `${window.location.pathname}${next ? `?${next}` : ''}`,
+    )
+  }, [])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -45,6 +45,23 @@ export default function LoginPage() {
     router.refresh()
   }
 
+  async function handleOAuth(provider: 'google' | 'github') {
+    setError('')
+    setLoading(true)
+    const supabase = createClient()
+    const { error: authError } = await supabase.auth.signInWithOAuth({
+      provider,
+      options: { redirectTo: `${window.location.origin}/auth/callback` },
+    })
+    if (authError) {
+      setError(authError.message)
+      setLoading(false)
+    }
+    // On success the browser is redirected to the provider — no further
+    // action needed here. We deliberately leave `loading` true so the
+    // button stays disabled until the redirect actually navigates away.
+  }
+
   return (
     <div className="min-h-screen bg-bg-elev grid grid-cols-2">
 
@@ -88,7 +105,9 @@ export default function LoginPage() {
           <div className="flex flex-col gap-2 mb-2">
             <button
               type="button"
-              className="flex items-center gap-2.5 px-[14px] py-[10px] border border-border-strong rounded-[7px] bg-bg text-[13px] text-text hover:opacity-80 transition-opacity"
+              onClick={() => void handleOAuth('google')}
+              disabled={loading}
+              className="flex items-center gap-2.5 px-[14px] py-[10px] border border-border-strong rounded-[7px] bg-bg text-[13px] text-text hover:opacity-80 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
             >
               <span className="w-[18px] h-[18px] rounded-[4px] bg-bg-muted flex items-center justify-center font-mono text-[10px] text-text-muted font-bold">G</span>
               <span className="flex-1 text-left">Continue with Google</span>
@@ -96,7 +115,9 @@ export default function LoginPage() {
             </button>
             <button
               type="button"
-              className="flex items-center gap-2.5 px-[14px] py-[10px] border border-border-strong rounded-[7px] bg-bg text-[13px] text-text hover:opacity-80 transition-opacity"
+              onClick={() => void handleOAuth('github')}
+              disabled={loading}
+              className="flex items-center gap-2.5 px-[14px] py-[10px] border border-border-strong rounded-[7px] bg-bg text-[13px] text-text hover:opacity-80 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
             >
               <span className="w-[18px] h-[18px] rounded-[4px] bg-bg-muted flex items-center justify-center font-mono text-[10px] text-text-muted font-bold">⌥</span>
               <span className="flex-1 text-left">Continue with GitHub</span>

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -15,6 +15,10 @@ const OAUTH_ERROR_MESSAGES: Record<string, string> = {
     'An account with this email already exists. Sign in with your password, then connect Google or GitHub from Settings → Sign-in methods.',
   identity_already_linked:
     'This provider is already connected to your account.',
+  identity_linked_to_other_user:
+    'This Google/GitHub account is already linked to a different Spanlens user. Sign in with that account, or use a different provider account.',
+  manual_linking_disabled:
+    'Account linking is currently disabled. Please contact support.',
   provider_disabled:
     'This sign-in method is currently unavailable. Please use another provider or email.',
   oauth_callback_failed: 'Sign-in failed. Please try again.',

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -88,6 +88,27 @@ function SignupPageInner() {
   const [loading, setLoading] = useState(false)
   const [sent, setSent] = useState(false)
 
+  async function handleOAuth(provider: 'google' | 'github') {
+    setError('')
+    setLoading(true)
+    const supabase = createClient()
+    // The callback route records Terms + Privacy consent automatically
+    // on first sign-in for OAuth users — the implicit-consent notice
+    // shown next to the SSO buttons covers the explicit acknowledgement.
+    const callback = `${window.location.origin}/auth/callback`
+    const next = inviteToken
+      ? `${callback}?next=${encodeURIComponent(`/invite?token=${inviteToken}`)}`
+      : callback
+    const { error: authError } = await supabase.auth.signInWithOAuth({
+      provider,
+      options: { redirectTo: next },
+    })
+    if (authError) {
+      setError(authError.message)
+      setLoading(false)
+    }
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setError('')
@@ -214,7 +235,9 @@ function SignupPageInner() {
               <div className="flex flex-col gap-2 mb-2">
                 <button
                   type="button"
-                  className="flex items-center gap-2.5 px-[14px] py-[10px] border border-border-strong rounded-[7px] bg-bg text-[13px] text-text hover:opacity-80 transition-opacity"
+                  onClick={() => void handleOAuth('google')}
+                  disabled={loading}
+                  className="flex items-center gap-2.5 px-[14px] py-[10px] border border-border-strong rounded-[7px] bg-bg text-[13px] text-text hover:opacity-80 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
                 >
                   <span className="w-[18px] h-[18px] rounded-[4px] bg-bg-muted flex items-center justify-center font-mono text-[10px] text-text-muted font-bold">G</span>
                   <span className="flex-1 text-left">Continue with Google</span>
@@ -222,12 +245,21 @@ function SignupPageInner() {
                 </button>
                 <button
                   type="button"
-                  className="flex items-center gap-2.5 px-[14px] py-[10px] border border-border-strong rounded-[7px] bg-bg text-[13px] text-text hover:opacity-80 transition-opacity"
+                  onClick={() => void handleOAuth('github')}
+                  disabled={loading}
+                  className="flex items-center gap-2.5 px-[14px] py-[10px] border border-border-strong rounded-[7px] bg-bg text-[13px] text-text hover:opacity-80 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
                 >
                   <span className="w-[18px] h-[18px] rounded-[4px] bg-bg-muted flex items-center justify-center font-mono text-[10px] text-text-muted font-bold">⌥</span>
                   <span className="flex-1 text-left">Continue with GitHub</span>
                 </button>
               </div>
+
+              <p className="text-[11px] text-text-faint leading-snug mb-2">
+                By continuing with Google or GitHub, you agree to our{' '}
+                <Link href="/terms" target="_blank" className="text-text-muted hover:text-text transition-colors underline underline-offset-2">Terms</Link>
+                {' '}and{' '}
+                <Link href="/privacy" target="_blank" className="text-text-muted hover:text-text transition-colors underline underline-offset-2">Privacy Policy</Link>.
+              </p>
 
               {/* Divider */}
               <div className="flex items-center gap-2.5 my-4">

--- a/apps/web/lib/oauth-consent.ts
+++ b/apps/web/lib/oauth-consent.ts
@@ -1,0 +1,67 @@
+import { TERMS_VERSION, PRIVACY_VERSION } from './legal-versions'
+
+/**
+ * Server-side helper invoked from the OAuth callback route handler.
+ *
+ * The email signup flow records Terms + Privacy consent client-side
+ * (signup/page.tsx:19-37) before calling signUp. The OAuth flow skips
+ * that step — the user clicks "Continue with Google/GitHub" and bounces
+ * straight to the provider. By the time we see them again in the
+ * callback we've already implicitly accepted their consent.
+ *
+ * This helper closes the gap: after exchangeCodeForSession succeeds we
+ * check whether this user has already accepted the current TERMS /
+ * PRIVACY versions, and POST any missing rows to /api/v1/me/consent.
+ * Idempotent — safe to call on every callback (including OAuth
+ * re-logins for users who accepted long ago).
+ *
+ * The endpoint captures IP + UA from the request server-side, so we
+ * deliberately do not forward them here.
+ */
+
+interface ConsentRow {
+  document: 'terms' | 'privacy'
+  version: string
+}
+
+interface ConsentListResponse {
+  success?: boolean
+  data?: ConsentRow[]
+}
+
+export async function recordOAuthConsentIfMissing(
+  accessToken: string,
+  origin: string,
+): Promise<void> {
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${accessToken}`,
+  }
+
+  const existingRes = await fetch(`${origin}/api/v1/me/consent`, {
+    headers,
+    cache: 'no-store',
+  })
+
+  let existing: ConsentRow[] = []
+  if (existingRes.ok) {
+    const body = (await existingRes.json().catch(() => ({}))) as ConsentListResponse
+    existing = body.data ?? []
+  }
+
+  const required: ConsentRow[] = [
+    { document: 'terms', version: TERMS_VERSION },
+    { document: 'privacy', version: PRIVACY_VERSION },
+  ]
+
+  const missing = required.filter(
+    (r) => !existing.some((e) => e.document === r.document && e.version === r.version),
+  )
+  if (missing.length === 0) return
+
+  await fetch(`${origin}/api/v1/me/consent`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ documents: missing }),
+  })
+}

--- a/apps/web/lib/oauth-consent.ts
+++ b/apps/web/lib/oauth-consent.ts
@@ -17,6 +17,21 @@ import { TERMS_VERSION, PRIVACY_VERSION } from './legal-versions'
  *
  * The endpoint captures IP + UA from the request server-side, so we
  * deliberately do not forward them here.
+ *
+ * ## SSRF hardening
+ *
+ * Earlier revisions took an `origin` argument derived from the request
+ * URL and built `${origin}/api/v1/me/consent`. CodeQL flagged this as
+ * `js/request-forgery` (critical): the callback route derives origin
+ * from `x-forwarded-host`, which is attacker-controllable, so a
+ * malicious header would have caused this helper to POST the user's
+ * access token to an external server. The Authorization header carries
+ * a live Supabase JWT — leaking that to an attacker is account takeover.
+ *
+ * Fix: pin the destination to the server URL configured at build /
+ * deploy time (`API_URL` / `NEXT_PUBLIC_API_URL`), exactly the same
+ * source `next.config.mjs` uses for its `/api/*` rewrite. The request
+ * never depends on user input again.
  */
 
 interface ConsentRow {
@@ -29,16 +44,26 @@ interface ConsentListResponse {
   data?: ConsentRow[]
 }
 
+function getServerBase(): string {
+  // Mirror the resolution order in apps/web/next.config.mjs so the
+  // helper and the rewrite always target the same upstream server.
+  return (
+    process.env.API_URL ??
+    process.env.NEXT_PUBLIC_API_URL ??
+    'http://localhost:3001'
+  )
+}
+
 export async function recordOAuthConsentIfMissing(
   accessToken: string,
-  origin: string,
 ): Promise<void> {
+  const base = getServerBase()
   const headers = {
     'Content-Type': 'application/json',
     Authorization: `Bearer ${accessToken}`,
   }
 
-  const existingRes = await fetch(`${origin}/api/v1/me/consent`, {
+  const existingRes = await fetch(`${base}/api/v1/me/consent`, {
     headers,
     cache: 'no-store',
   })
@@ -59,7 +84,7 @@ export async function recordOAuthConsentIfMissing(
   )
   if (missing.length === 0) return
 
-  await fetch(`${origin}/api/v1/me/consent`, {
+  await fetch(`${base}/api/v1/me/consent`, {
     method: 'POST',
     headers,
     body: JSON.stringify({ documents: missing }),

--- a/apps/web/lib/queries/use-identities.ts
+++ b/apps/web/lib/queries/use-identities.ts
@@ -1,0 +1,102 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { UserIdentity } from '@supabase/supabase-js'
+import { createClient } from '@/lib/supabase/client'
+
+export const identitiesQueryKey = ['identities'] as const
+
+/**
+ * Provider keys that we expose in the UI. Keep this in sync with the
+ * providers enabled in the Supabase Dashboard. Anything else returned
+ * by `getUserIdentities()` (e.g. magic-link `email` rows) is rendered
+ * as-is using the raw provider string.
+ */
+export type LinkableProvider = 'google' | 'github'
+
+/**
+ * All identities linked to the current Supabase user. One row per
+ * provider — a user who signed up via Google can later link GitHub
+ * (or email/password) here, and `data` will then contain multiple rows.
+ *
+ * Returns `null` only when there is no signed-in user. An empty array
+ * is unusual but possible right after sign-up and before the first
+ * identity is committed; callers should treat it as "no identities yet".
+ */
+export function useIdentities() {
+  return useQuery({
+    queryKey: identitiesQueryKey,
+    queryFn: async (): Promise<UserIdentity[] | null> => {
+      const supabase = createClient()
+      const { data, error } = await supabase.auth.getUserIdentities()
+      if (error) throw error
+      return data?.identities ?? null
+    },
+    staleTime: 60_000,
+  })
+}
+
+interface LinkIdentityVariables {
+  provider: LinkableProvider
+  /**
+   * Where to land after the provider OAuth flow + our `/auth/callback`
+   * complete. Default: back to the Sign-in methods tab so the user
+   * sees the freshly linked provider appear without hunting.
+   */
+  redirectPath?: string
+}
+
+/**
+ * Start the OAuth flow to attach an additional provider to the
+ * currently signed-in user. The browser is redirected to the provider;
+ * after consent it hits `/auth/v1/callback` → our `/auth/callback`,
+ * which calls `exchangeCodeForSession` and adds the new identity to
+ * the existing user record (no new user row created).
+ *
+ * The mutation resolves once Supabase has handed back the redirect URL;
+ * the actual identity will appear after the round-trip completes and
+ * the page re-mounts. We still invalidate `identitiesQueryKey` so any
+ * cached list is refetched on return.
+ */
+export function useLinkIdentity() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async ({
+      provider,
+      redirectPath = '/settings?tab=auth-methods',
+    }: LinkIdentityVariables) => {
+      const supabase = createClient()
+      const { data, error } = await supabase.auth.linkIdentity({
+        provider,
+        options: {
+          redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(redirectPath)}`,
+        },
+      })
+      if (error) throw error
+      return data
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: identitiesQueryKey })
+    },
+  })
+}
+
+/**
+ * Remove a linked identity. Callers must guard against removing the
+ * user's last sign-in method — Supabase will reject it, but the UI
+ * should not even surface the button in that case (better UX than a
+ * failed mutation toast).
+ */
+export function useUnlinkIdentity() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (identity: UserIdentity) => {
+      const supabase = createClient()
+      const { error } = await supabase.auth.unlinkIdentity(identity)
+      if (error) throw error
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: identitiesQueryKey })
+    },
+  })
+}

--- a/apps/web/lib/queries/use-identities.ts
+++ b/apps/web/lib/queries/use-identities.ts
@@ -47,16 +47,25 @@ interface LinkIdentityVariables {
 }
 
 /**
+ * Cookie used to remember the page that started a linkIdentity flow.
+ * `/auth/callback` reads + clears it on return. We use a cookie rather
+ * than `?next=` on the redirectTo URL because Supabase's redirect URL
+ * allowlist matches against the base URL — wildcards (and even some
+ * exact entries) reject a URL with `?query` appended, which causes
+ * Supabase to fall back to the project Site URL and dump the user on
+ * the marketing home page instead of /settings.
+ */
+const OAUTH_RETURN_COOKIE = 'sl_oauth_return'
+
+/**
  * Start the OAuth flow to attach an additional provider to the
  * currently signed-in user. The browser is redirected to the provider;
  * after consent it hits `/auth/v1/callback` → our `/auth/callback`,
  * which calls `exchangeCodeForSession` and adds the new identity to
  * the existing user record (no new user row created).
  *
- * The mutation resolves once Supabase has handed back the redirect URL;
- * the actual identity will appear after the round-trip completes and
- * the page re-mounts. We still invalidate `identitiesQueryKey` so any
- * cached list is refetched on return.
+ * We stash the desired return path in a short-lived cookie so the
+ * server callback can route the user back to where they started.
  */
 export function useLinkIdentity() {
   const qc = useQueryClient()
@@ -65,11 +74,18 @@ export function useLinkIdentity() {
       provider,
       redirectPath = '/settings?tab=auth-methods',
     }: LinkIdentityVariables) => {
+      // 5-minute lifetime is plenty for a provider round-trip and short
+      // enough to not pollute the cookie jar if the user abandons the
+      // flow. SameSite=Lax so the cookie survives the cross-site OAuth
+      // bounce (Strict would drop it on return).
+      if (typeof document !== 'undefined') {
+        document.cookie = `${OAUTH_RETURN_COOKIE}=${encodeURIComponent(redirectPath)}; path=/; max-age=300; samesite=lax`
+      }
       const supabase = createClient()
       const { data, error } = await supabase.auth.linkIdentity({
         provider,
         options: {
-          redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(redirectPath)}`,
+          redirectTo: `${window.location.origin}/auth/callback`,
         },
       })
       if (error) throw error

--- a/docs/auth-oauth-setup.md
+++ b/docs/auth-oauth-setup.md
@@ -126,3 +126,80 @@ After saving in the Supabase Dashboard:
 | Returns to `/login` immediately after OAuth | Middleware ran before Supabase set the cookie. Hard-refresh once; if persistent, check that `apps/web/middleware.ts` PUBLIC_PATHS includes `/auth/` (it does). |
 | No `user_consents` row for new OAuth user | The callback succeeded but `/api/v1/me/consent` POST failed. Check server logs for `[auth/callback] consent recording failed`. Server endpoint requires authJwt — the access token must be valid. |
 | Existing email user clicks Google, gets a separate account | Supabase by default does NOT link OAuth identities to existing email accounts unless email confirmation is shared. If we want auto-link later, enable "Same email = same account" or use identity linking API. |
+
+## 7. Account linking (Settings → Sign-in methods)
+
+Once at least one provider is connected, users can link / unlink
+providers from `/settings?tab=auth-methods`. This requires one extra
+project setting that is **disabled by default**:
+
+- Supabase Dashboard → Authentication → Sign In/Providers → **User
+  Signups** → toggle **"Allow manual linking"** ON → Save changes.
+
+Without that toggle, `supabase.auth.linkIdentity()` rejects every call
+with `"Manual linking is disabled"`.
+
+## 8. Operational gotchas observed in setup
+
+These four traps each cost a debug round-trip during the initial
+configuration. Worth checking on every new Supabase project.
+
+### 8.1 Always Reveal-verify pasted secrets
+
+Pasting a Client Secret into Supabase's password input field sometimes
+prepends an unexpected character (observed `a` prefix on both Google
+and GitHub secrets in the same session — looks like a key event from
+the dashboard's keyboard shortcuts firing into the focused input
+before the paste). The Save button accepts the (now-corrupted) value
+silently, then OAuth fails at token exchange with
+`Unable to exchange external code`.
+
+**Always:** save → reopen the provider drawer → click **Reveal** →
+verify the secret matches the source character-for-character before
+declaring done. Re-paste if it doesn't match.
+
+### 8.2 `1` (one) vs `l` (lowercase L) in GitHub Client IDs
+
+GitHub OAuth Client IDs are short alphanumeric strings (≈20 chars)
+where `1` and `l` are visually identical in many fonts. Manually
+transcribing from a screenshot leads to `Ov23liPp2XBkxPa6KJ1n` vs
+`Ov23liPp2XBkxPa6KJln` mistakes that surface as a 404 from
+`github.com/login/oauth/authorize`.
+
+**Always:** use GitHub's "Copy" button next to the Client ID,
+never re-type from sight.
+
+### 8.3 Redirect URL allowlist wildcard rules
+
+Supabase's allowlist supports glob-style wildcards but the matching is
+stricter than it looks:
+
+- `*` (single star) matches a single segment with no separator
+  characters. It will **not** match a Vercel preview branch URL whose
+  branch name contains hyphens, e.g.
+  `spanlens-*-sunes26s-projects.vercel.app` does **not** match
+  `spanlens-web-git-feat-oauth-login-sunes26s-projects.vercel.app`.
+- `**` (double star) matches any character sequence including
+  hyphens, but only inside path or host segments — it doesn't always
+  work in host position depending on Supabase version.
+
+**Recommendation:** for every long-running preview branch, add the
+exact deployment URL to the allowlist alongside the wildcard.
+Wildcards alone are not a reliable safety net.
+
+### 8.4 RedirectTo must match the *base* URL only
+
+When calling `supabase.auth.signInWithOAuth({ options: { redirectTo } })`
+or `supabase.auth.linkIdentity({ options: { redirectTo } })`, do not
+append `?query=string` to the `redirectTo` value — Supabase compares
+the full URL (including query) against the allowlist, and the query
+turns a matching entry into a mismatch. The user then silently lands
+on the project's Site URL (the marketing home page in our case)
+instead of `/auth/callback`.
+
+**Pattern we use** for the Settings → Sign-in methods link flow:
+keep `redirectTo: \`${origin}/auth/callback\``, and stash the desired
+return path in a short-lived cookie (`sl_oauth_return`, 5 min,
+SameSite=Lax). The callback route reads + clears the cookie.
+See `apps/web/lib/queries/use-identities.ts` and
+`apps/web/app/auth/callback/route.ts`.

--- a/docs/auth-oauth-setup.md
+++ b/docs/auth-oauth-setup.md
@@ -1,0 +1,128 @@
+# OAuth Setup — Google & GitHub Sign-in
+
+Operator guide for enabling the "Continue with Google" and "Continue with
+GitHub" buttons on `/login` and `/signup`. The buttons are already wired
+in the code — this doc covers the external configuration required to
+make them work.
+
+## Architecture recap
+
+```
+User clicks "Continue with Google"
+  → supabase.auth.signInWithOAuth({ provider: 'google',
+       options: { redirectTo: '<origin>/auth/callback' } })
+  → Browser redirected to https://accounts.google.com/...
+  → Google redirects to Supabase: https://<ref>.supabase.co/auth/v1/callback?code=...
+  → Supabase exchanges code, redirects to our /auth/callback?code=...
+  → Our route handler runs exchangeCodeForSession + recordOAuthConsentIfMissing
+  → Final redirect to /dashboard (which falls through to /onboarding for new users)
+```
+
+Two redirect URIs matter:
+1. **Provider → Supabase** (configured in Google/GitHub console):
+   `https://<supabase-ref>.supabase.co/auth/v1/callback`
+2. **Supabase → our app** (configured in Supabase Dashboard URL allowlist):
+   `https://<our-domain>/auth/callback`
+
+## 1. Google Cloud Console
+
+1. https://console.cloud.google.com → APIs & Services → Credentials
+2. **+ Create Credentials → OAuth client ID** (create OAuth consent screen first if
+   prompted; choose "External" + fill in app name / support email / Privacy /
+   Terms URLs)
+3. Application type: **Web application**
+4. Authorized JavaScript origins:
+   - `https://www.spanlens.io`
+   - `https://spanlens.io`
+   - `http://localhost:3000` (dev only)
+5. Authorized redirect URIs:
+   - `https://gebocvcsjlarxhyauadf.supabase.co/auth/v1/callback` (production)
+   - `http://127.0.0.1:54321/auth/v1/callback` (local dev — only if testing OAuth locally)
+6. Save → copy **Client ID** and **Client secret**.
+
+## 2. GitHub OAuth App
+
+1. https://github.com/settings/developers → OAuth Apps → **New OAuth App**
+2. Application name: `Spanlens` (production) or `Spanlens (Local)` (dev)
+3. Homepage URL: `https://www.spanlens.io`
+4. Authorization callback URL:
+   - Production app: `https://gebocvcsjlarxhyauadf.supabase.co/auth/v1/callback`
+   - Local-dev app: `http://127.0.0.1:54321/auth/v1/callback`
+   (GitHub OAuth Apps accept only one callback URL — create a separate
+   app for local dev if needed.)
+5. Register application → **Generate a new client secret** → copy
+   Client ID + Client secret.
+
+## 3. Supabase Dashboard
+
+URL: https://supabase.com/dashboard/project/gebocvcsjlarxhyauadf/auth/providers
+
+For **Google**:
+- Toggle "Enable Sign in with Google" ON
+- Client IDs (comma-separated, web only is fine): paste Google Client ID
+- Client Secret (for OAuth): paste Google Client secret
+- Leave "Skip nonce checks" and "Allow users without an email" OFF
+- Save
+
+For **GitHub**:
+- Toggle "Enable Sign in with GitHub" ON
+- Client ID: paste GitHub Client ID
+- Client Secret: paste GitHub Client secret
+- Save
+
+## 4. Supabase URL allowlist
+
+URL: https://supabase.com/dashboard/project/gebocvcsjlarxhyauadf/auth/url-configuration
+
+- **Site URL**: `https://www.spanlens.io`
+- **Redirect URLs** — add each on its own line:
+  - `https://www.spanlens.io/auth/callback`
+  - `https://spanlens.io/auth/callback`
+  - `https://spanlens-web.vercel.app/auth/callback`
+  - `https://spanlens-*-sunes26s-projects.vercel.app/auth/callback`
+  - `http://localhost:3000/auth/callback`
+
+Save.
+
+## 5. Local dev (optional)
+
+Only needed if you want to exercise OAuth end-to-end on your machine.
+The buttons will still render without these env vars but clicking them
+returns a Supabase error.
+
+1. Populate `apps/web/.env.local`:
+   ```
+   SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=<from step 1>
+   SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET=<from step 1>
+   SUPABASE_AUTH_EXTERNAL_GITHUB_CLIENT_ID=<from step 2 local app>
+   SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET=<from step 2 local app>
+   ```
+2. `supabase stop && supabase start` — the new env vars are read at
+   container boot, not on the fly.
+3. `pnpm dev` → http://localhost:3000/signup → click "Continue with Google".
+
+## 6. Verification
+
+After saving in the Supabase Dashboard:
+
+1. Open an incognito window → https://www.spanlens.io/signup
+2. Click "Continue with Google"
+3. Expected DevTools Network sequence:
+   - Click → `accounts.google.com/o/oauth2/v2/auth?...` (Google consent screen)
+   - After approve → `gebocvcsjlarxhyauadf.supabase.co/auth/v1/callback?code=...`
+   - → `www.spanlens.io/auth/callback?code=...`
+   - → `www.spanlens.io/dashboard` (which the dashboard layout bounces to `/onboarding`)
+4. In Supabase Dashboard → Authentication → Users, the new row should have
+   `app_metadata.provider = "google"` (or `"github"`).
+5. In the `user_consents` table (Supabase Table Editor), the new user has
+   two rows: `terms@<TERMS_VERSION>` and `privacy@<PRIVACY_VERSION>`.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| "redirect_uri_mismatch" from Google | Authorized redirect URI in Google Console doesn't exactly match `https://gebocvcsjlarxhyauadf.supabase.co/auth/v1/callback`. URLs are case-sensitive; trailing slash matters. |
+| Supabase returns to `/auth/callback?error=server_error` | Most often: Site URL or Redirect URLs allowlist missing the destination. Check step 4. |
+| Returns to `/login` immediately after OAuth | Middleware ran before Supabase set the cookie. Hard-refresh once; if persistent, check that `apps/web/middleware.ts` PUBLIC_PATHS includes `/auth/` (it does). |
+| No `user_consents` row for new OAuth user | The callback succeeded but `/api/v1/me/consent` POST failed. Check server logs for `[auth/callback] consent recording failed`. Server endpoint requires authJwt — the access token must be valid. |
+| Existing email user clicks Google, gets a separate account | Supabase by default does NOT link OAuth identities to existing email accounts unless email confirmation is shared. If we want auto-link later, enable "Same email = same account" or use identity linking API. |

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -49,3 +49,18 @@ enabled = true
 
 [analytics]
 enabled = false
+
+# OAuth providers — disabled by default. To enable locally, populate the
+# four env vars below (e.g. in apps/web/.env.local) and restart the stack
+# with `supabase stop && supabase start`. Production providers are
+# configured via Supabase Dashboard, not this file. See
+# docs/auth-oauth-setup.md for the full setup guide.
+[auth.external.google]
+enabled = true
+client_id = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID)"
+secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
+
+[auth.external.github]
+enabled = true
+client_id = "env(SUPABASE_AUTH_EXTERNAL_GITHUB_CLIENT_ID)"
+secret = "env(SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET)"


### PR DESCRIPTION
## Summary
- Connect existing "Continue with Google" / "Continue with GitHub" buttons on `/login` and `/signup` to `supabase.auth.signInWithOAuth`. The buttons were UI-only before — clicking did nothing.
- Auto-record Terms+Privacy consent for OAuth signups in `/auth/callback` via a new `lib/oauth-consent.ts` helper (idempotent: GET existing consents, POST only missing ones).
- Add `[auth.external.google|github]` blocks to `supabase/config.toml` for local-dev parity (production providers configured via Supabase Dashboard, not env).
- Document the full setup (Google Cloud Console + GitHub OAuth App + Supabase Dashboard provider/URL allowlist) in `docs/auth-oauth-setup.md`.

External configuration already completed during this work:
- Google Cloud OAuth Web Client ID: `162998029829-1gpvfsg1...` (project `spanlens`)
- GitHub OAuth App: created under the `spanlens` org (Client ID `Ov23liPp2XBkxPa6KJ1n`)
- Supabase Dashboard: both providers Enabled with secrets, Site URL set to `https://www.spanlens.io`, Redirect URLs allowlist has all 5 production/preview/local entries

## Test plan
- [ ] Vercel build green
- [ ] `pnpm --filter web typecheck && pnpm --filter web lint` (already verified locally)
- [ ] Incognito → `https://www.spanlens.io/signup` → "Continue with Google" → Google consent → land on `/dashboard` (bounces to `/onboarding` for new user)
- [ ] Incognito → `https://www.spanlens.io/signup` → "Continue with GitHub" → GitHub authorize → land on `/dashboard`
- [ ] Supabase Dashboard → Authentication → Users shows new row with `app_metadata.provider = "google"` (or `"github"`)
- [ ] `user_consents` table has 2 rows for the new user (`terms` + `privacy` at current versions)
- [ ] Logout + re-login via Google → no duplicate `user_consents` rows (helper is idempotent)