### PR TITLE
feat(mcp-server): add mcpName + bump 0.1.1 for MCP Registry

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@spanlens/mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
+  "mcpName": "io.github.spanlens/mcp-server",
   "description": "MCP server for Spanlens — query LLM cost, anomalies, traces, and per-user analytics from inside Cursor, Continue, or Claude Desktop.",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/src/version.ts
+++ b/packages/mcp-server/src/version.ts
@@ -1,4 +1,4 @@
 // Kept in a separate module so package.json doesn't have to be read at runtime
 // (avoids resolveJsonModule pulling the whole manifest into the bundle).
 // Bumped manually with each release; package.json stays canonical for npm.
-export const SERVER_VERSION = '0.1.0'
+export const SERVER_VERSION = '0.1.1'


### PR DESCRIPTION
## Summary

Prepares `@spanlens/mcp-server` for listing on **registry.modelcontextprotocol.io** (the official MCP server registry, which replaced the README list in `modelcontextprotocol/servers` per their CONTRIBUTING.md).

The registry's verifier reads `mcpName` from `package.json` and matches it against the registry entry name. Without that field, the registry rejects the listing.

## Changes

- `packages/mcp-server/package.json`:
  - Add `mcpName: "io.github.spanlens/mcp-server"` (required prefix for GitHub-based auth)
  - Bump version 0.1.0 → 0.1.1 (npm metadata is immutable per version, so a new release exposes `mcpName` to the registry verifier)
- `packages/mcp-server/src/version.ts` — keep `SERVER_VERSION` in sync

No runtime behaviour change.

## After merge

1. Tag + push: `git tag mcp-server-v0.1.1 && git push --tags` — publish-mcp-server.yml lands 0.1.1 on npm with the new metadata
2. Install `mcp-publisher` CLI (one-time, manual): `brew install mcp-publisher` or pre-built binary from [registry releases](https://github.com/modelcontextprotocol/registry/releases)
3. Run `mcp-publisher init` from packages/mcp-server/ → generates `server.json` template
4. `mcp-publisher login` (GitHub OAuth)
5. `mcp-publisher publish` → server appears at https://registry.modelcontextprotocol.io
6. (follow-up PR) Automate steps 3-5 inside publish-mcp-server.yml so future tag pushes land both npm and registry in one shot

## Test plan
- [x] `pnpm --filter @spanlens/mcp-server typecheck` — green
- [x] `pnpm --filter @spanlens/mcp-server test` — 6/6 pass
- [ ] Reviewer spot-check: confirm `mcpName` follows the `io.github.<owner>/<name>` schema (registry quickstart §1)
