### PR TITLE
chore: update github org references from sunes26 to spanlens

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -111,7 +111,7 @@
 - [x] Paddle Sandbox end-to-end 검증 (signup → upgrade → Paddle.js 오버레이 → webhook → plan=starter, status=active) — 테스트 카드 `4242 4242 4242 4242` 로 전체 플로우 성공. `transaction.completed` 핸들러가 `fetchPaddleSubscription` 으로 billing period 보강하도록 수정 완료.
 - [ ] **Paddle 프로덕션 KYC 통과** + Production price ID 환경변수 전환 — **외부 의존, 유저 작업**. 사업자등록증 + 신분증 + 웹사이트 URL + 이용약관 제출 → 심사 1~2주.
 - [ ] 에이전트 트레이싱 **내부 dogfood** 프로젝트 3개+ (본인 프로젝트들을 Spanlens로 관측) — **점진적**. SDK 배포 완료됐으므로 실제 서비스에 연결만 하면 됨. 현재 `projects=1, traces=0`.
-- [x] **셀프호스팅 공식 Docker 이미지** `docker pull ghcr.io/sunes26/spanlens-server:latest` 배포 — multi-stage node:22-alpine, non-root user, HEALTHCHECK 포함. `.github/workflows/docker-publish.yml` 로 amd64+arm64 자동 빌드. 3m 43s 소요. (※ GHCR 패키지 public 전환은 유저 수동 작업.)
+- [x] **셀프호스팅 공식 Docker 이미지** `docker pull ghcr.io/spanlens/spanlens-server:latest` 배포 — multi-stage node:22-alpine, non-root user, HEALTHCHECK 포함. `.github/workflows/docker-publish.yml` 로 amd64+arm64 자동 빌드. 3m 43s 소요. (※ GHCR 패키지 public 전환은 유저 수동 작업.)
 - [x] 스트리밍/논스트리밍 토큰·비용 ±1% 오차 유지 — server 39 + sdk 28 = 총 67 테스트 그린. OpenAI 프로덕션 streaming e2e 검증 완료.
 - [x] SDK npm publish 완료 — `@spanlens/sdk@0.1.0` (로컬 수동 publish) + `@spanlens/sdk@0.1.1` (CI 자동 publish, provenance 포함). `sdk-v*` 태그 푸시 시 `publish-sdk.yml` 자동 실행. LangChain/LlamaIndex 실기기 검증은 dogfood 단계에서 수행 예정.
 - [x] 보안: Provider Key 로그 노출 정적 스캔 0건 (test-e2e.ts도 마스킹 처리), RLS 누락 테이블 0건 (`SELECT FROM pg_tables WHERE rowsecurity=false AND schemaname='public'` = 빈 결과).
@@ -422,7 +422,7 @@ Product Hunt + HN + 커뮤니티 동시 런치. Phase 1~3에서 쌓은 차별화
 - [x] `db.ts` 에러 메시지 개선 — 어느 env var 빠졌는지 구체적으로 출력
 - [x] `docker-compose.yml` → `docker-compose.dev.yml` 이름 변경 (dev 전용 명시)
 - [x] `/docs/self-host` 재작성 — "plain Postgres 지원" 허위 주장 제거, "early access" 배너, Supabase 필수 + CLI 마이그레이션 스텝 + 각 gap을 inline 경고로 명시
-- [x] **GHCR 패키지를 public으로 전환** — 완료 (2026-04-22). 공식 이미지 `docker pull ghcr.io/sunes26/spanlens-server:latest` → 부팅 + `/health` 200 검증됨
+- [x] **GHCR 패키지를 public으로 전환** — 완료 (2026-04-22). 공식 이미지 `docker pull ghcr.io/spanlens/spanlens-server:latest` → 부팅 + `/health` 200 검증됨
 - [ ] 마이그레이션 번들 — `spanlens-migrate` Docker 이미지 또는 entrypoint 스크립트로 자동 적용 (현재는 유저가 repo clone + supabase CLI 설치 + `db push` 수동)
 - [ ] `spanlens-web` Docker 이미지 publish — 현재 workflow 없음. web 대시보드도 self-host 가능하게 별도 이미지 빌드 필요 (docs 주장과 일치시키기)
 - [ ] Plain Postgres 지원 — `@supabase/supabase-js` 직접 의존 제거, 얇은 abstraction layer 도입 (리팩토링 큼, 런칭 후 이관)

