### PR TITLE
feat(web): scale dashboard UI to 125% via zoom

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -66,7 +66,14 @@ export default async function DashboardLayout({ children }: { children: React.Re
     <CommandPaletteProvider>
       <SidebarProvider>
         <HydrationBoundary state={sidebarState}>
-          <div className="flex h-screen overflow-hidden bg-bg">
+          {/* Dashboard renders at 125% scale (zoom) for a roomier default
+              view. Height is divided by the SAME factor so the zoomed
+              container still resolves to exactly one viewport height — without
+              the correction, 100vh * 1.25 would overflow and add a stray
+              scrollbar. The zoom factor and the height divisor must always
+              match. Scoped to the dashboard only; landing/docs/demo keep
+              their 100% scale. */}
+          <div className="flex h-[calc(100vh/1.25)] overflow-hidden bg-bg [zoom:1.25]">
             <Sidebar />
             <main className="flex-1 overflow-y-auto min-w-0">
               {/* Pending workspace invitations surface here: any dashboard


### PR DESCRIPTION
## Summary

Apply a `1.25` CSS zoom to the `(dashboard)` layout container so the logged-in dashboard renders at 125% scale by default, giving a roomier view without users needing to touch browser zoom. Scoped to the dashboard only; landing, docs, and demo keep their 100% scale.

## Implementation

`apps/web/app/(dashboard)/layout.tsx` (single container):

```
- <div className="flex h-screen overflow-hidden bg-bg">
+ <div className="flex h-[calc(100vh/1.25)] overflow-hidden bg-bg [zoom:1.25]">
```

- `[zoom:1.25]` scales the whole subtree (sidebar, cards, charts, fonts, spacing) proportionally.
- `h-[calc(100vh/1.25)]` divides the height by the same factor. Chrome's `zoom` does **not** auto-adjust `vh`, so a plain `100vh` under `zoom:1.25` renders physically as 125vh and overflows. The divisor must always match the zoom factor.
- Tailwind arbitrary properties keep it in `className` (no inline styles).

## Verification

- `pnpm --filter web typecheck` passed
- `pnpm --filter web lint` passed
- Empirically measured Chrome `zoom`+`vh` behavior at 1280x800: `calc(100vh/factor)` + `zoom:factor` resolves to exactly one viewport height (no stray scrollbar); plain `100vh` overflows by the zoom factor.

## Known limitation

CSS `zoom` does not scale `document.body`-level portals (command palette, modals, toasts), so those overlays stay at 100% while the dashboard body is at 125%. Tracked for a follow-up if needed.