### PR TITLE
feat: add read-only scope for Spanlens API keys

### DIFF
--- a/apps/server/src/__tests__/auth-api-key.test.ts
+++ b/apps/server/src/__tests__/auth-api-key.test.ts
@@ -48,6 +48,7 @@ vi.mock('../lib/db.js', () => ({
                   data: {
                     id: 'key-1',
                     project_id: 'proj-1',
+                    scope: 'full',
                     projects: { organization_id: 'org-1' },
                   },
                   error: null,
@@ -70,6 +71,7 @@ function buildApp() {
       ok: true,
       orgId: c.get('organizationId'),
       projectId: c.get('projectId'),
+      scope: c.get('apiKeyScope'),
     }),
   )
   return app
@@ -83,9 +85,11 @@ describe('authApiKey — accepted transports', () => {
       headers: { Authorization: `Bearer ${VALID_KEY}` },
     })
     expect(res.status).toBe(200)
-    const body = (await res.json()) as { ok: boolean; orgId: string }
+    const body = (await res.json()) as { ok: boolean; orgId: string; scope: string }
     expect(body.ok).toBe(true)
     expect(body.orgId).toBe('org-1')
+    // scope is populated on the context so downstream guards can read it.
+    expect(body.scope).toBe('full')
   })
 
   test('x-api-key passes', async () => {

--- a/apps/server/src/__tests__/require-full-scope.test.ts
+++ b/apps/server/src/__tests__/require-full-scope.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test, vi } from 'vitest'
+import { Hono } from 'hono'
+import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
+
+/**
+ * requireFullScope rejects readonly Spanlens keys with 403 before they reach
+ * write handlers (proxy/* and ingest/*). Full-scope keys pass through.
+ *
+ * The DB mock returns whichever scope the test sets via `setMockScope` so we
+ * can drive both branches from a single test file without re-mocking per
+ * describe block.
+ */
+
+const FULL_KEY = 'sl_live_fulltestkey0123456789abcd'
+const FULL_HASH = 'full-hash'
+const RO_KEY = 'sl_live_ro_readonlytestkey0123456'
+const RO_HASH = 'ro-hash'
+
+vi.mock('../lib/crypto.js', () => ({
+  sha256Hex: async (raw: string) => {
+    if (raw === FULL_KEY) return FULL_HASH
+    if (raw === RO_KEY) return RO_HASH
+    return 'invalid-hash'
+  },
+}))
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: (_table: string) => ({
+      select: (_cols: string) => ({
+        eq: (col: string, val: string) => ({
+          eq: (_col2: string, _val2: unknown) => ({
+            single: async () => {
+              if (col !== 'key_hash') return { data: null, error: { message: 'not found' } }
+              if (val === FULL_HASH) {
+                return {
+                  data: {
+                    id: 'full-key-id',
+                    project_id: 'proj-1',
+                    scope: 'full',
+                    projects: { organization_id: 'org-1' },
+                  },
+                  error: null,
+                }
+              }
+              if (val === RO_HASH) {
+                return {
+                  data: {
+                    id: 'ro-key-id',
+                    project_id: 'proj-1',
+                    scope: 'readonly',
+                    projects: { organization_id: 'org-1' },
+                  },
+                  error: null,
+                }
+              }
+              return { data: null, error: { message: 'not found' } }
+            },
+          }),
+        }),
+      }),
+    }),
+  },
+}))
+
+function buildApp() {
+  const app = new Hono<ApiKeyContext>()
+  app.use('*', authApiKey)
+  app.use('*', requireFullScope)
+  app.post('/write', (c) => c.json({ ok: true }))
+  return app
+}
+
+describe('requireFullScope', () => {
+  const app = buildApp()
+
+  test('full-scope key passes the guard', async () => {
+    const res = await app.request('/write', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${FULL_KEY}` },
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: boolean }
+    expect(body.ok).toBe(true)
+  })
+
+  test('readonly key is rejected with 403 + READONLY_KEY code', async () => {
+    const res = await app.request('/write', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${RO_KEY}` },
+    })
+    expect(res.status).toBe(403)
+    const body = (await res.json()) as { error: string; code: string }
+    expect(body.code).toBe('READONLY_KEY')
+    // Error message should point the user at the dashboard so they know
+    // where to mint a full-access key instead of debugging blindly.
+    expect(body.error.toLowerCase()).toContain('read-only')
+  })
+
+  test('readonly rejection still surfaces 403 on every accepted transport', async () => {
+    // Both x-api-key (Anthropic) and x-goog-api-key (Gemini) must enforce
+    // the same scope rule — the rejection is at the middleware layer, not
+    // tied to a specific provider path.
+    for (const headers of [{ 'x-api-key': RO_KEY }, { 'x-goog-api-key': RO_KEY }]) {
+      const res = await app.request('/write', { method: 'POST', headers })
+      expect(res.status).toBe(403)
+    }
+  })
+
+  test('missing key returns 401 from authApiKey, not 403 from the scope guard', async () => {
+    const res = await app.request('/write', { method: 'POST' })
+    expect(res.status).toBe(401)
+  })
+})

