### PR TITLE
fix(web): scale dashboard overlays to 125% and remove sidebar collapse flash

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -1,4 +1,4 @@
-import { headers } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { HydrationBoundary } from '@tanstack/react-query'
 import { Sidebar } from '@/components/layout/sidebar'
@@ -6,6 +6,8 @@ import { SidebarShowToggle } from '@/components/layout/sidebar-show-toggle'
 import { DashboardContent } from '@/components/layout/dashboard-content'
 import { PendingInvitationsBanner } from '@/components/layout/pending-invitations-banner'
 import { SidebarProvider } from '@/lib/sidebar-context'
+import { SIDEBAR_COLLAPSED_COOKIE } from '@/lib/sidebar-cookie'
+import { OverlayContainerProvider, OverlayContainerTarget } from '@/lib/overlay-container'
 import { CommandPaletteProvider } from '@/components/command-palette'
 import { prefetchAll } from '@/lib/server/dehydrate'
 import { sidebarSpecs } from '@/lib/server/queries/sidebar'
@@ -64,33 +66,47 @@ export default async function DashboardLayout({ children }: { children: React.Re
 
   const sidebarState = await prefetchAll(sidebarSpecs())
 
+  // Seed the desktop collapse state from the cookie so SSR renders the right
+  // layout on first paint (no flash of the sidebar before hydration).
+  const cookieStore = await cookies()
+  const initialCollapsed = cookieStore.get(SIDEBAR_COLLAPSED_COOKIE)?.value === '1'
+
   return (
-    <CommandPaletteProvider>
-      <SidebarProvider>
-        <HydrationBoundary state={sidebarState}>
-          {/* Dashboard renders at 125% scale (zoom) for a roomier default
-              view. Height is divided by the SAME factor so the zoomed
-              container still resolves to exactly one viewport height — without
-              the correction, 100vh * 1.25 would overflow and add a stray
-              scrollbar. The zoom factor and the height divisor must always
-              match. Scoped to the dashboard only; landing/docs/demo keep
-              their 100% scale. */}
-          <div className="flex h-[calc(100vh/1.25)] overflow-hidden bg-bg [zoom:1.25]">
-            <Sidebar />
-            {/* Brings the sidebar back when it's collapsed to zero width.
-                Renders nothing while the sidebar is visible. */}
-            <SidebarShowToggle />
-            <main className="flex-1 overflow-y-auto min-w-0">
-              {/* Pending workspace invitations surface here: any dashboard
-                  page renders this banner at the top, so a user who never
-                  clicked the email link still sees the invite waiting for
-                  them. Self-hides when there are none / after dismissal. */}
-              <PendingInvitationsBanner />
-              <DashboardContent>{children}</DashboardContent>
-            </main>
-          </div>
-        </HydrationBoundary>
-      </SidebarProvider>
-    </CommandPaletteProvider>
+    // OverlayContainerProvider must sit above CommandPaletteProvider so the
+    // palette (and Radix dialogs) can read the portal target; the target node
+    // itself lives inside the zoom wrapper below, so overlays inherit the 125%
+    // scale instead of rendering at 100% off the document body.
+    <OverlayContainerProvider>
+      <CommandPaletteProvider>
+        <SidebarProvider initialCollapsed={initialCollapsed}>
+          <HydrationBoundary state={sidebarState}>
+            {/* Dashboard renders at 125% scale (zoom) for a roomier default
+                view. Height is divided by the SAME factor so the zoomed
+                container still resolves to exactly one viewport height — without
+                the correction, 100vh * 1.25 would overflow and add a stray
+                scrollbar. The zoom factor and the height divisor must always
+                match. Scoped to the dashboard only; landing/docs/demo keep
+                their 100% scale. */}
+            <div className="flex h-[calc(100vh/1.25)] overflow-hidden bg-bg [zoom:1.25]">
+              <Sidebar />
+              {/* Brings the sidebar back when it's collapsed to zero width.
+                  Renders nothing while the sidebar is visible. */}
+              <SidebarShowToggle />
+              <main className="flex-1 overflow-y-auto min-w-0">
+                {/* Pending workspace invitations surface here: any dashboard
+                    page renders this banner at the top, so a user who never
+                    clicked the email link still sees the invite waiting for
+                    them. Self-hides when there are none / after dismissal. */}
+                <PendingInvitationsBanner />
+                <DashboardContent>{children}</DashboardContent>
+              </main>
+              {/* Portal target for dialogs / command palette — inside the zoom
+                  wrapper so overlays render at the same 125% scale. */}
+              <OverlayContainerTarget />
+            </div>
+          </HydrationBoundary>
+        </SidebarProvider>
+      </CommandPaletteProvider>
+    </OverlayContainerProvider>
   )
 }

--- a/apps/web/components/command-palette-dialog.tsx
+++ b/apps/web/components/command-palette-dialog.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import React from 'react'
+import { createPortal } from 'react-dom'
 import { useRouter } from 'next/navigation'
+import { useOverlayContainer } from '@/lib/overlay-container'
 import {
   Command,
   CommandEmpty,
@@ -39,13 +41,16 @@ interface Props {
 
 export function CommandPaletteDialog({ navGroups, onClose }: Props) {
   const router = useRouter()
+  // Portal into the dashboard's zoom wrapper so the palette scales with the
+  // rest of the UI. Falls back to body (100%) if the target isn't mounted.
+  const container = useOverlayContainer()
 
   function handleSelect(href: string) {
     router.push(href)
     onClose()
   }
 
-  return (
+  return createPortal(
     <>
       {/* Backdrop */}
       <div
@@ -79,6 +84,7 @@ export function CommandPaletteDialog({ navGroups, onClose }: Props) {
           </CommandList>
         </Command>
       </div>
-    </>
+    </>,
+    container ?? document.body,
   )
 }

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { X } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useOverlayContainer } from '@/lib/overlay-container'
 
 const Dialog = DialogPrimitive.Root
 const DialogTrigger = DialogPrimitive.Trigger
@@ -24,8 +25,12 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPortal>
+>(({ className, children, ...props }, ref) => {
+  // On the dashboard this routes the portal into the zoom wrapper so the
+  // modal scales with the rest of the UI; null elsewhere → default body portal.
+  const container = useOverlayContainer()
+  return (
+  <DialogPortal container={container ?? undefined}>
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
@@ -42,7 +47,8 @@ const DialogContent = React.forwardRef<
       </DialogClose>
     </DialogPrimitive.Content>
   </DialogPortal>
-))
+  )
+})
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (

--- a/apps/web/lib/overlay-container.tsx
+++ b/apps/web/lib/overlay-container.tsx
@@ -1,0 +1,43 @@
+'use client'
+import { createContext, useContext, useState, type ReactNode } from 'react'
+
+/**
+ * Portal target for dashboard overlays (dialogs, command palette).
+ *
+ * The dashboard renders at 125% via CSS `zoom` on its layout container, but
+ * React portals (Radix dialogs) and inline command-palette overlays escape to
+ * `document.body` / the providers above the zoom wrapper, so they'd render at
+ * 100% while the rest of the UI is at 125%. To keep them consistent we render
+ * a target node INSIDE the zoom wrapper and portal overlays into it, so they
+ * inherit the same zoom scale.
+ *
+ * `useOverlayContainer()` returns null outside the dashboard (no provider), in
+ * which case overlays fall back to their default body portal unchanged.
+ */
+const OverlayContainerContext = createContext<HTMLElement | null>(null)
+const SetOverlayContainerContext = createContext<(el: HTMLElement | null) => void>(() => {})
+
+export function useOverlayContainer(): HTMLElement | null {
+  return useContext(OverlayContainerContext)
+}
+
+export function OverlayContainerProvider({ children }: { children: ReactNode }) {
+  const [node, setNode] = useState<HTMLElement | null>(null)
+  return (
+    <SetOverlayContainerContext.Provider value={setNode}>
+      <OverlayContainerContext.Provider value={node}>
+        {children}
+      </OverlayContainerContext.Provider>
+    </SetOverlayContainerContext.Provider>
+  )
+}
+
+/**
+ * Renders the actual portal target node. Must be placed INSIDE the zoom
+ * wrapper so portaled overlays inherit the dashboard zoom. The ref callback
+ * registers the node into context; overlays read it via useOverlayContainer().
+ */
+export function OverlayContainerTarget() {
+  const setNode = useContext(SetOverlayContainerContext)
+  return <div ref={setNode} />
+}

--- a/apps/web/lib/sidebar-context.tsx
+++ b/apps/web/lib/sidebar-context.tsx
@@ -1,53 +1,6 @@
 'use client'
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useState,
-  useSyncExternalStore,
-  type ReactNode,
-} from 'react'
-
-const COLLAPSE_STORAGE_KEY = 'sidebar-collapsed'
-
-/* ── Desktop collapse: localStorage-backed external store ──
- *
- * The desktop hide/show preference lives in localStorage so it survives
- * reloads. We read it through useSyncExternalStore rather than a
- * useEffect+setState dance: that keeps SSR safe (getServerSnapshot returns the
- * default), avoids the react-hooks/set-state-in-effect lint rule, and gives
- * cross-tab sync for free via the `storage` event.
- */
-function readCollapsed(): boolean {
-  try {
-    return localStorage.getItem(COLLAPSE_STORAGE_KEY) === '1'
-  } catch {
-    // localStorage can throw in private-mode / blocked-cookie contexts.
-    return false
-  }
-}
-
-const collapseListeners = new Set<() => void>()
-
-function subscribeCollapsed(callback: () => void): () => void {
-  collapseListeners.add(callback)
-  window.addEventListener('storage', callback)
-  return () => {
-    collapseListeners.delete(callback)
-    window.removeEventListener('storage', callback)
-  }
-}
-
-function writeCollapsed(next: boolean): void {
-  try {
-    localStorage.setItem(COLLAPSE_STORAGE_KEY, next ? '1' : '0')
-  } catch {
-    // Ignore persistence failures — the in-memory snapshot still updates.
-  }
-  // `storage` events don't fire in the tab that made the change, so notify
-  // this tab's subscribers explicitly.
-  collapseListeners.forEach((l) => l())
-}
+import { createContext, useContext, useState, type ReactNode } from 'react'
+import { writeSidebarCollapsedCookie } from '@/lib/sidebar-cookie'
 
 interface SidebarContextValue {
   /** Mobile drawer open/closed. Desktop ignores this (sidebar is in-flow). */
@@ -58,9 +11,11 @@ interface SidebarContextValue {
    * Desktop hide/show. Independent from `isOpen` on purpose: the mobile
    * drawer and the desktop hide are two different behaviors, and mixing them
    * into one flag leads to "closed the drawer on mobile, sidebar vanished on
-   * desktop" cross-talk. Persisted to localStorage. SSR + first paint default
-   * to `false` (visible); a collapsed user sees a one-frame flash of the
-   * sidebar before it hides, which we accept for simplicity.
+   * desktop" cross-talk.
+   *
+   * Seeded from a server-read cookie (`initialCollapsed`) so SSR renders the
+   * correct state on first paint — no flash of the sidebar before the client
+   * hydrates. Toggling updates the cookie so the next request stays in sync.
    */
   isCollapsed: boolean
   toggleCollapsed: () => void
@@ -74,16 +29,23 @@ const SidebarContext = createContext<SidebarContextValue>({
   toggleCollapsed: () => {},
 })
 
-export function SidebarProvider({ children }: { children: ReactNode }) {
+export function SidebarProvider({
+  children,
+  initialCollapsed = false,
+}: {
+  children: ReactNode
+  initialCollapsed?: boolean
+}) {
   const [isOpen, setIsOpen] = useState(false)
+  const [isCollapsed, setIsCollapsed] = useState(initialCollapsed)
 
-  // Server snapshot is always `false` (visible) — there's no localStorage on
-  // the server. The client snapshot reads the stored value after hydration.
-  const isCollapsed = useSyncExternalStore(subscribeCollapsed, readCollapsed, () => false)
-
-  const toggleCollapsed = useCallback(() => {
-    writeCollapsed(!readCollapsed())
-  }, [])
+  function toggleCollapsed() {
+    setIsCollapsed((v) => {
+      const next = !v
+      writeSidebarCollapsedCookie(next)
+      return next
+    })
+  }
 
   return (
     <SidebarContext.Provider

--- a/apps/web/lib/sidebar-cookie.ts
+++ b/apps/web/lib/sidebar-cookie.ts
@@ -1,0 +1,22 @@
+'use client'
+
+/**
+ * Shared helpers for the `sidebar-collapsed` cookie.
+ *
+ * The desktop sidebar collapse preference is stored in a cookie (not just
+ * localStorage) so the server can read it during SSR and render the dashboard
+ * in the correct collapsed/expanded state on the first paint. Without that,
+ * SSR always assumes "expanded" and a collapsed user sees the sidebar flash in
+ * before the client hydrates and hides it.
+ */
+
+export const SIDEBAR_COLLAPSED_COOKIE = 'sidebar-collapsed'
+
+const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365
+
+export function writeSidebarCollapsedCookie(collapsed: boolean): void {
+  if (typeof document === 'undefined') return
+  // Site-scoped, not Secure — works on http://localhost; the browser still
+  // restricts it to the current hostname in production.
+  document.cookie = `${SIDEBAR_COLLAPSED_COOKIE}=${collapsed ? '1' : '0'}; path=/; max-age=${ONE_YEAR_SECONDS}; samesite=lax`
+}


### PR DESCRIPTION
## Summary

Two polish fixes on top of the dashboard 125% zoom.

### 1. Portal scaling
Dialogs (Radix, portaled to `document.body`) and the command palette (rendered above the zoom wrapper) were rendering at 100% while the rest of the dashboard is at 125%. Added an `OverlayContainerProvider` whose target node lives **inside** the zoom wrapper and routed overlays into it:
- `lib/overlay-container.tsx` (new) — provider + target + `useOverlayContainer()`.
- `components/ui/dialog.tsx` — `DialogPortal container={…}` (null outside the dashboard → default body portal, unchanged).
- `components/command-palette-dialog.tsx` — `createPortal` into the target.

Verified in isolation (1280×800): a portaled overlay scales 1.25×, the backdrop covers the full viewport, the panel stays centered, and nothing is clipped by the wrapper's `overflow-hidden`.

### 2. No sidebar-collapse flash
The collapse preference moved from `localStorage` (server can't read it) to a **cookie**, so the server seeds the initial state during SSR. A collapsed user no longer sees the sidebar flash in before hydration hides it.
- `lib/sidebar-cookie.ts` (new) — cookie writer.
- `lib/sidebar-context.tsx` — `initialCollapsed` prop seeds state; toggling writes the cookie.
- `app/(dashboard)/layout.tsx` — reads the cookie via `cookies()`, wires the overlay provider.

## Verification
- `pnpm --filter web typecheck` passed
- `pnpm --filter web lint` passed