### PR TITLE
feat: 4B.1 typed score configs (NUMERIC / CATEGORICAL / BOOLEAN / TEXT)

### DIFF
--- a/apps/server/src/api/human-evals.ts
+++ b/apps/server/src/api/human-evals.ts
@@ -2,6 +2,40 @@ import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { requestsScope, selectRequests } from '../lib/requests-query.js'
+import { validateScore, type ScoreConfig } from '../lib/score-validation.js'
+
+/**
+ * Resolve a `scoreConfigId` (explicit or fallback to workspace default)
+ * into a full ScoreConfig row, scoped to the org. Returns null when the
+ * id doesn't resolve so the caller can surface a 404.
+ */
+async function loadScoreConfig(
+  orgId: string,
+  explicitId: string | null,
+): Promise<ScoreConfig | null> {
+  if (explicitId) {
+    const { data } = await supabaseAdmin
+      .from('score_configs')
+      .select('id, data_type, min_value, max_value, categories, bool_true_label, bool_false_label')
+      .eq('id', explicitId)
+      .eq('organization_id', orgId)
+      .is('archived_at', null)
+      .maybeSingle()
+    if (!data) return null
+    return data as ScoreConfig
+  }
+  // Fall back to the workspace's default. Workspaces always have one
+  // (the migration backfilled one per org and the CRUD route blocks
+  // archiving the only default), but we guard the null path anyway.
+  const { data } = await supabaseAdmin
+    .from('score_configs')
+    .select('id, data_type, min_value, max_value, categories, bool_true_label, bool_false_label')
+    .eq('organization_id', orgId)
+    .eq('is_default', true)
+    .is('archived_at', null)
+    .maybeSingle()
+  return (data as ScoreConfig | null) ?? null
+}
 
 export const humanEvalsRouter = new Hono<JwtContext>()
 
