### PR TITLE
fix(server): return real dispatch result from webhook test endpoint

### DIFF
--- a/apps/server/src/api/webhooks.ts
+++ b/apps/server/src/api/webhooks.ts
@@ -171,13 +171,21 @@ webhooksRouter.post('/:id/test', requireEdit, async (c) => {
 
   if (fetchError || !webhook) return c.json({ error: 'Webhook not found' }, 404)
 
-  await dispatchWebhookEvent(
+  const result = await dispatchWebhookEvent(
     { id: webhook.id as string, url: webhook.url as string, secret: webhook.secret as string },
     'test',
     {},
   )
 
-  return c.json({ success: true, data: { dispatched: true } })
+  return c.json({
+    success: true,
+    data: {
+      status: result.ok ? 'success' : 'failed',
+      http_status: result.httpStatus,
+      error_message: result.errorMessage,
+      duration_ms: result.durationMs,
+    },
+  })
 })
 
 // ── GET /api/v1/webhooks/:id/deliveries ─────────────────────────

--- a/apps/server/src/lib/webhook-dispatch.ts
+++ b/apps/server/src/lib/webhook-dispatch.ts
@@ -90,13 +90,14 @@ export async function sendWebhook(
  * Dispatches an event to a single webhook endpoint and writes a delivery record.
  *
  * On failure, sets `next_retry_at` for the first attempt so the retry cron
- * can pick it up. Returns the created delivery row ID.
+ * can pick it up. Returns the delivery result along with the created delivery
+ * row ID (empty string if the insert failed).
  */
 export async function dispatchWebhookEvent(
   webhook: WebhookRow,
   eventType: string,
   payloadObj: Record<string, unknown>,
-): Promise<string> {
+): Promise<DispatchResult & { deliveryId: string }> {
   const fullPayload = {
     ...payloadObj,
     event: eventType,
@@ -130,7 +131,13 @@ export async function dispatchWebhookEvent(
     .select('id')
     .single()
 
-  return (data as { id: string } | null)?.id ?? ''
+  return {
+    ok,
+    httpStatus,
+    errorMessage,
+    durationMs,
+    deliveryId: (data as { id: string } | null)?.id ?? '',
+  }
 }
 
 /**


### PR DESCRIPTION
@
## Problem

Clicking **Test** on a webhook (Settings → Webhooks) successfully delivers the event (verified: real HTTP POST + valid HMAC signature arrive at the receiver, and Delivery history shows `SUCCESS / HTTP 200`), but the inline **"Last test result"** line rendered:

```
undefined · HTTP — · undefinedms
```

## Root cause

A server/client contract mismatch:

- `POST /api/v1/webhooks/:id/test` returned `{ dispatched: true }`, discarding the dispatch outcome.
- The web client (`useTestWebhook` / `handleTest`) expects `{ status, http_status, error_message, duration_ms }` to build the result string, so every field was `undefined`.

The delivery itself, the `webhook_deliveries` record, and the Delivery history were all unaffected. Only the immediate echo line was broken.

## Fix

- `dispatchWebhookEvent` now returns the `DispatchResult` (already computed by `sendWebhook`: `ok`, `httpStatus`, `errorMessage`, `durationMs`) alongside the `deliveryId`. Both existing callers ignored the previous return value, so this is non-breaking.
- The `/test` endpoint shapes its response to match the client contract: `{ status, http_status, error_message, duration_ms }`.

No web changes needed: the client already expected this shape.

## Test plan

- [x] `pnpm --filter server typecheck` (clean)
- [x] `pnpm --filter server lint`
- [x] `pnpm --filter server test` (563 passed, incl. openapi-drift)
- [x] Local: clicked Test in the dashboard, "Last test result" now shows `success · HTTP 200 · 1216ms`
- [x] Verified end-to-end against a real receiver (payload + HMAC signature) on both local and production before the fix; this PR only corrects the UI echo
@