### PR TITLE
docs: Phase 4A changelog + feature pages refresh

### DIFF
--- a/apps/web/app/docs/features/audit-logs/page.tsx
+++ b/apps/web/app/docs/features/audit-logs/page.tsx
@@ -34,52 +34,108 @@ export default function AuditLogsDocs() {
       </ul>
 
       <h2>Recorded events</h2>
+      <p>
+        Twenty-four distinct actions are emitted across thirteen mutation routes. Severity
+        in the dashboard is inferred from the verb (<code>.delete</code> /{' '}
+        <code>.rotate</code> / <code>billing.*</code> / <code>workspace.*</code> are HIGH,{' '}
+        <code>.create</code> / <code>.update</code> / <code>.invite</code> are MED, the
+        rest are LOW). Every row carries the actor user id and IP address pulled from{' '}
+        <code>x-forwarded-for</code> / <code>x-real-ip</code> / <code>cf-connecting-ip</code>.
+      </p>
       <table>
         <thead>
           <tr>
-            <th>action</th>
-            <th>Description</th>
+            <th>Resource</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td><code>api_key.create</code></td>
-            <td>New Spanlens API key (<code>sl_live_*</code>) issued</td>
+            <td><strong>Spanlens key</strong></td>
+            <td>
+              <code>api_key.create</code> · <code>api_key.enable</code> ·{' '}
+              <code>api_key.disable</code> · <code>api_key.delete</code>
+            </td>
           </tr>
           <tr>
-            <td><code>api_key.delete</code></td>
-            <td>API key revoked</td>
+            <td><strong>Provider key</strong></td>
+            <td>
+              <code>provider_key.add</code> · <code>provider_key.update</code> ·{' '}
+              <code>provider_key.rotate</code> · <code>provider_key.delete</code>
+            </td>
           </tr>
           <tr>
-            <td><code>provider_key.add</code></td>
-            <td>OpenAI / Anthropic / Gemini provider key registered</td>
+            <td><strong>Prompt version</strong></td>
+            <td>
+              <code>prompt_version.create</code> · <code>prompt_version.rollback</code> ·{' '}
+              <code>prompt_version.delete</code>
+            </td>
           </tr>
           <tr>
-            <td><code>provider_key.delete</code></td>
-            <td>Provider key removed</td>
+            <td><strong>A/B experiment</strong></td>
+            <td>
+              <code>ab_experiment.start</code> · <code>ab_experiment.update</code> ·{' '}
+              <code>ab_experiment.conclude</code> · <code>ab_experiment.stop</code> ·{' '}
+              <code>ab_experiment.delete</code>
+            </td>
           </tr>
           <tr>
-            <td><code>member.invite</code></td>
-            <td>Team member invitation sent</td>
+            <td><strong>Members</strong></td>
+            <td>
+              <code>member.invite</code> · <code>member.invite_accept</code> ·{' '}
+              <code>member.invite_cancel</code> · <code>member.role_change</code> ·{' '}
+              <code>member.remove</code>
+            </td>
           </tr>
           <tr>
-            <td><code>member.role_change</code></td>
-            <td>Member role updated (admin / editor / viewer)</td>
+            <td><strong>Workspace</strong></td>
+            <td>
+              <code>workspace.rename</code> · <code>workspace.security_update</code> ·{' '}
+              <code>workspace.branding_update</code> · <code>workspace.overage_update</code>
+            </td>
           </tr>
           <tr>
-            <td><code>member.remove</code></td>
-            <td>Member removed from the organization</td>
+            <td><strong>Billing</strong></td>
+            <td>
+              <code>billing.checkout_create</code> · <code>billing.cancel</code>
+            </td>
           </tr>
           <tr>
-            <td><code>billing.plan.change</code></td>
-            <td>Plan upgraded or downgraded</td>
+            <td><strong>Project</strong></td>
+            <td>
+              <code>project.create</code> · <code>project.update</code> ·{' '}
+              <code>project.delete</code>
+            </td>
           </tr>
           <tr>
-            <td><code>org.settings.update</code></td>
-            <td>Organization name, security settings, or other org-level config changed</td>
+            <td><strong>Alert / channel</strong></td>
+            <td>
+              <code>alert.create</code> · <code>alert.update</code> ·{' '}
+              <code>alert.delete</code> · <code>notification_channel.create</code> ·{' '}
+              <code>notification_channel.delete</code>
+            </td>
+          </tr>
+          <tr>
+            <td><strong>Webhook</strong></td>
+            <td>
+              <code>webhook.create</code> · <code>webhook.update</code> ·{' '}
+              <code>webhook.delete</code>
+            </td>
+          </tr>
+          <tr>
+            <td><strong>Pending deletion queue</strong></td>
+            <td><code>pending_deletion.restore</code></td>
           </tr>
         </tbody>
       </table>
+
+      <p>
+        View the log in <a href="/settings">Settings</a> → <strong>Audit log</strong>{' '}
+        (admin-only full viewer with time-window + action filters, paginated 50 per page,
+        click any row to open a drawer with the metadata JSON, IP, and actor UUID). Editors
+        and viewers see the abbreviated table on the same Settings tab. Programmatic
+        consumers should hit the REST API below.
+      </p>
 
       <h2>API reference</h2>
 
@@ -90,7 +146,14 @@ export default function AuditLogsDocs() {
 GET /api/v1/audit-logs?limit=50&offset=0&action=api_key.create
 
 # Filter by user
-GET /api/v1/audit-logs?limit=50&offset=0&user_id=<uuid>`}</CodeBlock>
+GET /api/v1/audit-logs?limit=50&offset=0&user_id=<uuid>
+
+# Filter by inclusive time range (ISO 8601)
+GET /api/v1/audit-logs?from=2026-05-01T00:00:00Z&to=2026-05-31T23:59:59Z
+
+# List the distinct action values seen on this workspace
+# (powers the filter dropdown; capped at the last 1000 rows)
+GET /api/v1/audit-logs/actions`}</CodeBlock>
 
       <h3>Query parameters</h3>
       <table>
@@ -120,7 +183,22 @@ GET /api/v1/audit-logs?limit=50&offset=0&user_id=<uuid>`}</CodeBlock>
           <tr>
             <td><code>user_id</code></td>
             <td>(all)</td>
-            <td>Show only actions performed by a specific user.</td>
+            <td>Show only actions performed by a specific user (UUID).</td>
+          </tr>
+          <tr>
+            <td><code>from</code></td>
+            <td>(no lower bound)</td>
+            <td>
+              Inclusive lower bound on <code>created_at</code>, ISO 8601 timestamp.
+              Malformed values return 400.
+            </td>
+          </tr>
+          <tr>
+            <td><code>to</code></td>
+            <td>(no upper bound)</td>
+            <td>
+              Inclusive upper bound on <code>created_at</code>, ISO 8601 timestamp.
+            </td>
           </tr>
         </tbody>
       </table>

--- a/apps/web/app/docs/features/evals/page.tsx
+++ b/apps/web/app/docs/features/evals/page.tsx
@@ -29,6 +29,52 @@ export default function EvalsDocs() {
 
       <h2>How it works</h2>
 
+      <h3>Quick-start with a template</h3>
+      <p>
+        Visit <a href="/evals">/evals</a> on a fresh workspace and the empty state shows ten
+        built-in evaluator templates grouped into three categories. Click <em>Use template</em>{' '}
+        to pre-fill the New evaluator dialog with a curated criterion and a recommended judge
+        model — you only need to pick which prompt the evaluator targets.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th>Templates</th>
+            <th>Default judge</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Quality</strong> (5)</td>
+            <td>
+              Response quality · Readability · Completeness · Persona match · Conciseness
+            </td>
+            <td><code>gpt-4o-mini</code></td>
+          </tr>
+          <tr>
+            <td><strong>Safety</strong> (4)</td>
+            <td>
+              No PII leak · Toxicity · Hallucination · Prompt injection
+            </td>
+            <td><code>gpt-4o-mini</code> (Hallucination uses{' '}
+              <code>claude-3-5-sonnet</code> for reasoning depth)</td>
+          </tr>
+          <tr>
+            <td><strong>Cost</strong> (1)</td>
+            <td>Cost vs quality (could a cheaper model have produced this answer?)</td>
+            <td><code>claude-3-5-sonnet</code></td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Templates are stored in <code>evaluator_templates</code> on the server, not hard-coded
+        in the dashboard, so new templates can ship without a frontend deploy. The catalogue
+        is global (every workspace sees the same suggestions) and read-only from the dashboard;
+        every field on a template (criterion, judge provider/model, score range) is still
+        editable in the New evaluator dialog after you load it.
+      </p>
+
       <h3>Define an evaluator</h3>
       <p>An evaluator is a reusable definition of <em>how to score responses</em>.</p>
       <ul>

--- a/apps/web/app/docs/features/projects/page.tsx
+++ b/apps/web/app/docs/features/projects/page.tsx
@@ -88,9 +88,44 @@ export default function ProjectsDocs() {
       <ul>
         <li><code>name</code>, human label (e.g. &ldquo;prod-backend&rdquo;)</li>
         <li><code>key_prefix</code>, first 15 chars (Spanlens key only), shown in UI for ID</li>
-        <li><code>last_used_at</code>, updated on every successful auth</li>
+        <li>
+          <code>last_used_at</code>, updated on every successful auth (throttled to one
+          write per key per 5 minutes so the proxy hot path stays cheap)
+        </li>
         <li><code>is_active</code>, revoke flag; inactive keys return 401</li>
       </ul>
+
+      <h3>Stale key surfacing</h3>
+      <p>
+        The dashboard classifies each active key by how long it has been idle and surfaces
+        forgotten keys before they leak:
+      </p>
+      <ul>
+        <li>
+          <strong>30–89 days idle</strong> → neutral &ldquo;Stale&rdquo; badge on the key row
+          in <a href="/projects">/projects</a>.
+        </li>
+        <li>
+          <strong>90+ days idle</strong> → accent &ldquo;Consider revoking&rdquo; badge,
+          surfaced in two extra places so it&apos;s hard to miss:
+          <ul>
+            <li>
+              The sidebar <strong>Projects &amp; Keys</strong> entry carries a red count
+              of stale + revoke-tier keys.
+            </li>
+            <li>
+              The dashboard <strong>Needs Attention</strong> strip shows a warning card
+              with a sample key name and a deep link to <a href="/projects">/projects</a>.
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <p>
+        Keys that have never authenticated fall back to <code>created_at</code> as the
+        idleness floor — a brand-new key isn&apos;t flagged for the first 30 days. Revoked
+        keys (<code>is_active=false</code>) are excluded from staleness reporting entirely:
+        once you&apos;ve already disabled a key, nagging about it is noise.
+      </p>
 
       <h2>Using it</h2>
 
@@ -130,14 +165,29 @@ export default function ProjectsDocs() {
           changes.
         </li>
         <li>
-          <strong>Provider keys deactivated</strong> via the trash icon (soft delete, flips{' '}
-          <code>is_active = false</code>, preserves request logs).
-        </li>
-        <li>
-          <strong>Spanlens key hard-deleted</strong> via the trash icon on the Spanlens key
-          row. <code>ON DELETE CASCADE</code> removes all attached provider keys.
+          <strong>Deleted with a 72-hour grace period.</strong> The trash icon on a
+          Spanlens key or a provider key flips <code>is_active = false</code> right away
+          so the proxy stops accepting it, then queues a hard delete that runs every six
+          hours. While the row is in the queue you can restore it from{' '}
+          <a href="/settings">Settings</a> → <strong>Pending deletions</strong>. After the
+          grace window the hard delete runs and the row is gone for good.
         </li>
       </ul>
+
+      <h3>Restoring an accidental deletion</h3>
+      <p>
+        Misclicked the trash icon? Open <a href="/settings">Settings</a> →{' '}
+        <strong>Pending deletions</strong>. Every soft-deleted key, provider key, and
+        prompt version shows up there with a timer; click <em>Restore</em> to reactivate
+        the row. After the timer expires the row is hard-deleted and restore is no longer
+        possible — you&apos;d have to issue a fresh key (the SHA-256 hash is irreversible).
+      </p>
+      <p>
+        Audit events are recorded both for the original delete request
+        (<code>api_key.delete</code> / <code>provider_key.delete</code>) and for the
+        restore (<code>pending_deletion.restore</code>), so the trail stays intact even
+        when the action is reversed.
+      </p>
 
       <p>
         The page also surfaces a wizard hint: <code>npx @spanlens/cli init</code> can
@@ -159,7 +209,7 @@ POST   /api/v1/api-keys/issue                { "name": "prod-backend",
                                                "projectId": "<uuid>" }
 # → { "id": "...", "key": "sl_live_..." }   ← shown ONCE
 PATCH  /api/v1/api-keys/:id                  { "is_active": false }    # toggle
-DELETE /api/v1/api-keys/:id                  # hard delete (CASCADE provider_keys)
+DELETE /api/v1/api-keys/:id                  # is_active=false + 72h delete queue
 
 # ── Provider keys (under a specific Spanlens key) ─────────────
 GET    /api/v1/provider-keys?apiKeyId=<spanlens-key-uuid>
@@ -169,7 +219,12 @@ POST   /api/v1/provider-keys                 { "api_key_id": "<uuid>",
                                                "name": "prod-openai" }
 PATCH  /api/v1/provider-keys/:id             { "key": "sk-rotated..." }   # rotate
 PATCH  /api/v1/provider-keys/:id             { "name": "renamed" }        # rename
-DELETE /api/v1/provider-keys/:id             # soft delete (is_active=false)`}</CodeBlock>
+DELETE /api/v1/provider-keys/:id             # is_active=false + 72h delete queue
+
+# ── Pending deletions queue (restore within 72h) ──────────────
+GET    /api/v1/pending-deletions             # active queue
+GET    /api/v1/pending-deletions/history     # terminal rows (executed or cancelled)
+POST   /api/v1/pending-deletions/:id/restore # cancel + flip is_active back to true`}</CodeBlock>
 
       <h3>Tagging requests with a project from client code</h3>
       <p>