@@ -171,7 +205,18 @@ humanEvalsRouter.post('/human-evals', async (c) => {
   if (!orgId) return c.json({ error: 'Organization not found' }, 404)
   if (!userId) return c.json({ error: 'User not authenticated' }, 401)
 
-  let body: { requestId?: unknown; score?: unknown; rawScore?: unknown; comment?: unknown }
+  let body: {
+    requestId?: unknown
+    scoreConfigId?: unknown
+    value?: unknown
+    // Legacy fields kept so pre-4B.1 clients (current /annotation page)
+    // keep working until the UI catches up. When `value` is missing we
+    // fall back to `score` and feed it to the workspace's default
+    // NUMERIC config.
+    score?: unknown
+    rawScore?: unknown
+    comment?: unknown
+  }
   try {
     body = (await c.req.json()) as typeof body
   } catch {
@@ -179,13 +224,33 @@ humanEvalsRouter.post('/human-evals', async (c) => {
   }
 
   const requestId = typeof body.requestId === 'string' ? body.requestId.trim() : ''
-  const score = typeof body.score === 'number' ? body.score : NaN
+  const explicitConfigId =
+    typeof body.scoreConfigId === 'string' && body.scoreConfigId.trim().length > 0
+      ? body.scoreConfigId.trim()
+      : null
   const rawScore = typeof body.rawScore === 'number' ? body.rawScore : null
   const comment = typeof body.comment === 'string' ? body.comment.trim() || null : null
 
   if (!requestId) return c.json({ error: 'requestId is required' }, 400)
-  if (!Number.isFinite(score) || score < 0 || score > 1) {
-    return c.json({ error: 'score must be a number between 0 and 1' }, 400)
+
+  // Resolve the score config first so we know which value field to
+  // validate. Without a config we can't insert (the NOT NULL FK was
+  // intentionally avoided in the migration so existing rows survive,
+  // but new rows should always carry one).
+  const config = await loadScoreConfig(orgId, explicitConfigId)
+  if (!config) {
+    return c.json(
+      { error: explicitConfigId ? 'Score config not found' : 'No default score config configured for this workspace' },
+      explicitConfigId ? 404 : 500,
+    )
+  }
+
+  // Prefer the typed `value` field; fall back to legacy `score` for
+  // NUMERIC configs only.
+  const rawValue = body.value !== undefined ? body.value : body.score
+  const validation = validateScore(config, rawValue)
+  if (!validation.ok) {
+    return c.json({ error: validation.message }, 400)
   }
 
   // Look up prompt_version_id for denormalized filter
@@ -213,9 +278,16 @@ humanEvalsRouter.post('/human-evals', async (c) => {
         request_id: requestId,
         prompt_version_id: req.prompt_version_id,
         reviewer_id: userId,
-        score,
+        // Legacy `score` mirrors value_number for NUMERIC configs and is
+        // null for everything else. Pre-4B.1 dashboard queries that AVG
+        // this column keep working without changes.
+        score: validation.fields.score,
         raw_score: rawScore,
         comment,
+        score_config_id: config.id,
+        value_number: validation.fields.value_number,
+        value_string: validation.fields.value_string,
+        value_boolean: validation.fields.value_boolean,
       },
       { onConflict: 'request_id,reviewer_id' },
     )

--- a/apps/server/src/api/scoreConfigs.ts
+++ b/apps/server/src/api/scoreConfigs.ts
@@ -1,0 +1,369 @@
+import { Hono } from 'hono'
+import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { supabaseAdmin } from '../lib/db.js'
+import { recordAuditEvent } from '../lib/audit-log.js'
+import {
+  parseCategories,
+  validateScoreConfigShape,
+} from '../lib/score-validation.js'
+
+/**
+ * Score configs CRUD. Drives the typed-score work in 4B.1: every
+ * eval_result and human_eval row points at exactly one of these via
+ * `score_config_id`, and the type stored here determines which value
+ * column gets populated on insert.
+ *
+ * Mount path: /api/v1/score-configs.
+ *
+ * Auth model: workspace-scoped, JWT-only. We deliberately do NOT expose
+ * this to public sl_live_pub_* keys — score config CRUD is org admin
+ * work and goes through the dashboard, not the SDK.
+ */
+export const scoreConfigsRouter = new Hono<JwtContext>()
+
+scoreConfigsRouter.use('*', authJwt)
+
+interface ScoreConfigBody {
+  name?: unknown
+  description?: unknown
+  data_type?: unknown
+  min_value?: unknown
+  max_value?: unknown
+  categories?: unknown
+  bool_true_label?: unknown
+  bool_false_label?: unknown
+  is_default?: unknown
+  archived?: unknown
+}
+
+const ALLOWED_TYPES = ['NUMERIC', 'CATEGORICAL', 'BOOLEAN', 'TEXT'] as const
+
+function normaliseString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normaliseNullableString(value: unknown): string | null {
+  const s = normaliseString(value)
+  return s.length === 0 ? null : s
+}
+
+function normaliseNullableNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null
+  const n = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+// GET /api/v1/score-configs — active configs for the org, newest first
+scoreConfigsRouter.get('/', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  const includeArchived = c.req.query('includeArchived') === '1'
+
+  let query = supabaseAdmin
+    .from('score_configs')
+    .select('*')
+    .eq('organization_id', orgId)
+    .order('created_at', { ascending: false })
+
+  if (!includeArchived) query = query.is('archived_at', null)
+
+  const { data, error } = await query
+  if (error) return c.json({ error: 'Failed to load score configs' }, 500)
+  return c.json({ success: true, data: data ?? [] })
+})
+
+// GET /api/v1/score-configs/:id
+scoreConfigsRouter.get('/:id', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  const id = c.req.param('id')
+
+  const { data, error } = await supabaseAdmin
+    .from('score_configs')
+    .select('*')
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (error) return c.json({ error: 'Failed to load score config' }, 500)
+  if (!data) return c.json({ error: 'Score config not found' }, 404)
+  return c.json({ success: true, data })
+})
+
+// POST /api/v1/score-configs — create a new config
+scoreConfigsRouter.post('/', async (c) => {
+  const orgId = c.get('orgId')
+  const userId = c.get('userId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+
+  let body: ScoreConfigBody
+  try {
+    body = (await c.req.json()) as ScoreConfigBody
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400)
+  }
+
+  const name = normaliseString(body.name)
+  if (name.length === 0) return c.json({ error: 'name is required' }, 400)
+  if (name.length > 100) return c.json({ error: 'name must be 100 characters or fewer' }, 400)
+
+  const data_type = typeof body.data_type === 'string' ? body.data_type.toUpperCase() : ''
+  if (!ALLOWED_TYPES.includes(data_type as (typeof ALLOWED_TYPES)[number])) {
+    return c.json({ error: `data_type must be one of ${ALLOWED_TYPES.join(', ')}` }, 400)
+  }
+
+  const min_value = normaliseNullableNumber(body.min_value)
+  const max_value = normaliseNullableNumber(body.max_value)
+  const categories = Array.isArray(body.categories) ? body.categories : null
+
+  const shapeError = validateScoreConfigShape({
+    data_type,
+    min_value,
+    max_value,
+    categories,
+  })
+  if (shapeError) return c.json({ error: shapeError }, 400)
+
+  // For CATEGORICAL we store the cleaned list (deduped strings).
+  const categoriesClean = data_type === 'CATEGORICAL' ? parseCategories(categories) : null
+
+  const description = normaliseNullableString(body.description)
+  const bool_true_label = normaliseNullableString(body.bool_true_label)
+  const bool_false_label = normaliseNullableString(body.bool_false_label)
+
+  // If the caller asks for is_default we first clear the existing
+  // default on the workspace; the unique partial index would 23505
+  // otherwise. Two-step inside the same request rather than a CTE
+  // because the API surface is plain PostgREST.
+  const wantsDefault = body.is_default === true
+  if (wantsDefault) {
+    await supabaseAdmin
+      .from('score_configs')
+      .update({ is_default: false })
+      .eq('organization_id', orgId)
+      .eq('is_default', true)
+  }
+
+  const insertRow: {
+    organization_id: string
+    name: string
+    description: string | null
+    data_type: string
+    min_value: number | null
+    max_value: number | null
+    categories: string[] | null
+    bool_true_label: string | null
+    bool_false_label: string | null
+    is_default: boolean
+    created_by: string | null
+  } = {
+    organization_id: orgId,
+    name,
+    description,
+    data_type,
+    min_value,
+    max_value,
+    categories: categoriesClean,
+    bool_true_label,
+    bool_false_label,
+    is_default: wantsDefault,
+    created_by: userId ?? null,
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('score_configs')
+    .insert(insertRow)
+    .select()
+    .single()
+
+  if (error) {
+    if (error.code === '23505') {
+      return c.json({ error: 'A score config with that name already exists' }, 409)
+    }
+    return c.json({ error: 'Failed to create score config' }, 500)
+  }
+
+  void recordAuditEvent(c, {
+    action: 'score_config.create',
+    resourceType: 'score_config',
+    resourceId: data.id,
+    metadata: { name, data_type, is_default: wantsDefault },
+  })
+
+  return c.json({ success: true, data })
+})
+
+// PATCH /api/v1/score-configs/:id — update mutable fields
+scoreConfigsRouter.patch('/:id', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  const id = c.req.param('id')
+
+  let body: ScoreConfigBody
+  try {
+    body = (await c.req.json()) as ScoreConfigBody
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400)
+  }
+
+  // Load existing row so we can validate the merged shape.
+  const { data: existing, error: loadError } = await supabaseAdmin
+    .from('score_configs')
+    .select('*')
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (loadError) return c.json({ error: 'Failed to load score config' }, 500)
+  if (!existing) return c.json({ error: 'Score config not found' }, 404)
+
+  // Data type is immutable — flipping NUMERIC → BOOLEAN mid-stream
+  // would invalidate every existing value column. If the user really
+  // wants a different shape they archive this one and create a new
+  // config.
+  if (typeof body.data_type === 'string' && body.data_type !== existing.data_type) {
+    return c.json({ error: 'data_type cannot be changed; archive and create a new config instead' }, 400)
+  }
+
+  const updates: Record<string, unknown> = {}
+  let auditedFields: string[] = []
+
+  if (typeof body.name === 'string') {
+    const n = normaliseString(body.name)
+    if (n.length === 0) return c.json({ error: 'name must not be empty' }, 400)
+    if (n.length > 100) return c.json({ error: 'name must be 100 characters or fewer' }, 400)
+    updates.name = n
+    auditedFields.push('name')
+  }
+  if (body.description !== undefined) {
+    updates.description = normaliseNullableString(body.description)
+    auditedFields.push('description')
+  }
+  if (body.min_value !== undefined) {
+    updates.min_value = normaliseNullableNumber(body.min_value)
+    auditedFields.push('min_value')
+  }
+  if (body.max_value !== undefined) {
+    updates.max_value = normaliseNullableNumber(body.max_value)
+    auditedFields.push('max_value')
+  }
+  if (body.categories !== undefined) {
+    updates.categories = Array.isArray(body.categories)
+      ? parseCategories(body.categories)
+      : null
+    auditedFields.push('categories')
+  }
+  if (body.bool_true_label !== undefined) {
+    updates.bool_true_label = normaliseNullableString(body.bool_true_label)
+    auditedFields.push('bool_true_label')
+  }
+  if (body.bool_false_label !== undefined) {
+    updates.bool_false_label = normaliseNullableString(body.bool_false_label)
+    auditedFields.push('bool_false_label')
+  }
+
+  // Validate the merged shape — the existing row plus whatever fields
+  // the patch is replacing.
+  const merged = { ...existing, ...updates }
+  const shapeError = validateScoreConfigShape({
+    data_type: merged.data_type,
+    min_value: merged.min_value,
+    max_value: merged.max_value,
+    categories: merged.categories,
+  })
+  if (shapeError) return c.json({ error: shapeError }, 400)
+
+  if (body.archived === true && !existing.archived_at) {
+    updates.archived_at = new Date().toISOString()
+    auditedFields.push('archived')
+  } else if (body.archived === false && existing.archived_at) {
+    updates.archived_at = null
+    auditedFields.push('restored')
+  }
+
+  if (body.is_default === true && !existing.is_default) {
+    await supabaseAdmin
+      .from('score_configs')
+      .update({ is_default: false })
+      .eq('organization_id', orgId)
+      .eq('is_default', true)
+    updates.is_default = true
+    auditedFields.push('is_default')
+  } else if (body.is_default === false && existing.is_default) {
+    updates.is_default = false
+    auditedFields.push('is_default')
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return c.json({ success: true, data: existing })
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('score_configs')
+    .update(updates)
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .select()
+    .single()
+  if (error) {
+    if (error.code === '23505') {
+      return c.json({ error: 'A score config with that name already exists' }, 409)
+    }
+    return c.json({ error: 'Failed to update score config' }, 500)
+  }
+
+  void recordAuditEvent(c, {
+    action: 'score_config.update',
+    resourceType: 'score_config',
+    resourceId: id,
+    metadata: { fields: auditedFields },
+  })
+
+  return c.json({ success: true, data })
+})
+
+// DELETE /api/v1/score-configs/:id — soft delete (archive)
+//
+// We chose archive instead of hard delete because eval_results rows
+// reference this config and a hard delete would silently break the
+// dashboard charts that group by score_config_id. The unused-config
+// cleanup is a separate concern handled by a future cron.
+scoreConfigsRouter.delete('/:id', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  const id = c.req.param('id')
+
+  const { data: existing, error: loadError } = await supabaseAdmin
+    .from('score_configs')
+    .select('id, name, is_default, archived_at')
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  if (loadError) return c.json({ error: 'Failed to load score config' }, 500)
+  if (!existing) return c.json({ error: 'Score config not found' }, 404)
+  if (existing.archived_at) return c.json({ success: true, data: existing })
+
+  if (existing.is_default) {
+    return c.json(
+      { error: 'Cannot archive the default config; promote another config first' },
+      409,
+    )
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('score_configs')
+    .update({ archived_at: new Date().toISOString() })
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .select()
+    .single()
+  if (error) return c.json({ error: 'Failed to archive score config' }, 500)
+
+  void recordAuditEvent(c, {
+    action: 'score_config.archive',
+    resourceType: 'score_config',
+    resourceId: id,
+    metadata: { name: existing.name },
+  })
+
+  return c.json({ success: true, data })
+})

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -32,6 +32,7 @@ import { evalsRouter } from './api/evals.js'
 import { datasetsRouter } from './api/datasets.js'
 import { experimentsRouter } from './api/experiments.js'
 import { humanEvalsRouter } from './api/human-evals.js'
+import { scoreConfigsRouter } from './api/scoreConfigs.js'
 import { recommendationsRouter } from './api/recommendations.js'
 import { auditLogsRouter }     from './api/auditLogs.js'
 import { membersRouter }       from './api/members.js'
@@ -191,6 +192,8 @@ app.route('/api/v1/recommendations', recommendationsRouter)
 // pendingDeletions must be mounted BEFORE evalsRouter/humanEvalsRouter for
 // the same wildcard-collision reason as recommendations (gotcha #3).
 app.route('/api/v1/pending-deletions', pendingDeletionsRouter)
+// scoreConfigs has the same wildcard-collision concern as the routes above.
+app.route('/api/v1/score-configs',  scoreConfigsRouter)
 app.route('/api/v1',                evalsRouter)
 app.route('/api/v1/datasets',       datasetsRouter)
 app.route('/api/v1/experiments',    experimentsRouter)

--- a/apps/server/src/lib/score-validation.test.ts
+++ b/apps/server/src/lib/score-validation.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseCategories,
+  validateScore,
+  validateScoreConfigShape,
+  type ScoreConfig,
+} from './score-validation.js'
+
+function makeConfig(overrides: Partial<ScoreConfig> = {}): ScoreConfig {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    data_type: 'NUMERIC',
+    min_value: 0,
+    max_value: 1,
+    categories: null,
+    bool_true_label: null,
+    bool_false_label: null,
+    ...overrides,
+  }
+}
+
+describe('validateScore — NUMERIC', () => {
+  const config = makeConfig({ data_type: 'NUMERIC', min_value: 0, max_value: 1 })
+
+  it('accepts a number inside the range', () => {
+    const r = validateScore(config, 0.75)
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      expect(r.fields.score).toBe(0.75)
+      expect(r.fields.value_number).toBe(0.75)
+      expect(r.fields.value_string).toBeNull()
+      expect(r.fields.value_boolean).toBeNull()
+    }
+  })
+
+  it('mirrors the legacy `score` column', () => {
+    const r = validateScore(config, 1)
+    if (r.ok) expect(r.fields.score).toBe(r.fields.value_number)
+  })
+
+  it('rejects values below min', () => {
+    const r = validateScore(config, -0.1)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('NUMERIC_OUT_OF_RANGE')
+  })
+
+  it('rejects values above max', () => {
+    const r = validateScore(config, 1.5)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('NUMERIC_OUT_OF_RANGE')
+  })
+
+  it('rejects non-finite values (NaN, Infinity)', () => {
+    expect(validateScore(config, NaN).ok).toBe(false)
+    expect(validateScore(config, Infinity).ok).toBe(false)
+  })
+
+  it('coerces numeric strings', () => {
+    const r = validateScore(config, '0.5')
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.fields.value_number).toBe(0.5)
+  })
+
+  it('rejects garbage strings', () => {
+    const r = validateScore(config, 'not a number')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('INVALID_NUMERIC')
+  })
+
+  it('respects custom ranges (-1..1)', () => {
+    const wide = makeConfig({ data_type: 'NUMERIC', min_value: -1, max_value: 1 })
+    expect(validateScore(wide, -1).ok).toBe(true)
+    expect(validateScore(wide, 1).ok).toBe(true)
+    expect(validateScore(wide, 2).ok).toBe(false)
+  })
+})
+
+describe('validateScore — CATEGORICAL', () => {
+  const config = makeConfig({
+    data_type: 'CATEGORICAL',
+    min_value: null,
+    max_value: null,
+    categories: ['Helpful', 'Neutral', 'Unhelpful'],
+  })
+
+  it('accepts a value from the list', () => {
+    const r = validateScore(config, 'Helpful')
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      expect(r.fields.value_string).toBe('Helpful')
+      expect(r.fields.value_number).toBeNull()
+      expect(r.fields.score).toBeNull() // does NOT pollute legacy column
+    }
+  })
+
+  it('rejects values not in the list', () => {
+    const r = validateScore(config, 'Excellent')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('INVALID_CATEGORICAL')
+  })
+
+  it('rejects empty strings', () => {
+    const r = validateScore(config, '')
+    expect(r.ok).toBe(false)
+  })
+
+  it('rejects non-string types (numbers, booleans)', () => {
+    expect(validateScore(config, 1).ok).toBe(false)
+    expect(validateScore(config, true).ok).toBe(false)
+  })
+
+  it('is case sensitive (does NOT auto-correct casing)', () => {
+    const r = validateScore(config, 'helpful')
+    expect(r.ok).toBe(false)
+  })
+})
+
+describe('validateScore — BOOLEAN', () => {
+  const config = makeConfig({
+    data_type: 'BOOLEAN',
+    min_value: null,
+    max_value: null,
+  })
+
+  it('accepts real booleans', () => {
+    const r = validateScore(config, true)
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.fields.value_boolean).toBe(true)
+  })
+
+  it('accepts "true"/"false" string aliases', () => {
+    const r1 = validateScore(config, 'true')
+    const r2 = validateScore(config, 'false')
+    expect(r1.ok).toBe(true)
+    expect(r2.ok).toBe(true)
+    if (r1.ok) expect(r1.fields.value_boolean).toBe(true)
+    if (r2.ok) expect(r2.fields.value_boolean).toBe(false)
+  })
+
+  it('accepts pass/fail aliases', () => {
+    if (validateScore(config, 'pass').ok && validateScore(config, 'fail').ok) {
+      // ok
+    } else {
+      expect.fail('pass/fail aliases should be accepted')
+    }
+  })
+
+  it('does NOT silently coerce arbitrary truthy strings', () => {
+    // This is the bug we want to avoid: JS Boolean("false") === true.
+    const r = validateScore(config, 'maybe')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.code).toBe('INVALID_BOOLEAN')
+  })
+
+  it('keeps legacy score column null', () => {
+    const r = validateScore(config, true)
+    if (r.ok) {
+      expect(r.fields.score).toBeNull()
+      expect(r.fields.value_number).toBeNull()
+    }
+  })
+})
+
+describe('validateScore — TEXT', () => {
+  const config = makeConfig({
+    data_type: 'TEXT',
+    min_value: null,
+    max_value: null,
+  })
+
+  it('accepts a non-empty string', () => {
+    const r = validateScore(config, 'Customer praised the tone')
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.fields.value_string).toBe('Customer praised the tone')
+  })
+
+  it('trims surrounding whitespace', () => {
+    const r = validateScore(config, '  hello  ')
+    if (r.ok) expect(r.fields.value_string).toBe('hello')
+  })
+
+  it('rejects empty or whitespace-only strings', () => {
+    expect(validateScore(config, '').ok).toBe(false)
+    expect(validateScore(config, '   ').ok).toBe(false)
+  })
+
+  it('rejects non-string types', () => {
+    expect(validateScore(config, 42).ok).toBe(false)
+    expect(validateScore(config, null).ok).toBe(false)
+  })
+})
+
+describe('parseCategories', () => {
+  it('returns string[] from a clean JSONB array', () => {
+    expect(parseCategories(['A', 'B'])).toEqual(['A', 'B'])
+  })
+
+  it('filters out non-string entries', () => {
+    expect(parseCategories(['A', 1, null, 'B', ''])).toEqual(['A', 'B'])
+  })
+
+  it('returns empty array for non-array input', () => {
+    expect(parseCategories(null)).toEqual([])
+    expect(parseCategories('A,B')).toEqual([])
+    expect(parseCategories({ a: 1 })).toEqual([])
+  })
+})
+
+describe('validateScoreConfigShape', () => {
+  it('NUMERIC needs both bounds and min<max', () => {
+    expect(
+      validateScoreConfigShape({ data_type: 'NUMERIC', min_value: 0, max_value: 1, categories: null }),
+    ).toBeNull()
+    expect(
+      validateScoreConfigShape({ data_type: 'NUMERIC', min_value: 1, max_value: 1, categories: null }),
+    ).toMatch(/strictly less/)
+    expect(
+      validateScoreConfigShape({ data_type: 'NUMERIC', min_value: null, max_value: 1, categories: null }),
+    ).toMatch(/min_value and max_value/)
+  })
+
+  it('CATEGORICAL needs at least 2 unique categories', () => {
+    expect(
+      validateScoreConfigShape({
+        data_type: 'CATEGORICAL',
+        min_value: null,
+        max_value: null,
+        categories: ['A', 'B'],
+      }),
+    ).toBeNull()
+    expect(
+      validateScoreConfigShape({
+        data_type: 'CATEGORICAL',
+        min_value: null,
+        max_value: null,
+        categories: ['A'],
+      }),
+    ).toMatch(/at least 2/)
+    expect(
+      validateScoreConfigShape({
+        data_type: 'CATEGORICAL',
+        min_value: null,
+        max_value: null,
+        categories: ['A', 'A'],
+      }),
+    ).toMatch(/unique/)
+  })
+
+  it('BOOLEAN / TEXT accept any', () => {
+    expect(
+      validateScoreConfigShape({ data_type: 'BOOLEAN', min_value: null, max_value: null, categories: null }),
+    ).toBeNull()
+    expect(
+      validateScoreConfigShape({ data_type: 'TEXT', min_value: null, max_value: null, categories: null }),
+    ).toBeNull()
+  })
+
+  it('rejects unknown data_type', () => {
+    expect(
+      validateScoreConfigShape({ data_type: 'FOO', min_value: null, max_value: null, categories: null }),
+    ).toMatch(/Unknown data_type/)
+  })
+})

