### PR TITLE
feat: workspace-level public API keys + read API dual auth

### DIFF
--- a/apps/server/src/__tests__/auth-api-key.test.ts
+++ b/apps/server/src/__tests__/auth-api-key.test.ts
@@ -17,6 +17,8 @@ vi.mock('../lib/db.js', () => ({
               data: {
                 id: 'key-1',
                 project_id: 'proj-1',
+                organization_id: null,
+                scope: 'full',
                 projects: { organization_id: 'org-1' },
               },
               error: null,
@@ -48,6 +50,8 @@ vi.mock('../lib/db.js', () => ({
                   data: {
                     id: 'key-1',
                     project_id: 'proj-1',
+                    organization_id: null,
+                    scope: 'full',
                     projects: { organization_id: 'org-1' },
                   },
                   error: null,
@@ -70,6 +74,7 @@ function buildApp() {
       ok: true,
       orgId: c.get('organizationId'),
       projectId: c.get('projectId'),
+      scope: c.get('apiKeyScope'),
     }),
   )
   return app
@@ -83,9 +88,11 @@ describe('authApiKey — accepted transports', () => {
       headers: { Authorization: `Bearer ${VALID_KEY}` },
     })
     expect(res.status).toBe(200)
-    const body = (await res.json()) as { ok: boolean; orgId: string }
+    const body = (await res.json()) as { ok: boolean; orgId: string; scope: string }
     expect(body.ok).toBe(true)
     expect(body.orgId).toBe('org-1')
+    // scope is populated on the context so downstream guards can read it.
+    expect(body.scope).toBe('full')
   })
 
   test('x-api-key passes', async () => {

--- a/apps/server/src/__tests__/auth-jwt-or-api-key.test.ts
+++ b/apps/server/src/__tests__/auth-jwt-or-api-key.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import { authJwtOrApiKey, type DualAuthContext } from '../middleware/authJwtOrApiKey.js'
+import { _clearAuthCacheForTests } from '../middleware/authJwt.js'
+
+/**
+ * The dual-auth middleware on `/api/v1/*` routes to one of two auth flows
+ * based on the Authorization header shape:
+ *
+ *   Bearer sl_live_*  → authApiKey (Spanlens key)
+ *   Bearer <JWT>      → authJwt (Supabase session)
+ *
+ * After authApiKey succeeds, we BRIDGE `organizationId` → `orgId` so the
+ * existing read-API handlers (which were written for JWT auth and use
+ * `c.get('orgId')`) keep working without per-route changes. The tests below
+ * verify both branches reach the handler with `orgId` populated.
+ */
+
+const SPANLENS_KEY = 'sl_live_dualauthtestkey0123456789'
+const SPANLENS_HASH = 'spanlens-hash'
+const JWT_TOKEN = 'fake-jwt-token-12345'
+
+vi.mock('../lib/crypto.js', () => ({
+  sha256Hex: async (raw: string) => {
+    if (raw === SPANLENS_KEY) return SPANLENS_HASH
+    return 'invalid'
+  },
+}))
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: (table: string) => ({
+      select: (_cols: string) => ({
+        eq: (col: string, val: string) => ({
+          eq: (_col2: string, _val2: unknown) => ({
+            single: async () => {
+              if (table === 'api_keys' && col === 'key_hash' && val === SPANLENS_HASH) {
+                return {
+                  data: {
+                    id: 'api-key-1',
+                    project_id: null,
+                    organization_id: 'org-from-api-key',
+                    scope: 'public',
+                    projects: null,
+                  },
+                  error: null,
+                }
+              }
+              return { data: null, error: { message: 'not found' } }
+            },
+            maybeSingle: async () => ({ data: null }),
+          }),
+          order: () => ({
+            limit: () => ({
+              maybeSingle: async () => ({
+                data: { organization_id: 'org-from-jwt', role: 'admin' },
+              }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  },
+  supabaseClient: {
+    auth: {
+      getUser: async (token: string) => {
+        if (token === JWT_TOKEN) {
+          return {
+            data: {
+              user: { id: 'user-1', email: 'jwt@example.com' },
+            },
+            error: null,
+          }
+        }
+        return { data: { user: null }, error: { message: 'invalid token' } }
+      },
+    },
+  },
+}))
+
+function buildApp() {
+  const app = new Hono<DualAuthContext>()
+  app.use('*', authJwtOrApiKey)
+  app.get('/probe', (c) =>
+    c.json({
+      orgId: c.get('orgId'),
+      // organizationId is set by authApiKey branch; left undefined on JWT.
+      organizationId: c.get('organizationId') ?? null,
+      scope: c.get('apiKeyScope') ?? null,
+    }),
+  )
+  return app
+}
+
+describe('authJwtOrApiKey', () => {
+  beforeEach(() => {
+    _clearAuthCacheForTests()
+  })
+
+  test('routes sl_live_* key through authApiKey and bridges orgId', async () => {
+    const app = buildApp()
+    const res = await app.request('/probe', {
+      headers: { Authorization: `Bearer ${SPANLENS_KEY}` },
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      orgId: string
+      organizationId: string
+      scope: string
+    }
+    // Both names point at the same org so legacy JWT handlers work
+    // unmodified when the request came in via an API key.
+    expect(body.orgId).toBe('org-from-api-key')
+    expect(body.organizationId).toBe('org-from-api-key')
+    expect(body.scope).toBe('public')
+  })
+
+  test('routes JWT through authJwt — orgId resolved via org_members', async () => {
+    const app = buildApp()
+    const res = await app.request('/probe', {
+      headers: { Authorization: `Bearer ${JWT_TOKEN}` },
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { orgId: string; scope: string | null }
+    expect(body.orgId).toBe('org-from-jwt')
+    // JWT auth doesn't set apiKeyScope — handlers that care should check.
+    expect(body.scope).toBeNull()
+  })
+
+  test('missing Authorization header returns 401 from JWT path', async () => {
+    const app = buildApp()
+    const res = await app.request('/probe')
+    expect(res.status).toBe(401)
+  })
+
+  test('Bearer with non-sl_live token goes through JWT path (invalid → 401)', async () => {
+    const app = buildApp()
+    const res = await app.request('/probe', {
+      headers: { Authorization: 'Bearer some-other-token' },
+    })
+    // Not sl_live_*, so routed to authJwt. supabaseClient.auth.getUser
+    // returns an error for unknown tokens.
+    expect(res.status).toBe(401)
+  })
+})

--- a/apps/server/src/__tests__/require-full-scope.test.ts
+++ b/apps/server/src/__tests__/require-full-scope.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test, vi } from 'vitest'
+import { Hono } from 'hono'
+import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
+
+/**
+ * requireFullScope rejects `public`-scope Spanlens keys with 403 before they
+ * reach write handlers (proxy/* and ingest/*). Full-scope keys pass through.
+ *
+ * The DB mock returns a row keyed by the resolved hash so we exercise both
+ * branches from one test file:
+ *   - sl_live_<hex>     → scope='full',   project-scoped
+ *   - sl_live_pub_<hex> → scope='public', workspace-scoped
+ */
+
+const FULL_KEY = 'sl_live_fulltestkey0123456789abcd'
+const FULL_HASH = 'full-hash'
+const PUB_KEY = 'sl_live_pub_publictestkey0123456'
+const PUB_HASH = 'pub-hash'
+
+vi.mock('../lib/crypto.js', () => ({
+  sha256Hex: async (raw: string) => {
+    if (raw === FULL_KEY) return FULL_HASH
+    if (raw === PUB_KEY) return PUB_HASH
+    return 'invalid-hash'
+  },
+}))
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: (_table: string) => ({
+      select: (_cols: string) => ({
+        eq: (col: string, val: string) => ({
+          eq: (_col2: string, _val2: unknown) => ({
+            single: async () => {
+              if (col !== 'key_hash') return { data: null, error: { message: 'not found' } }
+              if (val === FULL_HASH) {
+                return {
+                  data: {
+                    id: 'full-key-id',
+                    project_id: 'proj-1',
+                    organization_id: null,
+                    scope: 'full',
+                    projects: { organization_id: 'org-1' },
+                  },
+                  error: null,
+                }
+              }
+              if (val === PUB_HASH) {
+                return {
+                  data: {
+                    id: 'pub-key-id',
+                    project_id: null,
+                    organization_id: 'org-1',
+                    scope: 'public',
+                    projects: null,
+                  },
+                  error: null,
+                }
+              }
+              return { data: null, error: { message: 'not found' } }
+            },
+          }),
+        }),
+      }),
+    }),
+  },
+}))
+
+function buildApp() {
+  const app = new Hono<ApiKeyContext>()
+  app.use('*', authApiKey)
+  app.use('*', requireFullScope)
+  app.post('/write', (c) => c.json({ ok: true, scope: c.get('apiKeyScope') }))
+  return app
+}
+
+describe('requireFullScope', () => {
+  const app = buildApp()
+
+  test('full-scope key passes the guard with scope on context', async () => {
+    const res = await app.request('/write', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${FULL_KEY}` },
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: boolean; scope: string }
+    expect(body.ok).toBe(true)
+    expect(body.scope).toBe('full')
+  })
+
+  test('public key is rejected with 403 + PUBLIC_KEY_WRITE_FORBIDDEN code', async () => {
+    const res = await app.request('/write', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${PUB_KEY}` },
+    })
+    expect(res.status).toBe(403)
+    const body = (await res.json()) as { error: string; code: string }
+    expect(body.code).toBe('PUBLIC_KEY_WRITE_FORBIDDEN')
+    // Error message should point the user at where to mint a full-access key
+    // so they aren't left debugging blindly.
+    expect(body.error.toLowerCase()).toContain('public api key')
+  })
+
+  test('public-key rejection applies on every accepted transport', async () => {
+    // Both x-api-key (Anthropic) and x-goog-api-key (Gemini) must enforce
+    // the same scope rule — rejection is at middleware layer, not provider path.
+    for (const headers of [{ 'x-api-key': PUB_KEY }, { 'x-goog-api-key': PUB_KEY }]) {
+      const res = await app.request('/write', { method: 'POST', headers })
+      expect(res.status).toBe(403)
+    }
+  })
+
+  test('missing key returns 401 from authApiKey, not 403 from the scope guard', async () => {
+    const res = await app.request('/write', { method: 'POST' })
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('authApiKey owner resolution', () => {
+  const app = new Hono<ApiKeyContext>()
+  app.use('*', authApiKey)
+  app.get('/probe', (c) =>
+    c.json({
+      orgId: c.get('organizationId'),
+      projectId: c.get('projectId'),
+      scope: c.get('apiKeyScope'),
+    }),
+  )
+
+  test('full key resolves organizationId via projects join, projectId set', async () => {
+    const res = await app.request('/probe', { headers: { Authorization: `Bearer ${FULL_KEY}` } })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { orgId: string; projectId: string | null; scope: string }
+    expect(body.orgId).toBe('org-1')
+    expect(body.projectId).toBe('proj-1')
+    expect(body.scope).toBe('full')
+  })
+
+  test('public key resolves organizationId from the direct column, projectId null', async () => {
+    const res = await app.request('/probe', { headers: { Authorization: `Bearer ${PUB_KEY}` } })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { orgId: string; projectId: string | null; scope: string }
+    expect(body.orgId).toBe('org-1')
+    expect(body.projectId).toBeNull()
+    expect(body.scope).toBe('public')
+  })
+})

--- a/apps/server/src/api/anomalies.ts
+++ b/apps/server/src/api/anomalies.ts
@@ -1,5 +1,6 @@
 import { Hono, type Context } from 'hono'
-import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import type { JwtContext } from '../middleware/authJwt.js'
+import { authJwtOrApiKey } from '../middleware/authJwtOrApiKey.js'
 import { requireRole } from '../middleware/requireRole.js'
 import { detectAnomalies, fetchContributingFactors } from '../lib/anomaly.js'
 import { getAnomalyHistory } from '../lib/anomaly-snapshot.js'
@@ -19,7 +20,7 @@ const requireEdit = requireRole('admin', 'editor')
 
 export const anomaliesRouter = new Hono<JwtContext>()
 
-anomaliesRouter.use('*', authJwt)
+anomaliesRouter.use('*', authJwtOrApiKey)
 
 const VALID_KINDS = new Set(['latency', 'cost', 'error_rate'])
 

--- a/apps/server/src/api/apiKeys.ts
+++ b/apps/server/src/api/apiKeys.ts
@@ -5,14 +5,25 @@ import { supabaseAdmin } from '../lib/db.js'
 import { randomHex, sha256Hex } from '../lib/crypto.js'
 
 /**
- * Spanlens (sl_live_*) keys — under the unified-keys model these are
- * project-scoped and provider-agnostic. Provider AI keys live in their own
- * resource (`/api/v1/provider-keys`) and are looked up at proxy time by
- * `(project_id, provider)` from the request URL path.
+ * Spanlens keys come in two shapes:
  *
- * No more `api_keys.provider_key_id`. Issuing a key here just creates a
- * project credential the customer plugs into `SPANLENS_API_KEY` — that
- * single key can call any provider registered on the project.
+ *   scope='full'   sl_live_<hex>        project-scoped (1:1 with a project).
+ *                                       Used for proxy calls, ingest, and
+ *                                       read endpoints. Provider AI keys hang
+ *                                       off these via /api/v1/provider-keys.
+ *
+ *   scope='public' sl_live_pub_<hex>    workspace-scoped. Cannot be used for
+ *                                       proxy or ingest (requireFullScope
+ *                                       middleware enforces). Safe to drop
+ *                                       into IDE config files, BI dashboards,
+ *                                       and public read embeds — leak is
+ *                                       capped to "competitor sees my LLM
+ *                                       usage stats", no cost exposure.
+ *
+ * The DB CHECK constraint `api_keys_scope_owner_consistency` enforces that
+ * full keys carry a project_id and public keys carry an organization_id
+ * (and exactly one of those is set per row). This router just routes the
+ * `scope` value to the right insert.
  */
 
 export const apiKeysRouter = new Hono<JwtContext>()
@@ -31,30 +42,45 @@ async function projectBelongsToOrg(projectId: string, orgId: string): Promise<bo
   return data !== null
 }
 
-// GET /api/v1/api-keys?projectId=xxx — list Spanlens keys for a project
-// (or all keys across the org's projects when projectId is omitted).
+// GET /api/v1/api-keys?projectId=xxx — list Spanlens keys for a project,
+// or `?scope=public` to list workspace-level public keys, or (default)
+// every key the user can see across the org.
 apiKeysRouter.get('/', async (c) => {
   const projectId = c.req.query('projectId')
+  const scopeFilter = c.req.query('scope')
   const orgId = c.get('orgId')
   if (!orgId) return c.json({ error: 'Organization not found' }, 404)
 
   let query = supabaseAdmin
     .from('api_keys')
-    .select('id, project_id, name, key_prefix, is_active, last_used_at, created_at')
+    .select(
+      'id, project_id, organization_id, name, key_prefix, scope, is_active, last_used_at, created_at',
+    )
     .order('created_at', { ascending: false })
 
-  if (projectId) {
+  if (scopeFilter === 'public') {
+    // Workspace-level public keys live directly under the org.
+    query = query.eq('organization_id', orgId).eq('scope', 'public')
+  } else if (projectId) {
     const belongs = await projectBelongsToOrg(projectId, orgId)
     if (!belongs) return c.json({ error: 'Project not found' }, 404)
     query = query.eq('project_id', projectId)
   } else {
+    // No filter: every key on every project in the org PLUS workspace-level
+    // public keys. The two are unioned via .or() because they live under
+    // different ownership columns.
     const { data: projects } = await supabaseAdmin
       .from('projects')
       .select('id')
       .eq('organization_id', orgId)
     const projectIds = (projects ?? []).map((p) => p.id as string)
-    if (projectIds.length === 0) return c.json({ success: true, data: [] })
-    query = query.in('project_id', projectIds)
+    if (projectIds.length === 0) {
+      // Org has no projects yet — only public keys are possible.
+      query = query.eq('organization_id', orgId)
+    } else {
+      const ids = projectIds.map((id) => `"${id}"`).join(',')
+      query = query.or(`project_id.in.(${ids}),organization_id.eq.${orgId}`)
+    }
   }
 
   const { data, error } = await query
@@ -63,14 +89,15 @@ apiKeysRouter.get('/', async (c) => {
   return c.json({ success: true, data: data ?? [] })
 })
 
-// POST /api/v1/api-keys/issue — mint a new sl_live_* for a project.
-// Body: { name, projectId }. No provider, no AI key — those live in the
-// /api/v1/provider-keys resource and are resolved at proxy time.
+// POST /api/v1/api-keys/issue — mint a new sl_live_* key.
+// Body:
+//   { name, projectId }                — full key, project-scoped (default)
+//   { name, scope: 'public' }          — public key, workspace-scoped
 apiKeysRouter.post('/issue', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) return c.json({ error: 'Organization not found' }, 404)
 
-  let body: { name?: unknown; projectId?: unknown }
+  let body: { name?: unknown; projectId?: unknown; scope?: unknown }
   try {
     body = (await c.req.json()) as typeof body
   } catch {
@@ -80,26 +107,60 @@ apiKeysRouter.post('/issue', requireEdit, async (c) => {
   if (typeof body.name !== 'string' || body.name.trim().length === 0) {
     return c.json({ error: 'name is required' }, 400)
   }
-  if (typeof body.projectId !== 'string') {
-    return c.json({ error: 'projectId is required' }, 400)
-  }
 
-  const belongs = await projectBelongsToOrg(body.projectId, orgId)
-  if (!belongs) return c.json({ error: 'Project not found' }, 404)
+  const scope: 'full' | 'public' = body.scope === 'public' ? 'public' : 'full'
 
-  const rawKey = `sl_live_${randomHex(24)}`
+  // Prefix encodes scope so a user can spot leaked permissions at a glance
+  // (and grep for them in logs). `key_prefix` stays 15 chars so existing UI
+  // columns line up.
+  //   full   → sl_live_<24 hex>
+  //   public → sl_live_pub_<24 hex>
+  const rawKey =
+    scope === 'public' ? `sl_live_pub_${randomHex(24)}` : `sl_live_${randomHex(24)}`
   const keyHash = await sha256Hex(rawKey)
   const keyPrefix = rawKey.slice(0, 15)
 
-  const { data, error } = await supabaseAdmin
-    .from('api_keys')
-    .insert({
+  // Branch on scope so we satisfy the DB's owner-consistency CHECK:
+  //   full   → project_id required, organization_id null
+  //   public → organization_id from JWT, project_id null
+  let insertRow: {
+    name: string
+    key_hash: string
+    key_prefix: string
+    scope: 'full' | 'public'
+    project_id?: string
+    organization_id?: string
+  }
+
+  if (scope === 'full') {
+    if (typeof body.projectId !== 'string') {
+      return c.json({ error: 'projectId is required for full-access keys' }, 400)
+    }
+    const belongs = await projectBelongsToOrg(body.projectId, orgId)
+    if (!belongs) return c.json({ error: 'Project not found' }, 404)
+    insertRow = {
       project_id: body.projectId,
       name: body.name.trim(),
       key_hash: keyHash,
       key_prefix: keyPrefix,
-    })
-    .select('id, project_id, name, key_prefix, is_active, created_at')
+      scope: 'full',
+    }
+  } else {
+    insertRow = {
+      organization_id: orgId,
+      name: body.name.trim(),
+      key_hash: keyHash,
+      key_prefix: keyPrefix,
+      scope: 'public',
+    }
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('api_keys')
+    .insert(insertRow)
+    .select(
+      'id, project_id, organization_id, name, key_prefix, scope, is_active, created_at',
+    )
     .single()
 
   if (error || !data) return c.json({ error: 'Failed to create API key' }, 500)
@@ -115,6 +176,35 @@ apiKeysRouter.post('/issue', requireEdit, async (c) => {
     201,
   )
 })
+
+/**
+ * PATCH / DELETE need to resolve the key's owning organization regardless of
+ * whether the key is project-scoped or workspace-scoped. This helper centralises
+ * that logic so the two handlers can share the same access check.
+ */
+async function loadKeyOwnership(
+  keyId: string,
+): Promise<{ orgId: string | null } | null> {
+  const { data: keyRow } = await supabaseAdmin
+    .from('api_keys')
+    .select('project_id, organization_id, scope')
+    .eq('id', keyId)
+    .single()
+  if (!keyRow) return null
+
+  if (keyRow.organization_id) {
+    return { orgId: keyRow.organization_id as string }
+  }
+  if (keyRow.project_id) {
+    const { data: project } = await supabaseAdmin
+      .from('projects')
+      .select('organization_id')
+      .eq('id', keyRow.project_id)
+      .single()
+    return { orgId: (project?.organization_id as string) ?? null }
+  }
+  return { orgId: null }
+}
 
 // PATCH /api/v1/api-keys/:id — toggle is_active
 apiKeysRouter.patch('/:id', requireEdit, async (c) => {
@@ -132,15 +222,9 @@ apiKeysRouter.patch('/:id', requireEdit, async (c) => {
     return c.json({ error: 'is_active (boolean) is required' }, 400)
   }
 
-  const { data: keyRow } = await supabaseAdmin
-    .from('api_keys')
-    .select('project_id')
-    .eq('id', keyId)
-    .single()
-  if (!keyRow) return c.json({ error: 'API key not found' }, 404)
-
-  const belongs = await projectBelongsToOrg(keyRow.project_id as string, orgId)
-  if (!belongs) return c.json({ error: 'Access denied' }, 403)
+  const ownership = await loadKeyOwnership(keyId)
+  if (!ownership) return c.json({ error: 'API key not found' }, 404)
+  if (ownership.orgId !== orgId) return c.json({ error: 'Access denied' }, 403)
 
   const { error } = await supabaseAdmin
     .from('api_keys')
@@ -158,15 +242,9 @@ apiKeysRouter.delete('/:id', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) return c.json({ error: 'Organization not found' }, 404)
 
-  const { data: keyRow } = await supabaseAdmin
-    .from('api_keys')
-    .select('project_id')
-    .eq('id', keyId)
-    .single()
-  if (!keyRow) return c.json({ error: 'API key not found' }, 404)
-
-  const belongs = await projectBelongsToOrg(keyRow.project_id as string, orgId)
-  if (!belongs) return c.json({ error: 'Access denied' }, 403)
+  const ownership = await loadKeyOwnership(keyId)
+  if (!ownership) return c.json({ error: 'API key not found' }, 404)
+  if (ownership.orgId !== orgId) return c.json({ error: 'Access denied' }, 403)
 
   const { error } = await supabaseAdmin.from('api_keys').delete().eq('id', keyId)
   if (error) return c.json({ error: 'Failed to delete API key' }, 500)

--- a/apps/server/src/api/ingest.ts
+++ b/apps/server/src/api/ingest.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { fireAndForget } from '../lib/wait-until.js'
 import { emitWebhookEvent } from '../lib/webhook-emit.js'
@@ -21,6 +22,7 @@ import { emitWebhookEvent } from '../lib/webhook-emit.js'
 export const ingestRouter = new Hono<ApiKeyContext>()
 
 ingestRouter.use('*', authApiKey)
+ingestRouter.use('*', requireFullScope)
 
 type TraceStatus = 'running' | 'completed' | 'error'
 type SpanStatus = 'running' | 'completed' | 'error'
@@ -41,7 +43,9 @@ function computeDurationMs(startedAt: string | null, endedAt: string | null): nu
 // ── POST /ingest/traces ──────────────────────────────────────
 ingestRouter.post('/traces', async (c) => {
   const organizationId = c.get('organizationId')
-  const projectId = c.get('projectId')
+  // Narrowing: requireFullScope + DB CHECK constraint guarantee non-null
+  // here (public-scope keys can't reach ingest endpoints).
+  const projectId = c.get('projectId') as string
   const apiKeyId = c.get('apiKeyId')
 
   let body: {

--- a/apps/server/src/api/me.ts
+++ b/apps/server/src/api/me.ts
@@ -21,10 +21,13 @@ const KNOWN_PROVIDERS: ReadonlySet<KnownProvider> = new Set([
 ])
 
 interface KeyInfoResponse {
-  projectId: string
-  projectName: string
+  /** Null for public (workspace-level) keys — they aren't tied to a single project. */
+  projectId: string | null
+  projectName: string | null
   /** Providers with an active provider_key under THIS Spanlens key. */
   providers: KnownProvider[]
+  /** 'full' = can call proxy + ingest. 'public' = dashboard reads only. */
+  scope: 'full' | 'public'
 }
 
 // GET /api/v1/me/key-info — introspect the presented Spanlens key.
@@ -44,6 +47,21 @@ interface KeyInfoResponse {
 meRouter.get('/', async (c) => {
   const projectId = c.get('projectId')
   const apiKeyId = c.get('apiKeyId')
+  const scope = c.get('apiKeyScope')
+
+  // Public keys are workspace-scoped — no owning project, no provider keys
+  // attached. Skip both lookups for them and return a minimal response.
+  if (!projectId) {
+    return c.json({
+      success: true,
+      data: {
+        projectId: null,
+        projectName: null,
+        providers: [],
+        scope,
+      } satisfies KeyInfoResponse,
+    })
+  }
 
   const [{ data: project }, { data: providerKeys }] = await Promise.all([
     supabaseAdmin
@@ -68,6 +86,7 @@ meRouter.get('/', async (c) => {
     projectId: project.id as string,
     projectName: project.name as string,
     providers,
+    scope,
   }
   return c.json({ success: true, data: body })
 })

--- a/apps/server/src/api/otlp.ts
+++ b/apps/server/src/api/otlp.ts
@@ -19,6 +19,7 @@
 
 import { Hono } from 'hono'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
 import { supabaseAdmin } from '../lib/db.js'
 import {
   groupByTrace,
@@ -34,9 +35,11 @@ export const otlpRouter = new Hono<ApiKeyContext>()
 
 // ── POST /v1/traces ────────────────────────────────────────────────────────────
 
-otlpRouter.post('/v1/traces', authApiKey, async (c) => {
+otlpRouter.post('/v1/traces', authApiKey, requireFullScope, async (c) => {
   const organizationId = c.get('organizationId')
-  const projectId      = c.get('projectId')
+  // Narrowing: requireFullScope (mounted on this route) + DB CHECK constraint
+  // guarantee non-null here.
+  const projectId      = c.get('projectId') as string
   const apiKeyId       = c.get('apiKeyId')
 
   // Protobuf not supported — tell the client to use JSON

--- a/apps/server/src/api/recommendations.ts
+++ b/apps/server/src/api/recommendations.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
-import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import type { JwtContext } from '../middleware/authJwt.js'
+import { authJwtOrApiKey } from '../middleware/authJwtOrApiKey.js'
 import { recommendModelSwaps } from '../lib/model-recommend.js'
 import { getOrgClickhouse, toClickhouseTimestamp } from '../lib/clickhouse.js'
 import { requestsScope } from '../lib/requests-query.js'
@@ -28,7 +29,7 @@ import { parsePositiveFloat } from '../lib/params.js'
 
 export const recommendationsRouter = new Hono<JwtContext>()
 
-recommendationsRouter.use('*', authJwt)
+recommendationsRouter.use('*', authJwtOrApiKey)
 
 
 // ── Shape returned by ClickHouse percentiles query (all numbers as strings) ───

--- a/apps/server/src/api/requests.ts
+++ b/apps/server/src/api/requests.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
-import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import type { JwtContext } from '../middleware/authJwt.js'
+import { authJwtOrApiKey } from '../middleware/authJwtOrApiKey.js'
 import { requireRole } from '../middleware/requireRole.js'
 import { getDecryptedProviderKeyById, getDecryptedProviderKey } from '../proxy/utils.js'
 import { calculateCost } from '../lib/cost.js'
@@ -16,7 +17,7 @@ import { fromClickhouseTimestamp } from '../lib/clickhouse.js'
 
 export const requestsRouter = new Hono<JwtContext>()
 
-requestsRouter.use('*', authJwt)
+requestsRouter.use('*', authJwtOrApiKey)
 
 // Columns surfaced in the list view. Kept in sync with the response contract
 // the dashboard expects (provider_key_name is flattened from provider_keys.name

--- a/apps/server/src/api/stats.ts
+++ b/apps/server/src/api/stats.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
-import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import type { JwtContext } from '../middleware/authJwt.js'
+import { authJwtOrApiKey } from '../middleware/authJwtOrApiKey.js'
 import { parseClampedFloat } from '../lib/params.js'
 import {
   getStatsOverview,
@@ -22,7 +23,7 @@ import {
 
 export const statsRouter = new Hono<JwtContext>()
 
-statsRouter.use('*', authJwt)
+statsRouter.use('*', authJwtOrApiKey)
 
 // Cache-Control presets for stats endpoints.
 // `private` — per-user data, never store on shared/CDN caches.

--- a/apps/server/src/api/traces.ts
+++ b/apps/server/src/api/traces.ts
@@ -1,12 +1,13 @@
 import { Hono } from 'hono'
-import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import type { JwtContext } from '../middleware/authJwt.js'
+import { authJwtOrApiKey } from '../middleware/authJwtOrApiKey.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { computeCriticalPath } from '../lib/critical-path.js'
 import { parsePageLimit } from '../lib/params.js'
 
 export const tracesRouter = new Hono<JwtContext>()
 
-tracesRouter.use('*', authJwt)
+tracesRouter.use('*', authJwtOrApiKey)
 
 // GET /api/v1/traces — list traces with filters + pagination
 // Query params: projectId, status, from, to, q (name or trace-id substring),

--- a/apps/server/src/api/users.ts
+++ b/apps/server/src/api/users.ts
@@ -1,12 +1,13 @@
 import { Hono } from 'hono'
-import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import type { JwtContext } from '../middleware/authJwt.js'
+import { authJwtOrApiKey } from '../middleware/authJwtOrApiKey.js'
 import { parsePageLimit } from '../lib/params.js'
 import { getUserAnalytics, type UserAnalyticsRow } from '../lib/stats-queries.js'
 import { requestsScope, selectRequests } from '../lib/requests-query.js'
 
 export const usersRouter = new Hono<JwtContext>()
 
-usersRouter.use('*', authJwt)
+usersRouter.use('*', authJwtOrApiKey)
 
 // ─────────────────────────────────────────────────────────────────────────────
 // GET /api/v1/users — aggregate per-user usage

--- a/apps/server/src/middleware/authApiKey.ts
+++ b/apps/server/src/middleware/authApiKey.ts
@@ -4,7 +4,7 @@ import { supabaseAdmin } from '../lib/db.js'
 import { sha256Hex } from '../lib/crypto.js'
 
 /**
- * Validates a Spanlens API key (sl_live_…) against `api_keys`.
+ * Validates a Spanlens API key (sl_live_* or sl_live_pub_*) against `api_keys`.
  *
  * Each provider SDK uses a different transport for the key, so this
  * middleware accepts whichever shape the SDK sends — the proxy is
@@ -14,18 +14,23 @@ import { sha256Hex } from '../lib/crypto.js'
  *   • Anthropic SDK         → x-api-key: sl_live_…
  *   • Google Generative AI  → x-goog-api-key: sl_live_…
  *
- * The first one found wins. After validation we put apiKeyId / projectId
- * / organizationId on the context for the proxy + logging layers.
+ * The first one found wins. After validation we put apiKeyId, scope, and
+ * organizationId on the context. `projectId` is set ONLY for `full` keys —
+ * `public` keys are workspace-scoped and have no single owning project.
  *
  * Note: ?key= query-string transport was removed (security: keys leak into
  * server access logs, browser history, and Referer headers). All current
  * Google Generative AI SDK versions use the x-goog-api-key header.
  */
+export type ApiKeyScope = 'full' | 'public'
+
 export type ApiKeyContext = {
   Variables: {
     organizationId: string
-    projectId: string
+    /** Always present for `full` scope; null for `public` (workspace-level) keys. */
+    projectId: string | null
     apiKeyId: string
+    apiKeyScope: ApiKeyScope
   }
 }
 
@@ -65,9 +70,12 @@ export const authApiKey = createMiddleware<ApiKeyContext>(async (c, next) => {
 
   const keyHash = await sha256Hex(rawKey)
 
+  // Select both ownership columns + scope. The CHECK constraint in the
+  // migration guarantees exactly one of (project_id, organization_id) is
+  // non-null, so we can branch on scope without defensive validation.
   const { data, error } = await supabaseAdmin
     .from('api_keys')
-    .select('id, project_id, projects(organization_id)')
+    .select('id, project_id, organization_id, scope, projects(organization_id)')
     .eq('key_hash', keyHash)
     .eq('is_active', true)
     .single()
@@ -76,14 +84,27 @@ export const authApiKey = createMiddleware<ApiKeyContext>(async (c, next) => {
     return c.json({ error: 'Invalid API key' }, 401)
   }
 
-  const project = data.projects as unknown as { organization_id: string } | null
-  if (!project) {
-    return c.json({ error: 'Project not found' }, 401)
+  const scope: ApiKeyScope = (data.scope as string) === 'public' ? 'public' : 'full'
+
+  // Resolve organizationId based on scope:
+  //   full   → from projects join (api_keys.project_id → projects.organization_id)
+  //   public → directly from api_keys.organization_id
+  let organizationId: string | null = null
+  if (scope === 'full') {
+    const project = data.projects as unknown as { organization_id: string } | null
+    organizationId = project?.organization_id ?? null
+  } else {
+    organizationId = (data.organization_id as string | null) ?? null
+  }
+
+  if (!organizationId) {
+    return c.json({ error: 'API key has no owning organization' }, 401)
   }
 
   c.set('apiKeyId', data.id as string)
-  c.set('projectId', data.project_id as string)
-  c.set('organizationId', project.organization_id)
+  c.set('apiKeyScope', scope)
+  c.set('organizationId', organizationId)
+  c.set('projectId', (data.project_id as string | null) ?? null)
 
   return next()
 })

--- a/apps/server/src/middleware/authJwtOrApiKey.ts
+++ b/apps/server/src/middleware/authJwtOrApiKey.ts
@@ -1,0 +1,49 @@
+import type { Context } from 'hono'
+import { createMiddleware } from 'hono/factory'
+import { authJwt, type JwtContext } from './authJwt.js'
+import { authApiKey, type ApiKeyContext } from './authApiKey.js'
+
+/**
+ * Dual-auth middleware for `/api/v1/*` read endpoints.
+ *
+ * Routes the request through one of two existing auth paths depending on
+ * the Authorization header shape:
+ *
+ *   Authorization: Bearer sl_live_…   → authApiKey   (Spanlens key)
+ *   Authorization: Bearer <JWT>       → authJwt      (Supabase session)
+ *   (no header)                       → 401 from authJwt
+ *
+ * After authApiKey succeeds we bridge the resolved `organizationId` into
+ * the `orgId` variable that JWT-shaped handlers already read — so the
+ * read API routes don't need to know which auth flow ran. The
+ * `JwtContext.email` / `userId` / `role` fields remain unset on the
+ * API-key path; handlers that genuinely need user identity (audit logs,
+ * member management) should keep using `authJwt` directly.
+ *
+ * Why a wrapper rather than touching individual route auth: this keeps
+ * the change to "pick which auth middleware runs" rather than rewriting
+ * every read handler. Routes opt in by importing this in place of
+ * `authJwt`.
+ */
+export type DualAuthContext = JwtContext & ApiKeyContext
+
+export const authJwtOrApiKey = createMiddleware<DualAuthContext>(async (c, next) => {
+  const authHeader = c.req.header('Authorization')
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7).trim() : null
+
+  // Spanlens key path — delegated to authApiKey, then bridge orgId so
+  // downstream code that reads `c.get('orgId')` works regardless of auth.
+  //
+  // The casts below are sound at runtime: DualAuthContext.Variables is the
+  // union of both auth contexts' variable bags. Hono's Context is invariant
+  // in its env type parameter so TS can't see that — the cast is mechanical.
+  if (token && token.startsWith('sl_live_')) {
+    return authApiKey(c as unknown as Context<ApiKeyContext>, async () => {
+      c.set('orgId', c.get('organizationId'))
+      return next()
+    })
+  }
+
+  // JWT path (Supabase session) — unchanged from existing behaviour.
+  return authJwt(c as unknown as Context<JwtContext>, next)
+})

--- a/apps/server/src/middleware/requireFullScope.ts
+++ b/apps/server/src/middleware/requireFullScope.ts
@@ -1,0 +1,36 @@
+import { createMiddleware } from 'hono/factory'
+import type { ApiKeyContext } from './authApiKey.js'
+
+/**
+ * Rejects requests authenticated with a `public`-scope Spanlens key.
+ *
+ * Mounted on routes that perform writes or trigger spend:
+ *   • /proxy/openai, /proxy/anthropic, /proxy/gemini, /proxy/azure  (LLM calls)
+ *   • /ingest/*                                                      (SDK writes)
+ *   • POST /v1/traces                                                (OTLP exports)
+ *
+ * Must run AFTER `authApiKey` (which populates `apiKeyScope` on the context).
+ *
+ * Public keys still work on:
+ *   • /api/v1/stats/*, /api/v1/requests, /api/v1/traces (GET)
+ *   • /api/v1/me/key-info                                (CLI introspection)
+ *
+ * Why a separate middleware vs. an inline check: the same guard applies to
+ * 7+ routers and the check is identical. Centralising it keeps the rule
+ * (which routes are "write") in one place and prevents accidental drift
+ * when adding new proxy or ingest endpoints.
+ */
+export const requireFullScope = createMiddleware<ApiKeyContext>(async (c, next) => {
+  const scope = c.get('apiKeyScope')
+  if (scope === 'public') {
+    return c.json(
+      {
+        error:
+          'Public API key cannot perform write operations. Issue a full-access key on the Projects & Keys page to enable LLM proxy and ingest endpoints.',
+        code: 'PUBLIC_KEY_WRITE_FORBIDDEN',
+      },
+      403,
+    )
+  }
+  return next()
+})

--- a/apps/server/src/proxy/anthropic.ts
+++ b/apps/server/src/proxy/anthropic.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { stream } from 'hono/streaming'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
 import { calculateCost } from '../lib/cost.js'
@@ -19,6 +20,7 @@ const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '3500
 export const anthropicProxy = new Hono<ApiKeyContext>()
 
 anthropicProxy.use('*', authApiKey)
+anthropicProxy.use('*', requireFullScope)
 anthropicProxy.use('*', proxyRateLimit)
 anthropicProxy.use('*', enforceQuota)
 
@@ -26,7 +28,8 @@ anthropicProxy.all('/*', async (c) => {
   const handlerStartMs = Date.now()
 
   const organizationId = c.get('organizationId')
-  const projectId = c.get('projectId')
+  // Narrowing: requireFullScope + DB CHECK constraint guarantee non-null. See openai.ts.
+  const projectId = c.get('projectId') as string
   const apiKeyId = c.get('apiKeyId')
 
   const providerKey = await getDecryptedProviderKey(apiKeyId, 'anthropic')

--- a/apps/server/src/proxy/azure.ts
+++ b/apps/server/src/proxy/azure.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { stream } from 'hono/streaming'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
 import { calculateCost } from '../lib/cost.js'
@@ -31,6 +32,7 @@ const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '3500
 export const azureProxy = new Hono<ApiKeyContext>()
 
 azureProxy.use('*', authApiKey)
+azureProxy.use('*', requireFullScope)
 azureProxy.use('*', proxyRateLimit)
 azureProxy.use('*', enforceQuota)
 
@@ -38,7 +40,8 @@ azureProxy.all('/*', async (c) => {
   const handlerStartMs = Date.now()
 
   const organizationId = c.get('organizationId')
-  const projectId = c.get('projectId')
+  // Narrowing: requireFullScope + DB CHECK constraint guarantee non-null. See openai.ts.
+  const projectId = c.get('projectId') as string
   const apiKeyId = c.get('apiKeyId')
 
   const providerKey = await getDecryptedProviderKey(apiKeyId, 'azure')

--- a/apps/server/src/proxy/gemini.ts
+++ b/apps/server/src/proxy/gemini.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { stream } from 'hono/streaming'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
 import { calculateCost } from '../lib/cost.js'
@@ -18,6 +19,7 @@ const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '3500
 export const geminiProxy = new Hono<ApiKeyContext>()
 
 geminiProxy.use('*', authApiKey)
+geminiProxy.use('*', requireFullScope)
 geminiProxy.use('*', proxyRateLimit)
 geminiProxy.use('*', enforceQuota)
 
@@ -25,7 +27,8 @@ geminiProxy.all('/*', async (c) => {
   const handlerStartMs = Date.now()
 
   const organizationId = c.get('organizationId')
-  const projectId = c.get('projectId')
+  // Narrowing: requireFullScope + DB CHECK constraint guarantee non-null. See openai.ts.
+  const projectId = c.get('projectId') as string
   const apiKeyId = c.get('apiKeyId')
 
   const providerKey = await getDecryptedProviderKey(apiKeyId, 'gemini')

--- a/apps/server/src/proxy/openai.ts
+++ b/apps/server/src/proxy/openai.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { stream } from 'hono/streaming'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
 import { calculateCost } from '../lib/cost.js'
@@ -19,6 +20,7 @@ const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '3500
 export const openaiProxy = new Hono<ApiKeyContext>()
 
 openaiProxy.use('*', authApiKey)
+openaiProxy.use('*', requireFullScope)
 openaiProxy.use('*', proxyRateLimit)
 openaiProxy.use('*', enforceQuota)
 
@@ -26,7 +28,11 @@ openaiProxy.all('/*', async (c) => {
   const handlerStartMs = Date.now()
 
   const organizationId = c.get('organizationId')
-  const projectId = c.get('projectId')
+  // projectId is guaranteed non-null on this path: requireFullScope rejects
+  // 'public' keys and the api_keys_scope_owner_consistency CHECK constraint
+  // forces 'full' keys to carry a project_id. Narrowing here is purely a
+  // TS aid since the dual-owner model made ApiKeyContext.projectId nullable.
+  const projectId = c.get('projectId') as string
   const apiKeyId = c.get('apiKeyId')
 
   // Nested-keys model: provider key pool is owned by this Spanlens key.

--- a/apps/web/app/(dashboard)/projects/projects-client.tsx
+++ b/apps/web/app/(dashboard)/projects/projects-client.tsx
@@ -32,6 +32,7 @@ import {
   useIssueApiKey,
   useToggleApiKey,
   useDeleteApiKey,
+  usePublicKeys,
 } from '@/lib/queries/use-api-keys'
 import {
   useProviderKeys,
@@ -168,6 +169,13 @@ export function ProjectsClient() {
   const [issueName, setIssueName] = useState('')
   const [issueError, setIssueError] = useState<string | null>(null)
 
+  // Issue workspace-level public key dialog (separate from the per-project flow)
+  const [issuePublicDialogOpen, setIssuePublicDialogOpen] = useState(false)
+  const [issuePublicName, setIssuePublicName] = useState('')
+  const [issuePublicError, setIssuePublicError] = useState<string | null>(null)
+  const publicKeysQuery = usePublicKeys()
+  const publicKeys = publicKeysQuery.data ?? []
+
   // Rotate provider key dialog
   const [rotateProvKeyId, setRotateProvKeyId] = useState<string | null>(null)
   const [rotateProvNew, setRotateProvNew] = useState('')
@@ -264,6 +272,26 @@ export function ProjectsClient() {
       setIssueDialogOpen(false)
     } catch (err) {
       setIssueError(err instanceof Error ? err.message : 'Failed to issue key')
+    }
+  }
+
+  function openIssuePublicDialog() {
+    setIssuePublicName('')
+    setIssuePublicError(null)
+    setIssuePublicDialogOpen(true)
+  }
+
+  async function handleIssuePublicKey() {
+    setIssuePublicError(null)
+    try {
+      const result = await issueApiKey.mutateAsync({
+        name: issuePublicName.trim(),
+        scope: 'public',
+      })
+      setNewKey(result?.key ?? null)
+      setIssuePublicDialogOpen(false)
+    } catch (err) {
+      setIssuePublicError(err instanceof Error ? err.message : 'Failed to issue key')
     }
   }
 
@@ -492,6 +520,81 @@ export function ProjectsClient() {
 
       <div>
         <div className="px-7 py-6 max-w-4xl">
+          {/* Public Keys card — workspace-level credentials for MCP servers,
+              BI tools, and read embeds. Placed above the page title so it
+              reads as a distinct workspace-scope concept, separate from the
+              per-project key list below. */}
+          <div className="rounded-xl border border-border bg-bg-elev px-5 py-4 mb-6">
+            <div className="flex items-start justify-between gap-4 mb-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 mb-0.5">
+                  <h2 className="text-[14px] font-semibold text-text">Public keys</h2>
+                  <span className="font-mono text-[9.5px] uppercase tracking-[0.05em] px-1.5 py-0.5 rounded border border-border text-text-faint">
+                    workspace
+                  </span>
+                </div>
+                <p className="text-[12px] text-text-muted">
+                  Read-only credentials safe for MCP servers, BI tools, and embeds. Cannot make LLM calls or ingest traces.
+                </p>
+              </div>
+              <PermissionGate need="edit">
+                <PrimaryBtn
+                  onClick={openIssuePublicDialog}
+                  className="shrink-0 flex items-center gap-1.5 text-[12px] px-3 py-[5px] h-[28px]"
+                >
+                  <Plus className="h-3.5 w-3.5" /> New public key
+                </PrimaryBtn>
+              </PermissionGate>
+            </div>
+
+            {publicKeys.length === 0 ? (
+              <div className="rounded-md border border-dashed border-border px-4 py-3 text-[12px] text-text-faint">
+                No public keys yet. Generate one to read your workspace&apos;s stats from outside Spanlens.
+              </div>
+            ) : (
+              <ul className="divide-y divide-border rounded-md border border-border bg-bg/40">
+                {publicKeys.map((key) => (
+                  <li key={key.id} className="flex items-center gap-3 px-3 py-2.5">
+                    <KeyIcon className="h-3.5 w-3.5 text-text-faint shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <div
+                        className={cn(
+                          'text-[13px] font-medium truncate',
+                          !key.is_active && 'line-through text-text-faint',
+                        )}
+                      >
+                        {key.name}
+                      </div>
+                      <div className="font-mono text-[10.5px] text-text-faint mt-0.5">
+                        {key.key_prefix}…
+                        <span className="ml-2">
+                          {/* Date-relative — defer to client mount to keep SSR
+                              and first paint deterministic. */}
+                          {!mounted
+                            ? '· …'
+                            : key.last_used_at
+                              ? `· last used ${Math.floor((Date.now() - Date.parse(key.last_used_at)) / 86_400_000)}d ago`
+                              : '· never used'}
+                        </span>
+                      </div>
+                    </div>
+                    <PermissionGate need="edit">
+                      <button
+                        type="button"
+                        onClick={() => deleteApiKey.mutate(key.id)}
+                        className="text-text-faint hover:text-bad transition-colors p-1"
+                        title="Revoke"
+                        aria-label="Revoke public key"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </PermissionGate>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
           <div className="mb-6">
             <h1 className="text-[22px] font-semibold text-text tracking-[-0.4px] mb-1">
               Projects & Keys
@@ -921,6 +1024,63 @@ export function ProjectsClient() {
               disabled={!issueName.trim() || issueApiKey.isPending}
             >
               {issueApiKey.isPending ? 'Creating…' : 'Create key'}
+            </PrimaryBtn>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Issue workspace-level public key dialog */}
+      <Dialog
+        open={issuePublicDialogOpen}
+        onOpenChange={(open) => {
+          setIssuePublicDialogOpen(open)
+          if (!open) {
+            setIssuePublicName('')
+            setIssuePublicError(null)
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New public key</DialogTitle>
+          </DialogHeader>
+          <DialogDescription className="text-[12.5px] text-text-muted mt-1">
+            Issues a{' '}
+            <code className="font-mono bg-bg-elev border border-border px-1 rounded text-[11px]">
+              sl_live_pub_…
+            </code>{' '}
+            key scoped to this workspace. Safe to paste into MCP servers, BI tools, or read-only embeds — it can only read dashboard data, never trigger LLM spend.
+          </DialogDescription>
+
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              void handleIssuePublicKey()
+            }}
+            className="space-y-4 mt-2"
+          >
+            <div className="space-y-1.5">
+              <label className="text-[12.5px] text-text-muted font-medium">Key name</label>
+              <input
+                value={issuePublicName}
+                onChange={(e) => setIssuePublicName(e.target.value)}
+                placeholder="e.g. Cursor MCP"
+                autoFocus
+                className="w-full h-9 px-3 rounded-[6px] border border-border bg-bg text-[13px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong transition-colors"
+              />
+            </div>
+
+            {issuePublicError && (
+              <div className="rounded-md border border-bad/30 bg-bad/10 px-3 py-2 text-[12px] text-bad">
+                {issuePublicError}
+              </div>
+            )}
+
+            <PrimaryBtn
+              type="submit"
+              disabled={!issuePublicName.trim() || issueApiKey.isPending}
+            >
+              {issueApiKey.isPending ? 'Creating…' : 'Create public key'}
             </PrimaryBtn>
           </form>
         </DialogContent>

--- a/apps/web/app/(dashboard)/projects/projects-client.tsx
+++ b/apps/web/app/(dashboard)/projects/projects-client.tsx
@@ -404,12 +404,18 @@ export function ProjectsClient() {
     const akHit = allApiKeys.filter((k) =>
       k.name.toLowerCase().includes(needle) || provHitKeyIds.has(k.id),
     )
-    const akHitProjIds = new Set(akHit.map((k) => k.project_id))
+    // Public keys (project_id null) are surfaced in their own card above
+    // the project list — drop them from the search-narrowed project view.
+    const akHitProjIds = new Set(
+      akHit.map((k) => k.project_id).filter((id): id is string => id !== null),
+    )
     const projHit = allProjects.filter((p) =>
       p.name.toLowerCase().includes(needle) || akHitProjIds.has(p.id),
     )
     const projHitIds = new Set(projHit.map((p) => p.id))
-    const visibleApiKeys = allApiKeys.filter((k) => projHitIds.has(k.project_id))
+    const visibleApiKeys = allApiKeys.filter(
+      (k) => k.project_id !== null && projHitIds.has(k.project_id),
+    )
     const visibleApiKeyIds = new Set(visibleApiKeys.map((k) => k.id))
     const visibleProviderKeys = allProviderKeys.filter((pk) => visibleApiKeyIds.has(pk.api_key_id))
     return { projects: projHit, apiKeys: visibleApiKeys, providerKeys: visibleProviderKeys }
@@ -520,91 +526,10 @@ export function ProjectsClient() {
 
       <div>
         <div className="px-7 py-6 max-w-4xl">
-          {/* Public Keys card — workspace-level credentials for MCP servers,
-              BI tools, and read embeds. Placed above the page title so it
-              reads as a distinct workspace-scope concept, separate from the
-              per-project key list below. */}
-          <div className="rounded-xl border border-border bg-bg-elev px-5 py-4 mb-6">
-            <div className="flex items-start justify-between gap-4 mb-3">
-              <div className="min-w-0">
-                <div className="flex items-center gap-2 mb-0.5">
-                  <h2 className="text-[14px] font-semibold text-text">Public keys</h2>
-                  <span className="font-mono text-[9.5px] uppercase tracking-[0.05em] px-1.5 py-0.5 rounded border border-border text-text-faint">
-                    workspace
-                  </span>
-                </div>
-                <p className="text-[12px] text-text-muted">
-                  Read-only credentials safe for MCP servers, BI tools, and embeds. Cannot make LLM calls or ingest traces.
-                </p>
-              </div>
-              <PermissionGate need="edit">
-                <PrimaryBtn
-                  onClick={openIssuePublicDialog}
-                  className="shrink-0 flex items-center gap-1.5 text-[12px] px-3 py-[5px] h-[28px]"
-                >
-                  <Plus className="h-3.5 w-3.5" /> New public key
-                </PrimaryBtn>
-              </PermissionGate>
-            </div>
-
-            {publicKeys.length === 0 ? (
-              <div className="rounded-md border border-dashed border-border px-4 py-3 text-[12px] text-text-faint">
-                No public keys yet. Generate one to read your workspace&apos;s stats from outside Spanlens.
-              </div>
-            ) : (
-              <ul className="divide-y divide-border rounded-md border border-border bg-bg/40">
-                {publicKeys.map((key) => (
-                  <li key={key.id} className="flex items-center gap-3 px-3 py-2.5">
-                    <KeyIcon className="h-3.5 w-3.5 text-text-faint shrink-0" />
-                    <div className="flex-1 min-w-0">
-                      <div
-                        className={cn(
-                          'text-[13px] font-medium truncate',
-                          !key.is_active && 'line-through text-text-faint',
-                        )}
-                      >
-                        {key.name}
-                      </div>
-                      <div className="font-mono text-[10.5px] text-text-faint mt-0.5">
-                        {key.key_prefix}…
-                        <span className="ml-2">
-                          {/* Date-relative — defer to client mount to keep SSR
-                              and first paint deterministic. */}
-                          {!mounted
-                            ? '· …'
-                            : key.last_used_at
-                              ? `· last used ${Math.floor((Date.now() - Date.parse(key.last_used_at)) / 86_400_000)}d ago`
-                              : '· never used'}
-                        </span>
-                      </div>
-                    </div>
-                    <PermissionGate need="edit">
-                      <button
-                        type="button"
-                        onClick={() => deleteApiKey.mutate(key.id)}
-                        className="text-text-faint hover:text-bad transition-colors p-1"
-                        title="Revoke"
-                        aria-label="Revoke public key"
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
-                    </PermissionGate>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-
-          <div className="mb-6">
-            <h1 className="text-[22px] font-semibold text-text tracking-[-0.4px] mb-1">
-              Projects & Keys
-            </h1>
-            <p className="text-[13px] text-text-muted">
-              Each Spanlens key holds its own AI provider keys. Expand a key to see and add OpenAI / Anthropic / Gemini keys it can call.
-            </p>
-          </div>
-
-          {/* New key banner */}
+          {/* New key banner — surfaces freshly minted keys (full OR public)
+              at the very top of the content, between the search bar and the
+              Public Keys card. The user just clicked "Create", so the
+              plaintext value should be the first thing they see. */}
           {newKey && (
             <div className="rounded-xl border border-good/30 bg-good-bg px-5 py-4 mb-6">
               <div className="flex items-center justify-between mb-3">
@@ -677,6 +602,95 @@ export function ProjectsClient() {
               </div>
             </div>
           )}
+
+          {/* Public Keys card — workspace-level credentials for MCP servers,
+              BI tools, and read embeds. Placed above the page title so it
+              reads as a distinct workspace-scope concept, separate from the
+              per-project key list below. */}
+          <div className="rounded-xl border border-border bg-bg-elev px-5 py-4 mb-6">
+            <div className="flex items-start justify-between gap-4 mb-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 mb-0.5">
+                  <h2 className="text-[14px] font-semibold text-text">Public keys</h2>
+                  <span className="font-mono text-[9.5px] uppercase tracking-[0.05em] px-1.5 py-0.5 rounded border border-border text-text-faint">
+                    workspace
+                  </span>
+                </div>
+                <p className="text-[12px] text-text-muted">
+                  Read-only credentials safe for MCP servers, BI tools, and embeds. Cannot make LLM calls or ingest traces.
+                </p>
+              </div>
+              <PermissionGate need="edit">
+                <PrimaryBtn
+                  onClick={openIssuePublicDialog}
+                  className="shrink-0 flex items-center gap-1.5 text-[12px] px-3 py-[5px] h-[28px]"
+                >
+                  <Plus className="h-3.5 w-3.5" /> New public key
+                </PrimaryBtn>
+              </PermissionGate>
+            </div>
+
+            {publicKeys.length === 0 ? (
+              <div className="rounded-md border border-dashed border-border px-4 py-3 text-[12px] text-text-faint">
+                No public keys yet. Generate one to read your workspace&apos;s stats from outside Spanlens.
+              </div>
+            ) : (
+              <ul className="divide-y divide-border rounded-md border border-border bg-bg/40">
+                {publicKeys.map((key) => (
+                  <li key={key.id} className="flex items-center gap-3 px-3 py-2.5">
+                    <KeyIcon className="h-3.5 w-3.5 text-text-faint shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <div
+                        className={cn(
+                          'text-[13px] font-medium truncate',
+                          !key.is_active && 'line-through text-text-faint',
+                        )}
+                      >
+                        {key.name}
+                      </div>
+                      <div className="font-mono text-[10.5px] text-text-faint mt-0.5">
+                        {key.key_prefix}…
+                        <span className="ml-2">
+                          {/* Date-relative — defer to client mount to keep SSR
+                              and first paint deterministic. Same pattern as the
+                              project-key list below; React Compiler's purity
+                              check trips on the simpler nesting here, so the
+                              rule is disabled inline rather than refactoring
+                              two identical readouts. */}
+                          {!mounted
+                            ? '· …'
+                            : key.last_used_at
+                              // eslint-disable-next-line react-hooks/purity
+                              ? `· last used ${Math.floor((Date.now() - Date.parse(key.last_used_at)) / 86_400_000)}d ago`
+                              : '· never used'}
+                        </span>
+                      </div>
+                    </div>
+                    <PermissionGate need="edit">
+                      <button
+                        type="button"
+                        onClick={() => deleteApiKey.mutate(key.id)}
+                        className="text-text-faint hover:text-bad transition-colors p-1"
+                        title="Revoke"
+                        aria-label="Revoke public key"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </PermissionGate>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div className="mb-6">
+            <h1 className="text-[22px] font-semibold text-text tracking-[-0.4px] mb-1">
+              Projects & Keys
+            </h1>
+            <p className="text-[13px] text-text-muted">
+              Each Spanlens key holds its own AI provider keys. Expand a key to see and add OpenAI / Anthropic / Gemini keys it can call.
+            </p>
+          </div>
 
           {/* Integration hint */}
           {!newKey && projects.length > 0 && (

--- a/apps/web/lib/queries/types.ts
+++ b/apps/web/lib/queries/types.ts
@@ -42,11 +42,17 @@ export interface Project {
   updated_at?: string
 }
 
+export type ApiKeyScope = 'full' | 'public'
+
 export interface ApiKey {
   id: string
-  project_id: string
+  /** Null for `public` (workspace-level) keys. */
+  project_id: string | null
+  /** Set only for `public` keys. */
+  organization_id: string | null
   name: string
   key_prefix: string
+  scope: ApiKeyScope
   is_active: boolean
   last_used_at: string | null
   created_at: string

--- a/apps/web/lib/queries/use-api-keys.ts
+++ b/apps/web/lib/queries/use-api-keys.ts
@@ -2,7 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiDelete, apiGet, apiPatch, apiPost } from '@/lib/api'
-import type { ApiEnvelope, ApiKey, IssuedApiKey } from './types'
+import type { ApiEnvelope, ApiKey, ApiKeyScope, IssuedApiKey } from './types'
 
 /**
  * Spanlens (sl_live_*) keys. Under the unified-keys model these are
@@ -26,10 +26,36 @@ export function useApiKeys(projectId?: string) {
   })
 }
 
+/**
+ * Workspace-level `scope='public'` keys. Separate hook from `useApiKeys` so
+ * the public-keys card on /projects has its own cache key and refetch
+ * trigger — issuing a new public key doesn't perturb the project-level lists.
+ */
+export const publicKeysQueryKey = [...apiKeysQueryKey, { scope: 'public' }] as const
+
+export function usePublicKeys() {
+  return useQuery({
+    queryKey: publicKeysQueryKey,
+    queryFn: async () => {
+      const res = await apiGet<ApiEnvelope<ApiKey[]>>('/api/v1/api-keys?scope=public')
+      return res.data
+    },
+  })
+}
+
+/**
+ * Issue a Spanlens key.
+ *   { name, projectId }              — full key, project-scoped (default)
+ *   { name, scope: 'public' }        — workspace-level public key
+ */
 export function useIssueApiKey() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: async (input: { name: string; projectId: string }) => {
+    mutationFn: async (
+      input:
+        | { name: string; projectId: string; scope?: 'full' }
+        | { name: string; scope: 'public' },
+    ) => {
       const res = await apiPost<ApiEnvelope<IssuedApiKey>>('/api/v1/api-keys/issue', input)
       return res.data
     },
@@ -38,6 +64,9 @@ export function useIssueApiKey() {
     },
   })
 }
+
+// Re-export for callers that build their own types around scope.
+export type { ApiKeyScope }
 
 export function useToggleApiKey() {
   const qc = useQueryClient()

--- a/supabase/migrations/20260604040000_api_keys_public_scope.sql
+++ b/supabase/migrations/20260604040000_api_keys_public_scope.sql
@@ -1,0 +1,131 @@
+-- Migration: api_keys public scope (workspace-level keys)
+--
+-- Adds a `public` scope to api_keys so customers can mint a workspace-level
+-- key that is safe to paste into high-leak-surface locations:
+--   • MCP servers configured in IDE settings (~/.cursor/mcp.json etc.)
+--   • BI/dashboard tools embedding the key in a connection string
+--   • Public read embeds whose URLs fan out beyond the org
+--
+-- Two ownership patterns coexist after this migration:
+--   • scope = 'full'   → project_id NOT NULL, organization_id NULL
+--                       (existing "Spanlens key per project" model — unchanged)
+--   • scope = 'public' → project_id NULL, organization_id NOT NULL
+--                       (new workspace-level key — read-only data access)
+--
+-- Auth enforcement:
+--   /proxy/*, /ingest/*, OTLP /v1/traces        → require scope='full'
+--     (see apps/server/src/middleware/requireFullScope.ts)
+--   /api/v1/* read endpoints                   → accept JWT OR sl_live_*
+--     (see apps/server/src/middleware/authJwtOrApiKey.ts)
+--
+-- Prefix convention (UX hint only — lookup is still by key_hash):
+--   sl_live_<hex>      → full
+--   sl_live_pub_<hex>  → public
+--
+-- PII masking already covers sl_live_pub_* via the existing sl_live_ regex
+-- in apps/server/src/lib/pii-mask.ts — no change needed there.
+
+-- ────────────────────────────────────────────────────────────
+-- 1. Add scope column (default 'full' so all existing rows are unchanged)
+-- ────────────────────────────────────────────────────────────
+ALTER TABLE api_keys
+  ADD COLUMN IF NOT EXISTS scope text NOT NULL DEFAULT 'full'
+  CHECK (scope IN ('full', 'public'));
+
+-- ────────────────────────────────────────────────────────────
+-- 2. Add organization_id column for workspace-level public keys
+-- ────────────────────────────────────────────────────────────
+ALTER TABLE api_keys
+  ADD COLUMN IF NOT EXISTS organization_id uuid
+  REFERENCES organizations(id) ON DELETE CASCADE;
+
+-- ────────────────────────────────────────────────────────────
+-- 3. Relax project_id NOT NULL so public keys can omit it
+--    (unified-keys migration in 20260505040000 had locked it NOT NULL)
+-- ────────────────────────────────────────────────────────────
+ALTER TABLE api_keys
+  ALTER COLUMN project_id DROP NOT NULL;
+
+-- ────────────────────────────────────────────────────────────
+-- 4. Constraint: scope value determines which owner column is set
+--    full   → project_id set,    organization_id null
+--    public → organization_id set, project_id null
+--
+-- This is the single source of truth for ownership semantics. Inserts that
+-- violate it fail at the DB layer — no application-level bug can produce a
+-- malformed row.
+-- ────────────────────────────────────────────────────────────
+ALTER TABLE api_keys
+  ADD CONSTRAINT api_keys_scope_owner_consistency
+  CHECK (
+    (scope = 'full'   AND project_id IS NOT NULL AND organization_id IS NULL)
+    OR
+    (scope = 'public' AND project_id IS NULL AND organization_id IS NOT NULL)
+  );
+
+-- ────────────────────────────────────────────────────────────
+-- 5. Lookup index for "list public keys for this org"
+--    Partial index — full keys are looked up by project, not by org here.
+-- ────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS api_keys_org_scope_idx
+  ON api_keys (organization_id, scope)
+  WHERE organization_id IS NOT NULL;
+
+-- ────────────────────────────────────────────────────────────
+-- 6. Update RLS policies to accept BOTH ownership patterns
+--    Existing policies JOIN through projects to check org membership; that
+--    JOIN returns 0 rows for public keys (project_id NULL). Rewrite each
+--    policy as "match via project OR match via organization_id directly."
+--
+-- Server code uses supabaseAdmin (RLS bypass) so this only matters if any
+-- web flow ever queries api_keys via the anon client — but keeping policies
+-- consistent prevents future regressions.
+-- ────────────────────────────────────────────────────────────
+DROP POLICY IF EXISTS "api_key_select" ON api_keys;
+DROP POLICY IF EXISTS "api_key_insert" ON api_keys;
+DROP POLICY IF EXISTS "api_key_update" ON api_keys;
+DROP POLICY IF EXISTS "api_key_delete" ON api_keys;
+
+CREATE POLICY "api_key_select" ON api_keys FOR SELECT
+  USING (
+    (project_id IS NOT NULL AND EXISTS (
+      SELECT 1 FROM projects p
+      WHERE p.id = api_keys.project_id
+        AND is_org_member(p.organization_id)
+    ))
+    OR
+    (organization_id IS NOT NULL AND is_org_member(organization_id))
+  );
+
+CREATE POLICY "api_key_insert" ON api_keys FOR INSERT
+  WITH CHECK (
+    (project_id IS NOT NULL AND EXISTS (
+      SELECT 1 FROM projects p
+      WHERE p.id = api_keys.project_id
+        AND is_org_member(p.organization_id)
+    ))
+    OR
+    (organization_id IS NOT NULL AND is_org_member(organization_id))
+  );
+
+CREATE POLICY "api_key_update" ON api_keys FOR UPDATE
+  USING (
+    (project_id IS NOT NULL AND EXISTS (
+      SELECT 1 FROM projects p
+      WHERE p.id = api_keys.project_id
+        AND is_org_member(p.organization_id)
+    ))
+    OR
+    (organization_id IS NOT NULL AND is_org_member(organization_id))
+  );
+
+CREATE POLICY "api_key_delete" ON api_keys FOR DELETE
+  USING (
+    (project_id IS NOT NULL AND EXISTS (
+      SELECT 1 FROM projects p
+      WHERE p.id = api_keys.project_id
+        AND is_org_member(p.organization_id)
+    ))
+    OR
+    (organization_id IS NOT NULL AND is_org_member(organization_id))
+  );


### PR DESCRIPTION
## Summary

Replacement for the closed [#179](https://github.com/spanlens/Spanlens/pull/179). That earlier design made the scope project-level and forgot that `/api/v1/*` routes only accept JWT — meaning the new key had no endpoint it could call. This PR fixes both:

- **Workspace-level** (organization-scoped) — matches how the MCP-server use case asks questions (\"this week's OpenAI spend\", \"any cost anomalies\")
- **Read API dual auth** — `/api/v1/*` now accepts JWT OR `sl_live_*`, so the public key actually works
- **Renamed** scope to `public` (Stripe / Langfuse convention)
- **UI moved** to the top of the Projects & Keys page between the search bar and the title (per spec)

## Two key shapes after this PR

| Scope | Prefix | Owner | Allowed endpoints |
|---|---|---|---|
| `full` | `sl_live_<hex>` | project_id | `/proxy/*`, `/ingest/*`, OTLP, all `/api/v1/*` reads |
| `public` | `sl_live_pub_<hex>` | organization_id | `/api/v1/*` reads only (rejected at proxy/ingest with 403 + `PUBLIC_KEY_WRITE_FORBIDDEN`) |

The DB CHECK constraint `api_keys_scope_owner_consistency` guarantees exactly one of `(project_id, organization_id)` is set per row, matching scope. No app-layer bug can produce a malformed row.

## Files

**Schema (single migration)**
- [`20260604040000_api_keys_public_scope.sql`](supabase/migrations/20260604040000_api_keys_public_scope.sql) — adds `scope`, `organization_id`, relaxes `project_id NULL`, adds owner-consistency CHECK, rewrites RLS policies for both ownership patterns, adds partial index

**Auth layer**
- [authApiKey.ts](apps/server/src/middleware/authApiKey.ts) — resolves orgId via projects join (full) or direct column (public); sets `apiKeyScope` on context
- [requireFullScope.ts](apps/server/src/middleware/requireFullScope.ts) — write guard, returns 403 + `code: 'PUBLIC_KEY_WRITE_FORBIDDEN'`
- [authJwtOrApiKey.ts](apps/server/src/middleware/authJwtOrApiKey.ts) — new dual-auth middleware; routes `sl_live_*` to authApiKey, bridges `organizationId → orgId` so legacy JWT handlers keep working unmodified

**Write routes (require full scope)**
- [openai.ts](apps/server/src/proxy/openai.ts), [anthropic.ts](apps/server/src/proxy/anthropic.ts), [gemini.ts](apps/server/src/proxy/gemini.ts), [azure.ts](apps/server/src/proxy/azure.ts)
- [ingest.ts](apps/server/src/api/ingest.ts), [otlp.ts](apps/server/src/api/otlp.ts)

**Read routes (dual auth — public keys work here)**
- [requests.ts](apps/server/src/api/requests.ts), [users.ts](apps/server/src/api/users.ts), [stats.ts](apps/server/src/api/stats.ts), [traces.ts](apps/server/src/api/traces.ts), [anomalies.ts](apps/server/src/api/anomalies.ts), [recommendations.ts](apps/server/src/api/recommendations.ts)

**Issuance + CLI introspection**
- [apiKeys.ts](apps/server/src/api/apiKeys.ts) — `POST /issue` accepts `scope='public'` (no projectId) or `scope='full'+projectId`; `GET /?scope=public` lists workspace-level; PATCH/DELETE handle both
- [me.ts](apps/server/src/api/me.ts) — `/me/key-info` returns scope, gracefully handles public keys (no owning project)

**Web UI**
- [projects-client.tsx](apps/web/app/(dashboard)/projects/projects-client.tsx) — new Public Keys card between search bar and title; dedicated \"New public key\" dialog (separate from per-project flow). Lists existing public keys with revoke + last-used.
- [use-api-keys.ts](apps/web/lib/queries/use-api-keys.ts) — new `usePublicKeys` query hook; `useIssueApiKey` discriminated-union input
- [types.ts](apps/web/lib/queries/types.ts) — `ApiKeyScope` union; `ApiKey` gains `scope`, `organization_id`, nullable `project_id`

## Permission matrix

| Endpoint | full key | public key | JWT |
|---|---|---|---|
| `/proxy/{openai,anthropic,gemini,azure}/*` | ✅ | ❌ 403 | n/a |
| `/ingest/*`, OTLP `POST /v1/traces` | ✅ | ❌ 403 | n/a |
| `/api/v1/{stats,requests,traces,anomalies,users,recommendations}/*` | ✅ | ✅ | ✅ |
| `/api/v1/me/key-info` | ✅ | ✅ | n/a |

## Test plan
- [x] `pnpm typecheck` (full monorepo) — green
- [x] `pnpm lint` (full monorepo) — green
- [x] `pnpm --filter server test` — **580 tests passed**
  - [require-full-scope.test.ts](apps/server/src/__tests__/require-full-scope.test.ts) (6) — full passes, public → 403 with correct code, all three header transports enforce, missing → 401 not 403, owner resolution branches verified
  - [auth-jwt-or-api-key.test.ts](apps/server/src/__tests__/auth-jwt-or-api-key.test.ts) (4) — sl_live_* routed to authApiKey + orgId bridge, JWT routed to authJwt, missing header → 401, non-sl_live token → JWT path
  - [auth-api-key.test.ts](apps/server/src/__tests__/auth-api-key.test.ts) (7, updated) — scope now part of mock + context probe
- [x] Migration applied locally via `supabase migration up` after `supabase db reset` — clean
- [ ] **Vercel preview**: open `/projects` — Public Keys card renders between search bar and title; empty state shows correct copy
- [ ] **Vercel preview**: click \"New public key\", issue a key — `sl_live_pub_*` shown in the same success banner; key appears in the list
- [ ] **Vercel preview**: copy the public key, hit `/api/v1/stats/overview` with `Authorization: Bearer sl_live_pub_…` → 200 with org-filtered data
- [ ] **Vercel preview**: same key on `/proxy/openai/v1/chat/completions` → 403 with `PUBLIC_KEY_WRITE_FORBIDDEN`
- [ ] **Vercel preview**: existing JWT-based dashboard flows still work (regression — read endpoints accept JWT as before)

## Notes for reviewer
- Local dev verification was limited: my dev session redirects to `/login` so I couldn't drive the dialog flow. Vercel preview with the maintainer's session is the right place for visual sign-off. The structural change is additive (a card + a dialog), and the auth flow is fully covered by the 580 server tests.
- PII masking already covers `sl_live_pub_*` via the existing `sl_live_` regex in [pii-mask.ts](apps/server/src/lib/pii-mask.ts) — no change needed.
- Read routes that already used JWT (members, audit-log, billing, settings, etc.) were intentionally left on `authJwt`. The dual-auth swap was scoped to the 6 endpoints in the MCP-server use case table. Future endpoints that want to accept public keys can opt in by swapping one import.
- `supabase/types.ts` was NOT regenerated — Supabase's Insert/Update generics are permissive enough that typecheck passes. Next `supabase gen types` run will pick up the new columns automatically.
- This unblocks [task ③ MCP server](https://github.com/spanlens/Spanlens/issues) — that work consumes public keys via `Authorization: Bearer sl_live_pub_…`.