### PR TITLE
chore(deps): split dependabot major bumps into individual PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,8 +36,13 @@ updates:
       - dependency-name: globals
         update-types: ["version-update:semver-major"]
     groups:
+      # Bundle every safe (minor + patch) bump into a single weekly PR.
+      # Majors land as individual PRs so each can be reviewed against
+      # its own breaking-change notes — TypeScript 6, zod 4, @types/node 25,
+      # @vitest/coverage-v8 4 all want code-level attention.
       all-deps:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # Next.js web app
   - package-ecosystem: npm
@@ -56,8 +61,13 @@ updates:
       - dependency-name: globals
         update-types: ["version-update:semver-major"]
     groups:
+      # Bundle every safe (minor + patch) bump into a single weekly PR.
+      # Majors land as individual PRs so each can be reviewed against
+      # its own breaking-change notes — TypeScript 6, zod 4, @types/node 25,
+      # @vitest/coverage-v8 4 all want code-level attention.
       all-deps:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # Hono server
   - package-ecosystem: npm
@@ -76,8 +86,13 @@ updates:
       - dependency-name: globals
         update-types: ["version-update:semver-major"]
     groups:
+      # Bundle every safe (minor + patch) bump into a single weekly PR.
+      # Majors land as individual PRs so each can be reviewed against
+      # its own breaking-change notes — TypeScript 6, zod 4, @types/node 25,
+      # @vitest/coverage-v8 4 all want code-level attention.
       all-deps:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # JS/TS SDK
   - package-ecosystem: npm
@@ -96,8 +111,13 @@ updates:
       - dependency-name: globals
         update-types: ["version-update:semver-major"]
     groups:
+      # Bundle every safe (minor + patch) bump into a single weekly PR.
+      # Majors land as individual PRs so each can be reviewed against
+      # its own breaking-change notes — TypeScript 6, zod 4, @types/node 25,
+      # @vitest/coverage-v8 4 all want code-level attention.
       all-deps:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # GitHub Actions
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary

Restricts the dependabot weekly \`all-deps\` group to **minor + patch only** across the four npm directories (root, /apps/web, /apps/server, /packages/sdk). Major bumps now land as **individual PRs** with their own per-package release notes attached, so each can be reviewed against its breaking-change risk.

## Why

PR #182 ([all-deps with 31 updates](https://github.com/spanlens/Spanlens/pull/182)) bundled 27 safe minor/patch bumps with 4 majors that materially affect our code:

| Package | Bump | Risk |
|---|---|---|
| **typescript** | 5.9 → **6.0** | strict-mode and deprecation changes |
| **zod** | 3.25 → **4.4** | schema API changes — affects MCP tools + server validators |
| **@types/node** | 22 → **25** | runtime target stays Node 22 LTS |
| **@vitest/coverage-v8** | 3 → **4** | vitest core stays on 3.2.6, coverage diverges |

One green CI badge on the merged group is not the same signal as "all 31 packages are backward compatible" — major bumps want code review.

## Follow-up

After this lands, the four open dependabot PRs (#182, #174, #173, #172) get closed. Dependabot will re-issue a clean minor/patch group on next Monday's schedule, and any major bumps will arrive as separate PRs the week after.

GitHub Actions group (\`/.github/workflows\`) keeps grouping everything together — those bumps are low risk and the workflows are small.

## Test plan
- [x] Single file change in \`.github/dependabot.yml\`
- [x] No runtime / build impact
- [ ] Reviewer spot-check: confirm group config matches dependabot's \`update-types\` syntax (per [dependabot config reference](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow))