### PR TITLE
chore(db): regenerate types.ts after feedback migration

### DIFF
--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -899,6 +899,50 @@ export type Database = {
           },
         ]
       }
+      feedback: {
+        Row: {
+          category: string
+          created_at: string
+          email: string | null
+          id: string
+          message: string
+          organization_id: string | null
+          source: string
+          status: string
+          user_id: string | null
+        }
+        Insert: {
+          category?: string
+          created_at?: string
+          email?: string | null
+          id?: string
+          message: string
+          organization_id?: string | null
+          source?: string
+          status?: string
+          user_id?: string | null
+        }
+        Update: {
+          category?: string
+          created_at?: string
+          email?: string | null
+          id?: string
+          message?: string
+          organization_id?: string | null
+          source?: string
+          status?: string
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "feedback_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       human_evals: {
         Row: {
           comment: string | null


### PR DESCRIPTION
@
## Summary

Regenerates `supabase/types.ts` via `supabase gen types` after the `feedback` table migration (`20260530120000_feedback.sql`) from #162.

The migration has been applied to **local + production** (`supabase db push --linked`). This PR brings the committed types in sync with the live schema, per the CLAUDE.md rule "마이그레이션 실행 후 반드시 supabase gen types 재실행".

Diff is scoped to the `feedback` table types only (Row/Insert/Update, +44 lines). No other tables changed.

## Test plan
- [x] `pnpm --filter server typecheck` passes against regenerated types
- [x] Migration history synced local ↔ remote (`supabase migration list --linked`)
@