--- a/apps/server/src/lib/score-validation.ts
+++ b/apps/server/src/lib/score-validation.ts
@@ -1,0 +1,245 @@
+/**
+ * Score config validation.
+ *
+ * Turns a (config, raw value) pair into the typed value columns that go
+ * into eval_results / human_evals, and surfaces user-friendly errors for
+ * the four cases the API exposes:
+ *
+ *   • NUMERIC value out of [min, max]
+ *   • CATEGORICAL value not in the allow-list
+ *   • BOOLEAN value not coercible to true/false
+ *   • TEXT value empty / non-string (we treat "" as not-a-score)
+ *
+ * The output shape is exactly the columns the result tables expect, so
+ * callers can spread it into an insert without re-mapping. The
+ * legacy `score` column is also filled when the config is NUMERIC, so
+ * pre-4B.1 dashboard queries (AVG(score)) keep working.
+ */
+
+export type ScoreConfigType = 'NUMERIC' | 'CATEGORICAL' | 'BOOLEAN' | 'TEXT'
+
+export interface ScoreConfig {
+  id: string
+  data_type: ScoreConfigType
+  min_value: number | null
+  max_value: number | null
+  categories: unknown // JSONB — validated at runtime
+  bool_true_label: string | null
+  bool_false_label: string | null
+}
+
+export interface NormalizedScoreFields {
+  /** Legacy numeric mirror; null when the score isn't numeric. */
+  score: number | null
+  value_number: number | null
+  value_string: string | null
+  value_boolean: boolean | null
+}
+
+export interface ValidationOk {
+  ok: true
+  fields: NormalizedScoreFields
+}
+
+export interface ValidationErr {
+  ok: false
+  /** Stable code the API can map to an HTTP status. */
+  code:
+    | 'INVALID_NUMERIC'
+    | 'NUMERIC_OUT_OF_RANGE'
+    | 'INVALID_CATEGORICAL'
+    | 'INVALID_BOOLEAN'
+    | 'INVALID_TEXT'
+    | 'INVALID_CONFIG'
+  /** Human-readable message safe to surface in 4xx responses. */
+  message: string
+}
+
+export type ValidationResult = ValidationOk | ValidationErr
+
+/**
+ * Validate a raw value against a config and return the typed columns to
+ * write. The caller must already have loaded the config from
+ * `score_configs` and confirmed it belongs to the right organization.
+ *
+ * Accepts a single `value` argument so call sites for NUMERIC don't have
+ * to invent a string. Type coercion is intentionally narrow — JS's
+ * `Boolean(value)` would happily accept the string "false" as `true`,
+ * which is exactly the kind of footgun we want to surface as a 400.
+ */
+export function validateScore(config: ScoreConfig, value: unknown): ValidationResult {
+  switch (config.data_type) {
+    case 'NUMERIC':
+      return validateNumeric(config, value)
+    case 'CATEGORICAL':
+      return validateCategorical(config, value)
+    case 'BOOLEAN':
+      return validateBoolean(config, value)
+    case 'TEXT':
+      return validateText(value)
+    default: {
+      // The CHECK constraint at the DB level prevents this in practice,
+      // but we guard the API layer so a corrupted row can't crash the
+      // process.
+      const exhaustive: never = config.data_type
+      return {
+        ok: false,
+        code: 'INVALID_CONFIG',
+        message: `Unknown score type: ${String(exhaustive)}`,
+      }
+    }
+  }
+}
+
+function validateNumeric(config: ScoreConfig, value: unknown): ValidationResult {
+  // Accept number or numeric string. NaN and infinity rejected.
+  const raw = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(raw)) {
+    return { ok: false, code: 'INVALID_NUMERIC', message: 'score must be a finite number' }
+  }
+
+  const min = config.min_value ?? 0
+  const max = config.max_value ?? 1
+  if (raw < min || raw > max) {
+    return {
+      ok: false,
+      code: 'NUMERIC_OUT_OF_RANGE',
+      message: `score ${raw} is outside the configured range [${min}, ${max}]`,
+    }
+  }
+
+  return {
+    ok: true,
+    fields: {
+      score: raw,
+      value_number: raw,
+      value_string: null,
+      value_boolean: null,
+    },
+  }
+}
+
+function validateCategorical(config: ScoreConfig, value: unknown): ValidationResult {
+  if (typeof value !== 'string' || value.length === 0) {
+    return {
+      ok: false,
+      code: 'INVALID_CATEGORICAL',
+      message: 'score must be one of the configured categories',
+    }
+  }
+
+  const categories = parseCategories(config.categories)
+  if (!categories.includes(value)) {
+    return {
+      ok: false,
+      code: 'INVALID_CATEGORICAL',
+      message: `score "${value}" is not in the allowed categories: ${categories.join(', ')}`,
+    }
+  }
+
+  return {
+    ok: true,
+    fields: {
+      score: null,
+      value_number: null,
+      value_string: value,
+      value_boolean: null,
+    },
+  }
+}
+
+function validateBoolean(_config: ScoreConfig, value: unknown): ValidationResult {
+  // Accept the actual boolean, the two true/false strings, and the two
+  // labels the workspace might have configured. Anything else is a 400.
+  let normalised: boolean | null = null
+  if (typeof value === 'boolean') {
+    normalised = value
+  } else if (value === 'true' || value === 'pass' || value === 'yes' || value === 1) {
+    normalised = true
+  } else if (value === 'false' || value === 'fail' || value === 'no' || value === 0) {
+    normalised = false
+  }
+
+  if (normalised === null) {
+    return {
+      ok: false,
+      code: 'INVALID_BOOLEAN',
+      message: 'score must be a boolean (true/false)',
+    }
+  }
+
+  return {
+    ok: true,
+    fields: {
+      score: null,
+      value_number: null,
+      value_string: null,
+      value_boolean: normalised,
+    },
+  }
+}
+
+function validateText(value: unknown): ValidationResult {
+  if (typeof value !== 'string') {
+    return { ok: false, code: 'INVALID_TEXT', message: 'score must be a string' }
+  }
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    return { ok: false, code: 'INVALID_TEXT', message: 'score must not be empty' }
+  }
+  return {
+    ok: true,
+    fields: {
+      score: null,
+      value_number: null,
+      value_string: trimmed,
+      value_boolean: null,
+    },
+  }
+}
+
+/**
+ * Parse the JSONB `categories` column into a string array. JSONB comes
+ * back as a parsed JS value from PostgREST so we just need to coerce
+ * the shape; any non-string entries are filtered out rather than
+ * throwing so a half-broken config doesn't 500 the whole route.
+ */
+export function parseCategories(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return []
+  return raw.filter((v): v is string => typeof v === 'string' && v.length > 0)
+}
+
+/**
+ * Validation guards for the *config* itself (used by the CRUD route).
+ * Returns null when the config row is shaped consistently for its type,
+ * an error string otherwise.
+ */
+export function validateScoreConfigShape(input: {
+  data_type: string
+  min_value: number | null
+  max_value: number | null
+  categories: unknown
+}): string | null {
+  switch (input.data_type) {
+    case 'NUMERIC': {
+      const min = input.min_value
+      const max = input.max_value
+      if (min === null || max === null) return 'NUMERIC config requires min_value and max_value'
+      if (!Number.isFinite(min) || !Number.isFinite(max)) return 'NUMERIC bounds must be finite'
+      if (min >= max) return 'min_value must be strictly less than max_value'
+      return null
+    }
+    case 'CATEGORICAL': {
+      const categories = parseCategories(input.categories)
+      if (categories.length < 2) return 'CATEGORICAL config requires at least 2 categories'
+      const dedup = new Set(categories)
+      if (dedup.size !== categories.length) return 'category names must be unique'
+      return null
+    }
+    case 'BOOLEAN':
+    case 'TEXT':
+      return null
+    default:
+      return `Unknown data_type: ${input.data_type}`
+  }
+}

