### PR TITLE
feat(web): add Feedback link to demo sidebar

### DIFF
--- a/apps/web/app/demo/feedback/page.tsx
+++ b/apps/web/app/demo/feedback/page.tsx
@@ -1,0 +1,96 @@
+'use client'
+import { useState } from 'react'
+import Link from 'next/link'
+import { Lightbulb, Bug, MessageSquarePlus } from 'lucide-react'
+import { Topbar } from '@/components/layout/topbar'
+import { cn } from '@/lib/utils'
+
+const MAX_LEN = 4000
+
+const CATEGORIES: { value: string; label: string; icon: typeof Lightbulb }[] = [
+  { value: 'feature', label: 'Feature idea', icon: Lightbulb },
+  { value: 'bug', label: 'Bug report', icon: Bug },
+  { value: 'other', label: 'Other', icon: MessageSquarePlus },
+]
+
+// Demo mockup of the real /feedback page. Read-only: there is no logged-in
+// account to submit as, so the category picker reflects local state but the
+// message box and submit button are disabled and point visitors to signup.
+export default function DemoFeedbackPage() {
+  const [category, setCategory] = useState('feature')
+
+  return (
+    <div className="-mx-4 -my-4 md:-mx-8 md:-my-7 flex flex-col min-h-screen">
+      <div className="sticky top-0 z-20 bg-bg">
+        <Topbar crumbs={[{ label: 'Demo' }, { label: 'Feedback' }]} />
+        <h1 className="sr-only">Feedback</h1>
+      </div>
+
+      <div className="flex flex-col gap-6 px-[22px] py-[22px] max-w-2xl w-full">
+        <div>
+          <h2 className="font-medium text-[20px] tracking-[-0.3px] text-text">Feedback</h2>
+          <p className="font-mono text-[11.5px] text-text-faint mt-1.5">
+            Tell us what would make Spanlens better. Feature ideas, bugs, anything. It goes straight to the team.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-5">
+          {/* Category */}
+          <div className="flex flex-col gap-2">
+            <label className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+              Category
+            </label>
+            <div className="flex gap-2 flex-wrap">
+              {CATEGORIES.map(({ value, label, icon: Icon }) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setCategory(value)}
+                  className={cn(
+                    'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[6px] border font-mono text-[11.5px] transition-colors',
+                    category === value
+                      ? 'border-accent text-accent bg-accent-bg'
+                      : 'border-border text-text-muted hover:text-text hover:border-border-strong',
+                  )}
+                >
+                  <Icon className="h-3.5 w-3.5" />
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Message */}
+          <div className="flex flex-col gap-2">
+            <label htmlFor="feedback-message" className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
+              Your message
+            </label>
+            <textarea
+              id="feedback-message"
+              disabled
+              readOnly
+              rows={8}
+              placeholder="I'd love it if Spanlens could…"
+              className="w-full resize-y rounded-[6px] border border-border bg-bg px-3 py-2.5 font-mono text-[12.5px] text-text-muted placeholder:text-text-faint focus:outline-none cursor-not-allowed leading-relaxed"
+            />
+            <div className="flex items-center justify-end">
+              <span className="font-mono text-[10.5px] text-text-faint">0 / {MAX_LEN}</span>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Link
+              href="/signup"
+              className="font-mono text-[12px] px-4 py-2 rounded-[6px] bg-text text-bg hover:opacity-90 transition-opacity"
+            >
+              Sign up to send feedback →
+            </Link>
+            <span className="font-mono text-[10.5px] text-text-faint">
+              Feedback is submitted as your account, so we can follow up.
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/layout/demo-sidebar.tsx
+++ b/apps/web/components/layout/demo-sidebar.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import { useTheme } from 'next-themes'
-import { Sun, Moon, Monitor, X } from 'lucide-react'
+import { Sun, Moon, Monitor, X, MessageSquarePlus } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useSidebar } from '@/lib/sidebar-context'
 
@@ -252,8 +252,21 @@ function SidebarContent() {
         </Link>
       </div>
 
-      {/* Theme + Sign out */}
+      {/* Feedback + Theme + Sign out */}
       <div className="px-[14px] pb-[14px] space-y-0.5">
+        <Link
+          href="/demo/feedback"
+          prefetch={false}
+          className={cn(
+            'flex w-full items-center gap-2 px-[10px] py-[6px] rounded-[5px] text-[13px] transition-colors',
+            pathname === '/demo/feedback' || pathname.startsWith('/demo/feedback/')
+              ? 'bg-bg-muted text-text font-medium'
+              : 'text-text-muted hover:bg-bg-muted hover:text-text',
+          )}
+        >
+          <MessageSquarePlus className="h-3.5 w-3.5 shrink-0" />
+          <span>Feedback</span>
+        </Link>
         <ThemeToggleButton />
         <button
           onClick={handleSignOut}


### PR DESCRIPTION
## Summary

라이브 사이드바(`apps/web/components/layout/sidebar.tsx`)의 푸터에는 Feedback 링크가 있지만 방문자용 데모 사이드바에는 없어 일관성이 빠져 있었습니다. 데모 사이드바 푸터(테마 토글 위)에 동일한 스타일의 Feedback 링크를 추가했습니다.

데모는 비로그인 방문자용이므로 실제 제출 페이지(`/feedback`, JWT 필요)로 보내지 않고, 기존 데모 패턴(읽기전용 목업 + signup CTA)을 따라 새 `/demo/feedback` 목업 페이지로 연결했습니다.

## Changes

- **`apps/web/components/layout/demo-sidebar.tsx`** — 푸터에 `MessageSquarePlus` 아이콘 + Feedback 링크 추가. 라이브 사이드바와 동일한 스타일/active 상태 처리, `prefetch={false}`. href만 `/demo/feedback`.
- **`apps/web/app/demo/feedback/page.tsx`** (신규) — 실제 feedback 페이지 레이아웃을 미러링한 읽기전용 목업. 카테고리 선택은 로컬 상태로 동작하지만 textarea는 disabled, 제출 버튼은 signup CTA(`/signup`)로 대체. `useSubmitFeedback`/JWT 호출 없음.

## Test plan

- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint`
- [ ] 데모(`/demo/*`) 진입 후 사이드바 Feedback 링크 클릭 → `/demo/feedback` 목업 렌더 확인
- [ ] 제출 버튼이 `/signup`으로 연결되는지 확인