--- a/apps/server/src/api/openapi.ts
+++ b/apps/server/src/api/openapi.ts
@@ -25,7 +25,7 @@ export const SPEC: OpenAPIV3.Document = {
     description:
       'REST API for Spanlens LLM observability. All authenticated endpoints require a Supabase JWT in `Authorization: Bearer <token>`. Proxy endpoints use a Spanlens API key.',
     contact: { email: 'support@spanlens.io' },
-    license: { name: 'MIT', url: 'https://github.com/sunes26/Spanlens/blob/main/LICENSE' },
+    license: { name: 'MIT', url: 'https://github.com/spanlens/Spanlens/blob/main/LICENSE' },
   },
   externalDocs: {
     description: 'Full documentation',

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -541,7 +541,7 @@ export default function LandingPage() {
             <div>{'  '}-p 3001:3001 \</div>
             <div>{'  '}-e <span className="text-[#b4e0a0]">SUPABASE_URL</span>=<span className="text-[#f2a65a]">&quot;https://...&quot;</span> \</div>
             <div>{'  '}-e <span className="text-[#b4e0a0]">ENCRYPTION_KEY</span>=<span className="text-[#f2a65a]">&quot;$(openssl rand -base64 32)&quot;</span> \</div>
-            <div>{'  '}ghcr.io/sunes26/spanlens-server:latest</div>
+            <div>{'  '}ghcr.io/spanlens/spanlens-server:latest</div>
             <div className="text-[#7a7a7a] mt-2.5"># → curl http://localhost:3001/health</div>
           </div>
         </div>

--- a/apps/web/components/layout/footer.tsx
+++ b/apps/web/components/layout/footer.tsx
@@ -61,7 +61,7 @@ export function Footer() {
           <div>
             <div className="text-text-faint mb-2 tracking-[0.05em] uppercase text-[10px]">Open Source</div>
             <div className="flex flex-col gap-1.5">
-              <a href="https://github.com/sunes26/Spanlens" target="_blank" rel="noopener noreferrer" className="hover:text-text transition-colors">GitHub</a>
+              <a href="https://github.com/spanlens/Spanlens" target="_blank" rel="noopener noreferrer" className="hover:text-text transition-colors">GitHub</a>
               <Link href="/docs/self-host" className="hover:text-text transition-colors">Self-host</Link>
             </div>
           </div>

--- a/apps/web/components/layout/marketing-nav.tsx
+++ b/apps/web/components/layout/marketing-nav.tsx
@@ -35,7 +35,7 @@ export function MarketingNav({ signupLabel = 'Start free →', subtitle }: Marke
           <Link href="/pricing" className="hover:text-text transition-colors">Pricing</Link>
           <Link href="/changelog" className="hover:text-text transition-colors">Changelog</Link>
           <a
-            href="https://github.com/sunes26/Spanlens"
+            href="https://github.com/spanlens/Spanlens"
             target="_blank"
             rel="noopener noreferrer"
             className="hover:text-text transition-colors"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     # Default: pull pre-built image from GHCR (no build required).
     # docker-entrypoint.sh patches NEXT_PUBLIC_* placeholders at startup.
     # To build locally instead: docker compose up -d --build
-    image: ghcr.io/sunes26/spanlens-web:latest
+    image: ghcr.io/spanlens/spanlens-web:latest
     build:
       context: .
       dockerfile: apps/web/Dockerfile
@@ -66,7 +66,7 @@ services:
   server:
     # Default: pull pre-built image from GHCR.
     # To build locally instead: docker compose up -d --build
-    image: ghcr.io/sunes26/spanlens-server:latest
+    image: ghcr.io/spanlens/spanlens-server:latest
     build:
       context: .
       dockerfile: apps/server/Dockerfile


### PR DESCRIPTION
## Summary

GitHub repo was transferred to the `spanlens` org and ghcr packages now live under `ghcr.io/spanlens/*` (public, visibility just enabled). This PR updates user-visible URL references that still pointed at the legacy `sunes26` paths.

**Updated (6 locations)**
- [apps/web/app/page.tsx:544](apps/web/app/page.tsx) — landing `docker run` example
- [apps/web/components/layout/marketing-nav.tsx:38](apps/web/components/layout/marketing-nav.tsx) — top nav GitHub link
- [apps/web/components/layout/footer.tsx:64](apps/web/components/layout/footer.tsx) — footer GitHub link
- [apps/server/src/api/openapi.ts:28](apps/server/src/api/openapi.ts) — OpenAPI spec license URL
- [docker-compose.yml:37,69](docker-compose.yml) — self-host image paths for web + server
- [ROADMAP.md:114,425](ROADMAP.md) — `docker pull` command examples in completed-task notes

**Intentionally left as `sunes26`**
- Vercel preview-URL regex in [apps/server/src/app.ts:70](apps/server/src/app.ts), [CLAUDE.md](CLAUDE.md), [docs/auth-oauth-setup.md](docs/auth-oauth-setup.md) — Vercel project ownership stays on the personal account, so preview URLs are still issued under `*-sunes26s-projects.vercel.app`.
- [.github/CODEOWNERS](.github/CODEOWNERS), [CONTRIBUTING.md:199](CONTRIBUTING.md), [docs/plans/infrastructure-region-survey.md:4](docs/plans/infrastructure-region-survey.md) — `@sunes26` is still the maintainer's GitHub username.
- [packages/sdk-python/CHANGELOG.md:9](packages/sdk-python/CHANGELOG.md) — historical fix record, mentions the old path by design.

## Test plan
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green
- [ ] Verify on Vercel preview: landing `docker run` block shows `ghcr.io/spanlens/spanlens-server:latest`
- [ ] Verify on Vercel preview: nav + footer GitHub links resolve to `github.com/spanlens/Spanlens`
- [ ] Verify on Vercel preview: `/openapi.json` `license.url` points at the new org
- [ ] Self-host smoke: `docker compose up` pulls `ghcr.io/spanlens/spanlens-{web,server}:latest` without auth error (depends on the GHCR visibility flip already done)