### PR TITLE
chore(deps): ignore @types/node major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,12 @@ version: 2
 #
 # - globals 17: paired with the vitest 4 bump; safe on its own but Dependabot
 #   keeps grouping them. Drop this once vitest 4 is unblocked.
+#
+# - @types/node 25+: runtime target is Node 22 LTS, so the typings stay on
+#   the 22.x line until the runtime moves. The TS 6 + @types/node 25
+#   combination already cost a Docker build break (CLAUDE.md gotcha #28);
+#   leaving majors un-ignored means dependabot keeps re-issuing the same
+#   broken PR every week. Re-enable when the runtime is bumped past 22.
 
 updates:
   - package-ecosystem: npm
@@ -37,6 +43,8 @@ updates:
       - dependency-name: vitest
         update-types: ["version-update:semver-major"]
       - dependency-name: globals
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
     groups:
       # Bundle every safe (minor + patch) bump into a single weekly PR.


### PR DESCRIPTION
## Summary

Adds `@types/node` to the existing major-ignore block in `.github/dependabot.yml`. PR #189 (22→25) is the immediate trigger; without this, dependabot keeps re-issuing the same risky PR every Monday.

## Why

- Runtime target is **Node 22 LTS** — typings should follow runtime, not lead it
- TS 6 + @types/node 25 combo already cost a Docker build break (CLAUDE.md gotcha #28) — that's the latent damage we don't want to keep stepping on

## After merge

- PR #189 closed (pointer to this entry in the close comment)
- Next Monday: no `@types/node` major in the dependabot output
- Re-enable when the runtime is bumped past Node 22

## Test plan
- [x] Single-line addition to existing ignore block
- [x] Schema unchanged — `dependency-name` + `update-types` shape mirrors the eslint / vitest / globals entries above
- [ ] After merge: confirm `gh pr close 189` is called and the dependabot/types-node-25.9.1 branch is deleted
