### PR TITLE
fix(web): stop nesting links inside clickable session/user rows

### DIFF
--- a/apps/web/app/(dashboard)/sessions/sessions-client.tsx
+++ b/apps/web/app/(dashboard)/sessions/sessions-client.tsx
@@ -349,22 +349,32 @@ export function SessionsClient() {
                 const lat = s.avg_latency_ms != null ? Math.round(Number(s.avg_latency_ms)) : null
                 const isSlow = lat != null && lat >= SLOW_LATENCY_MS
                 return (
-                  <Link
+                  <div
                     key={s.session_id}
-                    href={`/sessions/${encodeURIComponent(s.session_id)}`}
                     role="row"
-                    className="group grid grid-cols-[2fr_1fr_1fr_1fr] sm:grid-cols-[2fr_1.2fr_1fr_1fr_1fr_1fr] gap-3 items-center px-4 py-3 font-mono text-[12px] text-text hover:bg-bg-elev transition-colors"
+                    className="group relative grid grid-cols-[2fr_1fr_1fr_1fr] sm:grid-cols-[2fr_1.2fr_1fr_1fr_1fr_1fr] gap-3 items-center px-4 py-3 font-mono text-[12px] text-text hover:bg-bg-elev transition-colors"
                   >
+                    {/* Stretched overlay link: the whole row navigates to the
+                        session without wrapping the row in an <a>. Wrapping
+                        would nest the user link and copy button inside an
+                        anchor — invalid HTML that triggers a hydration error.
+                        Interactive children sit above this overlay via z-index. */}
+                    <Link
+                      href={`/sessions/${encodeURIComponent(s.session_id)}`}
+                      aria-label={`Open session ${s.session_id}`}
+                      className="absolute inset-0 z-[1]"
+                    />
                     <span className="flex items-center gap-1.5 min-w-0">
                       <span className="truncate">{s.session_id}</span>
-                      <CopyButton value={s.session_id} />
+                      <span className="relative z-[2]">
+                        <CopyButton value={s.session_id} />
+                      </span>
                     </span>
                     <span className="text-text-muted truncate hidden sm:block">
                       {s.user_id ? (
                         <Link
                           href={`/users/${encodeURIComponent(s.user_id)}`}
-                          onClick={(e) => e.stopPropagation()}
-                          className="hover:underline"
+                          className="relative z-[2] hover:underline"
                         >
                           {s.user_id}
                         </Link>
@@ -383,7 +393,7 @@ export function SessionsClient() {
                     <span className="text-text-faint text-right" title={fmtAbsolute(s.last_seen)}>
                       {fmtRelativeTime(s.last_seen)}
                     </span>
-                  </Link>
+                  </div>
                 )
               })}
             </div>

--- a/apps/web/app/(dashboard)/users/users-client.tsx
+++ b/apps/web/app/(dashboard)/users/users-client.tsx
@@ -469,20 +469,30 @@ export function UsersClient() {
                 const lat = u.avg_latency_ms != null ? Math.round(Number(u.avg_latency_ms)) : null
                 const isSlow = lat != null && lat >= SLOW_LATENCY_MS
                 return (
-                  <Link
+                  <div
                     key={u.user_id}
-                    href={`/users/${encodeURIComponent(u.user_id)}`}
                     onMouseEnter={() => setFocusedIdx(idx)}
                     role="row"
                     aria-selected={isFocused}
                     className={cn(
-                      'group grid grid-cols-[2fr_1fr_1fr_1fr] sm:grid-cols-[2fr_1fr_1fr_1fr_1fr_1fr] gap-3 items-center px-4 py-3 font-mono text-[12px] text-text transition-colors',
+                      'group relative grid grid-cols-[2fr_1fr_1fr_1fr] sm:grid-cols-[2fr_1fr_1fr_1fr_1fr_1fr] gap-3 items-center px-4 py-3 font-mono text-[12px] text-text transition-colors',
                       isFocused ? 'bg-bg-elev' : 'hover:bg-bg-elev',
                     )}
                   >
+                    {/* Stretched overlay link: the row navigates to the user
+                        without wrapping the row in an <a>. Wrapping would put
+                        the copy button (a <button>) inside an anchor — invalid
+                        HTML that triggers a hydration error. */}
+                    <Link
+                      href={`/users/${encodeURIComponent(u.user_id)}`}
+                      aria-label={`Open user ${u.user_id}`}
+                      className="absolute inset-0 z-[1]"
+                    />
                     <span className="flex items-center gap-1.5 min-w-0">
                       <span className="truncate">{u.user_id}</span>
-                      <CopyButton value={u.user_id} />
+                      <span className="relative z-[2]">
+                        <CopyButton value={u.user_id} />
+                      </span>
                     </span>
                     <span className="text-text-muted">
                       {fmtCount(u.total_requests)}
@@ -501,7 +511,7 @@ export function UsersClient() {
                     >
                       {fmtRelativeTime(u.last_seen)}
                     </span>
-                  </Link>
+                  </div>
                 )
               })}
             </div>


### PR DESCRIPTION
## Problem

The Sessions and Users tables render each row as a `<Link>` (`<a>`) wrapping interactive children:
- **Sessions:** a nested user `<Link>` → `<a>` inside `<a>` (the reported `In HTML, <a> cannot be a descendant of <a>` hydration error).
- **Both:** the copy button (`<button>`) inside the row anchor → `<button>` cannot be a descendant of `<a>`.

Both are invalid HTML; the browser reparses the DOM and React reports a hydration mismatch.

## Fix

Stretched-link pattern. Each row becomes a `<div role="row" class="relative">` with:
- a transparent overlay `<Link class="absolute inset-0 z-[1]">` for whole-row navigation,
- inner user link / copy button lifted above it with `z-[2]`.

Behavior is unchanged: row click opens the session/user, inner controls do their own thing. The `stopPropagation` workaround the nesting required is gone. Users' keyboard navigation is unaffected (it runs off the table's `onKeyDown` + `router.push`, not the row being a link).

## Verification
- `pnpm --filter web typecheck` passed
- `pnpm --filter web lint` passed