--- a/apps/web/app/(dashboard)/settings/score-configs/page.tsx
+++ b/apps/web/app/(dashboard)/settings/score-configs/page.tsx
@@ -1,0 +1,9 @@
+import { ScoreConfigsClient } from './score-configs-client'
+
+export const metadata = {
+  title: 'Score configs · Spanlens',
+}
+
+export default function ScoreConfigsPage() {
+  return <ScoreConfigsClient />
+}

--- a/apps/web/app/(dashboard)/settings/score-configs/score-configs-client.tsx
+++ b/apps/web/app/(dashboard)/settings/score-configs/score-configs-client.tsx
@@ -1,0 +1,574 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+import { Plus, Star, MessageSquare, ToggleRight, Type, Archive, RotateCcw } from 'lucide-react'
+import { Topbar } from '@/components/layout/topbar'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+import {
+  useAllScoreConfigs,
+  useCreateScoreConfig,
+  useUpdateScoreConfig,
+  useArchiveScoreConfig,
+  type ScoreConfig,
+  type ScoreConfigType,
+  type CreateScoreConfigInput,
+} from '@/lib/queries/use-score-configs'
+
+/**
+ * Score configs management UI.
+ *
+ * The page is intentionally read-flat: list all configs (active + archived)
+ * with type-coloured chips and inline actions. Creating a new config opens
+ * a single dialog that morphs based on the selected type — the form fields
+ * shown for NUMERIC (min/max) are different from CATEGORICAL (chip
+ * editor), and BOOLEAN gets a label pair. We keep the dialog over a
+ * separate "edit" page so admins can spin up new configs without leaving
+ * the list view.
+ *
+ * The legacy 0..1 NUMERIC config seeded by the 4B.1 migration is marked
+ * `is_default` and can't be archived from the UI — promoting a different
+ * config to default unlocks it.
+ */
+
+const TYPE_LABELS: Record<ScoreConfigType, string> = {
+  NUMERIC: 'Numeric',
+  CATEGORICAL: 'Categorical',
+  BOOLEAN: 'Boolean',
+  TEXT: 'Free text',
+}
+
+const TYPE_DESCRIPTIONS: Record<ScoreConfigType, string> = {
+  NUMERIC: 'Slider or stars on a fixed range. Aggregates as average.',
+  CATEGORICAL: 'Pick one from a fixed list. Aggregates as a distribution.',
+  BOOLEAN: 'Pass / fail toggle. Aggregates as pass rate.',
+  TEXT: 'Free-form label or note. No aggregation; surfaced as samples.',
+}
+
+const TYPE_ICONS: Record<ScoreConfigType, React.ReactElement> = {
+  NUMERIC: <Star className="h-3.5 w-3.5" />,
+  CATEGORICAL: <MessageSquare className="h-3.5 w-3.5" />,
+  BOOLEAN: <ToggleRight className="h-3.5 w-3.5" />,
+  TEXT: <Type className="h-3.5 w-3.5" />,
+}
+
+// Pretty-print the type-specific bounds for the list row. Keep the text
+// short — full details live in the edit dialog.
+function summariseConfig(config: ScoreConfig): string {
+  switch (config.data_type) {
+    case 'NUMERIC':
+      return `${config.min_value ?? 0} – ${config.max_value ?? 1}`
+    case 'CATEGORICAL':
+      return (config.categories ?? []).join(' / ')
+    case 'BOOLEAN':
+      return `${config.bool_true_label ?? 'Yes'} / ${config.bool_false_label ?? 'No'}`
+    case 'TEXT':
+      return 'Free text'
+  }
+}
+
+export function ScoreConfigsClient() {
+  const query = useAllScoreConfigs()
+  const archive = useArchiveScoreConfig()
+  const update = useUpdateScoreConfig()
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editing, setEditing] = useState<ScoreConfig | null>(null)
+
+  const { active, archived } = useMemo(() => {
+    const all = query.data ?? []
+    return {
+      active: all.filter((c) => !c.archived_at),
+      archived: all.filter((c) => c.archived_at),
+    }
+  }, [query.data])
+
+  return (
+    <>
+      <Topbar
+        crumbs={[
+          { label: 'Settings', href: '/settings' },
+          { label: 'Score configs' },
+        ]}
+      />
+      <div className="px-6 py-8 max-w-[1100px] mx-auto">
+        <div className="mb-6 flex items-start justify-between gap-4">
+          <div>
+            <Link
+              href="/settings"
+              className="font-mono text-[11px] text-text-faint hover:text-text-muted"
+            >
+              ← Settings
+            </Link>
+            <h1 className="mt-2 text-2xl font-semibold">Score configs</h1>
+            <p className="mt-1 text-[13px] text-text-muted max-w-[600px]">
+              Define how evaluators and reviewers score responses in this
+              workspace. Each config has a type — numeric, categorical,
+              boolean, or free text — and the annotation queue picks the
+              right input widget automatically.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => setCreateOpen(true)}
+            className="inline-flex items-center gap-1.5 rounded-[6px] bg-accent px-3 py-1.5 text-[12.5px] font-medium text-accent-fg hover:opacity-90"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New config
+          </button>
+        </div>
+
+        {query.isLoading ? (
+          <div className="space-y-2">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-14 rounded-[6px] bg-bg-elev animate-pulse" />
+            ))}
+          </div>
+        ) : active.length === 0 ? (
+          <EmptyState onCreate={() => setCreateOpen(true)} />
+        ) : (
+          <div className="space-y-2">
+            {active.map((config) => (
+              <ConfigRow
+                key={config.id}
+                config={config}
+                onEdit={() => setEditing(config)}
+                onArchive={() => {
+                  if (config.is_default) {
+                    window.alert(
+                      'Cannot archive the default config. Promote another config to default first.',
+                    )
+                    return
+                  }
+                  if (window.confirm(`Archive "${config.name}"? Existing scores using this config stay queryable but the picker will hide it.`)) {
+                    archive.mutate(config.id)
+                  }
+                }}
+                onPromote={() => {
+                  update.mutate({ id: config.id, is_default: true })
+                }}
+              />
+            ))}
+          </div>
+        )}
+
+        {archived.length > 0 && (
+          <details className="mt-8">
+            <summary className="font-mono text-[11.5px] text-text-faint hover:text-text-muted cursor-pointer">
+              Archived ({archived.length})
+            </summary>
+            <div className="mt-3 space-y-2">
+              {archived.map((config) => (
+                <ConfigRow
+                  key={config.id}
+                  config={config}
+                  archived
+                  onRestore={() => update.mutate({ id: config.id, archived: false })}
+                />
+              ))}
+            </div>
+          </details>
+        )}
+      </div>
+
+      <CreateConfigDialog open={createOpen} onClose={() => setCreateOpen(false)} />
+      {editing && (
+        <EditConfigDialog
+          config={editing}
+          onClose={() => setEditing(null)}
+        />
+      )}
+    </>
+  )
+}
+
+function EmptyState({ onCreate }: { onCreate: () => void }) {
+  return (
+    <div className="rounded-[6px] border border-border bg-bg p-10 text-center">
+      <p className="text-[13px] text-text mb-1">No active configs.</p>
+      <p className="font-mono text-[11.5px] text-text-faint mb-4">
+        At minimum your workspace has a default numeric config. If even that is missing the
+        backfill migration didn&apos;t run — check the deploy logs.
+      </p>
+      <button
+        type="button"
+        onClick={onCreate}
+        className="inline-flex items-center gap-1.5 rounded-[6px] bg-accent px-3 py-1.5 text-[12.5px] font-medium text-accent-fg hover:opacity-90"
+      >
+        <Plus className="h-3.5 w-3.5" />
+        Create config
+      </button>
+    </div>
+  )
+}
+
+interface ConfigRowProps {
+  config: ScoreConfig
+  archived?: boolean
+  onEdit?: () => void
+  onArchive?: () => void
+  onRestore?: () => void
+  onPromote?: () => void
+}
+
+function ConfigRow({ config, archived, onEdit, onArchive, onRestore, onPromote }: ConfigRowProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-3 rounded-[6px] border border-border bg-bg p-3 transition-colors',
+        archived && 'opacity-60',
+      )}
+    >
+      <span
+        className={cn(
+          'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10.5px] uppercase tracking-[0.04em]',
+          'border-border bg-bg-elev text-text-muted',
+        )}
+      >
+        {TYPE_ICONS[config.data_type]}
+        {TYPE_LABELS[config.data_type]}
+      </span>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-[13px] font-medium text-text">{config.name}</span>
+          {config.is_default && (
+            <span className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-accent">
+              Default
+            </span>
+          )}
+        </div>
+        <div className="font-mono text-[11px] text-text-faint truncate">
+          {summariseConfig(config)}
+        </div>
+        {config.description && (
+          <p className="mt-0.5 text-[11.5px] text-text-muted truncate">{config.description}</p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1">
+        {archived ? (
+          <button
+            type="button"
+            onClick={onRestore}
+            className="inline-flex items-center gap-1 rounded-[5px] px-2 py-1 text-[11.5px] text-text-muted hover:bg-bg-elev hover:text-text"
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+            Restore
+          </button>
+        ) : (
+          <>
+            {!config.is_default && onPromote && (
+              <button
+                type="button"
+                onClick={onPromote}
+                className="inline-flex items-center gap-1 rounded-[5px] px-2 py-1 text-[11.5px] text-text-muted hover:bg-bg-elev hover:text-text"
+              >
+                Promote
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onEdit}
+              className="inline-flex items-center gap-1 rounded-[5px] px-2 py-1 text-[11.5px] text-text-muted hover:bg-bg-elev hover:text-text"
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              onClick={onArchive}
+              className="inline-flex items-center gap-1 rounded-[5px] px-2 py-1 text-[11.5px] text-text-muted hover:bg-bg-elev hover:text-bad"
+            >
+              <Archive className="h-3.5 w-3.5" />
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Create dialog ────────────────────────────────────────────────────────────
+
+function CreateConfigDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="sm:max-w-[520px]">
+        <DialogHeader>
+          <DialogTitle>New score config</DialogTitle>
+        </DialogHeader>
+        <ConfigForm
+          mode="create"
+          onDone={onClose}
+        />
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function EditConfigDialog({ config, onClose }: { config: ScoreConfig; onClose: () => void }) {
+  return (
+    <Dialog open onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="sm:max-w-[520px]">
+        <DialogHeader>
+          <DialogTitle>Edit &ldquo;{config.name}&rdquo;</DialogTitle>
+        </DialogHeader>
+        <ConfigForm
+          mode="edit"
+          config={config}
+          onDone={onClose}
+        />
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+interface ConfigFormProps {
+  mode: 'create' | 'edit'
+  config?: ScoreConfig
+  onDone: () => void
+}
+
+function ConfigForm({ mode, config, onDone }: ConfigFormProps) {
+  const create = useCreateScoreConfig()
+  const update = useUpdateScoreConfig()
+  const [name, setName] = useState(config?.name ?? '')
+  const [description, setDescription] = useState(config?.description ?? '')
+  const [dataType, setDataType] = useState<ScoreConfigType>(config?.data_type ?? 'NUMERIC')
+  const [minValue, setMinValue] = useState(String(config?.min_value ?? 0))
+  const [maxValue, setMaxValue] = useState(String(config?.max_value ?? 1))
+  const [categoriesText, setCategoriesText] = useState((config?.categories ?? []).join(', '))
+  const [boolTrueLabel, setBoolTrueLabel] = useState(config?.bool_true_label ?? 'Pass')
+  const [boolFalseLabel, setBoolFalseLabel] = useState(config?.bool_false_label ?? 'Fail')
+  const [isDefault, setIsDefault] = useState(config?.is_default ?? false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    const trimmedName = name.trim()
+    if (trimmedName.length === 0) {
+      setError('Name is required')
+      return
+    }
+
+    try {
+      if (mode === 'create') {
+        const input: CreateScoreConfigInput = {
+          name: trimmedName,
+          description: description.trim() || null,
+          data_type: dataType,
+        }
+        if (dataType === 'NUMERIC') {
+          input.min_value = Number(minValue)
+          input.max_value = Number(maxValue)
+        }
+        if (dataType === 'CATEGORICAL') {
+          input.categories = categoriesText
+            .split(',')
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0)
+        }
+        if (dataType === 'BOOLEAN') {
+          input.bool_true_label = boolTrueLabel.trim() || null
+          input.bool_false_label = boolFalseLabel.trim() || null
+        }
+        if (isDefault) input.is_default = true
+        await create.mutateAsync(input)
+      } else if (config) {
+        const updates: Parameters<typeof update.mutateAsync>[0] = { id: config.id }
+        if (trimmedName !== config.name) updates.name = trimmedName
+        const trimmedDesc = description.trim() || null
+        if (trimmedDesc !== config.description) updates.description = trimmedDesc
+        if (dataType === 'NUMERIC') {
+          updates.min_value = Number(minValue)
+          updates.max_value = Number(maxValue)
+        }
+        if (dataType === 'CATEGORICAL') {
+          updates.categories = categoriesText
+            .split(',')
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0)
+        }
+        if (dataType === 'BOOLEAN') {
+          updates.bool_true_label = boolTrueLabel.trim() || null
+          updates.bool_false_label = boolFalseLabel.trim() || null
+        }
+        if (isDefault && !config.is_default) updates.is_default = true
+        await update.mutateAsync(updates)
+      }
+      onDone()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save config')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 pt-2">
+      <div>
+        <label className="block font-mono text-[10.5px] uppercase tracking-[0.04em] text-text-faint mb-1.5">
+          Name
+        </label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Brand voice"
+          maxLength={100}
+          className="w-full rounded-[5px] border border-border bg-bg px-2.5 py-1.5 text-[13px] outline-none focus:border-accent"
+        />
+      </div>
+
+      <div>
+        <label className="block font-mono text-[10.5px] uppercase tracking-[0.04em] text-text-faint mb-1.5">
+          Description (optional)
+        </label>
+        <input
+          type="text"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Short label shown in the picker"
+          className="w-full rounded-[5px] border border-border bg-bg px-2.5 py-1.5 text-[13px] outline-none focus:border-accent"
+        />
+      </div>
+
+      <div>
+        <label className="block font-mono text-[10.5px] uppercase tracking-[0.04em] text-text-faint mb-1.5">
+          Type {mode === 'edit' && <span className="normal-case text-text-faint">(immutable)</span>}
+        </label>
+        <div className="grid grid-cols-2 gap-2">
+          {(['NUMERIC', 'CATEGORICAL', 'BOOLEAN', 'TEXT'] as const).map((t) => (
+            <button
+              key={t}
+              type="button"
+              disabled={mode === 'edit'}
+              onClick={() => setDataType(t)}
+              className={cn(
+                'text-left rounded-[5px] border p-2.5 transition-colors',
+                dataType === t
+                  ? 'border-accent bg-accent-bg/40 text-text'
+                  : 'border-border bg-bg text-text-muted hover:border-border-strong',
+                mode === 'edit' && 'cursor-not-allowed opacity-60',
+              )}
+            >
+              <div className="flex items-center gap-1.5 text-[12.5px] font-medium">
+                {TYPE_ICONS[t]}
+                {TYPE_LABELS[t]}
+              </div>
+              <div className="mt-0.5 text-[10.5px] text-text-muted leading-snug">
+                {TYPE_DESCRIPTIONS[t]}
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {dataType === 'NUMERIC' && (
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block font-mono text-[10.5px] uppercase tracking-[0.04em] text-text-faint mb-1.5">
+              Min value
+            </label>
+            <input
+              type="number"
+              step="0.01"
+              value={minValue}
+              onChange={(e) => setMinValue(e.target.value)}
+              className="w-full rounded-[5px] border border-border bg-bg px-2.5 py-1.5 text-[13px] outline-none focus:border-accent"
+            />
+          </div>
+          <div>
+            <label className="block font-mono text-[10.5px] uppercase tracking-[0.04em] text-text-faint mb-1.5">
+              Max value
+            </label>
+            <input
+              type="number"
+              step="0.01"
+              value={maxValue}
+              onChange={(e) => setMaxValue(e.target.value)}
+              className="w-full rounded-[5px] border border-border bg-bg px-2.5 py-1.5 text-[13px] outline-none focus:border-accent"
+            />
+          </div>
+        </div>
+      )}
+
+      {dataType === 'CATEGORICAL' && (
+        <div>
+          <label className="block font-mono text-[10.5px] uppercase tracking-[0.04em] text-text-faint mb-1.5">
+            Categories (comma-separated, at least 2)
+          </label>
+          <input
+            type="text"
+            value={categoriesText}
+            onChange={(e) => setCategoriesText(e.target.value)}
+            placeholder="Helpful, Neutral, Unhelpful"
+            className="w-full rounded-[5px] border border-border bg-bg px-2.5 py-1.5 text-[13px] outline-none focus:border-accent"
+          />
+        </div>
+      )}
+
+      {dataType === 'BOOLEAN' && (
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block font-mono text-[10.5px] uppercase tracking-[0.04em] text-text-faint mb-1.5">
+              True label
+            </label>
+            <input
+              type="text"
+              value={boolTrueLabel}
+              onChange={(e) => setBoolTrueLabel(e.target.value)}
+              className="w-full rounded-[5px] border border-border bg-bg px-2.5 py-1.5 text-[13px] outline-none focus:border-accent"
+            />
+          </div>
+          <div>
+            <label className="block font-mono text-[10.5px] uppercase tracking-[0.04em] text-text-faint mb-1.5">
+              False label
+            </label>
+            <input
+              type="text"
+              value={boolFalseLabel}
+              onChange={(e) => setBoolFalseLabel(e.target.value)}
+              className="w-full rounded-[5px] border border-border bg-bg px-2.5 py-1.5 text-[13px] outline-none focus:border-accent"
+            />
+          </div>
+        </div>
+      )}
+
+      {!config?.is_default && (
+        <label className="flex items-center gap-2 font-mono text-[11.5px] text-text-muted">
+          <input
+            type="checkbox"
+            checked={isDefault}
+            onChange={(e) => setIsDefault(e.target.checked)}
+          />
+          Make this the default for new evaluators
+        </label>
+      )}
+
+      {error && (
+        <div className="rounded-[5px] border border-bad/30 bg-bad/10 px-2.5 py-1.5 text-[11.5px] text-bad">
+          {error}
+        </div>
+      )}
+
+      <div className="flex justify-end gap-2 pt-2">
+        <button
+          type="button"
+          onClick={onDone}
+          className="rounded-[5px] border border-border bg-bg px-3 py-1.5 text-[12.5px] text-text-muted hover:bg-bg-elev"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={create.isPending || update.isPending}
+          className="rounded-[5px] bg-accent px-3 py-1.5 text-[12.5px] font-medium text-accent-fg hover:opacity-90 disabled:opacity-50"
+        >
+          {mode === 'create' ? 'Create' : 'Save'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/apps/web/lib/queries/use-score-configs.ts
+++ b/apps/web/lib/queries/use-score-configs.ts
@@ -1,0 +1,134 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiDelete, apiGet, apiPatch, apiPost } from '@/lib/api'
+import type { ApiEnvelope } from './types'
+
+/**
+ * Score configs CRUD hooks.
+ *
+ * One workspace can have multiple configs (e.g. "Helpfulness" NUMERIC,
+ * "Persona" CATEGORICAL, "Pass/Fail" BOOLEAN); the management UI lives
+ * at /settings/score-configs and the annotation queue picks one at
+ * input time. Every workspace has at least one default (NUMERIC 0..1,
+ * seeded by the 4B.1 migration).
+ */
+
+export type ScoreConfigType = 'NUMERIC' | 'CATEGORICAL' | 'BOOLEAN' | 'TEXT'
+
+export interface ScoreConfig {
+  id: string
+  organization_id: string
+  name: string
+  description: string | null
+  data_type: ScoreConfigType
+  min_value: number | null
+  max_value: number | null
+  categories: string[] | null
+  bool_true_label: string | null
+  bool_false_label: string | null
+  archived_at: string | null
+  is_default: boolean
+  created_by: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface CreateScoreConfigInput {
+  name: string
+  description?: string | null
+  data_type: ScoreConfigType
+  min_value?: number | null
+  max_value?: number | null
+  categories?: string[] | null
+  bool_true_label?: string | null
+  bool_false_label?: string | null
+  is_default?: boolean
+}
+
+export interface UpdateScoreConfigInput {
+  name?: string
+  description?: string | null
+  min_value?: number | null
+  max_value?: number | null
+  categories?: string[] | null
+  bool_true_label?: string | null
+  bool_false_label?: string | null
+  archived?: boolean
+  is_default?: boolean
+}
+
+export const scoreConfigsKey = ['score-configs'] as const
+export const scoreConfigsKeyAll = ['score-configs', 'all'] as const
+
+export function useScoreConfigs() {
+  return useQuery({
+    queryKey: scoreConfigsKey,
+    queryFn: async () => {
+      const res = await apiGet<ApiEnvelope<ScoreConfig[]>>('/api/v1/score-configs')
+      return res.data ?? []
+    },
+    // Refetches on window focus by default. Configs change rarely so a
+    // 60-second stale window is enough to dedupe back-to-back navigations.
+    staleTime: 60_000,
+  })
+}
+
+/** Same as useScoreConfigs but includes archived rows. Used by the
+ *  management page so admins can restore mistakes. */
+export function useAllScoreConfigs() {
+  return useQuery({
+    queryKey: scoreConfigsKeyAll,
+    queryFn: async () => {
+      const res = await apiGet<ApiEnvelope<ScoreConfig[]>>(
+        '/api/v1/score-configs?includeArchived=1',
+      )
+      return res.data ?? []
+    },
+    staleTime: 60_000,
+  })
+}
+
+export function useCreateScoreConfig() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: CreateScoreConfigInput) => {
+      const res = await apiPost<ApiEnvelope<ScoreConfig>>('/api/v1/score-configs', input)
+      return res.data
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: scoreConfigsKey })
+      void qc.invalidateQueries({ queryKey: scoreConfigsKeyAll })
+    },
+  })
+}
+
+export function useUpdateScoreConfig() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ id, ...input }: UpdateScoreConfigInput & { id: string }) => {
+      const res = await apiPatch<ApiEnvelope<ScoreConfig>>(
+        `/api/v1/score-configs/${id}`,
+        input,
+      )
+      return res.data
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: scoreConfigsKey })
+      void qc.invalidateQueries({ queryKey: scoreConfigsKeyAll })
+    },
+  })
+}
+
+export function useArchiveScoreConfig() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await apiDelete(`/api/v1/score-configs/${id}`)
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: scoreConfigsKey })
+      void qc.invalidateQueries({ queryKey: scoreConfigsKeyAll })
+    },
+  })
+}

