### PR TITLE
feat: notification settings rework + outbound webhook events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,12 @@ npm-debug.log*
 # Internal planning documents — never commit to public repo
 *.pdf
 *.pptx
+
+# Claude Code local tooling (per-machine, not shared)
+.claude/worktrees/
+apps/web/.claude/
+
+# Local scratch / throwaway artifacts
+apps/web/tc-result.txt
+paddle_compare_*.png
+twitter_guide.txt

--- a/apps/server/src/__tests__/webhook-emit.test.ts
+++ b/apps/server/src/__tests__/webhook-emit.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests for the outbound webhook emitter (lib/webhook-emit.ts):
+//   - fans out to webhooks subscribed to the event, skips the rest
+//   - no-op when the org has no (matching) webhooks
+//   - per-org cache avoids re-querying; invalidateWebhookCache forces a refetch
+//   - best-effort: fetch errors and dispatch failures never throw
+// ─────────────────────────────────────────────────────────────────────────────
+
+const dispatchMock = vi.fn()
+let webhooksResult: { data: unknown; error: unknown }
+let fetchCount = 0
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => {
+            fetchCount++
+            return Promise.resolve(webhooksResult)
+          },
+        }),
+      }),
+    }),
+  },
+}))
+
+vi.mock('../lib/webhook-dispatch.js', () => ({
+  dispatchWebhookEvent: (...args: unknown[]) => dispatchMock(...args),
+}))
+
+type Emit = typeof import('../lib/webhook-emit.js').emitWebhookEvent
+type Invalidate = typeof import('../lib/webhook-emit.js').invalidateWebhookCache
+
+let emitWebhookEvent: Emit
+let invalidateWebhookCache: Invalidate
+
+const hook = (id: string, events: string[]) => ({
+  id,
+  url: `https://hooks.example.com/${id}`,
+  secret: `secret-${id}`,
+  events,
+})
+
+beforeEach(async () => {
+  vi.resetModules()
+  dispatchMock.mockReset().mockResolvedValue('delivery-id')
+  fetchCount = 0
+  webhooksResult = { data: [], error: null }
+  const mod = await import('../lib/webhook-emit.js')
+  emitWebhookEvent = mod.emitWebhookEvent
+  invalidateWebhookCache = mod.invalidateWebhookCache
+})
+
+describe('emitWebhookEvent', () => {
+  test('dispatches to a webhook subscribed to the event', async () => {
+    webhooksResult = { data: [hook('w1', ['request.created'])], error: null }
+
+    await emitWebhookEvent('org1', 'request.created', { request: { id: 'r1' } })
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1)
+    expect(dispatchMock).toHaveBeenCalledWith(
+      { id: 'w1', url: 'https://hooks.example.com/w1', secret: 'secret-w1' },
+      'request.created',
+      { request: { id: 'r1' } },
+    )
+  })
+
+  test('skips webhooks not subscribed to the event', async () => {
+    webhooksResult = { data: [hook('w1', ['trace.completed'])], error: null }
+
+    await emitWebhookEvent('org1', 'request.created', {})
+
+    expect(dispatchMock).not.toHaveBeenCalled()
+  })
+
+  test('fans out to every matching webhook', async () => {
+    webhooksResult = {
+      data: [
+        hook('w1', ['request.created']),
+        hook('w2', ['request.created', 'alert.triggered']),
+        hook('w3', ['alert.triggered']),
+      ],
+      error: null,
+    }
+
+    await emitWebhookEvent('org1', 'request.created', {})
+
+    expect(dispatchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('no-op when org has no webhooks', async () => {
+    webhooksResult = { data: [], error: null }
+
+    await emitWebhookEvent('org1', 'request.created', {})
+
+    expect(dispatchMock).not.toHaveBeenCalled()
+  })
+
+  test('short-circuits on empty orgId without querying', async () => {
+    await emitWebhookEvent('', 'request.created', {})
+
+    expect(fetchCount).toBe(0)
+    expect(dispatchMock).not.toHaveBeenCalled()
+  })
+
+  test('caches per org — a second emit does not re-query', async () => {
+    webhooksResult = { data: [hook('w1', ['request.created'])], error: null }
+
+    await emitWebhookEvent('org1', 'request.created', {})
+    await emitWebhookEvent('org1', 'request.created', {})
+
+    expect(fetchCount).toBe(1)
+    expect(dispatchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('invalidateWebhookCache forces a refetch', async () => {
+    webhooksResult = { data: [hook('w1', ['request.created'])], error: null }
+
+    await emitWebhookEvent('org1', 'request.created', {})
+    invalidateWebhookCache('org1')
+    await emitWebhookEvent('org1', 'request.created', {})
+
+    expect(fetchCount).toBe(2)
+  })
+
+  test('swallows fetch errors (best-effort, never throws)', async () => {
+    webhooksResult = { data: null, error: { message: 'boom' } }
+
+    await expect(emitWebhookEvent('org1', 'request.created', {})).resolves.toBeUndefined()
+    expect(dispatchMock).not.toHaveBeenCalled()
+  })
+
+  test('swallows dispatch failures', async () => {
+    webhooksResult = { data: [hook('w1', ['request.created'])], error: null }
+    dispatchMock.mockRejectedValueOnce(new Error('endpoint down'))
+
+    await expect(emitWebhookEvent('org1', 'request.created', {})).resolves.toBeUndefined()
+  })
+})

--- a/apps/server/src/api/alerts.ts
+++ b/apps/server/src/api/alerts.ts
@@ -155,7 +155,7 @@ alertsRouter.post('/channels', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) return c.json({ error: 'Organization not found' }, 404)
 
-  let body: { kind?: unknown; target?: unknown }
+  let body: { kind?: unknown; target?: unknown; label?: unknown }
   try {
     body = (await c.req.json()) as typeof body
   } catch {
@@ -177,9 +177,29 @@ alertsRouter.post('/channels', requireEdit, async (c) => {
     return c.json({ error: 'webhook target must start with https://' }, 400)
   }
 
+  const target = body.target.trim()
+  // Optional human-readable label (e.g. "#prod-alerts"). Empty string → null.
+  const label =
+    typeof body.label === 'string' && body.label.trim().length > 0
+      ? body.label.trim()
+      : null
+
+  // Dedup: a workspace can hold many channels of the same kind, but not the
+  // exact same destination twice — that would double-send every alert.
+  const { data: existing } = await supabaseAdmin
+    .from('notification_channels')
+    .select('id')
+    .eq('organization_id', orgId)
+    .eq('kind', body.kind)
+    .eq('target', target)
+    .maybeSingle()
+  if (existing) {
+    return c.json({ error: 'A channel with this destination already exists' }, 409)
+  }
+
   const { data, error } = await supabaseAdmin
     .from('notification_channels')
-    .insert({ organization_id: orgId, kind: body.kind, target: body.target.trim() })
+    .insert({ organization_id: orgId, kind: body.kind, target, label })
     .select('*')
     .single()
   if (error || !data) return c.json({ error: 'Failed to create channel' }, 500)

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -8,6 +8,7 @@ import { supabaseAdmin } from '../lib/db.js'
 // eslint-disable-next-line no-restricted-imports
 import { getClickhouse, getOrgClickhouse } from '../lib/clickhouse.js'
 import { deliverToChannel, type AlertNotification } from '../lib/notifiers.js'
+import { emitWebhookEvent } from '../lib/webhook-emit.js'
 import { retryFailedWebhooks } from '../lib/webhook-dispatch.js'
 import { computeAndReportOverages } from '../lib/paddle-usage.js'
 import { runQuotaWarningsJob } from '../lib/quota-warnings.js'
@@ -273,6 +274,20 @@ cronRouter.get('/evaluate-alerts', async (c) => {
       .from('alerts')
       .update({ last_triggered_at: new Date().toISOString() })
       .eq('id', alert.id)
+
+    // Outbound webhook: alert.triggered. Awaited (cron is a batch job, not
+    // latency-sensitive); best-effort so a webhook failure never aborts the run.
+    await emitWebhookEvent(alert.organization_id, 'alert.triggered', {
+      alert: {
+        id: alert.id,
+        name: alert.name,
+        type: alert.type,
+        threshold: alert.threshold,
+        current_value: current,
+        window_minutes: alert.window_minutes,
+      },
+      organization: { name: orgName },
+    })
 
     report.push({ alert_id: alert.id, fired: true })
   }

--- a/apps/server/src/api/ingest.ts
+++ b/apps/server/src/api/ingest.ts
@@ -1,6 +1,8 @@
 import { Hono } from 'hono'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
 import { supabaseAdmin } from '../lib/db.js'
+import { fireAndForget } from '../lib/wait-until.js'
+import { emitWebhookEvent } from '../lib/webhook-emit.js'
 
 /**
  * SDK용 ingestion 라우터 — authApiKey 미들웨어로 SHA-256 해시 API 키 검증.
@@ -150,6 +152,24 @@ ingestRouter.patch('/traces/:id', async (c) => {
 
   if (error || !data) {
     return c.json({ error: 'Trace not found or access denied' }, 404)
+  }
+
+  // Outbound webhook: trace.completed. fireAndForget so the SDK's PATCH
+  // response isn't blocked on customer-endpoint latency, and the promise is
+  // drained on Vercel (gotcha #8). Best-effort — no-op for orgs without a
+  // subscribed webhook.
+  if (data.status === 'completed') {
+    fireAndForget(
+      c,
+      emitWebhookEvent(organizationId, 'trace.completed', {
+        trace: {
+          id: data.id,
+          status: data.status,
+          ended_at: data.ended_at,
+          duration_ms: data.duration_ms,
+        },
+      }),
+    )
   }
 
   return c.json({ success: true, data })

--- a/apps/server/src/api/userNotificationPrefs.ts
+++ b/apps/server/src/api/userNotificationPrefs.ts
@@ -1,0 +1,78 @@
+import { Hono } from 'hono'
+import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { supabaseAdmin } from '../lib/db.js'
+
+/**
+ * /api/v1/me/notification-prefs — per-USER email notification preferences.
+ *
+ *   GET   /me/notification-prefs   — current user's prefs (defaults if unset)
+ *   PATCH /me/notification-prefs   — update one or more toggles
+ *
+ * Account-level, distinct from org-level notification_channels (which decide
+ * WHERE alerts go). These decide what email reaches THIS person. See the
+ * 20260529000100_user_notification_prefs migration for the boundary writeup.
+ *
+ * Defaults are all `true` so a user with no row yet is treated as opted in —
+ * matching the emails they already receive before this feature shipped.
+ */
+
+export const userNotificationPrefsRouter = new Hono<JwtContext>()
+
+userNotificationPrefsRouter.use('*', authJwt)
+
+interface NotificationPrefs {
+  security_alert_emails: boolean
+  marketing_emails: boolean
+  product_update_emails: boolean
+}
+
+const DEFAULT_PREFS: NotificationPrefs = {
+  security_alert_emails: true,
+  marketing_emails: true,
+  product_update_emails: true,
+}
+
+const PREF_KEYS = Object.keys(DEFAULT_PREFS) as (keyof NotificationPrefs)[]
+
+userNotificationPrefsRouter.get('/', async (c) => {
+  const userId = c.get('userId')
+
+  const { data, error } = await supabaseAdmin
+    .from('user_notification_prefs')
+    .select('security_alert_emails, marketing_emails, product_update_emails')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (error) return c.json({ error: 'Failed to fetch notification preferences' }, 500)
+  return c.json({ success: true, data: { ...DEFAULT_PREFS, ...(data ?? {}) } })
+})
+
+userNotificationPrefsRouter.patch('/', async (c) => {
+  const userId = c.get('userId')
+
+  let body: Partial<Record<keyof NotificationPrefs, unknown>>
+  try {
+    body = (await c.req.json()) as typeof body
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400)
+  }
+
+  // Pick only known boolean keys — ignore anything else the client sends.
+  const updates: Partial<NotificationPrefs> = {}
+  for (const key of PREF_KEYS) {
+    const value = body[key]
+    if (typeof value === 'boolean') updates[key] = value
+  }
+  if (Object.keys(updates).length === 0) {
+    return c.json({ error: 'No valid preference fields provided' }, 400)
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('user_notification_prefs')
+    .upsert({ user_id: userId, ...updates }, { onConflict: 'user_id' })
+    .select('security_alert_emails, marketing_emails, product_update_emails')
+    .single()
+
+  if (error || !data) return c.json({ error: 'Failed to save notification preferences' }, 500)
+  return c.json({ success: true, data: { ...DEFAULT_PREFS, ...data } })
+})

--- a/apps/server/src/api/webhooks.ts
+++ b/apps/server/src/api/webhooks.ts
@@ -4,6 +4,7 @@ import { requireRole } from '../middleware/requireRole.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { randomHex } from '../lib/crypto.js'
 import { dispatchWebhookEvent } from '../lib/webhook-dispatch.js'
+import { invalidateWebhookCache } from '../lib/webhook-emit.js'
 
 export const webhooksRouter = new Hono<JwtContext>()
 webhooksRouter.use('*', authJwt)
@@ -81,6 +82,7 @@ webhooksRouter.post('/', requireEdit, async (c) => {
     .single()
 
   if (error || !data) return c.json({ error: 'Failed to create webhook' }, 500)
+  invalidateWebhookCache(orgId)
   return c.json({ success: true, data }, 201)
 })
 
@@ -133,6 +135,7 @@ webhooksRouter.patch('/:id', requireEdit, async (c) => {
     .single()
 
   if (error || !data) return c.json({ error: 'Webhook not found' }, 404)
+  invalidateWebhookCache(orgId)
   return c.json({ success: true, data })
 })
 
@@ -149,6 +152,7 @@ webhooksRouter.delete('/:id', requireEdit, async (c) => {
     .eq('organization_id', orgId)
 
   if (error) return c.json({ error: 'Failed to delete webhook' }, 500)
+  invalidateWebhookCache(orgId)
   return c.json({ success: true })
 })
 

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -45,6 +45,7 @@ import { openapiRouter }       from './api/openapi.js'
 import { providerKeysRouter }  from './api/providerKeys.js'
 import { meRouter }            from './api/me.js'
 import { meRoleRouter }        from './api/meRole.js'
+import { userNotificationPrefsRouter } from './api/userNotificationPrefs.js'
 import { modelsRouter }        from './api/models.js'
 import { systemRouter }       from './api/system.js'
 import { adminModelPricesRouter } from './api/admin/modelPrices.js'
@@ -170,6 +171,7 @@ app.route('/api/v1/me/pending-invitations', meInvitationsRouter)
 app.route('/api/v1/dismissals',     dismissalsRouter)
 app.route('/api/v1/me/profile',     userProfilesRouter)
 app.route('/api/v1/me/consent',     userConsentRouter)
+app.route('/api/v1/me/notification-prefs', userNotificationPrefsRouter)  // JWT-auth — per-user email prefs
 app.route('/api/v1/me/role',        meRoleRouter)    // JWT-auth — current user's org role (sidebar uses this)
 app.route('/api/v1/models',         modelsRouter)    // JWT-auth — model catalog (grouped by provider) for Playground
 app.route('/api/v1/me',             meRouter)        // sl_live_* introspection (CLI), registered AFTER other /me/* prefixes

--- a/apps/server/src/lib/admin-emails.ts
+++ b/apps/server/src/lib/admin-emails.ts
@@ -1,11 +1,15 @@
 import { supabaseAdmin } from './db.js'
 
 /**
- * Resolve email addresses for all admin members of an org.
+ * Resolve email addresses for all admin members of an org who have NOT
+ * opted out of security alert emails.
  * Falls back to empty array if no admins are found or no emails are set.
  *
- * Used by leak-detection.ts and stale-key-digest.ts (admin alerts).
- * Security alert emails use a separate owner-only lookup in logger.ts.
+ * Used by leak-detection.ts and stale-key-digest.ts (admin alerts) — both
+ * are "security alert" emails, so they honour the per-user
+ * `security_alert_emails` preference (default true; only users who
+ * explicitly turned it off are excluded). Quota-warning emails use a
+ * separate owner-only lookup in logger.ts.
  */
 export async function getAdminEmails(orgId: string): Promise<string[]> {
   const { data: members } = await supabaseAdmin
@@ -17,8 +21,18 @@ export async function getAdminEmails(orgId: string): Promise<string[]> {
   const userIds = (members ?? []).map((m) => m.user_id)
   if (userIds.length === 0) return []
 
+  // Per-user opt-out: a row with security_alert_emails = false excludes that
+  // admin. Users with no prefs row default to opted-in.
+  const { data: optedOut } = await supabaseAdmin
+    .from('user_notification_prefs')
+    .select('user_id')
+    .in('user_id', userIds)
+    .eq('security_alert_emails', false)
+  const optedOutSet = new Set((optedOut ?? []).map((r) => r.user_id as string))
+
   const emails: string[] = []
   for (const userId of userIds) {
+    if (optedOutSet.has(userId)) continue
     const { data } = await supabaseAdmin.auth.admin.getUserById(userId)
     if (data?.user?.email) emails.push(data.user.email)
   }

--- a/apps/server/src/lib/logger.ts
+++ b/apps/server/src/lib/logger.ts
@@ -4,6 +4,7 @@ import { getClickhouse, toClickhouseTimestamp } from './clickhouse.js'
 import { maskApiKeysInBody, maskApiKeys } from './pii-mask.js'
 import { scanAll, type SecurityFlag } from './security-scan.js'
 import { sendEmail, renderSecurityAlertEmail } from './resend.js'
+import { emitWebhookEvent } from './webhook-emit.js'
 
 /**
  * Customer-controlled body logging mode (sent via the `x-spanlens-log-body`
@@ -318,5 +319,29 @@ export async function logRequestAsync(data: RequestLogData): Promise<void> {
     }).catch((err) => {
       console.error('[security-alert] failed:', err instanceof Error ? err.message : String(err))
     })
+  }
+
+  // ── Outbound webhook: request.created ──────────────────────────────────────
+  // Gated by an in-memory cache so orgs without a subscribed webhook pay only a
+  // Map lookup. Awaited inside the outer fireAndForget(c, logRequestAsync(...))
+  // drain budget (gotcha #8). Wrapped so a webhook failure never breaks logging.
+  try {
+    await emitWebhookEvent(data.organizationId, 'request.created', {
+      request: {
+        id: clickhouseRow.id,
+        provider: data.provider,
+        model: data.model,
+        prompt_tokens: data.promptTokens,
+        completion_tokens: data.completionTokens,
+        total_tokens: data.totalTokens,
+        cost_usd: data.costUsd,
+        latency_ms: data.latencyMs,
+        status_code: data.statusCode,
+        trace_id: data.traceId,
+        created_at: clickhouseRow.created_at,
+      },
+    })
+  } catch (err) {
+    console.error('[logger] request.created webhook emit failed:', err instanceof Error ? err.message : err)
   }
 }

--- a/apps/server/src/lib/webhook-emit.ts
+++ b/apps/server/src/lib/webhook-emit.ts
@@ -1,0 +1,138 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Outbound webhook event emitter.
+//
+// Fans an event out to every active webhook of an org that subscribes to it,
+// reusing dispatchWebhookEvent (HMAC signing + delivery record + retry).
+//
+// WHY THE CACHE
+// -------------
+// `request.created` fires on EVERY proxied LLM call. A DB lookup per call to
+// find "does this org have a webhook?" would put one extra Supabase query on
+// the hot logging path. Since the overwhelming majority of orgs have zero
+// webhooks, we cache the per-org active-webhook list in module memory with a
+// short TTL (stale-while-revalidate): the common no-webhook case costs a single
+// Map lookup. Per Vercel serverless, each instance has its own cache; webhook
+// CRUD calls invalidateWebhookCache so the originating instance reflects
+// changes immediately, and other instances catch up within CACHE_TTL_MS.
+//
+// Best-effort by design: a failed dispatch is recorded in webhook_deliveries
+// (the retry cron picks it up) and never propagates to the caller — emitting an
+// event must never break logging, ingest, or alert evaluation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { supabaseAdmin } from './db.js'
+import { dispatchWebhookEvent } from './webhook-dispatch.js'
+
+export type WebhookEventType = 'request.created' | 'trace.completed' | 'alert.triggered'
+
+interface ActiveWebhook {
+  id: string
+  url: string
+  secret: string
+  events: string[]
+}
+
+const CACHE_TTL_MS = 60 * 1000
+
+interface CacheEntry {
+  hooks: ActiveWebhook[]
+  fetchedAt: number
+}
+
+const cache = new Map<string, CacheEntry>()
+const refreshInFlight = new Map<string, Promise<void>>()
+
+async function fetchActiveWebhooks(orgId: string): Promise<ActiveWebhook[]> {
+  const { data, error } = await supabaseAdmin
+    .from('webhooks')
+    .select('id, url, secret, events')
+    .eq('organization_id', orgId)
+    .eq('is_active', true)
+
+  if (error) throw new Error(`webhooks fetch failed: ${error.message}`)
+
+  return (data ?? []).map((r) => {
+    const row = r as Record<string, unknown>
+    return {
+      id: row['id'] as string,
+      url: row['url'] as string,
+      secret: row['secret'] as string,
+      events: Array.isArray(row['events']) ? (row['events'] as string[]) : [],
+    }
+  })
+}
+
+async function getActiveWebhooksForOrg(orgId: string): Promise<ActiveWebhook[]> {
+  const now = Date.now()
+  const entry = cache.get(orgId)
+
+  if (entry) {
+    // Stale-while-revalidate: return what we have, refresh in the background.
+    if (now - entry.fetchedAt > CACHE_TTL_MS && !refreshInFlight.has(orgId)) {
+      const p = fetchActiveWebhooks(orgId)
+        .then((hooks) => {
+          cache.set(orgId, { hooks, fetchedAt: Date.now() })
+        })
+        .catch((err) => {
+          console.warn('[webhook-emit] background refresh failed:', err instanceof Error ? err.message : err)
+        })
+        .finally(() => {
+          refreshInFlight.delete(orgId)
+        })
+      refreshInFlight.set(orgId, p)
+    }
+    return entry.hooks
+  }
+
+  // Cold miss — await once, then cache. On error return empty (best-effort).
+  try {
+    const hooks = await fetchActiveWebhooks(orgId)
+    cache.set(orgId, { hooks, fetchedAt: now })
+    return hooks
+  } catch (err) {
+    console.warn('[webhook-emit] fetch failed:', err instanceof Error ? err.message : err)
+    return []
+  }
+}
+
+/** Drop an org's cached webhook list. Called from webhook CRUD so the
+ *  originating serverless instance reflects changes without waiting for TTL. */
+export function invalidateWebhookCache(orgId: string): void {
+  cache.delete(orgId)
+}
+
+/** Test helper — clears all cached state. */
+export function _resetWebhookCacheForTests(): void {
+  cache.clear()
+  refreshInFlight.clear()
+}
+
+/**
+ * Emit `eventType` to every active webhook of `orgId` subscribed to it.
+ * Best-effort and non-throwing: safe to call (and await) from hot paths,
+ * request handlers, and cron alike.
+ */
+export async function emitWebhookEvent(
+  orgId: string,
+  eventType: WebhookEventType,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  if (!orgId) return
+
+  const hooks = await getActiveWebhooksForOrg(orgId)
+  const matching = hooks.filter((h) => h.events.includes(eventType))
+  if (matching.length === 0) return
+
+  await Promise.all(
+    matching.map((h) =>
+      dispatchWebhookEvent({ id: h.id, url: h.url, secret: h.secret }, eventType, payload).catch(
+        (err) => {
+          console.error(
+            '[webhook-emit] dispatch failed:',
+            err instanceof Error ? err.message : err,
+          )
+        },
+      ),
+    ),
+  )
+}

--- a/apps/web/app/(dashboard)/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/alerts-client.tsx
@@ -2,18 +2,16 @@
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Bell, Mail, MessageSquare, Plus, Search, Trash2 } from 'lucide-react'
+import { Bell, Mail, MessageSquare, Plus, Search, Settings2, Trash2 } from 'lucide-react'
 import {
   useAlerts,
   useCreateAlert,
   useDeleteAlert,
   useUpdateAlert,
   useNotificationChannels,
-  useCreateChannel,
-  useDeleteChannel,
   useAlertDeliveries,
 } from '@/lib/queries/use-alerts'
-import type { AlertType, ChannelKind, AlertRow } from '@/lib/queries/types'
+import type { AlertType, AlertRow } from '@/lib/queries/types'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Topbar, LiveDot } from '@/components/layout/topbar'
@@ -174,8 +172,6 @@ export function AlertsClient() {
   const createAlert = useCreateAlert()
   const deleteAlert = useDeleteAlert()
   const updateAlert = useUpdateAlert()
-  const createChannel = useCreateChannel()
-  const deleteChannel = useDeleteChannel()
 
   // URL-backed search + status filter — shareable, survives reload.
   const search = sp.get('q') ?? ''
@@ -214,15 +210,12 @@ export function AlertsClient() {
   )
 
   const [alertDialogOpen, setAlertDialogOpen] = useState(false)
-  const [channelDialogOpen, setChannelDialogOpen] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [newName, setNewName] = useState('')
   const [newType, setNewType] = useState<AlertType>('budget')
   const [newThreshold, setNewThreshold] = useState('')
   const [newWindow, setNewWindow] = useState('60')
   const [newCooldown, setNewCooldown] = useState('60')
-  const [newChannelKind, setNewChannelKind] = useState<ChannelKind>('email')
-  const [newChannelTarget, setNewChannelTarget] = useState('')
 
   function openCreateAlert() {
     setEditingId(null)
@@ -304,13 +297,6 @@ export function AlertsClient() {
     }
     setAlertDialogOpen(false)
     setEditingId(null)
-  }
-
-  async function handleCreateChannel() {
-    if (!newChannelTarget.trim()) return
-    await createChannel.mutateAsync({ kind: newChannelKind, target: newChannelTarget.trim() })
-    setNewChannelTarget('')
-    setChannelDialogOpen(false)
   }
 
   // CSV / JSON export — client-side, RFC 4180 escaping.
@@ -397,17 +383,15 @@ export function AlertsClient() {
               >
                 <span className={cn('inline-block', mounted && isFetching && 'animate-spin')}>↻</span>
               </button>
+              <Link
+                href="/settings?tab=integrations"
+                title="Manage notification channels"
+                className="font-mono text-[11px] text-text-muted px-2 sm:px-[10px] py-[5px] border border-border rounded-[5px] bg-bg-elev hover:text-text transition-colors whitespace-nowrap shrink-0 flex items-center gap-1.5"
+              >
+                <Settings2 className="h-3.5 w-3.5 shrink-0" />
+                <span className="hidden sm:inline">Channels</span>
+              </Link>
               <PermissionGate need="edit">
-                <button
-                  type="button"
-                  onClick={() => setChannelDialogOpen(true)}
-                  title="Add channel"
-                  aria-label="Add channel"
-                  className="font-mono text-[11px] text-text-muted px-2 sm:px-[10px] py-[5px] border border-border rounded-[5px] bg-bg-elev hover:text-text transition-colors whitespace-nowrap shrink-0 flex items-center gap-1.5"
-                >
-                  <Bell className="h-3.5 w-3.5 shrink-0" />
-                  <span className="hidden sm:inline">Add channel</span>
-                </button>
                 <button
                   type="button"
                   onClick={openCreateAlert}
@@ -641,39 +625,44 @@ export function AlertsClient() {
             )}
 
             <div className="px-[22px] py-[18px]">
-              <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-3">
-                Notification channels
+              <div className="flex items-center justify-between mb-3 gap-2">
+                <span className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+                  Notification channels
+                </span>
+                <Link
+                  href="/settings?tab=integrations"
+                  className="font-mono text-[11px] text-accent hover:opacity-80 transition-opacity"
+                >
+                  Manage channels →
+                </Link>
               </div>
+              {/* Read-only here: every active rule fans out to these channels.
+                  Add/remove lives in Settings → Integrations (org-level). */}
               {mounted && channelsQuery.data === undefined ? (
                 <div className="h-12 bg-bg-elev rounded animate-pulse" />
               ) : channels.length === 0 ? (
                 <div className="rounded-[5px] border border-dashed border-border py-5 text-center font-mono text-[12px] text-text-muted">
-                  No channels yet, add an email or webhook to receive alerts.
+                  No channels yet.{' '}
+                  <Link href="/settings?tab=integrations" className="text-accent hover:opacity-80 transition-opacity">
+                    Connect Slack, Discord, or email
+                  </Link>{' '}
+                  to receive alerts.
                 </div>
               ) : (
                 <div className="rounded-[6px] border border-border overflow-hidden">
                   {channels.map((ch) => (
                     <div
                       key={ch.id}
-                      className="flex items-center justify-between px-[14px] py-3 border-b border-border last:border-0"
+                      className="flex items-center gap-3 px-[14px] py-3 border-b border-border last:border-0"
                     >
-                      <div className="flex items-center gap-3">
-                        <span className="text-text-muted">
-                          {ch.kind === 'email' ? <Mail className="h-3.5 w-3.5" /> : <MessageSquare className="h-3.5 w-3.5" />}
-                        </span>
-                        <span className="font-mono text-[11px] uppercase tracking-[0.04em] text-text-muted">{ch.kind}</span>
-                        <span className="font-mono text-[12px] text-text-faint truncate max-w-xs">{ch.target}</span>
-                      </div>
-                      <PermissionGate need="edit">
-                        <button
-                          type="button"
-                          onClick={() => void deleteChannel.mutateAsync(ch.id)}
-                          disabled={deleteChannel.isPending}
-                          className="text-text-faint hover:text-bad transition-colors p-1 disabled:opacity-40"
-                        >
-                          <Trash2 className="h-3.5 w-3.5" />
-                        </button>
-                      </PermissionGate>
+                      <span className="text-text-muted">
+                        {ch.kind === 'email' ? <Mail className="h-3.5 w-3.5" /> : <MessageSquare className="h-3.5 w-3.5" />}
+                      </span>
+                      <span className="font-mono text-[11px] uppercase tracking-[0.04em] text-text-muted">{ch.kind}</span>
+                      {ch.label && (
+                        <span className="font-mono text-[12px] text-text truncate max-w-[160px]">{ch.label}</span>
+                      )}
+                      <span className="font-mono text-[12px] text-text-faint truncate max-w-xs">{ch.target}</span>
                     </div>
                   ))}
                 </div>
@@ -779,45 +768,6 @@ export function AlertsClient() {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={channelDialogOpen} onOpenChange={setChannelDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Add notification channel</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4 mt-2">
-            <div className="space-y-2">
-              <label className="font-mono text-[11px] text-text-muted uppercase tracking-[0.04em]">Kind</label>
-              <Select value={newChannelKind} onValueChange={(v) => setNewChannelKind(v as ChannelKind)}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="email">Email (Resend)</SelectItem>
-                  <SelectItem value="slack">Slack webhook</SelectItem>
-                  <SelectItem value="discord">Discord webhook</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <label className="font-mono text-[11px] text-text-muted uppercase tracking-[0.04em]">
-                {newChannelKind === 'email' ? 'Email address' : 'Webhook URL'}
-              </label>
-              <input
-                value={newChannelTarget}
-                onChange={(e) => setNewChannelTarget(e.target.value)}
-                placeholder={newChannelKind === 'email' ? 'alerts@yourco.com' : 'https://hooks.slack.com/…'}
-                className="w-full h-9 px-3 rounded border border-border bg-bg text-[13px] focus:outline-none focus:border-border-strong"
-              />
-            </div>
-            <button
-              type="button"
-              onClick={() => void handleCreateChannel()}
-              disabled={!newChannelTarget.trim() || createChannel.isPending}
-              className="w-full py-2 rounded bg-text text-bg font-mono text-[13px] font-medium hover:opacity-90 transition-opacity disabled:opacity-40"
-            >
-              {createChannel.isPending ? 'Adding…' : 'Add channel'}
-            </button>
-          </div>
-        </DialogContent>
-      </Dialog>
     </div>
   )
 }

--- a/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
@@ -555,17 +555,7 @@ export function DashboardClient() {
       {/* Sticky topbar — keeps the time range + crumbs in view while the
           page scrolls natively (no inner overflow container). */}
       <div className="sticky top-0 z-20 bg-bg">
-        <Topbar
-          crumbs={[{ label: 'Dashboard' }]}
-          right={
-            <TimeRangeSelector
-              value={timeRange}
-              onChange={(v) => { setTimeRange(v); if (v !== 'custom') setCustomRange(null) }}
-              customRange={customRange}
-              onCustomRange={(r) => { setCustomRange(r); setTimeRange('custom') }}
-            />
-          }
-        />
+        <Topbar crumbs={[{ label: 'Dashboard' }]} />
       </div>
 
       <div>
@@ -621,35 +611,43 @@ export function DashboardClient() {
             ) : (
               <span className="text-text-faint">&nbsp;</span>
             )}
-            <div ref={exportRef} className="ml-auto relative shrink-0">
-              <button
-                type="button"
-                onClick={() => setExportOpen((v) => !v)}
-                className="font-mono text-[11px] text-text-muted hover:text-text border border-border rounded px-2.5 py-1 transition-colors"
-              >
-                Export ↓
-              </button>
-              {exportOpen && (
-                <>
-                  <div className="fixed inset-0 z-10" onClick={() => setExportOpen(false)} />
-                  <div className="absolute right-0 top-full mt-1 z-20 bg-bg-elev border border-border rounded shadow-sm min-w-[100px]">
-                    <button
-                      type="button"
-                      onClick={exportCsv}
-                      className="w-full text-left px-3 py-2 font-mono text-[11px] text-text-muted hover:text-text hover:bg-bg transition-colors"
-                    >
-                      CSV
-                    </button>
-                    <button
-                      type="button"
-                      onClick={exportJson}
-                      className="w-full text-left px-3 py-2 font-mono text-[11px] text-text-muted hover:text-text hover:bg-bg transition-colors"
-                    >
-                      JSON
-                    </button>
-                  </div>
-                </>
-              )}
+            <div className="ml-auto flex items-center gap-2 shrink-0">
+              <TimeRangeSelector
+                value={timeRange}
+                onChange={(v) => { setTimeRange(v); if (v !== 'custom') setCustomRange(null) }}
+                customRange={customRange}
+                onCustomRange={(r) => { setCustomRange(r); setTimeRange('custom') }}
+              />
+              <div ref={exportRef} className="relative shrink-0">
+                <button
+                  type="button"
+                  onClick={() => setExportOpen((v) => !v)}
+                  className="font-mono text-[11px] text-text-muted hover:text-text border border-border rounded px-2.5 py-1 transition-colors"
+                >
+                  Export ↓
+                </button>
+                {exportOpen && (
+                  <>
+                    <div className="fixed inset-0 z-10" onClick={() => setExportOpen(false)} />
+                    <div className="absolute right-0 top-full mt-1 z-20 bg-bg-elev border border-border rounded shadow-sm min-w-[100px]">
+                      <button
+                        type="button"
+                        onClick={exportCsv}
+                        className="w-full text-left px-3 py-2 font-mono text-[11px] text-text-muted hover:text-text hover:bg-bg transition-colors"
+                      >
+                        CSV
+                      </button>
+                      <button
+                        type="button"
+                        onClick={exportJson}
+                        className="w-full text-left px-3 py-2 font-mono text-[11px] text-text-muted hover:text-text hover:bg-bg transition-colors"
+                      >
+                        JSON
+                      </button>
+                    </div>
+                  </>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/apps/web/app/(dashboard)/savings/savings-client.tsx
+++ b/apps/web/app/(dashboard)/savings/savings-client.tsx
@@ -979,24 +979,6 @@ export function SavingsClient() {
           right={
             <div className="flex items-center gap-3">
               <LiveDot refetching={isFetching} />
-              <div className="flex items-center gap-1">
-                {WINDOW_OPTIONS.map((opt) => (
-                  <button
-                    key={opt.hours}
-                    type="button"
-                    onClick={() => setHoursUrl(opt.hours)}
-                    className={cn(
-                      'font-mono text-[11px] px-[8px] py-[3px] rounded-[4px] transition-colors',
-                      hours === opt.hours
-                        ? 'bg-bg-elev text-text border border-border-strong'
-                        : 'text-text-faint hover:text-text',
-                    )}
-                  >
-                    {opt.label}
-                  </button>
-                ))}
-                <span className="hidden sm:inline font-mono text-[11px] text-text-muted ml-1.5">Analysis window</span>
-              </div>
               <button
                 type="button"
                 onClick={() => void refetch()}
@@ -1146,6 +1128,26 @@ export function SavingsClient() {
           </button>
         )}
         <span className="flex-1" />
+
+        {/* Analysis window — relocated from the topbar to sit left of Export. */}
+        <div className="flex items-center gap-1">
+          {WINDOW_OPTIONS.map((opt) => (
+            <button
+              key={opt.hours}
+              type="button"
+              onClick={() => setHoursUrl(opt.hours)}
+              className={cn(
+                'font-mono text-[11px] px-[8px] py-[3px] rounded-[4px] transition-colors',
+                hours === opt.hours
+                  ? 'bg-bg-elev text-text border border-border-strong'
+                  : 'text-text-faint hover:text-text',
+              )}
+            >
+              {opt.label}
+            </button>
+          ))}
+          <span className="hidden sm:inline font-mono text-[11px] text-text-muted ml-1.5">Analysis window</span>
+        </div>
 
         <div ref={exportRef} className="relative">
           <button

--- a/apps/web/app/(dashboard)/security/security-client.tsx
+++ b/apps/web/app/(dashboard)/security/security-client.tsx
@@ -205,12 +205,6 @@ export function SecurityClient() {
           right={
             <div className="flex items-center gap-3">
               <LiveDot refetching={isFetching} />
-              <TimeRangeSelector
-                value={rangeParam}
-                onChange={(v) => updateQuery({ range: v === '24h' ? null : v, from: null, to: null, page: null })}
-                customRange={customRange}
-                onCustomRange={(r) => updateQuery({ range: 'custom', from: r.from, to: r.to, page: null })}
-              />
               <button
                 type="button"
                 onClick={refreshAll}
@@ -329,10 +323,18 @@ export function SecurityClient() {
             <span className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
               Detectors, {detectors.length} active · flag-only (no blocking unless enabled above)
             </span>
-            <ExportDropdown
-              filename="spanlens-security"
-              buildUrl={(fmt) => `/api/v1/exports/security?format=${fmt}`}
-            />
+            <div className="flex items-center gap-2">
+              <TimeRangeSelector
+                value={rangeParam}
+                onChange={(v) => updateQuery({ range: v === '24h' ? null : v, from: null, to: null, page: null })}
+                customRange={customRange}
+                onCustomRange={(r) => updateQuery({ range: 'custom', from: r.from, to: r.to, page: null })}
+              />
+              <ExportDropdown
+                filename="spanlens-security"
+                buildUrl={(fmt) => `/api/v1/exports/security?format=${fmt}`}
+              />
+            </div>
           </div>
 
           <div className="overflow-x-auto">

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -61,7 +61,14 @@ import {
   useWebhookDeliveries,
 } from '@/lib/queries/use-webhooks'
 import type { WebhookEvent, WebhookRow } from '@/lib/queries/types'
-import { useNotificationChannels } from '@/lib/queries/use-alerts'
+import { useNotificationChannels, useDeleteChannel } from '@/lib/queries/use-alerts'
+import {
+  useNotificationPrefs,
+  useUpdateNotificationPrefs,
+} from '@/lib/queries/use-notification-prefs'
+import type { ChannelKind, NotificationChannelRow } from '@/lib/queries/types'
+import { AddChannelDialog } from '@/components/channels/add-channel-dialog'
+import { PermissionGate } from '@/components/permission-gate'
 import { CronJobsPanel } from './cron-jobs-panel'
 
 // ─── types ───────────────────────────────────────────────────────────────────
@@ -1270,24 +1277,64 @@ function SignInMethodsTab() {
 
 // ─── NOTIFICATIONS tab ────────────────────────────────────────────────────────
 
+interface NotificationPrefDef {
+  key: 'security_alert_emails' | 'marketing_emails' | 'product_update_emails'
+  label: string
+  hint: string
+}
+
+const NOTIFICATION_PREFS: NotificationPrefDef[] = [
+  {
+    key: 'security_alert_emails',
+    label: 'Security alerts',
+    hint: 'Stale-key reminders and leaked-key detection alerts for workspaces you admin.',
+  },
+  {
+    key: 'product_update_emails',
+    label: 'Product updates',
+    hint: 'Occasional changelog and new-feature emails. No more than monthly.',
+  },
+  {
+    key: 'marketing_emails',
+    label: 'Marketing',
+    hint: 'Launch announcements and offers. You can opt out at any time.',
+  },
+]
+
 function NotificationsTab() {
+  const { data: prefs, isLoading } = useNotificationPrefs()
+  const update = useUpdateNotificationPrefs()
+
   return (
     <div className="max-w-[980px]">
       <TabHeader
         title="Notifications"
-        description="Alert routing lives on the Alerts page, where each rule is bound to a channel."
+        description="Which emails Spanlens sends you. These are personal to your account."
       />
 
-      <Section title="How notifications work today" className="mb-5">
-        <div className="px-6 py-5 space-y-3 text-[13px] text-text-muted leading-relaxed">
-          <p>
-            Each alert rule targets one channel (email, Slack, or Discord webhook). Channels are configured
-            on the <a href="/alerts" className="text-accent hover:opacity-80 transition-opacity">Alerts page</a>.
-          </p>
-          <p>
-            Personal notification preferences (per-event mute, quiet hours, mobile push) aren&apos;t built yet ,
-            every rule fires according to the thresholds you set on it.
-          </p>
+      <Section title="Email preferences" className="mb-5">
+        {NOTIFICATION_PREFS.map((pref) => (
+          <FormRow key={pref.key} label={pref.label} hint={pref.hint}>
+            <Toggle
+              on={prefs?.[pref.key] ?? true}
+              disabled={isLoading || update.isPending}
+              onToggle={() =>
+                void update.mutateAsync({ [pref.key]: !(prefs?.[pref.key] ?? true) })
+              }
+            />
+          </FormRow>
+        ))}
+      </Section>
+
+      <Section title="Alert routing" className="mb-5">
+        <div className="px-6 py-4 text-[13px] text-text-muted leading-relaxed">
+          Where alerts are delivered (Slack, Discord, or email channels) is a workspace-level
+          setting. Manage destinations in{' '}
+          <a href="/settings?tab=integrations" className="text-accent hover:opacity-80 transition-opacity">
+            Integrations
+          </a>{' '}
+          and the rules that trigger them on the{' '}
+          <a href="/alerts" className="text-accent hover:opacity-80 transition-opacity">Alerts page</a>.
         </div>
       </Section>
     </div>
@@ -1355,10 +1402,10 @@ function PreferencesTab() {
 
 // ─── WEBHOOKS tab ─────────────────────────────────────────────────────────────
 
-const ALL_WEBHOOK_EVENTS: { value: WebhookEvent; label: string }[] = [
-  { value: 'request.created',  label: 'request.created'  },
-  { value: 'trace.completed',  label: 'trace.completed'  },
-  { value: 'alert.triggered',  label: 'alert.triggered'  },
+const ALL_WEBHOOK_EVENTS: { value: WebhookEvent; label: string; hint: string }[] = [
+  { value: 'request.created',  label: 'request.created',  hint: 'fires on every LLM call' },
+  { value: 'trace.completed',  label: 'trace.completed',  hint: 'fires when a trace ends' },
+  { value: 'alert.triggered',  label: 'alert.triggered',  hint: 'fires when an alert rule trips' },
 ]
 
 function SecretField({ secret }: { secret: string }) {
@@ -1636,15 +1683,16 @@ function WebhooksTab() {
             <div>
               <label className="block text-[12px] text-text-muted mb-2">Events</label>
               <div className="space-y-2">
-                {ALL_WEBHOOK_EVENTS.map(({ value, label }) => (
-                  <label key={value} className="flex items-center gap-2 cursor-pointer">
+                {ALL_WEBHOOK_EVENTS.map(({ value, label, hint }) => (
+                  <label key={value} className="flex items-baseline gap-2 cursor-pointer">
                     <input
                       type="checkbox"
                       checked={newEvents.includes(value)}
                       onChange={() => toggleEvent(value)}
-                      className="rounded border-border"
+                      className="rounded border-border self-center"
                     />
                     <span className="font-mono text-[12px] text-text-muted">{label}</span>
+                    <span className="text-[11px] text-text-faint">{hint}</span>
                   </label>
                 ))}
               </div>
@@ -1669,92 +1717,149 @@ function WebhooksTab() {
 
 // ─── INTEGRATIONS tab ─────────────────────────────────────────────────────────
 
-function StatusPill({ connected }: { connected: boolean }) {
+interface ChannelProviderDef {
+  kind: ChannelKind
+  name: string
+  description: string
+}
+
+const CHANNEL_PROVIDERS: ChannelProviderDef[] = [
+  { kind: 'slack',   name: 'Slack',   description: 'Post alerts to Slack via incoming webhook.' },
+  { kind: 'discord', name: 'Discord', description: 'Post alerts to Discord via incoming webhook.' },
+  { kind: 'email',   name: 'Email',   description: 'Email alerts to one or more addresses.' },
+]
+
+const COMING_SOON: { id: string; name: string; description: string }[] = [
+  { id: 'pagerduty', name: 'PagerDuty', description: 'Route critical alerts to on-call engineers.' },
+  { id: 'datadog',   name: 'Datadog',   description: 'Forward metrics and traces to your Datadog account.' },
+]
+
+/** Webhook URLs are partially secret and unreadable — show only a tail. */
+function maskTarget(kind: ChannelKind, target: string): string {
+  if (kind === 'email') return target
+  const tail = target.length > 10 ? target.slice(-10) : target
+  return `••••${tail}`
+}
+
+function ProviderChannelCard({
+  provider,
+  channels,
+  onAdd,
+  onDelete,
+  deletingId,
+}: {
+  provider: ChannelProviderDef
+  channels: NotificationChannelRow[]
+  onAdd: () => void
+  onDelete: (id: string) => void
+  deletingId: string | null
+}) {
+  const mine = channels.filter((ch) => ch.kind === provider.kind)
   return (
-    <MonoPill variant={connected ? 'good' : 'neutral'} dot>
-      {connected ? 'Connected' : 'Not connected'}
-    </MonoPill>
+    <div className="rounded-[8px] border border-border bg-bg-elev p-5 flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-[15px] font-medium text-text mb-1">{provider.name}</div>
+          <div className="text-[12.5px] text-text-muted leading-relaxed">{provider.description}</div>
+        </div>
+        {mine.length > 0
+          ? <MonoPill variant="good" dot>{mine.length} connected</MonoPill>
+          : <MonoPill variant="neutral" dot>Not connected</MonoPill>}
+      </div>
+
+      {mine.length > 0 && (
+        <div className="rounded-[6px] border border-border overflow-hidden">
+          {mine.map((ch) => (
+            <div
+              key={ch.id}
+              className="flex items-center gap-3 px-[12px] py-2.5 border-b border-border last:border-0"
+            >
+              <div className="min-w-0 flex-1">
+                {ch.label && (
+                  <div className="font-mono text-[12px] text-text truncate">{ch.label}</div>
+                )}
+                <div className="font-mono text-[11px] text-text-faint truncate">{maskTarget(ch.kind, ch.target)}</div>
+              </div>
+              <PermissionGate need="edit">
+                <button
+                  type="button"
+                  onClick={() => onDelete(ch.id)}
+                  disabled={deletingId === ch.id}
+                  title="Remove channel"
+                  className="text-text-faint hover:text-bad transition-colors p-1 disabled:opacity-40 shrink-0"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              </PermissionGate>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <PermissionGate need="edit">
+        <div className="mt-auto">
+          <GhostBtn className="text-[12px]" onClick={onAdd}>
+            <Plus className="w-3.5 h-3.5" /> Add {provider.name} channel
+          </GhostBtn>
+        </div>
+      </PermissionGate>
+    </div>
   )
 }
 
 function IntegrationsTab() {
-  const { data: channels } = useNotificationChannels()
-  const hasSlack   = (channels ?? []).some((ch) => ch.kind === 'slack')
-  const hasDiscord = (channels ?? []).some((ch) => ch.kind === 'discord')
+  const { data: channels, isLoading } = useNotificationChannels()
+  const deleteChannel = useDeleteChannel()
+  const [addKind, setAddKind] = useState<ChannelKind | null>(null)
 
-  const integrations = [
-    {
-      id: 'slack',
-      name: 'Slack',
-      description: 'Send alert notifications to a Slack channel via incoming webhook.',
-      connected: hasSlack,
-    },
-    {
-      id: 'discord',
-      name: 'Discord',
-      description: 'Send alert notifications to a Discord channel via incoming webhook.',
-      connected: hasDiscord,
-    },
-    {
-      id: 'pagerduty',
-      name: 'PagerDuty',
-      description: 'Route critical alerts to on-call engineers.',
-      coming: true,
-    },
-    {
-      id: 'datadog',
-      name: 'Datadog',
-      description: 'Forward metrics and traces to your Datadog account.',
-      coming: true,
-    },
-  ] as const
+  const allChannels = channels ?? []
 
   return (
     <div className="max-w-[980px]">
       <TabHeader
         title="Integrations"
-        description="Connect Spanlens with the tools your team already uses."
+        description="Connect Spanlens with the tools your team already uses. Channels here receive every alert you configure on the Alerts page."
       />
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        {integrations.map((integration) => (
-          <div
-            key={integration.id}
-            className="rounded-[8px] border border-border bg-bg-elev p-5 flex flex-col gap-3"
-          >
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <div className="text-[15px] font-medium text-text mb-1">{integration.name}</div>
-                <div className="text-[12.5px] text-text-muted leading-relaxed">{integration.description}</div>
-              </div>
-              {'coming' in integration && integration.coming ? (
+      {isLoading ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {[1, 2].map((i) => <div key={i} className="h-40 bg-bg-elev rounded-[8px] animate-pulse" />)}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {CHANNEL_PROVIDERS.map((provider) => (
+            <ProviderChannelCard
+              key={provider.kind}
+              provider={provider}
+              channels={allChannels}
+              onAdd={() => setAddKind(provider.kind)}
+              onDelete={(id) => void deleteChannel.mutateAsync(id)}
+              deletingId={deleteChannel.isPending ? (deleteChannel.variables ?? null) : null}
+            />
+          ))}
+
+          {COMING_SOON.map((integration) => (
+            <div
+              key={integration.id}
+              className="rounded-[8px] border border-border bg-bg-elev p-5 flex flex-col gap-3 opacity-75"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-[15px] font-medium text-text mb-1">{integration.name}</div>
+                  <div className="text-[12.5px] text-text-muted leading-relaxed">{integration.description}</div>
+                </div>
                 <MonoPill variant="faint">coming soon</MonoPill>
-              ) : (
-                <StatusPill connected={('connected' in integration) ? integration.connected : false} />
-              )}
-            </div>
-            {'coming' in integration && integration.coming ? null : (
-              <div className="mt-auto">
-                {('connected' in integration) && integration.connected ? (
-                  <GhostBtn
-                    className="text-[12px]"
-                    onClick={() => { window.location.href = '/alerts' }}
-                  >
-                    Manage in Alerts
-                  </GhostBtn>
-                ) : (
-                  <GhostBtn
-                    className="text-[12px]"
-                    onClick={() => { window.location.href = '/alerts' }}
-                  >
-                    Connect
-                  </GhostBtn>
-                )}
               </div>
-            )}
-          </div>
-        ))}
-      </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <AddChannelDialog
+        open={addKind !== null}
+        onOpenChange={(open) => { if (!open) setAddKind(null) }}
+        {...(addKind ? { fixedKind: addKind } : {})}
+      />
     </div>
   )
 }

--- a/apps/web/app/(dashboard)/users/users-client.tsx
+++ b/apps/web/app/(dashboard)/users/users-client.tsx
@@ -323,17 +323,7 @@ export function UsersClient() {
     <div className="-mx-4 -my-4 md:-mx-8 md:-my-7 flex flex-col min-h-screen">
       {/* Sticky topbar — same pattern as dashboard/requests/traces. */}
       <div className="sticky top-0 z-20 bg-bg">
-        <Topbar
-          crumbs={[{ label: 'Users' }]}
-          right={
-            <TimeRangeSelector
-              value={rangeParam}
-              onChange={(v) => onRangeChange(v as TimeRange)}
-              customRange={customRange}
-              onCustomRange={onCustomRange}
-            />
-          }
-        />
+        <Topbar crumbs={[{ label: 'Users' }]} />
         <h1 className="sr-only">Users</h1>
       </div>
 
@@ -383,14 +373,25 @@ export function UsersClient() {
         </div>
 
         {/* Filter bar — key={search} remounts the form so the local input
-            resets when URL search changes (e.g. back/forward navigation). */}
-        <SearchForm
-          key={search}
-          initialSearch={search}
-          hasActiveSearch={!!search}
-          onChange={onSearch}
-          onClear={() => updateQuery({ search: null, page: null })}
-        />
+            resets when URL search changes (e.g. back/forward navigation).
+            Time range selector sits at the far right of this row. */}
+        <div className="flex items-center gap-3 flex-wrap">
+          <div className="flex-1 min-w-0">
+            <SearchForm
+              key={search}
+              initialSearch={search}
+              hasActiveSearch={!!search}
+              onChange={onSearch}
+              onClear={() => updateQuery({ search: null, page: null })}
+            />
+          </div>
+          <TimeRangeSelector
+            value={rangeParam}
+            onChange={(v) => onRangeChange(v as TimeRange)}
+            customRange={customRange}
+            onCustomRange={onCustomRange}
+          />
+        </div>
 
         {/* Table — mobile hides Tokens & Avg latency cols; user ID expands. */}
         <div

--- a/apps/web/components/channels/add-channel-dialog.tsx
+++ b/apps/web/components/channels/add-channel-dialog.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { useState } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { useCreateChannel } from '@/lib/queries/use-alerts'
+import type { ChannelKind } from '@/lib/queries/types'
+
+interface AddChannelDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** When set, the kind picker is hidden and locked to this kind. */
+  fixedKind?: ChannelKind
+}
+
+const KIND_LABEL: Record<ChannelKind, string> = {
+  email: 'Email address',
+  slack: 'Slack webhook URL',
+  discord: 'Discord webhook URL',
+}
+
+const KIND_PLACEHOLDER: Record<ChannelKind, string> = {
+  email: 'alerts@yourco.com',
+  slack: 'https://hooks.slack.com/…',
+  discord: 'https://discord.com/api/webhooks/…',
+}
+
+/**
+ * Shared "add a notification channel" modal, used by Settings → Integrations
+ * (provider cards pass `fixedKind`) and by the Alerts empty-state shortcut.
+ * Channels are org-level, so wherever it's opened it writes the same row.
+ *
+ * Form state resets when the dialog closes (not via useEffect) so the
+ * react-hooks/set-state-in-effect rule stays happy and a re-open with a
+ * different fixedKind starts clean.
+ */
+export function AddChannelDialog({ open, onOpenChange, fixedKind }: AddChannelDialogProps) {
+  const createChannel = useCreateChannel()
+  const [kind, setKind] = useState<ChannelKind>('email')
+  const [target, setTarget] = useState('')
+  const [label, setLabel] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  // When fixedKind is provided the picker is hidden and we follow the prop
+  // directly — no stale state across re-opens for different providers.
+  const effectiveKind = fixedKind ?? kind
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      setKind('email')
+      setTarget('')
+      setLabel('')
+      setError(null)
+    }
+    onOpenChange(next)
+  }
+
+  async function handleSubmit() {
+    if (!target.trim()) return
+    setError(null)
+    try {
+      await createChannel.mutateAsync({
+        kind: effectiveKind,
+        target: target.trim(),
+        ...(label.trim() ? { label: label.trim() } : {}),
+      })
+      handleOpenChange(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add channel')
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {fixedKind ? `Add ${fixedKind} channel` : 'Add notification channel'}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 mt-2">
+          {!fixedKind && (
+            <div className="space-y-2">
+              <label className="font-mono text-[11px] text-text-muted uppercase tracking-[0.04em]">Kind</label>
+              <Select value={kind} onValueChange={(v) => setKind(v as ChannelKind)}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="email">Email (Resend)</SelectItem>
+                  <SelectItem value="slack">Slack webhook</SelectItem>
+                  <SelectItem value="discord">Discord webhook</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <label className="font-mono text-[11px] text-text-muted uppercase tracking-[0.04em]">
+              {KIND_LABEL[effectiveKind]}
+            </label>
+            <input
+              value={target}
+              onChange={(e) => setTarget(e.target.value)}
+              placeholder={KIND_PLACEHOLDER[effectiveKind]}
+              className="w-full h-9 px-3 rounded border border-border bg-bg text-[13px] focus:outline-none focus:border-border-strong"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="font-mono text-[11px] text-text-muted uppercase tracking-[0.04em]">
+              Label <span className="text-text-faint normal-case tracking-normal">· optional, e.g. #prod-alerts</span>
+            </label>
+            <input
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="Give this channel a name"
+              className="w-full h-9 px-3 rounded border border-border bg-bg text-[13px] focus:outline-none focus:border-border-strong"
+            />
+          </div>
+
+          {error && <div className="text-[12.5px] text-bad">{error}</div>}
+
+          <button
+            type="button"
+            onClick={() => void handleSubmit()}
+            disabled={!target.trim() || createChannel.isPending}
+            className="w-full py-2 rounded bg-text text-bg font-mono text-[13px] font-medium hover:opacity-90 transition-opacity disabled:opacity-40"
+          >
+            {createChannel.isPending ? 'Adding…' : 'Add channel'}
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/lib/demo-data.ts
+++ b/apps/web/lib/demo-data.ts
@@ -681,8 +681,8 @@ export const DEMO_ALERTS: AlertRow[] = [
 ]
 
 export const DEMO_CHANNELS: NotificationChannelRow[] = [
-  { id: 'ch-001', kind: 'email', target: 'haeseong@acme.com', is_active: true, created_at: day(14) },
-  { id: 'ch-002', kind: 'slack', target: 'https://hooks.slack.com/services/T00000/B000000/XXXXXXXX', is_active: true, created_at: day(10) },
+  { id: 'ch-001', kind: 'email', target: 'haeseong@acme.com', label: null, is_active: true, created_at: day(14) },
+  { id: 'ch-002', kind: 'slack', target: 'https://hooks.slack.com/services/T00000/B000000/XXXXXXXX', label: '#prod-alerts', is_active: true, created_at: day(10) },
 ]
 
 export const DEMO_DELIVERIES: AlertDeliveryRow[] = [

--- a/apps/web/lib/queries/types.ts
+++ b/apps/web/lib/queries/types.ts
@@ -304,8 +304,17 @@ export interface NotificationChannelRow {
   id: string
   kind: ChannelKind
   target: string
+  /** Optional human-readable name, e.g. "#prod-alerts". Null for older rows. */
+  label: string | null
   is_active: boolean
   created_at: string
+}
+
+/** Per-user email notification preferences (Settings → Notifications). */
+export interface UserNotificationPrefs {
+  security_alert_emails: boolean
+  marketing_emails: boolean
+  product_update_emails: boolean
 }
 
 export interface AlertDeliveryRow {

--- a/apps/web/lib/queries/use-alerts.ts
+++ b/apps/web/lib/queries/use-alerts.ts
@@ -91,7 +91,7 @@ export function useNotificationChannels() {
 export function useCreateChannel() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: async (input: { kind: ChannelKind; target: string }) => {
+    mutationFn: async (input: { kind: ChannelKind; target: string; label?: string }) => {
       const res = await apiPost<ApiEnvelope<NotificationChannelRow>>(
         '/api/v1/alerts/channels',
         input,

--- a/apps/web/lib/queries/use-notification-prefs.ts
+++ b/apps/web/lib/queries/use-notification-prefs.ts
@@ -1,0 +1,37 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiGet, apiPatch } from '@/lib/api'
+import type { ApiEnvelope, UserNotificationPrefs } from './types'
+
+export const notificationPrefsKey = ['me', 'notification-prefs'] as const
+
+/** GET /api/v1/me/notification-prefs — current user's email preferences. */
+export function useNotificationPrefs() {
+  return useQuery({
+    queryKey: notificationPrefsKey,
+    queryFn: async () => {
+      const res = await apiGet<ApiEnvelope<UserNotificationPrefs>>(
+        '/api/v1/me/notification-prefs',
+      )
+      return res.data
+    },
+  })
+}
+
+/** PATCH /api/v1/me/notification-prefs — update one or more toggles. */
+export function useUpdateNotificationPrefs() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (update: Partial<UserNotificationPrefs>) => {
+      const res = await apiPatch<ApiEnvelope<UserNotificationPrefs>>(
+        '/api/v1/me/notification-prefs',
+        update,
+      )
+      return res.data
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: notificationPrefsKey })
+    },
+  })
+}

--- a/supabase/migrations/20260529000000_notification_channels_label.sql
+++ b/supabase/migrations/20260529000000_notification_channels_label.sql
@@ -1,0 +1,15 @@
+-- Migration: notification_channels_label
+--
+-- Adds an optional human-readable label to notification channels so a
+-- workspace can run MULTIPLE channels of the same kind (e.g. two Slack
+-- webhooks, "#prod-alerts" and "#oncall") and tell them apart in the UI.
+--
+-- Until now the Integrations UI collapsed each kind to a single boolean
+-- ("Slack connected: yes/no"), even though the table already allowed many
+-- rows per kind. Surfacing them as a list means raw webhook URLs would be
+-- the only distinguisher, which are unreadable and partially secret. The
+-- label fixes that; it is nullable so existing rows and the email kind
+-- (where the address is already readable) need no backfill.
+
+ALTER TABLE notification_channels
+  ADD COLUMN IF NOT EXISTS label TEXT;

--- a/supabase/migrations/20260529000100_user_notification_prefs.sql
+++ b/supabase/migrations/20260529000100_user_notification_prefs.sql
@@ -1,0 +1,49 @@
+-- Migration: user_notification_prefs
+--
+-- Per-USER notification preferences (account-level), distinct from the
+-- org-level notification_channels which decide WHERE alerts physically go.
+-- This table decides what reaches a given person.
+--
+-- Boundary recap:
+--   notification_channels  (org)   — Slack/Discord/email endpoints, shared
+--   user_notification_prefs (user) — "what email does THIS person consent to"
+--
+-- All three columns default to true so existing users are opted in to the
+-- same emails they receive today (no silent behaviour change on deploy):
+--   * security_alert_emails  — stale-key digest + leak-detection alerts.
+--                              WIRED today: the senders skip admins who
+--                              turned this off.
+--   * marketing_emails       — product marketing / launch emails. A consent
+--                              record honoured by future marketing sends;
+--                              no such sender exists yet.
+--   * product_update_emails  — changelog / "what's new" emails. Same: stored
+--                              now, honoured when that sender ships.
+--
+-- Writes go through the server's service-role client at
+-- /api/v1/me/notification-prefs (JWT). Users may read only their own row;
+-- there are deliberately no INSERT/UPDATE/DELETE policies for the
+-- authenticated role (deny-by-default), mirroring user_consents.
+
+CREATE TABLE user_notification_prefs (
+  user_id               UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  security_alert_emails BOOLEAN NOT NULL DEFAULT true,
+  marketing_emails      BOOLEAN NOT NULL DEFAULT true,
+  product_update_emails BOOLEAN NOT NULL DEFAULT true,
+
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE user_notification_prefs ENABLE ROW LEVEL SECURITY;
+
+-- Users may read their own preferences.
+CREATE POLICY "user_notif_prefs_select_own" ON user_notification_prefs
+  FOR SELECT USING (user_id = auth.uid());
+
+-- No INSERT/UPDATE/DELETE policies: all writes go through the server's
+-- service-role client, which bypasses RLS. Authenticated/anon roles are
+-- denied by default.
+
+CREATE TRIGGER user_notification_prefs_updated_at BEFORE UPDATE ON user_notification_prefs
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -1,8 +1,3 @@
-WARN: environment variable is unset: SUPABASE_AUTH_EXTERNAL_GITHUB_CLIENT_ID
-WARN: environment variable is unset: SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET
-WARN: environment variable is unset: SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID
-WARN: environment variable is unset: SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET
-Initialising login role...
 export type Json =
   | string
   | number
@@ -12,11 +7,6 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "14.5"
-  }
   graphql_public: {
     Tables: {
       [_ in never]: never
@@ -1113,6 +1103,7 @@ export type Database = {
           id: string
           is_active: boolean
           kind: string
+          label: string | null
           organization_id: string
           target: string
           updated_at: string
@@ -1122,6 +1113,7 @@ export type Database = {
           id?: string
           is_active?: boolean
           kind: string
+          label?: string | null
           organization_id: string
           target: string
           updated_at?: string
@@ -1131,6 +1123,7 @@ export type Database = {
           id?: string
           is_active?: boolean
           kind?: string
+          label?: string | null
           organization_id?: string
           target?: string
           updated_at?: string
@@ -2098,6 +2091,33 @@ export type Database = {
         }
         Relationships: []
       }
+      user_notification_prefs: {
+        Row: {
+          created_at: string
+          marketing_emails: boolean
+          product_update_emails: boolean
+          security_alert_emails: boolean
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          marketing_emails?: boolean
+          product_update_emails?: boolean
+          security_alert_emails?: boolean
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          marketing_emails?: boolean
+          product_update_emails?: boolean
+          security_alert_emails?: boolean
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       user_profiles: {
         Row: {
           created_at: string
@@ -2458,5 +2478,4 @@ export const Constants = {
     },
   },
 } as const
-A new version of Supabase CLI is available: v2.101.0 (currently installed v2.90.0)
-We recommend updating regularly for new features and bug fixes: https://supabase.com/docs/guides/cli/getting-started#updating-the-supabase-cli
+


### PR DESCRIPTION
## Summary
Reworks the Settings → Connect/Notifications area and makes the previously-dormant outbound webhook system actually fire.

### 1. Notification channels → Integrations (`4ee4e01`)
- Channels (Slack/Discord/email) are org-level, so Settings → Integrations is now their canonical home, with provider-centric cards that support multiple channels per kind.
- Alerts page keeps a read-only channel summary + a "Manage channels" link; channel CRUD is extracted into a shared `AddChannelDialog`.
- New nullable `notification_channels.label` so same-kind channels are distinguishable; duplicate (kind, target) on create returns 409.

### 2. Per-user notification preferences (`4ee4e01`)
- New `user_notification_prefs` table + `/api/v1/me/notification-prefs` (JWT) surfaced on Settings → Notifications.
- Security alert emails (stale-key digest, leak detection) now honour each admin's `security_alert_emails` opt-out via `getAdminEmails`.

### 3. Outbound webhook events (`2a61933`)
- The webhook delivery pipeline existed but no event was ever fired outside the manual `/test`, so subscribed webhooks silently never delivered.
- New `lib/webhook-emit.ts` (best-effort emitter + short-TTL in-memory SWR cache so the `request.created` hot path costs ~nothing for orgs with no webhook).
- Wired at source: `request.created` (logger), `trace.completed` (ingest, fireAndForget), `alert.triggered` (alert cron). Webhook CRUD invalidates the cache.

### 4. Housekeeping
- `chore` (`69e701e`): gitignore Claude worktrees + local scratch.
- `feat(web)` (`f41aa42`): move TimeRangeSelector inline beside Export across dashboard/savings/security/users.

## Test plan
- [x] `pnpm --filter web typecheck` — pass
- [x] `pnpm --filter server test` — 563 pass (incl. 9 new webhook-emit tests)
- [x] web + server `lint` — clean
- [x] Migrations applied locally (`supabase migration up --local`); schema + RLS + functional inserts verified against local DB
- [ ] Pre-existing `openapi-types` typecheck error remains (missing dev dep; unrelated to this PR)

## Deploy note
Includes two Supabase migrations (`20260529000000_notification_channels_label`, `20260529000100_user_notification_prefs`). The server client is untyped so it compiles without them, but **run `supabase db push` before/at deploy** or the Integrations "Add channel" (label) and Notifications tab will error at runtime.