### PR TITLE
fix(mcp-server): shorten server.json description for MCP Registry

### DIFF
--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.spanlens/mcp-server",
-  "description": "MCP server for Spanlens — query LLM cost, anomalies, traces, and per-user analytics from inside Cursor, Continue, or Claude Desktop.",
+  "description": "Query Spanlens LLM observability from Cursor, Claude Desktop, or Continue via MCP.",
   "repository": {
     "url": "https://github.com/spanlens/Spanlens",
     "source": "github",


### PR DESCRIPTION
## Summary

Registry's first publish call returned `422 expected length <= 100` on `body.description`. Our 137-char npm description doesn't fit; trimmed to 84 chars while keeping "Cursor / Claude Desktop / Continue" so the use case lands at first glance during registry search.

The registry entry has already been hand-fixed live (the value committed here is what `https://registry.modelcontextprotocol.io/v0/servers?search=io.github.spanlens` returns right now), so this PR is purely keeping the source-of-truth file in sync with what's published.

## Test plan
- [x] `mcp-publisher publish` succeeded against this description
- [x] live registry returns the trimmed string
- [ ] follow-up: wire the publish step into `publish-mcp-server.yml` so source vs live can't drift