### PR TITLE
feat(mcp-server): add server.json for MCP Registry listing

### DIFF
--- a/packages/mcp-server/.gitignore
+++ b/packages/mcp-server/.gitignore
@@ -1,0 +1,9 @@
+# Build output
+dist/
+
+# mcp-publisher CLI binary — downloaded locally for registry publishing,
+# not part of the source tree.
+mcp-publisher
+mcp-publisher.exe
+mcp-publisher.tar.gz
+LICENSE

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.spanlens/mcp-server",
+  "description": "MCP server for Spanlens — query LLM cost, anomalies, traces, and per-user analytics from inside Cursor, Continue, or Claude Desktop.",
+  "repository": {
+    "url": "https://github.com/spanlens/Spanlens",
+    "source": "github",
+    "subfolder": "packages/mcp-server"
+  },
+  "version": "0.1.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@spanlens/mcp-server",
+      "version": "0.1.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "SPANLENS_API_KEY",
+          "description": "Spanlens API key. Must be a scope=public key (sl_live_pub_*) issued from the Public Keys card at https://spanlens.io/projects — the server refuses to start with a full-access sl_live_* key.",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "SPANLENS_BASE_URL",
+          "description": "Override the API endpoint for self-hosted Spanlens. Default: https://api.spanlens.io",
+          "isRequired": false,
+          "format": "string",
+          "default": "https://api.spanlens.io"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the `server.json` file required by the [MCP Server Registry](https://registry.modelcontextprotocol.io). Plus a package-local `.gitignore` so the `mcp-publisher` binary and its bundled artifacts stay out of source control.

## What's in server.json

- **name**: `io.github.spanlens/mcp-server` (matches `mcpName` already shipped in `@spanlens/mcp-server@0.1.1`)
- **packages[0]**: npm registry pointer + stdio transport
- **environmentVariables**:
  - `SPANLENS_API_KEY` — required, secret, documented to be a `sl_live_pub_*` (public scope)
  - `SPANLENS_BASE_URL` — optional, self-host override, default `https://api.spanlens.io`

## After merge

```bash
cd packages/mcp-server
mcp-publisher login github    # one-time GitHub OAuth
mcp-publisher publish         # lands at registry.modelcontextprotocol.io
```

After that, IDE/agent clients that browse the registry can find Spanlens without us doing additional listing work in third-party MCP server catalogs.

## Follow-up (separate PR)

Wire the `login` + `publish` steps into `publish-mcp-server.yml` so every `mcp-server-v*` tag lands npm and the MCP Registry in one shot. Needs a GitHub OIDC token (no manual login) — registry supports it via `mcp-publisher login github-oidc`.

## Test plan
- [x] `mcp-publisher init` template populated and customised
- [x] schema URL matches the one mcp-publisher embeds (`2025-12-11`)
- [ ] Reviewer spot-check: confirm `environmentVariables` schema (`name`, `description`, `isRequired`, `format`, `isSecret`, `default`) matches registry expectations
- [ ] After merge: run the three commands in the box above and confirm the listing appears