--- a/apps/web/lib/changelog/entries.ts
+++ b/apps/web/lib/changelog/entries.ts
@@ -39,6 +39,50 @@ export type ChangelogTag =
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-06-06',
+    slug: 'evaluator-templates-quality-safety-cost',
+    title: 'Ten built-in evaluator templates across Quality / Safety / Cost',
+    tags: ['feature'],
+    body: [
+      'Opening [/evals](/evals) on a fresh workspace used to drop you at a blank New evaluator dialog. It now shows a curated catalogue of ten built-in templates split into three tabs — Quality (5), Safety (4), and Cost (1) — each with a recommended judge model and a tuned criterion you can run as-is or edit.',
+      'Hallucination and Cost-vs-quality default to `claude-3-5-sonnet` because their rubrics need more reasoning depth; the rest run on `gpt-4o-mini` so high-volume judging stays cheap. Templates ship as DB rows (`evaluator_templates` table) rather than hard-coded constants, so new ones can land without a frontend deploy.',
+      'See the full list and the prompt text for each criterion in the [Evals docs](/docs/features/evals#quick-start-with-a-template).',
+    ].join('\n\n'),
+  },
+  {
+    date: '2026-06-06',
+    slug: 'api-key-stale-tracking',
+    title: 'Spanlens keys now flag stale and revoke-tier idleness',
+    tags: ['improvement'],
+    body: [
+      'Every successful proxy auth now refreshes `api_keys.last_used_at` (throttled to one write per key per five minutes so the proxy hot path stays cheap). The dashboard buckets active keys by idleness and surfaces forgotten ones in three places.',
+      'A neutral "Stale" badge appears next to the key name on [/projects](/projects) after 30 days of silence; the badge flips to accent "Consider revoking" at 90 days. The Admin sidebar entry carries a red count of stale + revoke-tier keys, and the dashboard "Needs Attention" strip surfaces a warning card with a sample key name when at least one key has crossed the 90-day line.',
+      'Brand-new keys (no `last_used_at` yet) fall back to `created_at`, so an unused key isn\'t flagged on day one. Revoked keys are excluded from the count — nagging about already-disabled keys is noise. See [Projects & keys → Stale key surfacing](/docs/features/projects#stale-key-surfacing).',
+    ].join('\n\n'),
+  },
+  {
+    date: '2026-06-06',
+    slug: 'soft-delete-grace-period',
+    title: 'Accidental key/prompt deletions can be restored within 72 hours',
+    tags: ['improvement'],
+    body: [
+      'Clicking the trash icon on a Spanlens key, provider key, or prompt version used to hard-delete the row immediately, which meant a mis-click turned into a support ticket the moment proxy traffic started returning 401. Deletes now flip `is_active = false` right away (traffic stops within seconds) and queue the hard delete for 72 hours later.',
+      'A new **Pending deletions** tab under [Settings](/settings) lists every queued row with a countdown and a Restore button. Click Restore to flip `is_active` back to true and the deletion is cancelled; after the window expires the hard delete runs and the row is gone for good.',
+      'Both the original delete request and the restore are audited (`api_key.delete`, `pending_deletion.restore`, …) so the change trail stays intact even when the action is reversed. Full reference: [Projects & keys → Restoring an accidental deletion](/docs/features/projects#restoring-an-accidental-deletion).',
+    ].join('\n\n'),
+  },
+  {
+    date: '2026-06-06',
+    slug: 'audit-log-expanded-coverage',
+    title: 'Audit log now records twenty-four actions across thirteen routes',
+    tags: ['improvement'],
+    body: [
+      'Audit-log coverage used to be uneven — some destructive routes never wrote a row, so a security investigation often had to fall back to ClickHouse logs. Every mutation route that ships today now emits a row through a single helper, with the actor user id and IP (`x-forwarded-for` / `x-real-ip` / `cf-connecting-ip`) attached.',
+      'New actions are grouped by resource: Spanlens keys, provider keys (including `rotate`), prompt versions, A/B experiments, members and invitations, workspace settings, billing checkout / cancel, projects, alerts and channels, webhooks, and the new pending-deletion restore path. See the [full table](/docs/features/audit-logs#recorded-events).',
+      'The Settings audit-log tab is also rebuilt: time-window + action filters, paginated 50 per page, click any row to open a drawer with the full metadata JSON, IP, and event ID. Admins see every row; editors and viewers see an abbreviated preview on the same tab. Two new query parameters (`from`, `to`) are exposed via the REST API for ISO 8601 time-range filtering.',
+    ].join('\n\n'),
+  },
+  {
     date: '2026-06-04',
     slug: 'mcp-server-for-ide-agents',
     title: 'Query Spanlens from Cursor, Claude Desktop, or Continue via MCP',


### PR DESCRIPTION
## Summary

Catch the /docs feature pages and the public changelog up to the changes shipped in [#205](https://github.com/spanlens/Spanlens/pull/205) (Phase 4A Langfuse benchmarking).

- **Changelog**: 4 entries dated 2026-06-06 — evaluator templates, stale-key surfacing, soft delete grace period, audit log expansion.
- **`/docs/features/projects`**: new Stale key surfacing subsection + 72-hour grace period model replaces the old hard-delete copy + Restoring walkthrough + API code block updated with `/pending-deletions` endpoints.
- **`/docs/features/evals`**: new Quick-start with a template subsection with a Quality/Safety/Cost table.
- **`/docs/features/audit-logs`**: Recorded events rebuilt as resource-grouped table covering all 24 actions + `from`/`to` query params + `/audit-logs/actions` endpoint.

No behaviour change; documentation catching up to merged code.

## Test plan
- [x] Web typecheck + lint clean
- [ ] Visual diff on production once merged (preview deployment is enough confidence)