### PR TITLE
ci(mcp-server): publish to MCP Registry on every tag

### DIFF
--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -59,3 +59,62 @@ jobs:
           rm -f .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # ── MCP Registry publish ────────────────────────────────────────────
+      # Mirrors the npm release to registry.modelcontextprotocol.io so the
+      # listing's `version` stays in lock-step with what's actually on npm.
+      # Uses GitHub Actions OIDC (no manual OAuth) — works because the
+      # workflow's `permissions.id-token: write` is already granted above
+      # for npm provenance.
+      - name: Download mcp-publisher CLI
+        working-directory: packages/mcp-server
+        run: |
+          curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          chmod +x mcp-publisher
+          ./mcp-publisher --help | head -1
+
+      - name: Sync server.json version with package.json
+        working-directory: packages/mcp-server
+        run: |
+          # server.json's top-level `version` and `packages[0].version` must
+          # match the just-published npm version exactly, or the registry
+          # verifier rejects the publish. Read the canonical value from
+          # package.json so a forgotten manual edit on server.json can't
+          # take the workflow down.
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "Syncing server.json to v$PKG_VERSION"
+          node -e "
+            const fs = require('fs');
+            const s = JSON.parse(fs.readFileSync('server.json', 'utf8'));
+            s.version = '$PKG_VERSION';
+            if (Array.isArray(s.packages) && s.packages[0]) {
+              s.packages[0].version = '$PKG_VERSION';
+            }
+            fs.writeFileSync('server.json', JSON.stringify(s, null, 2) + '\n');
+          "
+          # Show the resolved file for the run log so a verify failure is
+          # easy to diagnose without re-running with --debug.
+          cat server.json | head -20
+
+      - name: Login to MCP Registry (GitHub Actions OIDC)
+        working-directory: packages/mcp-server
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        working-directory: packages/mcp-server
+        # The npm tarball needs a moment to propagate before the registry's
+        # verifier can fetch the `mcpName` from package.json metadata. A
+        # short retry loop covers the rare slow propagation; the typical
+        # delay is sub-second.
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if ./mcp-publisher publish; then
+              echo "::notice::MCP Registry publish succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "::warning::publish attempt $attempt failed — sleeping then retrying"
+            sleep 15
+          done
+          echo "::error::MCP Registry publish failed after 5 attempts"
+          exit 1

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/mcp-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "mcpName": "io.github.spanlens/mcp-server",
   "description": "MCP server for Spanlens — query LLM cost, anomalies, traces, and per-user analytics from inside Cursor, Continue, or Claude Desktop.",
   "type": "module",

--- a/packages/mcp-server/src/version.ts
+++ b/packages/mcp-server/src/version.ts
@@ -1,4 +1,4 @@
 // Kept in a separate module so package.json doesn't have to be read at runtime
 // (avoids resolveJsonModule pulling the whole manifest into the bundle).
 // Bumped manually with each release; package.json stays canonical for npm.
-export const SERVER_VERSION = '0.1.1'
+export const SERVER_VERSION = '0.1.2'


### PR DESCRIPTION
## Summary

Extends `publish-mcp-server.yml` so a single `mcp-server-v*` tag push lands the package on **both** npm and `registry.modelcontextprotocol.io` in one workflow run — no human in the loop.

Before this PR: npm publish was automated, MCP Registry was a 4-step manual ritual (`mcp-publisher` binary download → `init` → `login github` device flow → `publish`).

## Workflow additions

1. **Download `mcp-publisher`** Linux binary in-place (`packages/mcp-server/`).
2. **Sync `server.json` version** from `package.json` — both top-level `version` and `packages[0].version`. Prevents a stale hand-edited `server.json` from blocking the publish.
3. **`mcp-publisher login github-oidc`** — uses the GitHub Actions OIDC token (no device flow / no manual OAuth). Works because `permissions.id-token: write` is already granted for npm provenance.
4. **`mcp-publisher publish`** with a 5-attempt × 15s retry loop to absorb npm propagation lag (the registry verifier fetches `mcpName` from the just-published tarball).

## Validation included

- Bumps to **0.1.2** so this PR's merge tag (`mcp-server-v0.1.2`) exercises the round-trip end-to-end.
- Pre-merge: `pnpm --filter @spanlens/mcp-server typecheck && test` green.
- Post-merge: tag push triggers workflow → npm 0.1.2 lands → registry 0.1.2 lands. I'll confirm both via curl after merge.

## Future release flow (after merge)

```bash
# bump version in package.json + src/version.ts
git commit -m 'feat(mcp-server): ...'
git tag mcp-server-v<X.Y.Z>
git push --tags
```

That's it. The workflow handles npm + MCP Registry.

## Test plan
- [x] `pnpm --filter @spanlens/mcp-server typecheck && test` — green
- [ ] After merge: `mcp-server-v0.1.2` tag push triggers the workflow
- [ ] npm 0.1.2 lands at https://www.npmjs.com/package/@spanlens/mcp-server
- [ ] MCP Registry 0.1.2 lands at https://registry.modelcontextprotocol.io/v0/servers?search=io.github.spanlens
