### PR TITLE
feat(web): add collapsible sidebar toggle on desktop

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -2,6 +2,8 @@ import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { HydrationBoundary } from '@tanstack/react-query'
 import { Sidebar } from '@/components/layout/sidebar'
+import { SidebarShowToggle } from '@/components/layout/sidebar-show-toggle'
+import { DashboardContent } from '@/components/layout/dashboard-content'
 import { PendingInvitationsBanner } from '@/components/layout/pending-invitations-banner'
 import { SidebarProvider } from '@/lib/sidebar-context'
 import { CommandPaletteProvider } from '@/components/command-palette'
@@ -75,13 +77,16 @@ export default async function DashboardLayout({ children }: { children: React.Re
               their 100% scale. */}
           <div className="flex h-[calc(100vh/1.25)] overflow-hidden bg-bg [zoom:1.25]">
             <Sidebar />
+            {/* Brings the sidebar back when it's collapsed to zero width.
+                Renders nothing while the sidebar is visible. */}
+            <SidebarShowToggle />
             <main className="flex-1 overflow-y-auto min-w-0">
               {/* Pending workspace invitations surface here: any dashboard
                   page renders this banner at the top, so a user who never
                   clicked the email link still sees the invite waiting for
                   them. Self-hides when there are none / after dismissal. */}
               <PendingInvitationsBanner />
-              <div className="px-4 py-4 md:px-8 md:py-7">{children}</div>
+              <DashboardContent>{children}</DashboardContent>
             </main>
           </div>
         </HydrationBoundary>

--- a/apps/web/components/layout/dashboard-content.tsx
+++ b/apps/web/components/layout/dashboard-content.tsx
@@ -1,0 +1,25 @@
+'use client'
+import { useSidebar } from '@/lib/sidebar-context'
+import { cn } from '@/lib/utils'
+
+/**
+ * Content padding wrapper that reacts to the desktop sidebar collapse state.
+ * When the sidebar is hidden, the floating "show sidebar" button sits at the
+ * top-left of this area; without extra clearance it overlaps the page's own
+ * header (e.g. the "Dashboard" breadcrumb). We add left padding on desktop
+ * while collapsed so the button always has its own gutter. Mobile is
+ * unaffected (the button is desktop-only).
+ */
+export function DashboardContent({ children }: { children: React.ReactNode }) {
+  const { isCollapsed } = useSidebar()
+  return (
+    <div
+      className={cn(
+        'px-4 py-4 md:py-7 md:pr-8',
+        isCollapsed ? 'md:pl-16' : 'md:pl-8',
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/apps/web/components/layout/sidebar-show-toggle.tsx
+++ b/apps/web/components/layout/sidebar-show-toggle.tsx
@@ -1,0 +1,27 @@
+'use client'
+import { PanelLeft } from 'lucide-react'
+import { useSidebar } from '@/lib/sidebar-context'
+
+/**
+ * Floating "show sidebar" control. When the desktop sidebar is collapsed to
+ * zero width there's no in-sidebar button left to bring it back, so we surface
+ * this small fixed button at the top-left of the content area. Desktop-only
+ * (md:): mobile uses the drawer + its own X, and never sets `isCollapsed`.
+ */
+export function SidebarShowToggle() {
+  const { isCollapsed, toggleCollapsed } = useSidebar()
+
+  if (!isCollapsed) return null
+
+  return (
+    <button
+      type="button"
+      onClick={toggleCollapsed}
+      aria-label="Show sidebar"
+      title="Show sidebar"
+      className="hidden md:inline-flex fixed left-3 top-3 z-30 items-center justify-center p-1.5 rounded-[6px] border border-border bg-bg-elev text-text-faint shadow-sm hover:text-text hover:bg-bg-muted transition-colors"
+    >
+      <PanelLeft size={16} />
+    </button>
+  )
+}

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { useTheme } from '@/components/providers/theme-provider'
-import { Sun, Moon, Monitor, X, MessageSquarePlus } from 'lucide-react'
+import { Sun, Moon, Monitor, X, MessageSquarePlus, PanelLeftClose } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { createClient } from '@/lib/supabase/client'
 import { useStatsOverview } from '@/lib/queries/use-stats'
@@ -294,7 +294,7 @@ export function Sidebar() {
   const anomalies = useAnomalies({ observationHours: 24 })
   const alerts = useAlerts()
   const recommendations = useRecommendations({ hours: 24 })
-  const { isOpen, close } = useSidebar()
+  const { isOpen, close, isCollapsed, toggleCollapsed } = useSidebar()
   // Capture "now" once at mount — drives the "firing in last hour" badge.
   // Tanstack query refetches refresh `alerts.data`, so a fixed anchor here
   // is fine for the small UI sliver this affects.
@@ -354,8 +354,12 @@ export function Sidebar() {
           'fixed inset-y-0 left-0 z-50 w-[272px] h-screen',
           'transition-transform duration-200 ease-in-out',
           isOpen ? 'translate-x-0' : '-translate-x-full',
-          // Desktop: back in flow, always visible
-          'md:relative md:w-56 md:shrink-0 md:translate-x-0 md:transition-none',
+          // Desktop: back in flow. Width animates between full (w-56) and
+          // hidden (w-0) so the "hide sidebar" toggle collapses it smoothly;
+          // overflow-hidden clips the content while it's at zero width.
+          'md:relative md:shrink-0 md:translate-x-0',
+          'md:transition-[width] md:duration-200 md:ease-in-out',
+          isCollapsed ? 'md:w-0 md:overflow-hidden md:border-r-0' : 'md:w-56',
         )}
       >
       {/* Mobile close button */}
@@ -368,9 +372,20 @@ export function Sidebar() {
         <X size={16} />
       </button>
 
-      {/* Logo */}
-      <div className="px-[18px] pt-[18px] pb-3">
+      {/* Logo + desktop hide toggle. The hide button is desktop-only
+          (md:inline-flex) because mobile already closes via the drawer X
+          above; on desktop it collapses the sidebar to zero width. */}
+      <div className="px-[18px] pt-[18px] pb-3 flex items-center justify-between gap-2">
         <LogoMark />
+        <button
+          type="button"
+          onClick={toggleCollapsed}
+          className="hidden md:inline-flex shrink-0 p-1 rounded-[5px] text-text-faint hover:text-text hover:bg-bg-muted transition-colors"
+          aria-label="Hide sidebar"
+          title="Hide sidebar"
+        >
+          <PanelLeftClose size={16} />
+        </button>
       </div>
 
       {/* Workspace / project switcher */}

--- a/apps/web/lib/sidebar-context.tsx
+++ b/apps/web/lib/sidebar-context.tsx
@@ -1,26 +1,98 @@
 'use client'
-import { createContext, useContext, useState, type ReactNode } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from 'react'
+
+const COLLAPSE_STORAGE_KEY = 'sidebar-collapsed'
+
+/* ── Desktop collapse: localStorage-backed external store ──
+ *
+ * The desktop hide/show preference lives in localStorage so it survives
+ * reloads. We read it through useSyncExternalStore rather than a
+ * useEffect+setState dance: that keeps SSR safe (getServerSnapshot returns the
+ * default), avoids the react-hooks/set-state-in-effect lint rule, and gives
+ * cross-tab sync for free via the `storage` event.
+ */
+function readCollapsed(): boolean {
+  try {
+    return localStorage.getItem(COLLAPSE_STORAGE_KEY) === '1'
+  } catch {
+    // localStorage can throw in private-mode / blocked-cookie contexts.
+    return false
+  }
+}
+
+const collapseListeners = new Set<() => void>()
+
+function subscribeCollapsed(callback: () => void): () => void {
+  collapseListeners.add(callback)
+  window.addEventListener('storage', callback)
+  return () => {
+    collapseListeners.delete(callback)
+    window.removeEventListener('storage', callback)
+  }
+}
+
+function writeCollapsed(next: boolean): void {
+  try {
+    localStorage.setItem(COLLAPSE_STORAGE_KEY, next ? '1' : '0')
+  } catch {
+    // Ignore persistence failures — the in-memory snapshot still updates.
+  }
+  // `storage` events don't fire in the tab that made the change, so notify
+  // this tab's subscribers explicitly.
+  collapseListeners.forEach((l) => l())
+}
 
 interface SidebarContextValue {
+  /** Mobile drawer open/closed. Desktop ignores this (sidebar is in-flow). */
   isOpen: boolean
   toggle: () => void
   close: () => void
+  /**
+   * Desktop hide/show. Independent from `isOpen` on purpose: the mobile
+   * drawer and the desktop hide are two different behaviors, and mixing them
+   * into one flag leads to "closed the drawer on mobile, sidebar vanished on
+   * desktop" cross-talk. Persisted to localStorage. SSR + first paint default
+   * to `false` (visible); a collapsed user sees a one-frame flash of the
+   * sidebar before it hides, which we accept for simplicity.
+   */
+  isCollapsed: boolean
+  toggleCollapsed: () => void
 }
 
 const SidebarContext = createContext<SidebarContextValue>({
   isOpen: false,
   toggle: () => {},
   close: () => {},
+  isCollapsed: false,
+  toggleCollapsed: () => {},
 })
 
 export function SidebarProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false)
+
+  // Server snapshot is always `false` (visible) — there's no localStorage on
+  // the server. The client snapshot reads the stored value after hydration.
+  const isCollapsed = useSyncExternalStore(subscribeCollapsed, readCollapsed, () => false)
+
+  const toggleCollapsed = useCallback(() => {
+    writeCollapsed(!readCollapsed())
+  }, [])
+
   return (
     <SidebarContext.Provider
       value={{
         isOpen,
         toggle: () => setIsOpen((v) => !v),
         close: () => setIsOpen(false),
+        isCollapsed,
+        toggleCollapsed,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary

Users can now hide the dashboard sidebar to get a wider content area.

- **Hide:** a `PanelLeftClose` button in the sidebar header collapses it to zero width on desktop (smooth `width` transition).
- **Show:** a floating `PanelLeft` button at the top-left of the content area brings it back.
- **Persisted:** the collapse preference survives reloads via `localStorage`, read through `useSyncExternalStore` (SSR-safe, plus cross-tab sync for free).
- **Desktop-only:** mobile keeps its existing drawer behavior; `isCollapsed` is kept separate from the mobile `isOpen` flag to avoid cross-talk.

## Files

- `lib/sidebar-context.tsx` — adds `isCollapsed` / `toggleCollapsed` backed by an external localStorage store.
- `components/layout/sidebar.tsx` — hide button in the logo row; `<aside>` collapses to `md:w-0 md:overflow-hidden md:border-r-0` when hidden.
- `components/layout/sidebar-show-toggle.tsx` (new) — floating show button, rendered only while collapsed.
- `components/layout/dashboard-content.tsx` (new) — content padding wrapper that widens its left gutter while collapsed so the floating button never overlaps a page header (e.g. the "Dashboard" breadcrumb).
- `app/(dashboard)/layout.tsx` — wires in the new components.

## Verification

- `pnpm --filter web typecheck` passed
- `pnpm --filter web lint` passed