### PR TITLE
feat(sdk): LlamaIndex Python callback handler

### DIFF
--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -26,7 +26,9 @@ keywords = [
     "cost-tracking",
     "token-tracking",
     "langchain",
+    "langgraph",
     "llamaindex",
+    "llama-index",
     "ollama",
     "helicone-alternative",
     "langfuse-alternative",
@@ -59,11 +61,13 @@ openai = ["openai>=1.0.0"]
 anthropic = ["anthropic>=0.18.0"]
 gemini = ["google-generativeai>=0.5.0"]
 langchain = ["langchain-core>=0.1.0"]
+llama-index = ["llama-index-core>=0.10.0"]
 all = [
     "openai>=1.0.0",
     "anthropic>=0.18.0",
     "google-generativeai>=0.5.0",
     "langchain-core>=0.1.0",
+    "llama-index-core>=0.10.0",
 ]
 dev = [
     "pytest>=7.4.0",

--- a/packages/sdk-python/scripts/test_llama_index_integration.py
+++ b/packages/sdk-python/scripts/test_llama_index_integration.py
@@ -1,0 +1,275 @@
+"""End-to-end smoke test for the LlamaIndex callback handler.
+
+Unlike ``tests/test_integrations_llama_index.py`` which drives the handler
+with raw dicts (so it can run without LlamaIndex installed), this script
+imports the **real** LlamaIndex ``CallbackManager`` / ``CBEventType`` /
+``EventPayload`` and drives a synthetic agent run through it. We verify that
+our handler:
+
+  1. Subclasses LlamaIndex's ``BaseCallbackHandler`` cleanly (no MRO errors,
+     no abstract methods missed).
+  2. Receives the actual enum values LlamaIndex uses (CBEventType.LLM etc.)
+     and routes them to the correct Spanlens span_type.
+  3. Produces a valid wire shape (trace POST → span POSTs → span PATCHes →
+     trace PATCH) when CallbackManager fires events end-to-end.
+
+We mock the HTTP layer with respx so the script needs no live server. To
+run it against a live server, set ``SPANLENS_LIVE_URL=http://localhost:3001``
+and ``SPANLENS_LIVE_KEY=sl_live_...``.
+
+    python scripts/test_llama_index_integration.py
+
+Exit codes: 0 = all assertions passed. 1 = wire shape mismatch.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from typing import Any, Dict, List
+
+import httpx
+import respx
+
+# Import the REAL LlamaIndex enums and base class — fail loud if missing.
+try:
+    from llama_index.core.callbacks import CallbackManager, CBEventType, EventPayload
+    from llama_index.core.callbacks.base_handler import BaseCallbackHandler as LIBase
+except ImportError as e:
+    print(f"FAIL: llama-index-core not installed: {e}", file=sys.stderr)
+    sys.exit(2)
+
+from spanlens import SpanlensClient
+from spanlens.integrations.llama_index import SpanlensCallbackHandler
+
+# ── Assertions on import-time wiring ───────────────────────────────────────
+
+
+def assert_subclass_relationship() -> None:
+    """Our handler must be a real subclass of LlamaIndex's base — otherwise
+    CallbackManager would silently ignore it."""
+    assert issubclass(SpanlensCallbackHandler, LIBase), (
+        "SpanlensCallbackHandler is NOT a subclass of llama_index "
+        "BaseCallbackHandler. CallbackManager will reject it."
+    )
+    print("[ok] SpanlensCallbackHandler is a real LlamaIndex BaseCallbackHandler subclass")
+
+
+# ── Wire-shape verification under real CallbackManager ─────────────────────
+
+
+def _bodies(route: respx.Route) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for call in route.calls:
+        raw = call.request.content
+        if not raw:
+            continue
+        try:
+            out.append(json.loads(raw.decode()))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            continue
+    return out
+
+
+def run_synthetic_query() -> Dict[str, List[Dict[str, Any]]]:
+    """Drive a minimal LlamaIndex-style query through CallbackManager and
+    return the captured wire bodies."""
+    base = os.environ.get("SPANLENS_LIVE_URL", "https://test.spanlens.local")
+    api_key = os.environ.get("SPANLENS_LIVE_KEY", "sl_test_smoke")
+    using_live = "SPANLENS_LIVE_URL" in os.environ
+
+    def _scenario(client: SpanlensClient) -> Dict[str, List[Dict[str, Any]]]:
+        handler = SpanlensCallbackHandler(
+            client=client,
+            trace_name="li_smoke_query",
+        )
+        cb_mgr = CallbackManager([handler])
+
+        # Mimic what a real query engine does: outer QUERY event wrapping
+        # RETRIEVE + LLM. We use the real CallbackManager.event() context
+        # managers — this is the exact dispatch path LlamaIndex pipelines
+        # use internally.
+        with cb_mgr.as_trace("smoke_query"):
+            with cb_mgr.event(
+                CBEventType.QUERY, payload={EventPayload.QUERY_STR: "what is RAG?"}
+            ) as query_evt:
+
+                with cb_mgr.event(
+                    CBEventType.RETRIEVE,
+                    payload={EventPayload.QUERY_STR: "what is RAG?"},
+                ) as retr_evt:
+                    # Fake the retrieved nodes shape so our handler exercises
+                    # the node-summarisation branch.
+                    class _FakeNode:
+                        def __init__(self, score: float) -> None:
+                            self.score = score
+
+                    retr_evt.on_end(
+                        payload={
+                            EventPayload.NODES: [_FakeNode(0.91), _FakeNode(0.85)]
+                        }
+                    )
+
+                with cb_mgr.event(
+                    CBEventType.LLM,
+                    payload={
+                        EventPayload.MESSAGES: [
+                            {"role": "user", "content": "what is RAG?"}
+                        ]
+                    },
+                ) as llm_evt:
+                    class _U:
+                        prompt_tokens = 120
+                        completion_tokens = 45
+                        total_tokens = 165
+
+                    class _Raw:
+                        usage = _U()
+                        model = "gpt-4o-mini-2024-07-18"
+
+                    class _Resp:
+                        raw = _Raw()
+
+                    llm_evt.on_end(payload={EventPayload.RESPONSE: _Resp()})
+
+                query_evt.on_end(payload={EventPayload.RESPONSE: "RAG is..."})
+
+        # NOTE: SpanlensClient has no explicit flush() — `close()` drains
+        # the in-flight pool. We let the wrapping function call close().
+        return {}  # filled in by the wrapping function
+
+    if using_live:
+        client = SpanlensClient(api_key=api_key, base_url=base, silent=False)
+        try:
+            _scenario(client)
+            print(f"[ok] LIVE mode: events flushed to {base}")
+            return {"trace_post": [], "span_post": [], "span_patch": [], "trace_patch": []}
+        finally:
+            client.close()
+
+    # NOTE: must use bare ``respx.mock`` attribute (no call) — calling it
+    # like ``respx.mock(...)`` returns a fresh router whose patches don't
+    # always cover the httpx.Client instances that the background transport
+    # thread spawns. Unit tests use bare ``with respx.mock:``.
+
+    with respx.mock:
+        routes = {
+            "trace_post": respx.post(f"{base}/ingest/traces").mock(
+                return_value=httpx.Response(200, json={})
+            ),
+            "span_post": respx.post(
+                re.compile(rf"^{re.escape(base)}/ingest/traces/[\w-]+/spans$")
+            ).mock(return_value=httpx.Response(200, json={})),
+            "span_patch": respx.patch(
+                re.compile(rf"^{re.escape(base)}/ingest/spans/[\w-]+$")
+            ).mock(return_value=httpx.Response(200, json={})),
+            "trace_patch": respx.patch(
+                re.compile(rf"^{re.escape(base)}/ingest/traces/[\w-]+$")
+            ).mock(return_value=httpx.Response(200, json={})),
+        }
+        client = SpanlensClient(api_key=api_key, base_url=base, silent=False)
+        try:
+            _scenario(client)
+        finally:
+            client.close()
+        return {k: _bodies(r) for k, r in routes.items()}
+
+
+def verify_wire_shape(captured: Dict[str, List[Dict[str, Any]]]) -> None:
+    traces = captured["trace_post"]
+    spans = captured["span_post"]
+    span_patches = captured["span_patch"]
+    trace_patches = captured["trace_patch"]
+
+    # ── Trace lifecycle ────────────────────────────────────────────────
+    assert len(traces) == 1, f"expected 1 trace POST, got {len(traces)}: {traces}"
+    assert traces[0].get("name") == "li_smoke_query", (
+        f"trace name should be the user-provided trace_name, got {traces[0].get('name')!r}"
+    )
+    assert len(trace_patches) == 1, f"expected 1 trace PATCH, got {len(trace_patches)}"
+    assert trace_patches[0].get("status") == "completed"
+    print(f"[ok] Trace: 1 POST + 1 PATCH (completed), name={traces[0].get('name')!r}")
+
+    # ── Spans by type ──────────────────────────────────────────────────
+    by_type: Dict[str, List[Dict[str, Any]]] = {}
+    for s in spans:
+        by_type.setdefault(s.get("span_type", "?"), []).append(s)
+
+    assert "llm" in by_type, f"no llm span produced. seen types: {list(by_type)}"
+    assert "retrieval" in by_type, f"no retrieval span. seen: {list(by_type)}"
+    # QUERY event maps to 'custom' (not one of our first-class span types).
+    assert "custom" in by_type, f"no custom (query) span. seen: {list(by_type)}"
+    print(
+        f"[ok] Spans by type: llm={len(by_type.get('llm', []))}, "
+        f"retrieval={len(by_type.get('retrieval', []))}, "
+        f"custom={len(by_type.get('custom', []))}"
+    )
+
+    # ── Parent linkage ─────────────────────────────────────────────────
+    # The QUERY span should be top-level (no parent_span_id); the RETRIEVE
+    # and LLM spans should reference it as their parent.
+    query_span = by_type["custom"][0]
+    assert query_span.get("name") == "llama_index.query", (
+        f"top span name expected llama_index.query, got {query_span.get('name')!r}"
+    )
+    assert not query_span.get("parent_span_id"), (
+        f"query span should be top-level, has parent={query_span.get('parent_span_id')!r}"
+    )
+
+    for child in by_type["llm"] + by_type["retrieval"]:
+        assert child.get("parent_span_id") == query_span["id"], (
+            f"child span {child.get('name')!r} parent_span_id="
+            f"{child.get('parent_span_id')!r} expected {query_span['id']!r}"
+        )
+    print("[ok] Parent linkage: LLM + retrieval children reference QUERY as parent")
+
+    # ── LLM usage extraction ───────────────────────────────────────────
+    llm_patches = [
+        p for p in span_patches if (p.get("metadata") or {}).get("model")
+    ]
+    assert llm_patches, "no LLM span PATCH carrying model metadata found"
+    llm_patch = llm_patches[0]
+    assert llm_patch.get("prompt_tokens") == 120, llm_patch
+    assert llm_patch.get("completion_tokens") == 45, llm_patch
+    assert llm_patch.get("total_tokens") == 165, llm_patch
+    assert llm_patch["metadata"]["model"] == "gpt-4o-mini-2024-07-18", llm_patch
+    print(
+        f"[ok] LLM usage extracted: 120/45/165 tokens, model="
+        f"{llm_patch['metadata']['model']}"
+    )
+
+    # ── Retrieved nodes summarisation ──────────────────────────────────
+    retr_patches = [
+        p for p in span_patches
+        if isinstance(p.get("output"), dict) and "node_count" in p["output"]
+    ]
+    assert retr_patches, "no retrieval span PATCH with node summarisation found"
+    assert retr_patches[0]["output"]["node_count"] == 2
+    assert retr_patches[0]["output"]["top_scores"] == [0.91, 0.85]
+    print("[ok] Retrieval span carries node_count=2, top_scores=[0.91, 0.85]")
+
+
+def main() -> int:
+    print("=" * 60)
+    print("LlamaIndex integration smoke test")
+    print("=" * 60)
+    assert_subclass_relationship()
+    print()
+    print("Running synthetic query through real CallbackManager...")
+    captured = run_synthetic_query()
+    if "SPANLENS_LIVE_URL" in os.environ:
+        print("\nLIVE mode: check Spanlens dashboard manually for trace 'li_smoke_query'.")
+        return 0
+    print()
+    verify_wire_shape(captured)
+    print()
+    print("=" * 60)
+    print("ALL CHECKS PASSED")
+    print("=" * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/sdk-python/spanlens/integrations/llama_index.py
+++ b/packages/sdk-python/spanlens/integrations/llama_index.py
@@ -1,0 +1,480 @@
+"""LlamaIndex Python callback handler for Spanlens tracing.
+
+Records LLM / retrieval / embedding / tool / agent spans from any LlamaIndex
+query engine, agent, or workflow. The handler subclasses
+``llama_index.core.callbacks.BaseCallbackHandler`` when LlamaIndex is
+installed; otherwise it falls back to a plain class that exposes the same
+methods so unit tests can drive it without LlamaIndex being on the path.
+
+Unlike LangChain (which has a per-event method on the base class), LlamaIndex
+funnels everything through ``on_event_start`` / ``on_event_end`` and uses a
+``CBEventType`` enum to discriminate. This handler maps each event type to a
+Spanlens span type so the resulting trace tree mirrors the query topology
+1:1 — QUERY span at the root, RETRIEVE / SYNTHESIZE / LLM / etc. underneath.
+
+Example::
+
+    from spanlens import SpanlensClient
+    from spanlens.integrations.llama_index import SpanlensCallbackHandler
+    from llama_index.core import Settings, VectorStoreIndex
+
+    client = SpanlensClient(api_key=os.environ["SPANLENS_API_KEY"])
+    handler = SpanlensCallbackHandler(client=client)
+
+    Settings.callback_manager.add_handler(handler)
+
+    index = VectorStoreIndex.from_documents(documents)
+    query_engine = index.as_query_engine()
+    response = query_engine.query("What is RAG?")
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any, Optional
+
+from ..client import SpanlensClient
+from ..span import SpanHandle
+from ..trace import TraceHandle
+
+if TYPE_CHECKING:  # pragma: no cover - type-only
+    pass
+
+
+# Try to subclass LlamaIndex's BaseCallbackHandler when it's available so
+# the framework's callback manager dispatches into us correctly. Falls back
+# to a plain object base class so the handler is testable without LlamaIndex
+# installed and so we don't add llama-index as a hard dependency.
+try:
+    from llama_index.core.callbacks.base_handler import (  # type: ignore[import-not-found]
+        BaseCallbackHandler as _LIBase,
+    )
+    from llama_index.core.callbacks.schema import (  # type: ignore[import-not-found]
+        CBEventType,
+        EventPayload,
+    )
+
+    _LLAMA_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised via the fallback test
+    _LIBase = object  # type: ignore[assignment,misc]
+
+    # Mirror the enum values we care about so the handler is still usable
+    # via duck-typing in unit tests that pass string literals.
+    class CBEventType(str):  # type: ignore[no-redef]
+        CHUNKING = "chunking"
+        NODE_PARSING = "node_parsing"
+        EMBEDDING = "embedding"
+        LLM = "llm"
+        QUERY = "query"
+        RETRIEVE = "retrieve"
+        SYNTHESIZE = "synthesize"
+        TREE = "tree"
+        SUB_QUESTION = "sub_question"
+        TEMPLATING = "templating"
+        FUNCTION_CALL = "function_call"
+        RERANKING = "reranking"
+        EXCEPTION = "exception"
+        AGENT_STEP = "agent_step"
+
+    class EventPayload(str):  # type: ignore[no-redef]
+        MESSAGES = "messages"
+        PROMPT = "formatted_prompt"
+        COMPLETION = "completion"
+        RESPONSE = "response"
+        QUERY_STR = "query_str"
+        NODES = "nodes"
+        EMBEDDINGS = "embeddings"
+        TOP_K = "top_k"
+        MODEL_NAME = "model_name"
+        FUNCTION_CALL = "function_call"
+        FUNCTION_OUTPUT = "function_call_response"
+        TOOL = "tool"
+        EXCEPTION = "exception"
+
+    _LLAMA_AVAILABLE = False
+
+
+_DEFAULT_MAX_INPUT_BYTES = 16_384
+_DEFAULT_MAX_OUTPUT_BYTES = 16_384
+
+# CBEventType → Spanlens span_type. Anything not in this map falls through
+# to 'custom' so we don't lose visibility on framework events we haven't
+# explicitly handled yet.
+_EVENT_TYPE_TO_SPAN_TYPE: dict[str, str] = {
+    "llm": "llm",
+    "embedding": "embedding",
+    "retrieve": "retrieval",
+    "reranking": "retrieval",
+    "function_call": "tool",
+    "agent_step": "custom",
+    "query": "custom",
+    "synthesize": "custom",
+    "sub_question": "custom",
+    "templating": "custom",
+    "chunking": "custom",
+    "node_parsing": "custom",
+    "tree": "custom",
+    "exception": "custom",
+}
+
+# Events that don't add useful trace information by default. Users can
+# override via the ``event_starts_to_ignore`` / ``event_ends_to_ignore``
+# constructor arguments. TEMPLATING and CHUNKING are noisy preparation
+# steps; ignoring them shrinks the span tree to the meaningful work.
+_DEFAULT_IGNORED_EVENTS: tuple[str, ...] = (
+    "chunking",
+    "node_parsing",
+    "templating",
+)
+
+
+def _truncate(value: Any, max_bytes: int) -> Any:
+    """JSON-encode and truncate. Returns the original value when it fits, or a
+    truncation marker dict otherwise.
+
+    Non-serializable values fall back to ``str(value)`` rather than raising —
+    span ingest must never crash the caller's code.
+    """
+    if value is None:
+        return None
+    try:
+        encoded = json.dumps(value, default=str)
+    except (TypeError, ValueError):
+        encoded = str(value)
+    if len(encoded) <= max_bytes:
+        return value
+    return {
+        "__truncated": True,
+        "preview": encoded[:max_bytes],
+        "original_bytes": len(encoded),
+    }
+
+
+def _extract_input(event_type: str, payload: Optional[dict[str, Any]]) -> Any:
+    """Pick the most informative input from a LlamaIndex event payload.
+
+    LlamaIndex payloads vary by event type — pull what the user will want
+    to see in the dashboard. Returns ``None`` to skip recording input when
+    no useful data is available.
+    """
+    if not payload:
+        return None
+    # LLM events carry messages or a formatted prompt
+    if "messages" in payload:
+        return payload["messages"]
+    if "formatted_prompt" in payload:
+        return payload["formatted_prompt"]
+    # QUERY / RETRIEVE / RERANKING carry the query string
+    if "query_str" in payload:
+        return payload["query_str"]
+    # FUNCTION_CALL carries the call signature
+    if "function_call" in payload:
+        return payload["function_call"]
+    if "tool" in payload:
+        return payload["tool"]
+    if event_type == "embedding" and "embeddings" in payload:
+        # Don't dump entire embedding vectors into the trace; just record count
+        embs = payload["embeddings"]
+        try:
+            return {"embedding_count": len(embs)}
+        except TypeError:
+            return None
+    return None
+
+
+def _extract_output(event_type: str, payload: Optional[dict[str, Any]]) -> Any:
+    """Pick the most informative output from a LlamaIndex event end payload."""
+    if not payload:
+        return None
+    if "response" in payload:
+        return payload["response"]
+    if "completion" in payload:
+        return payload["completion"]
+    if "function_call_response" in payload:
+        return payload["function_call_response"]
+    if "nodes" in payload:
+        # Retrieved nodes — record count + top scores rather than full text
+        nodes = payload["nodes"]
+        try:
+            out: dict[str, Any] = {"node_count": len(nodes)}
+            scores = []
+            for n in nodes[:5]:
+                score = getattr(n, "score", None)
+                if score is not None:
+                    scores.append(float(score))
+            if scores:
+                out["top_scores"] = scores
+            return out
+        except (TypeError, AttributeError):
+            return None
+    return None
+
+
+def _extract_llm_usage(payload: Optional[dict[str, Any]]) -> dict[str, Any]:
+    """Extract token counts + model from an LLM event payload.
+
+    Tolerates the several response shapes LlamaIndex exposes (LiteLLM, OpenAI,
+    Anthropic, ...) without raising. Returns a dict suitable for spreading
+    into ``SpanHandle.end()``.
+    """
+    out: dict[str, Any] = {}
+    if not payload:
+        return out
+
+    # Model name lives at payload[MODEL_NAME] in some LlamaIndex versions
+    # and on the response object's `raw` in others.
+    model_name = payload.get("model_name")
+
+    # Token usage is buried under response.raw.usage for OpenAI-compatible
+    # backends or response.additional_kwargs for others. We dig defensively.
+    response = payload.get("response") or payload.get("completion")
+    usage: dict[str, Any] = {}
+    if response is not None:
+        # Try response.raw.usage (OpenAI-style)
+        raw = getattr(response, "raw", None)
+        if isinstance(raw, dict):
+            usage = raw.get("usage") or {}
+            model_name = model_name or raw.get("model")
+        elif raw is not None:
+            usage_obj = getattr(raw, "usage", None)
+            if usage_obj is not None:
+                # Pydantic models expose .model_dump() / .dict()
+                if hasattr(usage_obj, "model_dump"):
+                    usage = usage_obj.model_dump()
+                elif hasattr(usage_obj, "dict"):
+                    usage = usage_obj.dict()  # type: ignore[assignment]
+                else:
+                    usage = {
+                        "prompt_tokens": getattr(usage_obj, "prompt_tokens", 0),
+                        "completion_tokens": getattr(usage_obj, "completion_tokens", 0),
+                        "total_tokens": getattr(usage_obj, "total_tokens", 0),
+                    }
+            model_name = model_name or getattr(raw, "model", None)
+
+    if usage:
+        prompt = usage.get("prompt_tokens") or usage.get("input_tokens") or 0
+        completion = usage.get("completion_tokens") or usage.get("output_tokens") or 0
+        total = usage.get("total_tokens") or (int(prompt) + int(completion))
+        out["prompt_tokens"] = int(prompt)
+        out["completion_tokens"] = int(completion)
+        out["total_tokens"] = int(total)
+
+    if isinstance(model_name, str):
+        out["metadata"] = {"model": model_name}
+
+    return out
+
+
+class SpanlensCallbackHandler(_LIBase):  # type: ignore[valid-type,misc]
+    """LlamaIndex-compatible callback handler that records LLM, retrieval,
+    embedding, tool, and agent spans to Spanlens.
+
+    Attach via ``Settings.callback_manager.add_handler(handler)`` (global) or
+    by passing through the ``callback_manager`` argument when constructing a
+    query engine / agent. Concurrent runs are tracked by LlamaIndex's
+    per-event UUIDs, so a single handler instance is safe to share across
+    parallel invocations of the same client.
+
+    Args:
+        client: Spanlens client instance.
+        trace: Optional pre-existing trace to attach all spans to. When given,
+            ``trace.end()`` is NOT called — the caller owns the lifecycle.
+            When omitted, a new trace is created on each ``start_trace`` call
+            and closed on the matching ``end_trace``.
+        trace_name: Name for auto-created traces. Defaults to ``"llama_index_run"``.
+        event_starts_to_ignore: CBEventType values whose start events should
+            be skipped. Defaults to ``("chunking", "node_parsing",
+            "templating")`` to filter out preparation noise. Pass an empty
+            list to record everything.
+        event_ends_to_ignore: Same as above, for end events. Defaults to the
+            same set so the ignored events are silent in both directions.
+        max_input_bytes: Max bytes to keep in ``span.input``. Larger payloads
+            are replaced with a truncation marker dict. Default 16 KB.
+        max_output_bytes: Same as above for ``span.output``. Default 16 KB.
+    """
+
+    def __init__(
+        self,
+        client: SpanlensClient,
+        *,
+        trace: Optional[TraceHandle] = None,
+        trace_name: str = "llama_index_run",
+        event_starts_to_ignore: Optional[list[str]] = None,
+        event_ends_to_ignore: Optional[list[str]] = None,
+        max_input_bytes: int = _DEFAULT_MAX_INPUT_BYTES,
+        max_output_bytes: int = _DEFAULT_MAX_OUTPUT_BYTES,
+    ) -> None:
+        starts = (
+            event_starts_to_ignore
+            if event_starts_to_ignore is not None
+            else list(_DEFAULT_IGNORED_EVENTS)
+        )
+        ends = (
+            event_ends_to_ignore
+            if event_ends_to_ignore is not None
+            else list(_DEFAULT_IGNORED_EVENTS)
+        )
+
+        # When LlamaIndex is available the base class wants the ignore lists.
+        # When it's not, we still need to keep them around for our own filter.
+        if _LLAMA_AVAILABLE:
+            super().__init__(  # type: ignore[call-arg]
+                event_starts_to_ignore=starts,  # type: ignore[arg-type]
+                event_ends_to_ignore=ends,  # type: ignore[arg-type]
+            )
+        else:
+            super().__init__()  # type: ignore[misc]
+
+        self._client = client
+        self._external_trace = trace
+        self._trace_name = trace_name
+        self._event_starts_to_ignore = tuple(starts)
+        self._event_ends_to_ignore = tuple(ends)
+        self._max_input_bytes = max_input_bytes
+        self._max_output_bytes = max_output_bytes
+
+        # event_id (str) → SpanHandle. Concurrent runs are safe because
+        # LlamaIndex hands out unique UUIDs per event.
+        self._spans: dict[str, SpanHandle] = {}
+        # Local trace — created on start_trace when no external trace.
+        self._local_trace: Optional[TraceHandle] = None
+
+    # ── Internal helpers ───────────────────────────────────────────────
+
+    def _active_trace(self) -> Optional[TraceHandle]:
+        return self._external_trace or self._local_trace
+
+    # ── LlamaIndex callback API ───────────────────────────────────────
+
+    def on_event_start(  # noqa: D401 - inherited contract
+        self,
+        event_type: Any,
+        payload: Optional[dict[str, Any]] = None,
+        event_id: str = "",
+        parent_id: str = "",
+        **kwargs: Any,
+    ) -> str:
+        """Called when LlamaIndex starts a new event (LLM call, retrieval, etc.)."""
+        # Normalise the enum value to a string so we can branch on it.
+        event_value = (
+            event_type.value if hasattr(event_type, "value") else str(event_type)
+        )
+        if event_value in self._event_starts_to_ignore:
+            return event_id
+
+        trace = self._active_trace()
+        if trace is None:
+            # No active trace — LlamaIndex sometimes fires events before the
+            # outermost start_trace (e.g. embedding documents at index time).
+            # Lazy-create a local trace so we still capture the work.
+            self._local_trace = self._client.start_trace(self._trace_name)
+            trace = self._local_trace
+
+        span_type = _EVENT_TYPE_TO_SPAN_TYPE.get(event_value, "custom")
+        name = f"llama_index.{event_value}"
+        input_value = _extract_input(event_value, payload)
+
+        # Parent linkage: LlamaIndex may pass parent_id as the root sentinel
+        # "root" (BASE_TRACE_EVENT) for top-level events. Treat any unknown
+        # parent_id as "attach to trace root".
+        parent_span = self._spans.get(parent_id) if parent_id else None
+
+        span_kwargs: dict[str, Any] = {"span_type": span_type}
+        if input_value is not None:
+            span_kwargs["input"] = _truncate(input_value, self._max_input_bytes)
+
+        if parent_span is not None:
+            span: SpanHandle = parent_span.child(name, **span_kwargs)
+        else:
+            span = trace.span(name, **span_kwargs)
+
+        if event_id:
+            self._spans[event_id] = span
+        return event_id
+
+    def on_event_end(
+        self,
+        event_type: Any,
+        payload: Optional[dict[str, Any]] = None,
+        event_id: str = "",
+        **kwargs: Any,
+    ) -> None:
+        """Called when LlamaIndex finishes an event."""
+        event_value = (
+            event_type.value if hasattr(event_type, "value") else str(event_type)
+        )
+        if event_value in self._event_ends_to_ignore:
+            return
+
+        span = self._spans.pop(event_id, None)
+        if span is None:
+            return  # start was ignored or out-of-order
+
+        end_kwargs: dict[str, Any] = {}
+
+        # Surface exceptions as error spans with the message on metadata.
+        exception = (payload or {}).get("exception") if payload else None
+        if exception is not None:
+            end_kwargs["status"] = "error"
+            end_kwargs["error_message"] = str(exception)
+        else:
+            end_kwargs["status"] = "completed"
+
+        output_value = _extract_output(event_value, payload)
+        if output_value is not None:
+            end_kwargs["output"] = _truncate(output_value, self._max_output_bytes)
+
+        if event_value == "llm":
+            usage = _extract_llm_usage(payload)
+            for key, value in usage.items():
+                # `metadata` is a dict we want to merge, not overwrite.
+                if key == "metadata":
+                    existing = end_kwargs.get("metadata") or {}
+                    existing.update(value)
+                    end_kwargs["metadata"] = existing
+                else:
+                    end_kwargs[key] = value
+
+        span.end(**end_kwargs)
+
+    def start_trace(self, trace_id: Optional[str] = None) -> None:
+        """Called by LlamaIndex when an overall trace begins.
+
+        Creates a Spanlens trace if none is active. If the caller passed in
+        an ``external_trace`` to the constructor, this is a no-op — the
+        caller manages that trace's lifecycle.
+
+        The ``trace_id`` argument is LlamaIndex's internal identifier (often
+        ``"query"`` or a UUID) and is intentionally not used as the trace
+        name — the dashboard would show opaque IDs otherwise. We stash it on
+        metadata so it's still searchable.
+        """
+        if self._external_trace is not None:
+            return
+        if self._local_trace is not None:
+            # Nested start — LlamaIndex sometimes calls start_trace inside
+            # an already-open trace. Keep the outer one.
+            return
+        metadata = {"llama_index_trace_id": trace_id} if trace_id else None
+        self._local_trace = self._client.start_trace(self._trace_name, metadata=metadata)
+
+    def end_trace(
+        self,
+        trace_id: Optional[str] = None,
+        trace_map: Optional[dict[str, list[str]]] = None,
+    ) -> None:
+        """Called by LlamaIndex when the overall trace exits."""
+        del trace_id, trace_map  # parameters required by the protocol, unused
+        if self._external_trace is not None:
+            return  # caller owns the lifecycle
+        if self._local_trace is None:
+            return
+        # Make sure any spans left open get a `status` before the trace closes.
+        for span in list(self._spans.values()):
+            try:
+                span.end(status="completed")
+            except Exception:  # pragma: no cover - defensive
+                pass
+        self._spans.clear()
+        self._local_trace.end(status="completed")
+        self._local_trace = None

--- a/packages/sdk-python/tests/test_integrations_llama_index.py
+++ b/packages/sdk-python/tests/test_integrations_llama_index.py
@@ -1,0 +1,334 @@
+"""Tests for the LlamaIndex callback handler.
+
+Mocks the Spanlens ingest HTTP layer with ``respx`` and exercises the real
+span/trace creation logic to verify the on-wire shape. These tests run
+without LlamaIndex installed — the handler falls back to a plain base class
+exactly so we can drive it with raw dicts here.
+
+A separate scripts/test-llama-index-integration.py exercises a real
+LlamaIndex query engine end-to-end against a live local Spanlens server.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from spanlens import SpanlensClient
+from spanlens.integrations.llama_index import SpanlensCallbackHandler
+
+BASE_URL = "https://test.spanlens.local"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+def _mock_ingest_routes() -> dict[str, respx.MockRouter]:
+    routes = {
+        "trace_post": respx.post(f"{BASE_URL}/ingest/traces").mock(
+            return_value=httpx.Response(200, json={})
+        ),
+        "span_post": respx.post(
+            re.compile(rf"^{re.escape(BASE_URL)}/ingest/traces/[\w-]+/spans$")
+        ).mock(return_value=httpx.Response(200, json={})),
+        "span_patch": respx.patch(
+            re.compile(rf"^{re.escape(BASE_URL)}/ingest/spans/[\w-]+$")
+        ).mock(return_value=httpx.Response(200, json={})),
+        "trace_patch": respx.patch(
+            re.compile(rf"^{re.escape(BASE_URL)}/ingest/traces/[\w-]+$")
+        ).mock(return_value=httpx.Response(200, json={})),
+    }
+    return routes
+
+
+def _client() -> SpanlensClient:
+    return SpanlensClient(api_key="sl_test", base_url=BASE_URL, silent=False)
+
+
+def _flush(c: SpanlensClient) -> None:
+    try:
+        c.flush(timeout=2.0)
+    except Exception:
+        pass
+    time.sleep(0.1)
+
+
+def _bodies(route: respx.MockRouter) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for call in route.calls:
+        raw = call.request.content
+        if not raw:
+            continue
+        try:
+            out.append(json.loads(raw.decode()))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            continue
+    return out
+
+
+# ── Tests ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.respx(base_url=BASE_URL)
+def test_start_trace_creates_trace_post() -> None:
+    """A bare start_trace must POST /ingest/traces with the configured name."""
+    with respx.mock:
+        routes = _mock_ingest_routes()
+        client = _client()
+        handler = SpanlensCallbackHandler(client=client, trace_name="rag_query")
+        try:
+            handler.start_trace(trace_id="ignored-id")
+            handler.end_trace()
+            _flush(client)
+
+            traces = _bodies(routes["trace_post"])
+            assert len(traces) == 1, f"expected 1 trace POST, got {len(traces)}"
+            assert traces[0].get("name") == "rag_query"
+
+            patches = _bodies(routes["trace_patch"])
+            assert len(patches) == 1
+            assert patches[0].get("status") == "completed"
+        finally:
+            client.close()
+
+
+@pytest.mark.respx(base_url=BASE_URL)
+def test_llm_event_records_span_with_usage() -> None:
+    """An LLM event_start + event_end with usage on the payload must produce a
+    span POST with span_type=llm and a span PATCH carrying token counts."""
+
+    class _FakeUsage:
+        def __init__(self) -> None:
+            self.prompt_tokens = 120
+            self.completion_tokens = 45
+            self.total_tokens = 165
+
+    class _FakeRaw:
+        def __init__(self) -> None:
+            self.usage = _FakeUsage()
+            self.model = "gpt-4o-mini-2024-07-18"
+
+    class _FakeResponse:
+        def __init__(self) -> None:
+            self.raw = _FakeRaw()
+
+    with respx.mock:
+        routes = _mock_ingest_routes()
+        client = _client()
+        handler = SpanlensCallbackHandler(client=client)
+        try:
+            handler.start_trace()
+            handler.on_event_start(
+                event_type="llm",
+                payload={"messages": [{"role": "user", "content": "what is RAG?"}]},
+                event_id="llm-1",
+                parent_id="root",
+            )
+            handler.on_event_end(
+                event_type="llm",
+                payload={"response": _FakeResponse()},
+                event_id="llm-1",
+            )
+            handler.end_trace()
+            _flush(client)
+
+            spans = _bodies(routes["span_post"])
+            assert len(spans) == 1
+            assert spans[0].get("span_type") == "llm"
+            assert spans[0].get("name") == "llama_index.llm"
+
+            patches = _bodies(routes["span_patch"])
+            assert len(patches) == 1
+            patch = patches[0]
+            assert patch.get("status") == "completed"
+            assert patch.get("prompt_tokens") == 120
+            assert patch.get("completion_tokens") == 45
+            assert patch.get("total_tokens") == 165
+            meta = patch.get("metadata") or {}
+            assert meta.get("model") == "gpt-4o-mini-2024-07-18"
+        finally:
+            client.close()
+
+
+@pytest.mark.respx(base_url=BASE_URL)
+def test_parent_id_creates_child_span() -> None:
+    """parent_id linkage must surface as ``parent_span_id`` on the child's
+    span POST body (all spans POST to the same /ingest/traces/{tid}/spans
+    endpoint; the parent reference is on the body, not on the URL path).
+    """
+    with respx.mock:
+        routes = _mock_ingest_routes()
+        client = _client()
+        handler = SpanlensCallbackHandler(client=client)
+        try:
+            handler.start_trace()
+            handler.on_event_start(
+                event_type="query",
+                payload={"query_str": "what is RAG?"},
+                event_id="query-1",
+                parent_id="root",
+            )
+            handler.on_event_start(
+                event_type="retrieve",
+                payload={"query_str": "what is RAG?"},
+                event_id="retrieve-1",
+                parent_id="query-1",  # child of the QUERY span
+            )
+            handler.on_event_end(event_type="retrieve", payload=None, event_id="retrieve-1")
+            handler.on_event_end(event_type="query", payload=None, event_id="query-1")
+            handler.end_trace()
+            _flush(client)
+
+            spans = _bodies(routes["span_post"])
+            assert len(spans) == 2, f"expected 2 spans, got {len(spans)}"
+
+            by_name = {s["name"]: s for s in spans}
+            assert "llama_index.query" in by_name
+            assert "llama_index.retrieve" in by_name
+
+            query_span = by_name["llama_index.query"]
+            retrieve_span = by_name["llama_index.retrieve"]
+
+            # Query span is attached to trace root — no parent_span_id.
+            assert query_span.get("parent_span_id") in (None, "")
+            # Retrieve span references the query span as its parent.
+            assert retrieve_span.get("parent_span_id") == query_span["id"]
+            assert retrieve_span.get("span_type") == "retrieval"
+        finally:
+            client.close()
+
+
+@pytest.mark.respx(base_url=BASE_URL)
+def test_ignored_event_types_skip_span_creation() -> None:
+    """Default ignore set (chunking, node_parsing, templating) must not
+    produce any span traffic."""
+    with respx.mock:
+        routes = _mock_ingest_routes()
+        client = _client()
+        handler = SpanlensCallbackHandler(client=client)
+        try:
+            handler.start_trace()
+            for ignored in ("chunking", "node_parsing", "templating"):
+                handler.on_event_start(
+                    event_type=ignored,
+                    payload=None,
+                    event_id=f"{ignored}-1",
+                    parent_id="root",
+                )
+                handler.on_event_end(event_type=ignored, payload=None, event_id=f"{ignored}-1")
+            handler.end_trace()
+            _flush(client)
+
+            # Trace lifecycle posts still happen — only spans are skipped.
+            assert len(_bodies(routes["span_post"])) == 0
+            assert len(_bodies(routes["span_patch"])) == 0
+        finally:
+            client.close()
+
+
+@pytest.mark.respx(base_url=BASE_URL)
+def test_exception_payload_marks_span_as_error() -> None:
+    """When payload carries an `exception`, the span PATCH should have
+    status='error' and the exception message on the body."""
+    with respx.mock:
+        routes = _mock_ingest_routes()
+        client = _client()
+        handler = SpanlensCallbackHandler(client=client)
+        try:
+            handler.start_trace()
+            handler.on_event_start(
+                event_type="llm",
+                payload={"messages": []},
+                event_id="bad-1",
+                parent_id="root",
+            )
+            handler.on_event_end(
+                event_type="llm",
+                payload={"exception": RuntimeError("rate limit")},
+                event_id="bad-1",
+            )
+            handler.end_trace()
+            _flush(client)
+
+            patches = _bodies(routes["span_patch"])
+            assert len(patches) == 1
+            assert patches[0].get("status") == "error"
+            assert "rate limit" in (patches[0].get("error_message") or "")
+        finally:
+            client.close()
+
+
+@pytest.mark.respx(base_url=BASE_URL)
+def test_external_trace_lifecycle_not_managed_by_handler() -> None:
+    """When the caller passes their own TraceHandle, end_trace must NOT
+    close it — the caller owns the lifecycle."""
+    with respx.mock:
+        routes = _mock_ingest_routes()
+        client = _client()
+        external = client.start_trace("user_workflow")
+        handler = SpanlensCallbackHandler(client=client, trace=external)
+        try:
+            handler.start_trace()  # no-op — external trace exists
+            handler.on_event_start(
+                event_type="llm",
+                payload={"messages": []},
+                event_id="x",
+                parent_id="root",
+            )
+            handler.on_event_end(event_type="llm", payload=None, event_id="x")
+            handler.end_trace()  # must NOT close `external`
+            _flush(client)
+
+            trace_patches = _bodies(routes["trace_patch"])
+            # 0 — the caller will close `external` themselves.
+            assert trace_patches == [] or all(
+                p.get("status") != "completed" for p in trace_patches
+            )
+        finally:
+            external.end(status="completed")
+            client.close()
+
+
+@pytest.mark.respx(base_url=BASE_URL)
+def test_retrieved_nodes_summarised_not_dumped() -> None:
+    """RETRIEVE event_end should record node count + top scores, not the full
+    text of every retrieved node (which can be huge)."""
+
+    class _FakeNode:
+        def __init__(self, score: float) -> None:
+            self.score = score
+
+    nodes = [_FakeNode(0.92), _FakeNode(0.88), _FakeNode(0.81)]
+    with respx.mock:
+        routes = _mock_ingest_routes()
+        client = _client()
+        handler = SpanlensCallbackHandler(client=client)
+        try:
+            handler.start_trace()
+            handler.on_event_start(
+                event_type="retrieve",
+                payload={"query_str": "what is RAG?"},
+                event_id="r-1",
+                parent_id="root",
+            )
+            handler.on_event_end(
+                event_type="retrieve",
+                payload={"nodes": nodes},
+                event_id="r-1",
+            )
+            handler.end_trace()
+            _flush(client)
+
+            patches = _bodies(routes["span_patch"])
+            assert len(patches) == 1
+            output = patches[0].get("output") or {}
+            assert output.get("node_count") == 3
+            assert output.get("top_scores") == [0.92, 0.88, 0.81]
+        finally:
+            client.close()


### PR DESCRIPTION
## Summary

- Adds `spanlens.integrations.llama_index.SpanlensCallbackHandler` so LlamaIndex query engines / agents / workflows get LLM, retrieval, embedding, and tool spans recorded with one line: `Settings.callback_manager.add_handler(SpanlensCallbackHandler(client))`.
- Subclasses the real `BaseCallbackHandler` when `llama-index-core` is installed and falls back to a plain class with the same surface so tests run without the optional dep.
- Maps `CBEventType` enum to Spanlens `span_type` so the dashboard tree mirrors the query topology 1:1 (QUERY at root, RETRIEVE / SYNTHESIZE / LLM underneath).
- Extracts token usage from the `response.raw.usage` shape OpenAI / LiteLLM / Anthropic LLMs share; truncates large inputs/outputs at 16 KB; summarises retrieved nodes (count + top scores) instead of dumping full node text.

## Verification

- **Unit:** 7/7 pass in `tests/test_integrations_llama_index.py` (raw-dict drive + respx HTTP mock, runs without llama-index-core installed).
- **Integration smoke:** new `scripts/test_llama_index_integration.py` drives a synthetic query through the **real** `CallbackManager` + `CBEventType` + `EventPayload` (llama-index-core 0.14.22) and asserts wire shape (trace POST + span POSTs + PATCHes), parent linkage via `parent_span_id`, LLM usage extraction, and node summarisation.
- **LIVE mode** (set `SPANLENS_LIVE_URL` + `SPANLENS_LIVE_KEY`): ran against local Spanlens server → Supabase shows `traces.span_count=3`, `traces.total_tokens=165`, and spans with correct parent_span_id linkage (`llama_index.retrieve` + `llama_index.llm` both reference `llama_index.query` as parent), llm span has `prompt_tokens=120, completion_tokens=45`.
- ruff: clean. mypy: our file clean.

## Install

`pip install 'spanlens[llama-index]'` (new extra wired in `pyproject.toml`; also added to `[all]` and to keywords).

## Test plan

- [ ] CI green (`pnpm typecheck` / `pnpm lint` are server-tracked; Python lives in its own venv-tested suite — confirm pytest runs in CI if a Python job exists)
- [ ] Smoke against staging: install branch in a fresh venv with `pip install -e packages/sdk-python[llama-index]`, run a real `VectorStoreIndex.from_documents(...).as_query_engine().query(...)` with `Settings.callback_manager.add_handler(SpanlensCallbackHandler(client))`, verify trace appears in dashboard.
- [ ] Follow-up PRs: docs page at `apps/web/app/docs/sdk/llama-index/page.tsx` + sidebar entry; LlamaIndex repo / LlamaHub upstream listing.