--- a/apps/server/src/api/apiKeys.ts
+++ b/apps/server/src/api/apiKeys.ts
@@ -40,7 +40,7 @@ apiKeysRouter.get('/', async (c) => {
 
   let query = supabaseAdmin
     .from('api_keys')
-    .select('id, project_id, name, key_prefix, is_active, last_used_at, created_at')
+    .select('id, project_id, name, key_prefix, scope, is_active, last_used_at, created_at')
     .order('created_at', { ascending: false })
 
   if (projectId) {
@@ -70,7 +70,7 @@ apiKeysRouter.post('/issue', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) return c.json({ error: 'Organization not found' }, 404)
 
-  let body: { name?: unknown; projectId?: unknown }
+  let body: { name?: unknown; projectId?: unknown; scope?: unknown }
   try {
     body = (await c.req.json()) as typeof body
   } catch {
@@ -84,10 +84,21 @@ apiKeysRouter.post('/issue', requireEdit, async (c) => {
     return c.json({ error: 'projectId is required' }, 400)
   }
 
+  // scope: 'full' (default, can call proxy + ingest) or 'readonly' (dashboard
+  // reads only — safe for MCP servers / BI tools / public read embeds where
+  // the key sits in a high-leak-surface location).
+  const scope: 'full' | 'readonly' = body.scope === 'readonly' ? 'readonly' : 'full'
+
   const belongs = await projectBelongsToOrg(body.projectId, orgId)
   if (!belongs) return c.json({ error: 'Project not found' }, 404)
 
-  const rawKey = `sl_live_${randomHex(24)}`
+  // Prefix encodes scope so a user can spot leaked permissions at a glance
+  // (and grep for them in logs). `key_prefix` stays the same length (15)
+  // regardless of scope so existing UI columns line up.
+  //   full      → sl_live_<24 hex>
+  //   readonly  → sl_live_ro_<24 hex>
+  const rawKey =
+    scope === 'readonly' ? `sl_live_ro_${randomHex(24)}` : `sl_live_${randomHex(24)}`
   const keyHash = await sha256Hex(rawKey)
   const keyPrefix = rawKey.slice(0, 15)
 
@@ -98,8 +109,9 @@ apiKeysRouter.post('/issue', requireEdit, async (c) => {
       name: body.name.trim(),
       key_hash: keyHash,
       key_prefix: keyPrefix,
+      scope,
     })
-    .select('id, project_id, name, key_prefix, is_active, created_at')
+    .select('id, project_id, name, key_prefix, scope, is_active, created_at')
     .single()
 
   if (error || !data) return c.json({ error: 'Failed to create API key' }, 500)

--- a/apps/server/src/api/ingest.ts
+++ b/apps/server/src/api/ingest.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { fireAndForget } from '../lib/wait-until.js'
 import { emitWebhookEvent } from '../lib/webhook-emit.js'
@@ -21,6 +22,7 @@ import { emitWebhookEvent } from '../lib/webhook-emit.js'
 export const ingestRouter = new Hono<ApiKeyContext>()
 
 ingestRouter.use('*', authApiKey)
+ingestRouter.use('*', requireFullScope)
 
 type TraceStatus = 'running' | 'completed' | 'error'
 type SpanStatus = 'running' | 'completed' | 'error'

--- a/apps/server/src/api/me.ts
+++ b/apps/server/src/api/me.ts
@@ -25,6 +25,8 @@ interface KeyInfoResponse {
   projectName: string
   /** Providers with an active provider_key under THIS Spanlens key. */
   providers: KnownProvider[]
+  /** 'full' = can call proxy + ingest. 'readonly' = dashboard reads only. */
+  scope: 'full' | 'readonly'
 }
 
 // GET /api/v1/me/key-info — introspect the presented Spanlens key.
@@ -68,6 +70,7 @@ meRouter.get('/', async (c) => {
     projectId: project.id as string,
     projectName: project.name as string,
     providers,
+    scope: c.get('apiKeyScope'),
   }
   return c.json({ success: true, data: body })
 })

--- a/apps/server/src/api/otlp.ts
+++ b/apps/server/src/api/otlp.ts
@@ -19,6 +19,7 @@
 
 import { Hono } from 'hono'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
 import { supabaseAdmin } from '../lib/db.js'
 import {
   groupByTrace,
@@ -34,7 +35,7 @@ export const otlpRouter = new Hono<ApiKeyContext>()
 
 // ── POST /v1/traces ────────────────────────────────────────────────────────────
 
-otlpRouter.post('/v1/traces', authApiKey, async (c) => {
+otlpRouter.post('/v1/traces', authApiKey, requireFullScope, async (c) => {
   const organizationId = c.get('organizationId')
   const projectId      = c.get('projectId')
   const apiKeyId       = c.get('apiKeyId')

--- a/apps/server/src/middleware/authApiKey.ts
+++ b/apps/server/src/middleware/authApiKey.ts
@@ -21,11 +21,14 @@ import { sha256Hex } from '../lib/crypto.js'
  * server access logs, browser history, and Referer headers). All current
  * Google Generative AI SDK versions use the x-goog-api-key header.
  */
+export type ApiKeyScope = 'full' | 'readonly'
+
 export type ApiKeyContext = {
   Variables: {
     organizationId: string
     projectId: string
     apiKeyId: string
+    apiKeyScope: ApiKeyScope
   }
 }
 
@@ -67,7 +70,7 @@ export const authApiKey = createMiddleware<ApiKeyContext>(async (c, next) => {
 
   const { data, error } = await supabaseAdmin
     .from('api_keys')
-    .select('id, project_id, projects(organization_id)')
+    .select('id, project_id, scope, projects(organization_id)')
     .eq('key_hash', keyHash)
     .eq('is_active', true)
     .single()
@@ -81,9 +84,12 @@ export const authApiKey = createMiddleware<ApiKeyContext>(async (c, next) => {
     return c.json({ error: 'Project not found' }, 401)
   }
 
+  const scope = (data.scope as string | null) === 'readonly' ? 'readonly' : 'full'
+
   c.set('apiKeyId', data.id as string)
   c.set('projectId', data.project_id as string)
   c.set('organizationId', project.organization_id)
+  c.set('apiKeyScope', scope)
 
   return next()
 })

--- a/apps/server/src/middleware/requireFullScope.ts
+++ b/apps/server/src/middleware/requireFullScope.ts
@@ -1,0 +1,36 @@
+import { createMiddleware } from 'hono/factory'
+import type { ApiKeyContext } from './authApiKey.js'
+
+/**
+ * Rejects requests authenticated with a `readonly`-scope Spanlens key.
+ *
+ * Mounted on routes that perform writes or trigger spend:
+ *   • /proxy/openai, /proxy/anthropic, /proxy/gemini, /proxy/azure  (LLM calls)
+ *   • /ingest/*                                                      (SDK writes)
+ *   • POST /v1/traces                                                (OTLP exports)
+ *
+ * Must run AFTER `authApiKey` (which populates `apiKeyScope` on the context).
+ *
+ * Read-only keys still work on:
+ *   • /api/v1/stats/*, /api/v1/requests/*, /api/v1/traces/* (GET)
+ *   • /api/v1/me/key-info                                   (CLI introspection)
+ *
+ * Why a separate middleware vs. an inline check: the same guard applies to
+ * 7+ routers and the check is identical. Centralising it keeps the rule
+ * (which routes are "write") in one place and prevents accidental drift
+ * when adding new proxy or ingest endpoints.
+ */
+export const requireFullScope = createMiddleware<ApiKeyContext>(async (c, next) => {
+  const scope = c.get('apiKeyScope')
+  if (scope === 'readonly') {
+    return c.json(
+      {
+        error:
+          'Read-only API key cannot perform write operations. Issue a full-access key at /projects to enable LLM proxy and ingest endpoints.',
+        code: 'READONLY_KEY',
+      },
+      403,
+    )
+  }
+  return next()
+})

--- a/apps/server/src/proxy/anthropic.ts
+++ b/apps/server/src/proxy/anthropic.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { stream } from 'hono/streaming'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
 import { calculateCost } from '../lib/cost.js'
@@ -19,6 +20,7 @@ const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '3500
 export const anthropicProxy = new Hono<ApiKeyContext>()
 
 anthropicProxy.use('*', authApiKey)
+anthropicProxy.use('*', requireFullScope)
 anthropicProxy.use('*', proxyRateLimit)
 anthropicProxy.use('*', enforceQuota)
 

--- a/apps/server/src/proxy/azure.ts
+++ b/apps/server/src/proxy/azure.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { stream } from 'hono/streaming'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
 import { calculateCost } from '../lib/cost.js'
@@ -31,6 +32,7 @@ const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '3500
 export const azureProxy = new Hono<ApiKeyContext>()
 
 azureProxy.use('*', authApiKey)
+azureProxy.use('*', requireFullScope)
 azureProxy.use('*', proxyRateLimit)
 azureProxy.use('*', enforceQuota)
 

--- a/apps/server/src/proxy/gemini.ts
+++ b/apps/server/src/proxy/gemini.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { stream } from 'hono/streaming'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
 import { calculateCost } from '../lib/cost.js'
@@ -18,6 +19,7 @@ const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '3500
 export const geminiProxy = new Hono<ApiKeyContext>()
 
 geminiProxy.use('*', authApiKey)
+geminiProxy.use('*', requireFullScope)
 geminiProxy.use('*', proxyRateLimit)
 geminiProxy.use('*', enforceQuota)
 

--- a/apps/server/src/proxy/openai.ts
+++ b/apps/server/src/proxy/openai.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { stream } from 'hono/streaming'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
 import { calculateCost } from '../lib/cost.js'
@@ -19,6 +20,7 @@ const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '3500
 export const openaiProxy = new Hono<ApiKeyContext>()
 
 openaiProxy.use('*', authApiKey)
+openaiProxy.use('*', requireFullScope)
 openaiProxy.use('*', proxyRateLimit)
 openaiProxy.use('*', enforceQuota)
 

--- a/apps/web/app/(dashboard)/projects/projects-client.tsx
+++ b/apps/web/app/(dashboard)/projects/projects-client.tsx
@@ -33,6 +33,7 @@ import {
   useToggleApiKey,
   useDeleteApiKey,
 } from '@/lib/queries/use-api-keys'
+import type { ApiKeyScope } from '@/lib/queries/types'
 import {
   useProviderKeys,
   useAddProviderKey,
@@ -166,6 +167,7 @@ export function ProjectsClient() {
   const [issueDialogOpen, setIssueDialogOpen] = useState(false)
   const [issueProjectId, setIssueProjectId] = useState('')
   const [issueName, setIssueName] = useState('')
+  const [issueScope, setIssueScope] = useState<ApiKeyScope>('full')
   const [issueError, setIssueError] = useState<string | null>(null)
 
   // Rotate provider key dialog
@@ -249,6 +251,7 @@ export function ProjectsClient() {
   function openIssueDialog(projectId: string) {
     setIssueProjectId(projectId)
     setIssueName('')
+    setIssueScope('full')
     setIssueError(null)
     setIssueDialogOpen(true)
   }
@@ -259,6 +262,7 @@ export function ProjectsClient() {
       const result = await issueApiKey.mutateAsync({
         name: issueName.trim(),
         projectId: issueProjectId,
+        scope: issueScope,
       })
       setNewKey(result?.key ?? null)
       setIssueDialogOpen(false)
@@ -705,11 +709,19 @@ export function ProjectsClient() {
                                 <div className="flex-1 min-w-0">
                                   <div
                                     className={cn(
-                                      'text-[13.5px] font-semibold truncate',
+                                      'text-[13.5px] font-semibold truncate flex items-center gap-2',
                                       !key.is_active && 'line-through text-text-faint',
                                     )}
                                   >
-                                    {key.name}
+                                    <span className="truncate">{key.name}</span>
+                                    {key.scope === 'readonly' && (
+                                      <span
+                                        className="shrink-0 font-mono text-[9.5px] uppercase tracking-[0.05em] px-1.5 py-0.5 rounded border border-border bg-bg-elev text-text-muted"
+                                        title="Dashboard reads only — cannot call LLM proxy or ingest"
+                                      >
+                                        Read-only
+                                      </span>
+                                    )}
                                   </div>
                                   <div className="font-mono text-[10.5px] text-text-faint mt-0.5">
                                     {key.key_prefix}…
@@ -882,7 +894,11 @@ export function ProjectsClient() {
         open={issueDialogOpen}
         onOpenChange={(open) => {
           setIssueDialogOpen(open)
-          if (!open) { setIssueProjectId(''); setIssueError(null) }
+          if (!open) {
+            setIssueProjectId('')
+            setIssueScope('full')
+            setIssueError(null)
+          }
         }}
       >
         <DialogContent>
@@ -909,6 +925,52 @@ export function ProjectsClient() {
                 className="w-full h-9 px-3 rounded-[6px] border border-border bg-bg text-[13px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong transition-colors"
               />
             </div>
+
+            <fieldset className="space-y-2">
+              <legend className="text-[12.5px] text-text-muted font-medium">Permission</legend>
+              <label className="flex items-start gap-2.5 rounded-[6px] border border-border p-3 cursor-pointer hover:border-border-strong transition-colors">
+                <input
+                  type="radio"
+                  name="issueScope"
+                  value="full"
+                  checked={issueScope === 'full'}
+                  onChange={() => setIssueScope('full')}
+                  className="mt-0.5"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="text-[13px] text-text font-medium flex items-center gap-2">
+                    Full access
+                    <code className="font-mono text-[10.5px] text-text-faint bg-bg-elev border border-border px-1 rounded">
+                      sl_live_…
+                    </code>
+                  </div>
+                  <div className="text-[11.5px] text-text-muted mt-0.5">
+                    Make LLM proxy calls, ingest traces, and read dashboard data.
+                  </div>
+                </div>
+              </label>
+              <label className="flex items-start gap-2.5 rounded-[6px] border border-border p-3 cursor-pointer hover:border-border-strong transition-colors">
+                <input
+                  type="radio"
+                  name="issueScope"
+                  value="readonly"
+                  checked={issueScope === 'readonly'}
+                  onChange={() => setIssueScope('readonly')}
+                  className="mt-0.5"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="text-[13px] text-text font-medium flex items-center gap-2">
+                    Read-only
+                    <code className="font-mono text-[10.5px] text-text-faint bg-bg-elev border border-border px-1 rounded">
+                      sl_live_ro_…
+                    </code>
+                  </div>
+                  <div className="text-[11.5px] text-text-muted mt-0.5">
+                    Dashboard reads only. Safe for MCP servers, BI tools, and embeds where the key sits in a high-leak-surface location.
+                  </div>
+                </div>
+              </label>
+            </fieldset>
 
             {issueError && (
               <div className="rounded-md border border-bad/30 bg-bad/10 px-3 py-2 text-[12px] text-bad">

--- a/apps/web/lib/queries/types.ts
+++ b/apps/web/lib/queries/types.ts
@@ -42,11 +42,14 @@ export interface Project {
   updated_at?: string
 }
 
+export type ApiKeyScope = 'full' | 'readonly'
+
 export interface ApiKey {
   id: string
   project_id: string
   name: string
   key_prefix: string
+  scope: ApiKeyScope
   is_active: boolean
   last_used_at: string | null
   created_at: string

--- a/apps/web/lib/queries/use-api-keys.ts
+++ b/apps/web/lib/queries/use-api-keys.ts
@@ -2,7 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiDelete, apiGet, apiPatch, apiPost } from '@/lib/api'
-import type { ApiEnvelope, ApiKey, IssuedApiKey } from './types'
+import type { ApiEnvelope, ApiKey, ApiKeyScope, IssuedApiKey } from './types'
 
 /**
  * Spanlens (sl_live_*) keys. Under the unified-keys model these are
@@ -29,7 +29,7 @@ export function useApiKeys(projectId?: string) {
 export function useIssueApiKey() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: async (input: { name: string; projectId: string }) => {
+    mutationFn: async (input: { name: string; projectId: string; scope?: ApiKeyScope }) => {
       const res = await apiPost<ApiEnvelope<IssuedApiKey>>('/api/v1/api-keys/issue', input)
       return res.data
     },

--- a/supabase/migrations/20260604030000_api_keys_scope.sql
+++ b/supabase/migrations/20260604030000_api_keys_scope.sql
@@ -1,0 +1,31 @@
+-- Migration: api_keys.scope
+--
+-- Adds a permission tier to Spanlens (sl_live_*) keys so that customers can
+-- mint a read-only key for surfaces that don't need write access but DO put
+-- the key in a high-leak-surface location:
+--   • MCP servers configured in IDE settings (`~/.cursor/mcp.json` etc.)
+--   • BI/dashboard tools that embed the key in connection strings
+--   • Public read-only embeds (share links that fan out beyond the org)
+--
+-- Auth layer enforces this in `apps/server/src/middleware/requireFullScope.ts`:
+-- `readonly` keys are rejected (403) by /proxy/*, /ingest/*, and /v1/traces
+-- (OTLP). Read endpoints (/api/v1/stats/*, /api/v1/requests, /me/key-info)
+-- accept both scopes.
+--
+-- Existing keys are backfilled to `full` so nothing breaks for current users.
+-- The prefix convention is purely a UX hint:
+--   sl_live_*       → full (existing)
+--   sl_live_ro_*    → readonly (new)
+-- The scope COLUMN is the source of truth for authorization; lookup is still
+-- by `key_hash` (see authApiKey.ts), unchanged.
+
+ALTER TABLE api_keys
+  ADD COLUMN IF NOT EXISTS scope text NOT NULL DEFAULT 'full'
+  CHECK (scope IN ('full', 'readonly'));
+
+-- Index on (project_id, scope) so the UI can quickly filter keys by tier
+-- without scanning the project's whole key list. Small table per org but
+-- it's the natural shape of the "show me all read-only keys for this
+-- project" query the dashboard will run.
+CREATE INDEX IF NOT EXISTS api_keys_project_scope_idx
+  ON api_keys (project_id, scope);


### PR DESCRIPTION
## Summary

Adds a permission tier to `sl_live_*` keys so customers can mint a **read-only credential** for surfaces that put the key in a high-leak-surface location — MCP servers in IDE config files (`~/.cursor/mcp.json`), BI tools where the key sits in a connection string, public read embeds.

This is the prerequisite for [#4 MCP server](./../../issues) (Tier 1 ② ③). Without it, IDE configs would carry a full-access key that could be exfiltrated by dotfile sync, a screen share, or another MCP server reading filesystem, then used to incur LLM proxy spend.

## What changed

**Auth layer**
- [authApiKey.ts](apps/server/src/middleware/authApiKey.ts) loads `scope` onto context (`apiKeyScope: 'full' | 'readonly'`)
- New [requireFullScope.ts](apps/server/src/middleware/requireFullScope.ts) middleware returns 403 + `code: 'READONLY_KEY'` when scope is readonly
- Mounted on every write route: 4 proxy routers ([openai](apps/server/src/proxy/openai.ts), [anthropic](apps/server/src/proxy/anthropic.ts), [gemini](apps/server/src/proxy/gemini.ts), [azure](apps/server/src/proxy/azure.ts)), [ingest.ts](apps/server/src/api/ingest.ts), [otlp.ts](apps/server/src/api/otlp.ts)
- Read paths unchanged: [me.ts](apps/server/src/api/me.ts) `/api/v1/me/key-info` accepts both scopes and now returns `scope` so the CLI / MCP server can self-check

**Key issuance**
- [apiKeys.ts](apps/server/src/api/apiKeys.ts) `POST /issue` body accepts `scope?: 'full' | 'readonly'` (default `full`)
- Prefix encodes scope so leaked permissions are spottable at a glance: `sl_live_<hex>` vs `sl_live_ro_<hex>`. Lookup is still by `key_hash`, unchanged
- PII masking already covers `sl_live_ro_*` via the existing `sl_live_` regex in [pii-mask.ts](apps/server/src/lib/pii-mask.ts) — no change needed

**Web UI**
- Single Permission radio group added to the existing "New Spanlens key" dialog under `/projects` ([projects-client.tsx:880](apps/web/app/(dashboard)/projects/projects-client.tsx))
- Small **Read-only** badge on key list rows so users can see at a glance which keys are restricted
- Default stays **Full access** — existing flow unchanged
- [use-api-keys.ts](apps/web/lib/queries/use-api-keys.ts) mutation accepts optional `scope`; [types.ts](apps/web/lib/queries/types.ts) adds `ApiKeyScope` union and the `scope` field on `ApiKey`

**Migration**
- [`20260604030000_api_keys_scope.sql`](supabase/migrations/20260604030000_api_keys_scope.sql): `ALTER TABLE api_keys ADD COLUMN scope text NOT NULL DEFAULT 'full' CHECK (scope IN ('full','readonly'))` + `(project_id, scope)` index
- Existing keys backfill to `'full'` via DEFAULT — no breakage for current users
- Idempotent (`IF NOT EXISTS`). Runs ahead of code deploy via [deploy-server.yml](.github/workflows/deploy-server.yml) (see CLAUDE.md gotcha #25)

## Permission matrix (post-merge)

| Endpoint | full | readonly |
|---|---|---|
| `/proxy/{openai,anthropic,gemini,azure}/*` | ✅ | ❌ 403 |
| `/ingest/*`, `POST /v1/traces` (OTLP) | ✅ | ❌ 403 |
| `/api/v1/stats/*`, `/requests/*`, `/traces/*` (GET) | ✅ | ✅ |
| `/api/v1/me/key-info` | ✅ | ✅ |

## Test plan
- [x] `pnpm typecheck` (full monorepo) — green
- [x] `pnpm lint` (full monorepo) — green
- [x] `pnpm --filter server test` — **574 tests passed** including 4 new cases in [require-full-scope.test.ts](apps/server/src/__tests__/require-full-scope.test.ts) (full passes, readonly→403, all three header transports enforce, missing key still 401) and updated [auth-api-key.test.ts](apps/server/src/__tests__/auth-api-key.test.ts) (scope populated on context)
- [ ] **Vercel preview**: open `/projects`, click "+ New Spanlens key" — verify Permission section with both radios renders, default is Full, Read-only badge appears on listed keys with `scope: 'readonly'`
- [ ] **Vercel preview**: issue a readonly key, hit `/proxy/openai/v1/chat/completions` with it → 403 with `READONLY_KEY` code
- [ ] **Vercel preview**: issue a readonly key, GET `/api/v1/me/key-info` → 200 with `scope: 'readonly'` in response

## Notes for reviewer
- Dev-server browser verification was skipped locally because the dev stack requires Supabase + ClickHouse Docker; Vercel preview will exercise the UI path. The UI change is structural (2 radios + 1 badge, no JS logic) so unit tests on the server side cover the dangerous part
- `supabase/types.ts` was NOT regenerated — Supabase's Insert/Update generics are permissive about extra fields and typecheck passed. Next `supabase gen types` run will pick up `scope` automatically (CLAUDE.md guidance)
- Vercel preview regex and personal `@sunes26` references left untouched per the previous PR #178 decision