### PR TITLE
fix(server): make node types explicit in tsconfig

### DIFF
--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -14,7 +14,8 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

Fixes the Docker build that started failing in docker-publish #194 immediately after PR #187 merged. CI `Typecheck / Lint / Test / Build` was already green and Vercel `spanlens-server` deploys are unaffected — only the docker-publish workflow (which builds the GHCR image for self-hosters) is broken.

## What's broken

`docker-publish` log (PR #194 / commit `dc9ee20`):

```
[builder 12/12] RUN pnpm exec tsc --project tsconfig.json
src/api/billing.ts(72,14): error TS2591: Cannot find name 'process'.
... (50+ identical errors across api/, lib/, middleware/, proxy/)
src/lib/logger.ts(1,28): error TS2591: Cannot find name 'node:crypto'.
src/lib/resend.ts(58,62): error TS2503: Cannot find namespace 'NodeJS'.
```

## Why it broke now

Local typechecks (`pnpm typecheck` at the monorepo root) keep working because pnpm installs hoist every workspace's `@types/*` into a shared `node_modules/@types` and TypeScript's default "auto-include all @types" rule then picks up `@types/node`.

The Dockerfile installs with `--filter server`, which produces a narrower hoist tree. Under **TypeScript 6 + @types/node 25** (introduced in PR #56 back on 5/25 and unchanged since) the implicit lookup of workspace-installed type packages no longer surfaces `@types/node` automatically in that narrower tree. TS 5 was more forgiving here.

PR #187 merged a flurry of minor/patch bumps that shuffled the lockfile enough to trip the latent issue. The deps in #187 itself are fine — TS 6 + node 25 majors are pre-existing.

## Fix

Pin `types: ["node"]` in `apps/server/tsconfig.json`. This tells tsc exactly which type packages to load, independent of how pnpm hoists `node_modules`. Works identically under root install and under `--filter server` install.

## Verification

- [x] `pnpm --filter server typecheck` — green
- [ ] docker-publish workflow on this PR — pending

The next docker-publish run should reach the runtime stage and push the image to ghcr.io.

## Out of scope

The bigger question of whether TS 6 + @types/node 25 are the right pins (target runtime is Node 22 LTS) is a separate follow-up. This PR is the minimal change to unblock the Docker image publish.