### PR TITLE
feat(web): LangGraph topology view on trace detail pages

### DIFF
--- a/apps/web/app/compare/langsmith/page.tsx
+++ b/apps/web/app/compare/langsmith/page.tsx
@@ -48,7 +48,7 @@ const whyCompetitor: ComparePoint[] = [
   {
     title: 'You need first-party LangGraph trace support',
     body:
-      'LangGraph nodes, edges, and state transitions render natively in LangSmith. Spanlens captures every LangGraph node as an OTel span and renders the waterfall; the dedicated graph view is on our near-term roadmap. If a graph visual is a hard requirement today, pick LangSmith.',
+      'LangGraph nodes, edges, and state transitions render natively in LangSmith. Spanlens also renders a graph topology view of your LangGraph runs (with the critical path highlighted), but the depth of state-transition introspection in LangSmith is still ahead. If you need to debug LangGraph state mutations specifically, LangSmith goes deeper.',
   },
   {
     title: 'You want one vendor for framework + observability',
@@ -78,7 +78,12 @@ const groups: CompareGroup[] = [
         spanlens: 'yes',
         competitor: 'yes',
       },
-      { feature: 'LangGraph native graph view', spanlens: 'no', competitor: 'yes' },
+      {
+        feature: 'LangGraph graph topology view',
+        spanlens: 'yes',
+        competitor: 'yes',
+        note: 'Both render the node graph. LangSmith goes deeper into state-transition introspection.',
+      },
       { feature: 'Vercel AI SDK', spanlens: 'yes', competitor: 'yes' },
     ],
   },

--- a/apps/web/app/demo/traces/[id]/page.tsx
+++ b/apps/web/app/demo/traces/[id]/page.tsx
@@ -1,10 +1,14 @@
 'use client'
-import { use, useState } from 'react'
+import { use, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { Topbar } from '@/components/layout/topbar'
 import { cn } from '@/lib/utils'
 import { DEMO_TRACES, DEMO_TRACE_DETAILS } from '@/lib/demo-data'
 import type { SpanRow } from '@/lib/queries/types'
+import { TopologyGraph } from '@/components/traces/topology-graph'
+import { shouldShowGraphView } from '@/lib/topology'
+
+type TraceView = 'timeline' | 'graph'
 
 // ── Helpers ────────────────────────────────────────────────────
 
@@ -245,6 +249,12 @@ export default function DemoTraceDetailPage({ params }: { params: Promise<{ id: 
   const prevTrace = traceIdx > 0 ? DEMO_TRACES[traceIdx - 1] : null
   const nextTrace = traceIdx < DEMO_TRACES.length - 1 ? DEMO_TRACES[traceIdx + 1] : null
 
+  const graphAvailable = useMemo(
+    () => (traceDetail ? shouldShowGraphView(traceDetail.spans) : false),
+    [traceDetail],
+  )
+  const [view, setView] = useState<TraceView>(graphAvailable ? 'graph' : 'timeline')
+
   if (!traceDetail) {
     return (
       <div className="-mx-4 -my-4 md:-mx-8 md:-my-7 flex flex-col h-screen overflow-hidden bg-bg">
@@ -366,49 +376,95 @@ export default function DemoTraceDetailPage({ params }: { params: Promise<{ id: 
         </div>
       )}
 
-      {/* Main area: waterfall + optional detail panel */}
+      {/* Main area: waterfall or graph + optional detail panel */}
       <div className="flex-1 flex overflow-hidden">
-        {/* Waterfall */}
-        <div className="flex-1 overflow-auto">
-          {/* Waterfall header */}
-          <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-bg-muted sticky top-0 z-10">
-            <span className="shrink-0 w-[220px] font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">Span</span>
-            <span className="flex-1 font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">Timeline</span>
-            <span className="shrink-0 w-16 text-right font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">Dur</span>
+        <div className="flex-1 flex flex-col overflow-hidden">
+          {/* View toggle */}
+          <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-bg-muted shrink-0">
+            <span className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">View</span>
+            <div
+              className="flex border border-border rounded-[5px] overflow-hidden bg-bg font-mono text-[10px] tracking-[0.03em]"
+              title={graphAvailable ? undefined : 'Graph view requires LangChain / LangGraph callback spans'}
+            >
+              {([
+                ['timeline', 'Timeline'],
+                ['graph', 'Graph'],
+              ] as [TraceView, string][]).map(([v, label]) => {
+                const isGraph = v === 'graph'
+                const disabled = isGraph && !graphAvailable
+                return (
+                  <button
+                    key={v}
+                    type="button"
+                    disabled={disabled}
+                    onClick={() => !disabled && setView(v)}
+                    className={cn(
+                      'px-[10px] py-[4px] inline-flex items-center',
+                      view === v ? 'bg-text text-bg' : 'text-text-muted hover:text-text transition-colors',
+                      disabled && 'opacity-40 cursor-not-allowed hover:text-text-muted',
+                    )}
+                  >
+                    {label}
+                  </button>
+                )
+              })}
+            </div>
+            <span className="flex-1" />
+            <span className="font-mono text-[10.5px] text-text-faint">{spans.length} spans</span>
           </div>
 
-          {flatSpans.map(({ span, depth }) => (
-            <SpanWaterfallRow
-              key={span.id}
-              span={span}
-              depth={depth}
-              totalDurationMs={totalDurationMs}
-              traceStartMs={traceStartMs}
-              isSelected={selectedSpanId === span.id}
-              onClick={() => setSelectedSpanId(selectedSpanId === span.id ? null : span.id)}
-            />
-          ))}
+          {view === 'graph' ? (
+            <div className="flex-1 min-h-0 relative">
+              <TopologyGraph
+                spans={spans}
+                criticalSpanIds={traceDetail.critical_span_ids ?? []}
+                onSelectSpan={(s) => setSelectedSpanId(selectedSpanId === s.id ? null : s.id)}
+                selectedSpanId={selectedSpanId}
+              />
+            </div>
+          ) : (
+            <div className="flex-1 overflow-auto">
+              {/* Waterfall column header */}
+              <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-bg-muted/60 sticky top-0 z-10">
+                <span className="shrink-0 w-[220px] font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">Span</span>
+                <span className="flex-1 font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">Timeline</span>
+                <span className="shrink-0 w-16 text-right font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">Dur</span>
+              </div>
 
-          {flatSpans.length === 0 && (
-            <div className="flex items-center justify-center h-32 text-[13px] text-text-muted">
-              No spans recorded for this trace.
+              {flatSpans.map(({ span, depth }) => (
+                <SpanWaterfallRow
+                  key={span.id}
+                  span={span}
+                  depth={depth}
+                  totalDurationMs={totalDurationMs}
+                  traceStartMs={traceStartMs}
+                  isSelected={selectedSpanId === span.id}
+                  onClick={() => setSelectedSpanId(selectedSpanId === span.id ? null : span.id)}
+                />
+              ))}
+
+              {flatSpans.length === 0 && (
+                <div className="flex items-center justify-center h-32 text-[13px] text-text-muted">
+                  No spans recorded for this trace.
+                </div>
+              )}
+
+              {/* Trace metadata footer */}
+              <div className="px-4 py-4 border-t border-border mt-2">
+                <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-2">Trace metadata</div>
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-2 font-mono text-[11px] text-text-muted">
+                  <span><span className="text-text-faint">ID:</span> {traceDetail.id}</span>
+                  <span><span className="text-text-faint">Started:</span> {new Date(traceDetail.started_at).toLocaleString()}</span>
+                  {Boolean(traceDetail.metadata?.environment) && (
+                    <span><span className="text-text-faint">Env:</span> {String(traceDetail.metadata?.environment ?? '')}</span>
+                  )}
+                  {Boolean(traceDetail.metadata?.agent_version) && (
+                    <span><span className="text-text-faint">Version:</span> {String(traceDetail.metadata?.agent_version ?? '')}</span>
+                  )}
+                </div>
+              </div>
             </div>
           )}
-
-          {/* Trace metadata footer */}
-          <div className="px-4 py-4 border-t border-border mt-2">
-            <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-2">Trace metadata</div>
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-2 font-mono text-[11px] text-text-muted">
-              <span><span className="text-text-faint">ID:</span> {traceDetail.id}</span>
-              <span><span className="text-text-faint">Started:</span> {new Date(traceDetail.started_at).toLocaleString()}</span>
-              {Boolean(traceDetail.metadata?.environment) && (
-                <span><span className="text-text-faint">Env:</span> {String(traceDetail.metadata?.environment ?? '')}</span>
-              )}
-              {Boolean(traceDetail.metadata?.agent_version) && (
-                <span><span className="text-text-faint">Version:</span> {String(traceDetail.metadata?.agent_version ?? '')}</span>
-              )}
-            </div>
-          </div>
         </div>
 
         {/* Span detail panel */}

--- a/apps/web/app/docs/integrations/langgraph/page.tsx
+++ b/apps/web/app/docs/integrations/langgraph/page.tsx
@@ -15,7 +15,9 @@ export default function LangGraphIntegration() {
         LangGraph reuses LangChain&apos;s callback contract, so the same Spanlens handler
         works for both. Every node invocation becomes a span; the <code>runId</code> and{' '}
         <code>parentRunId</code> on each callback give Spanlens the graph topology, which
-        shows up as a nested tree in <a href="/traces">/traces</a>.
+        renders in two ways on <a href="/traces">/traces</a>: as a Gantt waterfall (Timeline
+        tab) and as a node-and-edge graph (Graph tab) with the critical path highlighted in
+        accent color.
       </p>
 
       <h2>Install</h2>

--- a/apps/web/components/traces/topology-graph.tsx
+++ b/apps/web/components/traces/topology-graph.tsx
@@ -1,0 +1,388 @@
+'use client'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Controls,
+  Background,
+  BaseEdge,
+  Handle,
+  Position,
+  useInternalNode,
+  useReactFlow,
+  useNodesInitialized,
+  type Edge,
+  type EdgeProps,
+  type Node,
+  type NodeProps,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import { cn } from '@/lib/utils'
+import type { SpanRow, SpanType } from '@/lib/queries/types'
+import { buildTopology, type Topology, type TopologyNode } from '@/lib/topology'
+
+/* ── Formatting helpers ─────────────────────────────────────────────────── */
+
+function fmtMs(ms: number | null): string {
+  if (ms == null) return '—'
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  return `${(ms / 1000).toFixed(2)}s`
+}
+
+function fmtCost(usd: number | null): string {
+  if (usd == null || usd === 0) return '—'
+  if (usd < 0.001) return `<$0.001`
+  if (usd < 1) return `$${usd.toFixed(3)}`
+  return `$${usd.toFixed(2)}`
+}
+
+const CHILD_GLYPH: Record<SpanType, string> = {
+  llm: '◆',
+  tool: '⚙',
+  retrieval: '⌕',
+  embedding: '~',
+  custom: '·',
+}
+
+const CHILD_LABEL: Record<SpanType, string> = {
+  llm: 'LLM',
+  tool: 'tool',
+  retrieval: 'ret',
+  embedding: 'embd',
+  custom: 'span',
+}
+
+/* ── Custom node ────────────────────────────────────────────────────────── */
+
+interface TopologyNodeData {
+  node: TopologyNode
+  isSelected: boolean
+  onSelect: (span: SpanRow) => void
+  [key: string]: unknown
+}
+
+function TopologyNodeView({ data }: NodeProps<Node<TopologyNodeData>>) {
+  const { node, isSelected } = data
+  const errored = node.status === 'error'
+  const running = node.status === 'running'
+
+  // Pick single most "interesting" child category for the chip row.
+  const childChips: Array<{ type: SpanType; count: number }> = []
+  for (const type of ['llm', 'tool', 'retrieval', 'embedding', 'custom'] as SpanType[]) {
+    const count = node.childCounts[type]
+    if (count > 0) childChips.push({ type, count })
+  }
+
+  return (
+    <div
+      className={cn(
+        'group relative flex flex-col items-stretch text-left rounded-md border bg-bg-elev w-full h-full px-3 py-2 transition-colors cursor-pointer pointer-events-auto',
+        'hover:border-border-strong',
+        isSelected && 'ring-2 ring-accent ring-offset-1 ring-offset-bg',
+        node.isCritical
+          ? 'border-accent'
+          : errored
+          ? 'border-bad'
+          : 'border-border',
+        node.isRoot && 'bg-bg',
+      )}
+      style={{ width: node.width, height: node.height }}
+    >
+      {/* Top row: name + critical badge */}
+      <div className="flex items-center gap-1.5 min-w-0">
+        {node.isRoot && (
+          <span className="font-mono text-[8.5px] uppercase tracking-[0.06em] text-text-faint shrink-0">
+            graph
+          </span>
+        )}
+        <span
+          className={cn(
+            'text-[12.5px] font-medium truncate flex-1',
+            node.isCritical ? 'text-accent' : 'text-text',
+          )}
+        >
+          {node.label}
+        </span>
+        {node.isCritical && (
+          <span
+            className="font-mono text-[8.5px] uppercase tracking-[0.06em] text-accent shrink-0"
+            title="On critical path"
+          >
+            CP
+          </span>
+        )}
+        {errored && (
+          <span className="font-mono text-[8.5px] uppercase tracking-[0.06em] text-bad shrink-0">
+            ERR
+          </span>
+        )}
+        {running && (
+          <span className="font-mono text-[8.5px] uppercase tracking-[0.06em] text-accent animate-pulse shrink-0">
+            ●
+          </span>
+        )}
+      </div>
+
+      {/* Mid row: duration + cost */}
+      <div className="flex items-center gap-3 mt-1.5 font-mono text-[10.5px] text-text-muted">
+        <span className="truncate">{fmtMs(node.durationMs)}</span>
+        <span className="text-text-faint">·</span>
+        <span className="truncate">{fmtCost(node.costUsd)}</span>
+        {node.totalTokens > 0 && (
+          <>
+            <span className="text-text-faint">·</span>
+            <span className="truncate">{node.totalTokens.toLocaleString()}t</span>
+          </>
+        )}
+      </div>
+
+      {/* Bottom row: child-type chips */}
+      {childChips.length > 0 && (
+        <div className="flex items-center gap-1 mt-1.5 flex-wrap">
+          {childChips.map((c) => (
+            <span
+              key={c.type}
+              className="inline-flex items-center gap-0.5 font-mono text-[9.5px] text-text-faint px-1 py-[1px] rounded-[3px] border border-border bg-bg"
+            >
+              <span>{CHILD_GLYPH[c.type]}</span>
+              <span>{c.count}</span>
+              <span className="opacity-70">{CHILD_LABEL[c.type]}</span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Handles (invisible but required for edges to attach).
+          Explicit ids force every edge to attach at the same point on the
+          node (center-top for incoming, center-bottom for outgoing), which
+          stops React Flow from auto-spreading multiple outgoing edges
+          across an invisible source band. */}
+      <Handle
+        id="t"
+        type="target"
+        position={Position.Top}
+        className="!w-2 !h-2 !bg-border !border-0 opacity-0"
+      />
+      <Handle
+        id="s"
+        type="source"
+        position={Position.Bottom}
+        className="!w-2 !h-2 !bg-border !border-0 opacity-0"
+      />
+    </div>
+  )
+}
+
+const NODE_TYPES = { topology: TopologyNodeView }
+
+/* ── Custom step edge ───────────────────────────────────────────────────────
+ *
+ * React Flow's built-in step edge computes endpoint X coordinates from the
+ * source/target node's MEASURED DOM width (getBoundingClientRect). When the
+ * browser applies any scaling that makes measured width disagree with the
+ * width we passed in the node spec (HiDPI quirks, OS display scaling, browser
+ * zoom, custom CSS), the edge anchors at the wrong horizontal position.
+ *
+ * This component bypasses that by reading the source/target node's authoritative
+ * `position.x` (which is the node centre because we use nodeOrigin=[0.5, 0])
+ * and routing the path through those coordinates directly. The Y coordinates
+ * come from React Flow as-is since vertical alignment was never the problem.
+ */
+function CustomStepEdge(props: EdgeProps) {
+  const sourceNode = useInternalNode(props.source)
+  const targetNode = useInternalNode(props.target)
+  const { style, markerEnd, markerStart, id, interactionWidth } = props
+
+  if (!sourceNode || !targetNode) return null
+
+  // With nodeOrigin=[0.5, 0], position.x is the node's centre and position.y
+  // is its TOP. Anchor 2px outside the source's bottom edge and the target's
+  // top edge so the line reads as a connector touching the box rather than
+  // bleeding into the border.
+  const EDGE_GAP = 2
+  const sourceX = sourceNode.position.x
+  const targetX = targetNode.position.x
+  const sourceHeight = sourceNode.measured?.height ?? sourceNode.height ?? 78
+  const sourceY = sourceNode.position.y + sourceHeight + EDGE_GAP
+  const targetY = targetNode.position.y - EDGE_GAP
+
+  // Step routing: down from source centre, horizontal to target column, down
+  // into target centre. When source and target share a column the horizontal
+  // segment degenerates to length 0 (clean vertical line).
+  const midY = (sourceY + targetY) / 2
+  const path = `M ${sourceX} ${sourceY} L ${sourceX} ${midY} L ${targetX} ${midY} L ${targetX} ${targetY}`
+
+  // BaseEdge has `exactOptionalPropertyTypes`-strict props, so only spread
+  // the values we actually have rather than forwarding `undefined` for any.
+  const baseProps: Parameters<typeof BaseEdge>[0] = { id, path, style }
+  if (markerEnd !== undefined) baseProps.markerEnd = markerEnd
+  if (markerStart !== undefined) baseProps.markerStart = markerStart
+  if (interactionWidth !== undefined) baseProps.interactionWidth = interactionWidth
+
+  return <BaseEdge {...baseProps} />
+}
+
+const EDGE_TYPES = { 'custom-step': CustomStepEdge }
+
+/* ── Main component ─────────────────────────────────────────────────────── */
+
+export interface TopologyGraphProps {
+  spans: SpanRow[]
+  criticalSpanIds: readonly string[]
+  onSelectSpan: (span: SpanRow) => void
+  selectedSpanId: string | null
+}
+
+function TopologyGraphInner({
+  spans,
+  criticalSpanIds,
+  onSelectSpan,
+  selectedSpanId,
+}: TopologyGraphProps) {
+  const topology: Topology | null = useMemo(
+    () => buildTopology(spans, criticalSpanIds),
+    [spans, criticalSpanIds],
+  )
+
+  const { nodes, edges } = useMemo(() => {
+    if (!topology) return { nodes: [] as Node[], edges: [] as Edge[] }
+    const flowNodes: Node[] = topology.nodes.map((n) => ({
+      id: n.id,
+      type: 'topology',
+      position: { x: n.x, y: n.y },
+      // width/height on the node spec is the single source of truth for
+      // both layout AND React Flow's internal handle/edge math. We
+      // deliberately do NOT also pass `style.width/height`, because that
+      // creates two sources React Flow can drift between (manifesting as
+      // edges anchoring at ~62% of the node instead of at the centre).
+      // The custom node component reads width/height directly via NodeProps
+      // and sizes itself.
+      width: n.width,
+      height: n.height,
+      data: {
+        node: n,
+        isSelected: n.id === selectedSpanId,
+        onSelect: onSelectSpan,
+      } satisfies TopologyNodeData,
+      draggable: false,
+      selectable: false,
+    }))
+    const flowEdges: Edge[] = topology.edges.map((e) => ({
+      id: e.id,
+      source: e.source,
+      target: e.target,
+      sourceHandle: 's',
+      targetHandle: 't',
+      // Use our custom edge component that anchors at the source/target
+      // node's authoritative `position.x` (centre), not React Flow's
+      // DOM-measured handle position.
+      type: 'custom-step',
+      animated: false,
+      style: {
+        stroke: e.isCritical
+          ? 'var(--accent)'
+          : e.isParallel
+          ? 'var(--text-faint)'
+          : 'var(--border-strong)',
+        strokeWidth: e.isCritical ? 2 : 1.25,
+        strokeDasharray: e.isParallel ? '4 3' : undefined,
+      },
+    }))
+    return { nodes: flowNodes, edges: flowEdges }
+  }, [topology, selectedSpanId, onSelectSpan])
+
+  const { fitView } = useReactFlow()
+  const nodesInitialized = useNodesInitialized()
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [hasFittedFor, setHasFittedFor] = useState<string | null>(null)
+  const topologyKey = topology
+    ? `${topology.nodes.length}:${topology.width}:${topology.height}`
+    : null
+
+  // Robust fit: wait for BOTH nodes to be measured AND the container to have
+  // a non-trivial height. Watching the container with a ResizeObserver covers
+  // the flex-layout race where height transitions from 0 → final on mount.
+  useEffect(() => {
+    if (!nodesInitialized || !topology || !topologyKey) return
+    if (hasFittedFor === topologyKey) return
+    const el = containerRef.current
+    if (!el) return
+
+    const tryFit = () => {
+      if (el.clientHeight > 80 && el.clientWidth > 80) {
+        fitView({ padding: 0.18, duration: 0 })
+        setHasFittedFor(topologyKey)
+        return true
+      }
+      return false
+    }
+
+    if (tryFit()) return
+
+    const ro = new ResizeObserver(() => tryFit())
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [nodesInitialized, topology, topologyKey, hasFittedFor, fitView])
+
+  if (!topology) {
+    return (
+      <div className="flex h-full items-center justify-center text-center px-8">
+        <div className="max-w-md">
+          <div className="font-mono text-[10.5px] uppercase tracking-[0.06em] text-text-faint mb-2">
+            No graph topology
+          </div>
+          <p className="text-[13px] text-text-muted leading-relaxed">
+            This trace does not contain enough <code>chain.*</code> spans to render a
+            graph view. Use the Timeline tab to inspect the Gantt waterfall.
+          </p>
+          <p className="mt-3 text-[12px] text-text-faint leading-relaxed">
+            The graph view is populated automatically when you instrument with the
+            Spanlens LangChain / LangGraph callback handler.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div ref={containerRef} className="h-full w-full bg-bg">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={NODE_TYPES}
+        edgeTypes={EDGE_TYPES}
+        // nodeOrigin=[0.5, 0] means node.position refers to the top-CENTER
+        // (not top-left) of the node. Our layout writes centre coordinates,
+        // so this puts our coordinate system and React Flow's in lockstep.
+        nodeOrigin={[0.5, 0]}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={true}
+        zoomOnDoubleClick={false}
+        onNodeClick={(_, node) => {
+          const d = node.data as TopologyNodeData | undefined
+          if (d) d.onSelect(d.node.span)
+        }}
+        proOptions={{ hideAttribution: true }}
+        minZoom={0.2}
+        maxZoom={2}
+        defaultEdgeOptions={{ type: 'step' }}
+      >
+        <Background gap={20} size={1} color="var(--border)" />
+        <Controls
+          showInteractive={false}
+          position="bottom-right"
+          className="!bg-bg-elev !border !border-border !rounded-md !shadow-none [&>button]:!bg-bg-elev [&>button]:!border-border [&>button]:!text-text-muted [&>button:hover]:!bg-bg-muted"
+        />
+      </ReactFlow>
+    </div>
+  )
+}
+
+export function TopologyGraph(props: TopologyGraphProps) {
+  return (
+    <ReactFlowProvider>
+      <TopologyGraphInner {...props} />
+    </ReactFlowProvider>
+  )
+}

--- a/apps/web/components/traces/trace-panel.tsx
+++ b/apps/web/components/traces/trace-panel.tsx
@@ -3,9 +3,13 @@ import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { Gantt } from '@/components/traces/gantt'
+import { TopologyGraph } from '@/components/traces/topology-graph'
 import { useTrace } from '@/lib/queries/use-traces'
 import { Skeleton } from '@/components/ui/skeleton'
 import type { SpanRow, SpanType } from '@/lib/queries/types'
+import { shouldShowGraphView } from '@/lib/topology'
+
+type TraceView = 'timeline' | 'graph'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 export function fmtMs(ms: number | null): string {
@@ -526,8 +530,11 @@ function TracePanelInner({ traceId }: TracePanelProps) {
   const [typeFilter, setTypeFilter] = useState<SpanType | 'all'>('all')
   const [errorsOnly, setErrorsOnly] = useState(false)
   const [errorJumpIdx, setErrorJumpIdx] = useState(0)
+  const [view, setView] = useState<TraceView>('timeline')
 
   const { data: trace, isLoading, isError } = useTrace(traceId)
+
+  const graphAvailable = useMemo(() => (trace ? shouldShowGraphView(trace.spans) : false), [trace])
 
   const filteredSpans = useMemo(() => {
     if (!trace) return []
@@ -725,9 +732,47 @@ function TracePanelInner({ traceId }: TracePanelProps) {
               : <>{trace.span_count} total</>
             }
           </span>
+
+          <div
+            className="flex border border-border rounded-[5px] overflow-hidden bg-bg-elev font-mono text-[10px] tracking-[0.03em]"
+            title={graphAvailable ? undefined : 'Graph view requires LangChain / LangGraph callback spans'}
+          >
+            {([
+              ['timeline', 'Timeline'],
+              ['graph', 'Graph'],
+            ] as [TraceView, string][]).map(([v, label]) => {
+              const isGraph = v === 'graph'
+              const disabled = isGraph && !graphAvailable
+              return (
+                <button
+                  key={v}
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => !disabled && setView(v)}
+                  className={cn(
+                    'px-[8px] py-[4px] inline-flex items-center',
+                    view === v ? 'bg-text text-bg' : 'text-text-muted hover:text-text transition-colors',
+                    disabled && 'opacity-40 cursor-not-allowed hover:text-text-muted',
+                  )}
+                >
+                  {label}
+                </button>
+              )
+            })}
+          </div>
         </div>
 
-        {/* Gantt */}
+        {/* Gantt or Graph */}
+        {view === 'graph' ? (
+          <div className="flex-1 min-h-0 relative" style={{ minHeight: 400 }}>
+            <TopologyGraph
+              spans={trace.spans}
+              criticalSpanIds={trace.critical_span_ids ?? []}
+              onSelectSpan={setSelectedSpan}
+              selectedSpanId={selectedSpan?.id ?? null}
+            />
+          </div>
+        ) : (
         <div className="overflow-auto flex-1 min-h-0">
           <div className="p-[22px]">
             <Gantt
@@ -791,6 +836,7 @@ function TracePanelInner({ traceId }: TracePanelProps) {
             )}
           </div>
         </div>
+        )}
       </div>
 
       {selectedSpan && (

--- a/apps/web/lib/changelog/entries.ts
+++ b/apps/web/lib/changelog/entries.ts
@@ -40,6 +40,17 @@ export type ChangelogTag =
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
     date: '2026-06-01',
+    slug: 'langgraph-topology-view',
+    title: 'LangGraph topology view in /traces',
+    tags: ['feature'],
+    body: [
+      'Trace detail pages now have a Timeline / Graph toggle. The Graph view renders LangGraph (and any LangChain callback) traces as a node-and-edge diagram, with each `chain.*` span as a node and edges inferred from sibling execution order. Parallel fan-out, sequential transitions, and the critical path are all visible at a glance.',
+      'Critical-path nodes and edges are drawn in accent color so the slowest dependency chain stands out without reading numbers. Click any node to open the existing span drawer.',
+      'The Graph tab is enabled automatically when a trace contains enough `chain.*` spans to be worth the view (currently 20% of total spans). Simple two-call RAG traces continue to default to the Gantt. See the [LangGraph integration docs](/docs/integrations/langgraph) for instrumentation details.',
+    ].join('\n\n'),
+  },
+  {
+    date: '2026-06-01',
     slug: 'public-status-page',
     title: 'Public status page at status.spanlens.io',
     tags: ['reliability'],

--- a/apps/web/lib/demo-data.ts
+++ b/apps/web/lib/demo-data.ts
@@ -35,6 +35,20 @@ const ts = (base: number, offsetMs: number) => new Date(base + offsetMs).toISOSt
 
 export const DEMO_TRACES: TraceRow[] = [
   {
+    id: 'demo-trace-langgraph',
+    project_id: 'demo-proj',
+    name: 'multi-agent-orchestrator',
+    status: 'completed',
+    started_at: min(0.2),
+    ended_at: ts(N - 0.2 * 60_000, 3200),
+    duration_ms: 3200,
+    span_count: 11,
+    total_tokens: 2607,
+    total_cost_usd: 0.0036,
+    error_message: null,
+    created_at: min(0.2),
+  },
+  {
     id: 'demo-trace-001',
     project_id: 'demo-proj',
     name: 'Customer Support Agent',
@@ -329,10 +343,120 @@ function makeSimpleDetail(trace: TraceRow): TraceDetail {
   }
 }
 
+// ── LangGraph demo trace ─────────────────────────────────────────────────────
+//
+// Shape mirrors what the Spanlens LangChain / LangGraph callback handler
+// emits: a `chain.<node_name>` root + sequential nodes, a `chain.dispatch`
+// node containing parallel fan-out branches (`chain.lookup_*`), each branch
+// in turn wrapping its own llm / tool / retrieval children. The trace is the
+// one the Graph view was designed for — toggling between Timeline and Graph
+// on this trace is the demo "money shot".
+
+const T_LANGGRAPH = N - 0.2 * 60_000
+
+function lgSpan(
+  id: string,
+  parentId: string | null,
+  name: string,
+  spanType: SpanRow['span_type'],
+  offsetMs: number,
+  durationMs: number,
+  extras: Partial<SpanRow> = {},
+): SpanRow {
+  return {
+    id,
+    parent_span_id: parentId,
+    name,
+    span_type: spanType,
+    status: 'completed',
+    started_at: ts(T_LANGGRAPH, offsetMs),
+    ended_at: ts(T_LANGGRAPH, offsetMs + durationMs),
+    duration_ms: durationMs,
+    input: null,
+    output: null,
+    metadata: null,
+    error_message: null,
+    request_id: null,
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+    cost_usd: null,
+    ...extras,
+  }
+}
+
+const DEMO_SPANS_LANGGRAPH: SpanRow[] = [
+  lgSpan('lg-root', null, 'chain.agent_orchestrator', 'custom', 0, 3200, {
+    input: { user_message: 'Where is my order #4421 and can I get a refund if it never arrived?' },
+    output: { reply: 'Your order shipped Tuesday and is out for delivery today; let me know if it does not arrive by end of day and I will start the refund.', resolved: true },
+  }),
+
+  lgSpan('lg-classify', 'lg-root', 'chain.classify_intent', 'custom', 0, 450, {
+    input: { user_message: 'Where is my order #4421 and can I get a refund if it never arrived?' },
+    output: { intents: ['order_status', 'refund_policy'], confidence: 0.94 },
+  }),
+  lgSpan('lg-classify-llm', 'lg-classify', 'llm.ChatOpenAI', 'llm', 20, 410, {
+    prompt_tokens: 280,
+    completion_tokens: 24,
+    total_tokens: 304,
+    cost_usd: 0.0008,
+    metadata: { model: 'gpt-4o-mini', provider: 'openai' },
+  }),
+
+  lgSpan('lg-dispatch', 'lg-root', 'chain.dispatch', 'custom', 450, 2700, {
+    input: { intents: ['order_status', 'refund_policy'] },
+    output: { branches_used: ['lookup_order', 'lookup_kb'], parallel: true },
+  }),
+
+  lgSpan('lg-order', 'lg-dispatch', 'chain.lookup_order', 'custom', 450, 1100),
+  lgSpan('lg-order-tool', 'lg-order', 'tool.shopify_query', 'tool', 470, 840, {
+    input: { order_id: '4421' },
+    output: { status: 'out_for_delivery', shipped_at: '2026-05-30T09:21:00Z', carrier: 'UPS' },
+  }),
+  lgSpan('lg-order-llm', 'lg-order', 'llm.ChatOpenAI', 'llm', 1320, 220, {
+    prompt_tokens: 412,
+    completion_tokens: 31,
+    total_tokens: 443,
+    cost_usd: 0.0005,
+    metadata: { model: 'gpt-4o-mini', provider: 'openai' },
+  }),
+
+  lgSpan('lg-kb', 'lg-dispatch', 'chain.lookup_kb', 'custom', 450, 2700),
+  lgSpan('lg-kb-retrieval', 'lg-kb', 'retrieval.PineconeStore', 'retrieval', 470, 300, {
+    input: { query: 'refund policy undelivered shipment', top_k: 5 },
+    output: { docs: [{ id: 'kb-220', title: 'Refunds for undelivered orders', score: 0.93 }, { id: 'kb-118', title: 'Carrier disputes', score: 0.81 }] },
+  }),
+  lgSpan('lg-kb-llm', 'lg-kb', 'llm.ChatAnthropic', 'llm', 800, 2330, {
+    prompt_tokens: 1320,
+    completion_tokens: 540,
+    total_tokens: 1860,
+    cost_usd: 0.0023,
+    metadata: { model: 'claude-haiku-4-5', provider: 'anthropic' },
+  }),
+
+  lgSpan('lg-compose', 'lg-root', 'chain.compose_final', 'custom', 3150, 40, {
+    output: { reply: 'Your order shipped Tuesday and is out for delivery today; let me know if it does not arrive by end of day and I will start the refund.' },
+  }),
+]
+
+export const DEMO_TRACE_LANGGRAPH_DETAIL: TraceDetail = {
+  ...DEMO_TRACES[0]!,
+  metadata: { user_id: 'u_demo_alice', session_id: 'sess_demo_1', environment: 'production', agent_version: '3.4.0' },
+  api_key_id: 'demo-key-001',
+  organization_id: 'demo-org-001',
+  updated_at: ts(T_LANGGRAPH, 3200),
+  spans: DEMO_SPANS_LANGGRAPH,
+  // Critical path: root → classify → dispatch → lookup_kb (slowest branch)
+  // → compose_final. The kb LLM call is the actual bottleneck inside the
+  // branch and is highlighted alongside its chain ancestor.
+  critical_span_ids: ['lg-root', 'lg-classify', 'lg-dispatch', 'lg-kb', 'lg-kb-llm', 'lg-compose'],
+}
+
 export const DEMO_TRACE_DETAILS: Record<string, TraceDetail> = {
+  'demo-trace-langgraph': DEMO_TRACE_LANGGRAPH_DETAIL,
   'demo-trace-002': DEMO_TRACE_002_DETAIL,
   ...Object.fromEntries(
-    DEMO_TRACES.filter((t) => t.id !== 'demo-trace-002').map((t) => [t.id, makeSimpleDetail(t)]),
+    DEMO_TRACES.filter((t) => t.id !== 'demo-trace-002' && t.id !== 'demo-trace-langgraph').map((t) => [t.id, makeSimpleDetail(t)]),
   ),
 }
 

--- a/apps/web/lib/mock-traces.ts
+++ b/apps/web/lib/mock-traces.ts
@@ -1,0 +1,113 @@
+/**
+ * Dev-only mock trace fixtures used to validate the trace UI (topology graph,
+ * Gantt) without needing real backend data. Only consumed by `useTrace` when
+ * NODE_ENV === 'development' and the trace id matches a known mock slug.
+ */
+import type { SpanRow, TraceDetail } from '@/lib/queries/types'
+
+const BASE = new Date('2026-06-01T08:00:00.000Z').getTime()
+
+function span(
+  id: string,
+  parent: string | null,
+  name: string,
+  type: SpanRow['span_type'],
+  startMs: number,
+  durationMs: number,
+  opts: Partial<SpanRow> = {},
+): SpanRow {
+  const started = new Date(BASE + startMs).toISOString()
+  const ended = new Date(BASE + startMs + durationMs).toISOString()
+  return {
+    id,
+    parent_span_id: parent,
+    name,
+    span_type: type,
+    status: 'completed',
+    started_at: started,
+    ended_at: ended,
+    duration_ms: durationMs,
+    input: opts.input ?? null,
+    output: opts.output ?? null,
+    metadata: opts.metadata ?? null,
+    error_message: null,
+    request_id: opts.request_id ?? null,
+    prompt_tokens: opts.prompt_tokens ?? 0,
+    completion_tokens: opts.completion_tokens ?? 0,
+    total_tokens: opts.total_tokens ?? 0,
+    cost_usd: opts.cost_usd ?? null,
+  }
+}
+
+/**
+ * Mirrors the example from /docs/integrations/langgraph:
+ *   customer-support-agent
+ *   └── chain.agent_orchestrator
+ *       ├── chain.classify_intent (sequential)
+ *       ├── chain.dispatch (parallel fan-out inside)
+ *       │   ├── chain.lookup_order
+ *       │   └── chain.lookup_kb       ← critical
+ *       └── chain.compose_final
+ */
+export function mockLangGraphTrace(): TraceDetail {
+  const spans: SpanRow[] = [
+    // Root LangGraph wrapper
+    span('s_root', null, 'chain.agent_orchestrator', 'custom', 0, 3200),
+
+    // Sequential: classify
+    span('s_classify', 's_root', 'chain.classify_intent', 'custom', 0, 450),
+    span('s_classify_llm', 's_classify', 'llm.ChatOpenAI', 'llm', 20, 410, {
+      prompt_tokens: 280,
+      completion_tokens: 24,
+      total_tokens: 304,
+      cost_usd: 0.0008,
+    }),
+
+    // Dispatcher node containing parallel fan-out
+    span('s_dispatch', 's_root', 'chain.dispatch', 'custom', 450, 2700),
+
+    // Parallel branch A: lookup_order
+    span('s_order', 's_dispatch', 'chain.lookup_order', 'custom', 450, 1100),
+    span('s_order_tool', 's_order', 'tool.shopify_query', 'tool', 470, 840),
+    span('s_order_llm', 's_order', 'llm.ChatOpenAI', 'llm', 1320, 220, {
+      prompt_tokens: 412,
+      completion_tokens: 31,
+      total_tokens: 443,
+      cost_usd: 0.0005,
+    }),
+
+    // Parallel branch B: lookup_kb (critical path passes through here)
+    span('s_kb', 's_dispatch', 'chain.lookup_kb', 'custom', 450, 2700),
+    span('s_kb_retrieval', 's_kb', 'retrieval.PineconeStore', 'retrieval', 470, 300),
+    span('s_kb_llm', 's_kb', 'llm.ChatAnthropic', 'llm', 800, 2330, {
+      prompt_tokens: 1320,
+      completion_tokens: 540,
+      total_tokens: 1860,
+      cost_usd: 0.0023,
+    }),
+
+    // Sequential: compose_final after dispatch
+    span('s_compose', 's_root', 'chain.compose_final', 'custom', 3150, 40),
+  ]
+
+  return {
+    id: '__demo_langgraph__',
+    project_id: 'mock_project',
+    organization_id: 'mock_org',
+    api_key_id: null,
+    name: 'customer-support-agent',
+    status: 'completed',
+    started_at: new Date(BASE).toISOString(),
+    ended_at: new Date(BASE + 3200).toISOString(),
+    duration_ms: 3200,
+    span_count: spans.length,
+    total_tokens: 2607,
+    total_cost_usd: 0.0036,
+    error_message: null,
+    created_at: new Date(BASE).toISOString(),
+    updated_at: new Date(BASE + 3200).toISOString(),
+    metadata: { user_id: 'u_demo', session_id: 's_demo' },
+    spans,
+    critical_span_ids: ['s_root', 's_classify', 's_dispatch', 's_kb', 's_kb_llm', 's_compose'],
+  }
+}

--- a/apps/web/lib/queries/use-traces.ts
+++ b/apps/web/lib/queries/use-traces.ts
@@ -57,6 +57,11 @@ export function useTrace(id: string) {
   return useQuery({
     queryKey: traceQueryKey(id),
     queryFn: async () => {
+      // Dev-only mock fixtures so the UI can be validated without seeded data.
+      if (process.env.NODE_ENV === 'development' && id.startsWith('__demo_')) {
+        const { mockLangGraphTrace } = await import('@/lib/mock-traces')
+        if (id === '__demo_langgraph__') return mockLangGraphTrace()
+      }
       const res = await apiGet<ApiEnvelope<TraceDetail>>(`/api/v1/traces/${id}`)
       return res.data
     },

--- a/apps/web/lib/topology.ts
+++ b/apps/web/lib/topology.ts
@@ -1,0 +1,344 @@
+import type { SpanRow, SpanType, TraceStatus } from '@/lib/queries/types'
+
+/**
+ * One node in the LangGraph topology view.
+ * Built from a single `chain.*` span; rolls up cost / tokens from descendants.
+ */
+export interface TopologyNode {
+  id: string
+  /** Display label (chain name stripped of "chain." prefix). */
+  label: string
+  /** True for the synthetic graph-root chain span. */
+  isRoot: boolean
+  status: TraceStatus
+  durationMs: number | null
+  /** Rolled up from this node's descendants (including non-chain LLM/tool/retrieval spans). */
+  costUsd: number | null
+  /** Rolled up token total. */
+  totalTokens: number
+  /** Direct non-chain child span counts (LLM / tool / retrieval / embedding / custom). */
+  childCounts: Record<SpanType, number>
+  /** Whether this chain node is on the critical path. */
+  isCritical: boolean
+  /** Original span for drawer / inspection. */
+  span: SpanRow
+  /** Layout (filled in by dagre). */
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface TopologyEdge {
+  id: string
+  source: string
+  target: string
+  isCritical: boolean
+  /** True when source.end > target.start (siblings that overlapped in time). */
+  isParallel: boolean
+}
+
+export interface Topology {
+  nodes: TopologyNode[]
+  edges: TopologyEdge[]
+  width: number
+  height: number
+  /** Fraction of spans that are chain.* — used to decide whether graph view is worth showing. */
+  chainShare: number
+}
+
+const NODE_WIDTH = 220
+const NODE_HEIGHT = 78
+/** Two siblings count as sequential if there is at most this much overlap in ms. */
+const SEQUENTIAL_TOLERANCE_MS = 2
+
+function ms(d: Date): number {
+  return d.getTime()
+}
+
+function spanStart(s: SpanRow): number {
+  return ms(new Date(s.started_at))
+}
+
+function spanEnd(s: SpanRow): number {
+  if (s.ended_at) return ms(new Date(s.ended_at))
+  if (s.duration_ms != null) return spanStart(s) + s.duration_ms
+  return spanStart(s)
+}
+
+function isChain(s: SpanRow): boolean {
+  return s.name.startsWith('chain.')
+}
+
+function stripChain(name: string): string {
+  return name.replace(/^chain\./, '')
+}
+
+/**
+ * Walk down from `rootId` and accumulate cost / tokens across every descendant.
+ * Cost on chain spans themselves is generally null (they are wrapper spans);
+ * the LLM / tool children carry the real numbers.
+ */
+function rollup(
+  rootId: string,
+  childrenByParent: Map<string | null, SpanRow[]>,
+): { costUsd: number | null; totalTokens: number } {
+  let cost = 0
+  let hasCost = false
+  let tokens = 0
+  const stack: string[] = [rootId]
+  while (stack.length > 0) {
+    const id = stack.pop()!
+    const kids = childrenByParent.get(id) ?? []
+    for (const k of kids) {
+      if (k.cost_usd != null) {
+        cost += k.cost_usd
+        hasCost = true
+      }
+      tokens += k.total_tokens
+      stack.push(k.id)
+    }
+  }
+  return { costUsd: hasCost ? cost : null, totalTokens: tokens }
+}
+
+/**
+ * Build a LangGraph-style topology from a flat list of spans.
+ *
+ * Topology rules:
+ *   - Nodes = every `chain.*` span.
+ *   - For each non-root chain span X with a chain parent P:
+ *       * If a previous chain-sibling Y exists with Y.end <= X.start (within
+ *         SEQUENTIAL_TOLERANCE_MS), draw a sequential edge Y → X.
+ *       * Otherwise X is a fan-out head from P: draw an entry edge P → X.
+ *   - Edge is marked `isCritical` when both endpoints are on the critical path.
+ *   - Edge is marked `isParallel` only for entry edges P → X where X has a
+ *     concurrent sibling (used purely for styling).
+ *
+ * Returns null if the trace has fewer than 2 chain spans (graph view would be empty / pointless).
+ */
+export function buildTopology(
+  spans: SpanRow[],
+  criticalSpanIds: readonly string[],
+): Topology | null {
+  const chainSpans = spans.filter(isChain)
+  if (chainSpans.length < 2) return null
+
+  const chainIdSet = new Set(chainSpans.map((s) => s.id))
+  const criticalSet = new Set(criticalSpanIds)
+  const spanById = new Map(spans.map((s) => [s.id, s] as const))
+
+  // Build parent → children map (across the whole span set, not just chains).
+  const childrenByParent = new Map<string | null, SpanRow[]>()
+  for (const s of spans) {
+    const arr = childrenByParent.get(s.parent_span_id)
+    if (arr) arr.push(s)
+    else childrenByParent.set(s.parent_span_id, [s])
+  }
+
+  // Walk up from each chain span to find its nearest chain ancestor.
+  function chainParent(s: SpanRow): SpanRow | null {
+    let cur = s.parent_span_id
+    while (cur) {
+      const p = spanById.get(cur)
+      if (!p) return null
+      if (isChain(p)) return p
+      cur = p.parent_span_id
+    }
+    return null
+  }
+
+  // Build nodes.
+  const nodeMap = new Map<string, TopologyNode>()
+  for (const s of chainSpans) {
+    const directChildren = childrenByParent.get(s.id) ?? []
+    const childCounts: Record<SpanType, number> = {
+      llm: 0,
+      tool: 0,
+      retrieval: 0,
+      embedding: 0,
+      custom: 0,
+    }
+    for (const c of directChildren) {
+      if (!chainIdSet.has(c.id)) childCounts[c.span_type]++
+    }
+    const { costUsd, totalTokens } = rollup(s.id, childrenByParent)
+    const parentChain = chainParent(s)
+    nodeMap.set(s.id, {
+      id: s.id,
+      label: stripChain(s.name),
+      isRoot: parentChain === null,
+      status: s.status,
+      durationMs: s.duration_ms,
+      costUsd,
+      totalTokens,
+      childCounts,
+      isCritical: criticalSet.has(s.id),
+      span: s,
+      x: 0,
+      y: 0,
+      width: NODE_WIDTH,
+      height: NODE_HEIGHT,
+    })
+  }
+
+  // Build edges by sibling time ordering.
+  const edges: TopologyEdge[] = []
+  // Group chain spans by their nearest chain parent (null for the synthetic graph root group).
+  const byParent = new Map<string | null, SpanRow[]>()
+  for (const s of chainSpans) {
+    const p = chainParent(s)
+    const key = p?.id ?? null
+    const arr = byParent.get(key)
+    if (arr) arr.push(s)
+    else byParent.set(key, [s])
+  }
+
+  for (const [parentId, group] of byParent) {
+    const sorted = [...group].sort((a, b) => spanStart(a) - spanStart(b))
+    for (let i = 0; i < sorted.length; i++) {
+      const cur = sorted[i]!
+      // Find latest previous sibling that finished before `cur` started.
+      let pred: SpanRow | null = null
+      for (let j = i - 1; j >= 0; j--) {
+        const prev = sorted[j]!
+        if (spanEnd(prev) - spanStart(cur) <= SEQUENTIAL_TOLERANCE_MS) {
+          pred = prev
+          break
+        }
+      }
+      if (pred) {
+        edges.push({
+          id: `${pred.id}->${cur.id}`,
+          source: pred.id,
+          target: cur.id,
+          isCritical: criticalSet.has(pred.id) && criticalSet.has(cur.id),
+          isParallel: false,
+        })
+      } else if (parentId) {
+        // Fan-out / entry edge from the parent chain.
+        const hasParallelTwin = sorted.some(
+          (other) =>
+            other.id !== cur.id &&
+            Math.abs(spanStart(other) - spanStart(cur)) <= SEQUENTIAL_TOLERANCE_MS,
+        )
+        edges.push({
+          id: `${parentId}->${cur.id}`,
+          source: parentId,
+          target: cur.id,
+          isCritical: criticalSet.has(parentId) && criticalSet.has(cur.id),
+          isParallel: hasParallelTwin,
+        })
+      }
+    }
+  }
+
+  // Layout: recursive subtree-width tree layout.
+  //
+  // Our edge inference guarantees each node has at most one incoming edge
+  // (either parent-chain entry, or sequential-predecessor sibling), so the
+  // result is always a tree (possibly a forest if multiple roots exist).
+  // dagre's general DAG layout left parents a few pixels off-centre above
+  // their children — visible whenever a fan-out had ≥3 branches. A simple
+  // bottom-up subtree-width pass gives perfectly symmetric placement.
+  const RANK_SEP = 64
+  const NODE_SEP = 36
+  const MARGIN = 24
+
+  const childrenAdj = new Map<string, string[]>()
+  const hasParentEdge = new Set<string>()
+  for (const e of edges) {
+    const arr = childrenAdj.get(e.source)
+    if (arr) arr.push(e.target)
+    else childrenAdj.set(e.source, [e.target])
+    hasParentEdge.add(e.target)
+  }
+  const roots: string[] = []
+  for (const id of nodeMap.keys()) if (!hasParentEdge.has(id)) roots.push(id)
+
+  const subWidthCache = new Map<string, number>()
+  function subtreeWidth(id: string): number {
+    const cached = subWidthCache.get(id)
+    if (cached !== undefined) return cached
+    const kids = childrenAdj.get(id) ?? []
+    if (kids.length === 0) {
+      subWidthCache.set(id, NODE_WIDTH)
+      return NODE_WIDTH
+    }
+    let total = 0
+    for (const k of kids) total += subtreeWidth(k) + NODE_SEP
+    total -= NODE_SEP
+    const w = Math.max(NODE_WIDTH, total)
+    subWidthCache.set(id, w)
+    return w
+  }
+
+  // Sort each node's children by execution start time so visual reading
+  // order matches what happened.
+  function kidsSorted(id: string): string[] {
+    const kids = childrenAdj.get(id) ?? []
+    return [...kids].sort((a, b) => {
+      const sa = nodeMap.get(a)?.span.started_at ?? ''
+      const sb = nodeMap.get(b)?.span.started_at ?? ''
+      return sa.localeCompare(sb)
+    })
+  }
+
+  function place(id: string, centerX: number, rank: number): void {
+    const node = nodeMap.get(id)
+    if (!node) return
+    // Store node CENTER (not top-left); combined with React Flow's
+    // nodeOrigin=[0.5, 0], React Flow renders the node anchored at this
+    // centre point. This eliminates the off-by-half-width drift between
+    // our authoritative layout coordinates and React Flow's edge endpoint
+    // calculations, which had been anchoring edges at ~62% of node width
+    // when the two coordinate conventions disagreed.
+    node.x = centerX
+    node.y = MARGIN + rank * (NODE_HEIGHT + RANK_SEP)
+    const kids = kidsSorted(id)
+    if (kids.length === 0) return
+    let totalKidsWidth = 0
+    for (const k of kids) totalKidsWidth += subtreeWidth(k) + NODE_SEP
+    totalKidsWidth -= NODE_SEP
+    let cursor = centerX - totalKidsWidth / 2
+    for (const k of kids) {
+      const w = subtreeWidth(k)
+      place(k, cursor + w / 2, rank + 1)
+      cursor += w + NODE_SEP
+    }
+  }
+
+  let rootCursor = MARGIN
+  for (const r of roots) {
+    const w = subtreeWidth(r)
+    place(r, rootCursor + w / 2, 0)
+    rootCursor += w + NODE_SEP
+  }
+
+  let maxX = 0
+  let maxY = 0
+  for (const n of nodeMap.values()) {
+    maxX = Math.max(maxX, n.x + n.width)
+    maxY = Math.max(maxY, n.y + n.height)
+  }
+
+  return {
+    nodes: Array.from(nodeMap.values()),
+    edges,
+    width: maxX,
+    height: maxY,
+    chainShare: spans.length > 0 ? chainSpans.length / spans.length : 0,
+  }
+}
+
+/**
+ * Heuristic: is this trace "graph-shaped" enough to warrant the topology view?
+ * Looks for at least 2 chain spans AND ≥20% of all spans being chains.
+ * Tuned so simple two-call RAG traces stay on the Gantt by default.
+ */
+export function shouldShowGraphView(spans: SpanRow[]): boolean {
+  if (spans.length === 0) return false
+  const chains = spans.filter(isChain).length
+  if (chains < 2) return false
+  return chains / spans.length >= 0.2
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.105.4",
     "@tanstack/react-query": "^5.100.10",
+    "@xyflow/react": "^12.10.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.100.10
         version: 5.100.10(react@19.2.6)
+      '@xyflow/react':
+        specifier: ^12.10.2
+        version: 12.10.2(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -2235,6 +2238,9 @@ packages:
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
 
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
   '@types/d3-ease@3.0.2':
     resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
 
@@ -2247,6 +2253,9 @@ packages:
   '@types/d3-scale@4.0.9':
     resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
 
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
   '@types/d3-shape@3.1.8':
     resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
 
@@ -2255,6 +2264,12 @@ packages:
 
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -2579,6 +2594,15 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
+  '@xyflow/react@12.10.2':
+    resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.76':
+    resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
+
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -2791,6 +2815,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -2854,6 +2881,14 @@ packages:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
 
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
     engines: {node: '>=12'}
@@ -2874,6 +2909,10 @@ packages:
     resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
     engines: {node: '>=12'}
 
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
   d3-shape@3.2.0:
     resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
     engines: {node: '>=12'}
@@ -2888,6 +2927,16 @@ packages:
 
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
   damerau-levenshtein@1.0.8:
@@ -4748,6 +4797,21 @@ packages:
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -6519,6 +6583,10 @@ snapshots:
 
   '@types/d3-color@3.1.3': {}
 
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
   '@types/d3-ease@3.0.2': {}
 
   '@types/d3-interpolate@3.0.4':
@@ -6531,6 +6599,8 @@ snapshots:
     dependencies:
       '@types/d3-time': 3.0.4
 
+  '@types/d3-selection@3.0.11': {}
+
   '@types/d3-shape@3.1.8':
     dependencies:
       '@types/d3-path': 3.1.1
@@ -6538,6 +6608,15 @@ snapshots:
   '@types/d3-time@3.0.4': {}
 
   '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
 
   '@types/deep-eql@4.0.2': {}
 
@@ -6901,6 +6980,29 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
+  '@xyflow/react@12.10.2(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@xyflow/system': 0.0.76
+      classcat: 5.0.5
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      zustand: 4.5.7(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.76':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   acorn-import-attributes@1.9.5(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -7132,6 +7234,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  classcat@5.0.5: {}
+
   client-only@0.0.1: {}
 
   clsx@2.1.1: {}
@@ -7184,6 +7288,13 @@ snapshots:
 
   d3-color@3.1.0: {}
 
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
   d3-ease@3.0.1: {}
 
   d3-format@3.1.2: {}
@@ -7202,6 +7313,8 @@ snapshots:
       d3-time: 3.1.0
       d3-time-format: 4.1.0
 
+  d3-selection@3.0.0: {}
+
   d3-shape@3.2.0:
     dependencies:
       d3-path: 3.1.0
@@ -7215,6 +7328,23 @@ snapshots:
       d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   damerau-levenshtein@1.0.8: {}
 
@@ -9368,3 +9498,11 @@ snapshots:
       zod: 4.4.3
 
   zod@4.4.3: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      immer: 11.1.8
+      react: 19.2.6


### PR DESCRIPTION
## Summary

Adds a **Graph view** tab to `/traces/[id]` (and the matching `/demo/traces/[id]`) that renders LangChain / LangGraph callback traces as a node-and-edge diagram with the critical path highlighted, alongside the existing Gantt timeline view.

## Why this matters

- **Closes the LangSmith parity gap.** Visitors on `/compare/langsmith` no longer see "graph visual is on our roadmap" as a reason to pick LangSmith over Spanlens. That sentence is replaced with concrete copy.
- **Critical Path reads stronger on graphs than on Gantt.** The trace's longest dependency chain (already our differentiator) becomes a visual element rather than a description in a side panel.
- **PH-launch asset.** The demo trace at `/demo/traces/demo-trace-langgraph` is hero-screenshot-ready.

## What ships

### New layout + render
- `apps/web/lib/topology.ts` — walks the span tree, isolates `chain.*` nodes, infers edges from sibling time ordering (sequential vs parallel fan-out), lays them out with a recursive subtree-width tree algorithm. Every parent is centred above its children with pixel-perfect symmetry, including ancestor chains of single-child parents.
- `apps/web/components/traces/topology-graph.tsx` — React Flow render of the topology, with a **custom step edge** that anchors at each node's layout-defined centre instead of React Flow's DOM-measured handle position. This fixes off-by-~12%-of-width artifacts under HiDPI / OS display scaling, and also pulls edge ends 2px outside the box borders so the line reads as a connector rather than bleeding into the border.

### UX
- Critical-path nodes get an accent border + `CP` badge.
- Critical edges get accent stroke; parallel siblings get dashed strokes.
- Non-LangGraph traces (chain.* share below 20%) auto-disable the Graph tab.
- Trace detail (dashboard + demo): Timeline / Graph toggle in the filter toolbar, view swap below it, drawer integration unchanged.

### Demo + docs + changelog
- `DEMO_TRACE_LANGGRAPH_DETAIL`: 11-span customer-support agent topology (`chain.agent_orchestrator → classify_intent → dispatch → {lookup_order, lookup_kb} → compose_final`, each chain node wrapping its own LLM / tool / retrieval children). Critical path runs through `lookup_kb`'s LLM call.
- `/docs/integrations/langgraph`: roadmap sentence replaced with concrete copy describing the Timeline / Graph tabs.
- `/compare/langsmith`: LangGraph card reframed from "Spanlens doesn't render the graph topology" to a fair "both render it; LangSmith goes deeper on state-transition introspection". Feature row updated to yes / yes with a note.
- New changelog entry at `/changelog`.

### Dev-only fixtures
- `lib/mock-traces.ts` + a `NODE_ENV`-gated branch in `useTrace` let us drive `/traces/__demo_langgraph__` during development to validate the Graph view without seeded production data. Both are dynamic-imported and excluded from production builds.

## Verification

- `pnpm --filter web typecheck` + `pnpm --filter web lint` both clean.
- Custom edge endpoint x measurement on the running app matches node centre to floating-point precision (`diff ≈ 3e-5 px`).
- Demo flow: `/demo/traces` → top row `multi-agent-orchestrator` → opens with Graph view active.

## Test plan

- [ ] Open `/traces/__demo_langgraph__` (dev): Graph tab renders 6 chain nodes in a tree, with the CP column (`agent_orchestrator → classify_intent → dispatch → lookup_kb`) perfectly vertical.
- [ ] Click any node: span drawer opens, node gets accent ring.
- [ ] Toggle to Timeline: existing Gantt view restored, no layout shift.
- [ ] Open a non-LangGraph trace (`/traces/<any 1-span trace>`): Graph tab is disabled with hover hint.
- [ ] Demo path: `/demo/traces` → `multi-agent-orchestrator` → Graph view active by default.
- [ ] `/docs/integrations/langgraph` + `/compare/langsmith`: updated copy reads naturally.