--- a/supabase/migrations/20260608010000_score_configs.sql
+++ b/supabase/migrations/20260608010000_score_configs.sql
@@ -1,0 +1,184 @@
+-- 20260608010000_score_configs.sql
+--
+-- Typed score configs for evals + human feedback.
+--
+-- Before this migration, every eval result and every human feedback row
+-- carried a single `score float` column normalized to 0..1. That's
+-- enough for "helpfulness on a slider" but it can't represent:
+--
+--   • CATEGORICAL: A/B preference, persona match { 'on_brand', 'off_brand' }
+--   • BOOLEAN: pass/fail toggles (toxicity, PII leak, prompt injection)
+--   • TEXT: free-form labels or reviewer comments treated as the primary
+--     scoring signal (rare but Langfuse supports it; we match)
+--
+-- We introduce a `score_configs` table that defines, per workspace, the
+-- shape of a score: its name (e.g. "Helpfulness"), its type, and
+-- type-specific bounds (numeric min/max, categorical category list).
+--
+-- The result tables (`eval_results`, `human_evals`) gain a nullable
+-- `score_config_id` pointer plus three typed value columns
+-- (`value_number`, `value_string`, `value_boolean`). Exactly one of
+-- the value columns may be non-null for a given row. The legacy
+-- `score float` column stays and is filled with the same value as
+-- `value_number` whenever the config is NUMERIC, so every existing
+-- dashboard query keeps working without changes.
+--
+-- Why a separate score_configs table per workspace (not a global
+-- enum or a free-text column):
+--   • Each workspace wants its own vocabulary. Acme Corp's eval names
+--     ("brand voice", "compliance") aren't ours to predict.
+--   • Categorical configs need a fixed allow-list of values; storing
+--     it on the config row is cheaper than re-validating each insert
+--     against a side table.
+--   • Future per-workspace defaults (e.g. "every new evaluator gets
+--     the Helpfulness config attached") need stable IDs.
+
+-- ── Configs table ────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS score_configs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+
+  -- Display name shown in dropdowns and chart titles.
+  name TEXT NOT NULL,
+  -- Short description for the management UI; nullable for legacy defaults.
+  description TEXT,
+
+  data_type TEXT NOT NULL CHECK (
+    data_type IN ('NUMERIC', 'CATEGORICAL', 'BOOLEAN', 'TEXT')
+  ),
+
+  -- NUMERIC bounds. Both NULL when type != NUMERIC. min < max enforced
+  -- at the application layer (a CHECK across nullable columns is awkward
+  -- and we want to surface user-friendly errors anyway).
+  min_value DOUBLE PRECISION,
+  max_value DOUBLE PRECISION,
+
+  -- CATEGORICAL category list as JSONB array of strings. NULL for other
+  -- types. We use JSONB instead of text[] so the column is queryable
+  -- with `jsonb_array_elements_text()` without an explicit cast and
+  -- because PostgREST surfaces JSONB as native JSON in the API.
+  categories JSONB,
+
+  -- BOOLEAN labels for the "true" / "false" sides of the toggle. Stored
+  -- once so the UI doesn't need to hard-code "Pass / Fail" forever.
+  -- Falls back to "Yes" / "No" in the UI when NULL.
+  bool_true_label TEXT,
+  bool_false_label TEXT,
+
+  -- Soft-delete flag so existing eval_results pointing at the config
+  -- don't break when a workspace archives it. The CRUD UI hides
+  -- archived configs from the picker but keeps them queryable for
+  -- historical charts.
+  archived_at TIMESTAMPTZ,
+
+  -- Marks the default config a workspace gets pre-seeded with. The
+  -- backfill below sets one per existing org so the picker isn't
+  -- empty for legacy rows.
+  is_default BOOLEAN NOT NULL DEFAULT false,
+
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- Name uniqueness across active rows only — archived rows can share
+  -- a name with the new active row that replaced them.
+  CONSTRAINT score_configs_name_unique_per_org
+    UNIQUE (organization_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS score_configs_org_active_idx
+  ON score_configs (organization_id, created_at DESC)
+  WHERE archived_at IS NULL;
+
+-- At most one default per workspace. Backfill below enforces this
+-- on existing rows.
+CREATE UNIQUE INDEX IF NOT EXISTS score_configs_default_uniq
+  ON score_configs (organization_id)
+  WHERE is_default = true AND archived_at IS NULL;
+
+ALTER TABLE score_configs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY score_configs_select_org_members ON score_configs
+  FOR SELECT USING (is_org_member(organization_id));
+
+CREATE POLICY score_configs_deny_writes ON score_configs
+  AS RESTRICTIVE FOR ALL TO anon, authenticated
+  USING (false) WITH CHECK (false);
+
+CREATE POLICY score_configs_service_role_all ON score_configs
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ── eval_results: typed value columns ────────────────────────────────────────
+
+ALTER TABLE eval_results
+  ADD COLUMN IF NOT EXISTS score_config_id UUID
+    REFERENCES score_configs(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS value_number DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS value_string TEXT,
+  ADD COLUMN IF NOT EXISTS value_boolean BOOLEAN;
+
+-- Existing rows: leave score_config_id NULL. Aggregation code falls
+-- back to the legacy `score` column when the config pointer is missing.
+
+CREATE INDEX IF NOT EXISTS eval_results_score_config_idx
+  ON eval_results (score_config_id)
+  WHERE score_config_id IS NOT NULL;
+
+-- ── human_evals: typed value columns ─────────────────────────────────────────
+
+ALTER TABLE human_evals
+  ADD COLUMN IF NOT EXISTS score_config_id UUID
+    REFERENCES score_configs(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS value_number DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS value_string TEXT,
+  ADD COLUMN IF NOT EXISTS value_boolean BOOLEAN;
+
+CREATE INDEX IF NOT EXISTS human_evals_score_config_idx
+  ON human_evals (score_config_id)
+  WHERE score_config_id IS NOT NULL;
+
+-- Drop the NOT NULL on human_evals.score so new categorical/boolean/text
+-- rows can save without inventing a fake float. Existing rows keep their
+-- score values.
+ALTER TABLE human_evals ALTER COLUMN score DROP NOT NULL;
+
+-- ── updated_at trigger for score_configs ─────────────────────────────────────
+-- Mirrors the pattern used by other config-style tables in this schema
+-- (alerts, webhooks). Keeps audit-log entries showing meaningful update
+-- timestamps without the API having to remember to set them.
+
+CREATE OR REPLACE FUNCTION score_configs_touch_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS score_configs_updated_at_trg ON score_configs;
+CREATE TRIGGER score_configs_updated_at_trg
+  BEFORE UPDATE ON score_configs
+  FOR EACH ROW
+  EXECUTE FUNCTION score_configs_touch_updated_at();
+
+-- ── Backfill: one default NUMERIC config per existing organization ───────────
+-- Idempotent: skips any org that already has a default. Run order matters
+-- because the unique index above forbids two defaults per org.
+
+INSERT INTO score_configs (organization_id, name, description, data_type, min_value, max_value, is_default)
+SELECT
+  o.id,
+  'Helpfulness',
+  'Default numeric score, 0 (not helpful) to 1 (fully addresses the user). Pre-seeded for backward compatibility.',
+  'NUMERIC',
+  0.0,
+  1.0,
+  true
+FROM organizations o
+WHERE NOT EXISTS (
+  SELECT 1 FROM score_configs sc
+  WHERE sc.organization_id = o.id
+    AND sc.is_default = true
+    AND sc.archived_at IS NULL
+);

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -1,8 +1,3 @@
-WARN: environment variable is unset: SUPABASE_AUTH_EXTERNAL_GITHUB_CLIENT_ID
-WARN: environment variable is unset: SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET
-WARN: environment variable is unset: SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID
-WARN: environment variable is unset: SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET
-Connecting to db 5432
 export type Json =
   | string
   | number
@@ -542,6 +537,10 @@ export type Database = {
           reasoning: string | null
           request_id: string | null
           score: number
+          score_config_id: string | null
+          value_boolean: boolean | null
+          value_number: number | null
+          value_string: string | null
         }
         Insert: {
           created_at?: string
@@ -554,6 +553,10 @@ export type Database = {
           reasoning?: string | null
           request_id?: string | null
           score: number
+          score_config_id?: string | null
+          value_boolean?: boolean | null
+          value_number?: number | null
+          value_string?: string | null
         }
         Update: {
           created_at?: string
@@ -566,6 +569,10 @@ export type Database = {
           reasoning?: string | null
           request_id?: string | null
           score?: number
+          score_config_id?: string | null
+          value_boolean?: boolean | null
+          value_number?: number | null
+          value_string?: string | null
         }
         Relationships: [
           {
@@ -587,6 +594,13 @@ export type Database = {
             columns: ["organization_id"]
             isOneToOne: false
             referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "eval_results_score_config_id_fkey"
+            columns: ["score_config_id"]
+            isOneToOne: false
+            referencedRelation: "score_configs"
             referencedColumns: ["id"]
           },
         ]
@@ -1013,8 +1027,12 @@ export type Database = {
           raw_score: number | null
           request_id: string
           reviewer_id: string
-          score: number
+          score: number | null
+          score_config_id: string | null
           updated_at: string
+          value_boolean: boolean | null
+          value_number: number | null
+          value_string: string | null
         }
         Insert: {
           comment?: string | null
@@ -1025,8 +1043,12 @@ export type Database = {
           raw_score?: number | null
           request_id: string
           reviewer_id: string
-          score: number
+          score?: number | null
+          score_config_id?: string | null
           updated_at?: string
+          value_boolean?: boolean | null
+          value_number?: number | null
+          value_string?: string | null
         }
         Update: {
           comment?: string | null
@@ -1037,8 +1059,12 @@ export type Database = {
           raw_score?: number | null
           request_id?: string
           reviewer_id?: string
-          score?: number
+          score?: number | null
+          score_config_id?: string | null
           updated_at?: string
+          value_boolean?: boolean | null
+          value_number?: number | null
+          value_string?: string | null
         }
         Relationships: [
           {
@@ -1053,6 +1079,13 @@ export type Database = {
             columns: ["prompt_version_id"]
             isOneToOne: false
             referencedRelation: "prompt_versions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "human_evals_score_config_id_fkey"
+            columns: ["score_config_id"]
+            isOneToOne: false
+            referencedRelation: "score_configs"
             referencedColumns: ["id"]
           },
         ]
@@ -1864,6 +1897,68 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "saved_filters_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      score_configs: {
+        Row: {
+          archived_at: string | null
+          bool_false_label: string | null
+          bool_true_label: string | null
+          categories: Json | null
+          created_at: string
+          created_by: string | null
+          data_type: string
+          description: string | null
+          id: string
+          is_default: boolean
+          max_value: number | null
+          min_value: number | null
+          name: string
+          organization_id: string
+          updated_at: string
+        }
+        Insert: {
+          archived_at?: string | null
+          bool_false_label?: string | null
+          bool_true_label?: string | null
+          categories?: Json | null
+          created_at?: string
+          created_by?: string | null
+          data_type: string
+          description?: string | null
+          id?: string
+          is_default?: boolean
+          max_value?: number | null
+          min_value?: number | null
+          name: string
+          organization_id: string
+          updated_at?: string
+        }
+        Update: {
+          archived_at?: string | null
+          bool_false_label?: string | null
+          bool_true_label?: string | null
+          categories?: Json | null
+          created_at?: string
+          created_by?: string | null
+          data_type?: string
+          description?: string | null
+          id?: string
+          is_default?: boolean
+          max_value?: number | null
+          min_value?: number | null
+          name?: string
+          organization_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "score_configs_organization_id_fkey"
             columns: ["organization_id"]
             isOneToOne: false
             referencedRelation: "organizations"
@@ -2695,5 +2790,3 @@ export const Constants = {
   },
 } as const
 
-A new version of Supabase CLI is available: v2.105.0 (currently installed v2.90.0)
-We recommend updating regularly for new features and bug fixes: https://supabase.com/docs/guides/cli/getting-started#updating-the-supabase-cli


### PR DESCRIPTION
## Summary

First PR of [4B.1 ScoreConfig 타입화](docs/plans/langfuse-benchmarking-success-criteria.md). Pre-4B.1 every eval result and human feedback row carried a single \`score float\` normalized to 0..1 — enough for a slider but not for the categorical, boolean, and free-text shapes that real workspaces want (persona checks, pass/fail toggles, reviewer notes).

This PR ships the backend infrastructure + admin management UI. The annotation widget switch, the eval-runner judge response parser, and the typed aggregation charts are each follow-up PRs.

## Migration safety

\`20260608010000_score_configs.sql\` — **additive** (new table + new nullable columns on existing tables). Backfill seeds one default \`Helpfulness\` NUMERIC 0..1 config per existing org, so the picker is never empty for legacy data. No backfill required for existing eval_results / human_evals rows; the aggregation code falls back to the legacy \`score\` column when \`score_config_id\` is NULL.

The only schema-tightening change: \`human_evals.score\` drops NOT NULL so categorical/boolean/text rows can save without inventing a fake float. Existing rows keep their values; the legacy POST contract still works (caller supplies \`score\`, server treats it as the default NUMERIC config's value).

## Scope kept narrow

| In this PR | Follow-up PR |
|---|---|
| Backend: score_configs CRUD + validation | eval-runner judge response parser (NUMERIC + BOOLEAN) |
| human-evals POST extended with \`scoreConfigId\` + \`value\` | Annotation widget switch (categorical radio / boolean toggle / text textarea) |
| /settings/score-configs management page | Typed aggregation charts (CategoricalDistribution, BOOLEAN pass-rate) |

## Test plan

- [x] Server typecheck + lint clean
- [x] Web typecheck + lint clean
- [x] 661 server unit tests pass (added 29 in \`score-validation.test.ts\`)
- [x] Local migration applied + verified one default config per org
- [x] Chrome MCP visual: /settings/score-configs renders, New config dialog morphs by type, CATEGORICAL config creation end-to-end works
- [ ] Production: verify default config row gets backfilled for every existing org on deploy
- [ ] Production: navigate to /settings/score-configs once deployed and confirm seed visible