### PR TITLE
ci(mcp-server): add npm publish workflow

### DIFF
--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -1,0 +1,61 @@
+name: Publish @spanlens/mcp-server
+
+# Triggers:
+#   • push a git tag like `mcp-server-v0.1.0` → automated publish
+#   • manual via workflow_dispatch
+#
+# Reuses the NPM_TOKEN secret. Requires the token to grant publish on
+# @spanlens scope (or specifically on @spanlens/mcp-server). Same scope
+# as @spanlens/cli and @spanlens/sdk, so the existing Granular token's
+# scope-wide selection works without rotation.
+
+on:
+  push:
+    tags:
+      - 'mcp-server-v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # npm provenance attestation
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Test MCP server
+        run: pnpm --filter @spanlens/mcp-server test
+
+      - name: Build MCP server
+        run: pnpm --filter @spanlens/mcp-server build
+
+      - name: Publish to npm
+        working-directory: packages/mcp-server
+        run: |
+          if [ -z "$NPM_TOKEN" ]; then
+            echo "::error::NPM_TOKEN secret is empty or not forwarded"
+            exit 1
+          fi
+          # Write the token to a package-local .npmrc and pass it explicitly
+          # via --userconfig. The setup-node action plants NPM_CONFIG_USERCONFIG
+          # pointing at its own .npmrc, which would shadow the file we wrote
+          # if we relied on the default lookup (CLAUDE.md CI gotcha #1).
+          printf '//registry.npmjs.org/:_authToken=%s\n' "$NPM_TOKEN" > .npmrc
+          unset NPM_CONFIG_USERCONFIG
+          npm publish --provenance --access public --userconfig "$PWD/.npmrc"
+          rm -f .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish-mcp-server.yml` so `mcp-server-v*` tags trigger an automated build → test → `npm publish` flow for `@spanlens/mcp-server`. Mirrors the existing `publish-cli.yml` and `publish-sdk.yml` workflows.

## Trigger

```bash
git tag mcp-server-v0.1.0
git push --tags
```

Or manual via Actions UI (`workflow_dispatch`).

## Steps

1. `pnpm install --frozen-lockfile`
2. `pnpm --filter @spanlens/mcp-server test` (6 unit tests)
3. `pnpm --filter @spanlens/mcp-server build`
4. `npm publish --provenance --access public` from `packages/mcp-server/`

The `--provenance` flag emits a signed attestation (requires `id-token: write`, already set in permissions). The `--userconfig` + `unset NPM_CONFIG_USERCONFIG` dance works around the setup-node shadowing issue documented in CLAUDE.md CI/CD gotcha #1.

## Secret reuse

Reuses `NPM_TOKEN` — the same Granular token that publishes `@spanlens/cli` and `@spanlens/sdk`. Because `@spanlens/mcp-server` is in the same scope, no token rotation needed if the existing token has `Packages and scopes` set to "all packages of @spanlens" (the default when the scope was first created — see CLAUDE.md CI/CD gotcha #2).

If the token is restricted to specific packages, `npm publish` will return 403 on first publish and we'll need to either:
- Add `@spanlens/mcp-server` to the existing token's allow-list, or
- Issue a new Granular token (90-day max, Bypass 2FA checkbox MUST be ticked — CLAUDE.md CI/CD gotchas #8 and #9)

## After merge

1. `git tag mcp-server-v0.1.0 && git push --tags` — triggers the workflow
2. Verify via `npx -y @spanlens/mcp-server` (should refuse to start without `SPANLENS_API_KEY`, which is correct)
3. Open a follow-up PR to `modelcontextprotocol/servers` community list with the now-installable npx command

## Test plan
- [x] Workflow YAML mirrors publish-cli.yml verbatim except for filter / tag prefix / working directory
- [x] `pnpm --filter @spanlens/mcp-server test` passes locally (6/6)
- [x] `pnpm --filter @spanlens/mcp-server build` succeeds locally
- [ ] After merge: tag push triggers the workflow and lands the package on npm
- [ ] `npx -y @spanlens/mcp-server` smoke from a clean shell