### PR TITLE
feat: 4B.2 Spanlens dogfoods itself — eval-runner posts traces internally

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -57,3 +57,14 @@ CLICKHOUSE_URL=http://localhost:8123
 CLICKHOUSE_USER=spanlens
 CLICKHOUSE_PASSWORD=spanlens
 CLICKHOUSE_DB=spanlens
+
+# 4B.2 — Spanlens dogfoods itself. When both vars are set the
+# eval-runner posts a `eval_run` trace to a dedicated "spanlens-team"
+# workspace so we can see our own LLM-judge cost / latency / errors in
+# /traces alongside customer data. Leave blank locally and in CI — the
+# tracing helper degrades to no-op so nothing leaks to production.
+#
+# SPANLENS_INTERNAL_BASE_URL=https://server.spanlens.io
+# SPANLENS_INTERNAL_API_KEY=sl_live_<hex>
+SPANLENS_INTERNAL_BASE_URL=
+SPANLENS_INTERNAL_API_KEY=

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -16,6 +16,7 @@ import { requestsScope, selectRequests } from './requests-query.js'
 import { aes256Decrypt } from './crypto.js'
 import { calculateCost } from './cost.js'
 import { buildOpenAIBody } from './playground-runner.js'
+import { startInternalTrace } from './internal-tracing.js'
 
 const JUDGE_CONCURRENCY = 5
 const MAX_RESPONSE_CHARS = 4000 // truncate long responses fed to judge
@@ -637,6 +638,19 @@ export async function runEvalRun(input: RunInput): Promise<void> {
     .update({ status: 'running' })
     .eq('id', evalRunId)
 
+  // 4B.2 — dogfood ourselves. Every eval run posts a trace to the
+  // spanlens-team workspace so we see our own eval cost / latency /
+  // error rate in the same /traces view our customers use. The handle
+  // is created up front so per-sample spans can chain off its
+  // creationPromise without a blocking await.
+  const internalTrace = startInternalTrace('eval_run', {
+    eval_run_id: evalRunId,
+    evaluator_id: evaluatorId,
+    organization_id: organizationId,
+    source,
+    sample_size: sampleSize,
+  })
+
   try {
     // Load evaluator config. `score_config_id` is nullable — when NULL we
     // keep the legacy NUMERIC-only behaviour exactly so existing
@@ -850,17 +864,50 @@ export async function runEvalRun(input: RunInput): Promise<void> {
       return
     }
 
-    // Score each sample with the judge LLM
+    // Score each sample with the judge LLM. Each sample becomes one
+    // `llm_judge` span under the eval_run trace so we can see per-call
+    // cost / latency / token use in /traces. Span lifecycle is
+    // intentionally outside the try/catch so a failed judge call still
+    // gets ended with status='error' instead of leaving a dangling
+    // LIVE span.
     const outcomes = await pool(preparedSamples, JUDGE_CONCURRENCY, async (sample): Promise<SampleOutcome | null> => {
+      const span = internalTrace.startSpan('llm_judge', {
+        spanType: 'llm',
+        metadata: {
+          judge_provider: config.judge_provider,
+          judge_model: config.judge_model,
+          request_id: sample.requestId,
+          dataset_item_id: sample.datasetItemId,
+        },
+      })
       try {
         const outcome = await callJudge(config, sample.responseText, judgeKey)
-        if (!outcome) return null
+        if (!outcome) {
+          span.end({ status: 'error', errorMessage: 'callJudge returned null' })
+          return null
+        }
+        span.end({
+          status: 'completed',
+          output: {
+            score: outcome.score,
+            value_number: outcome.value_number,
+            value_string: outcome.value_string,
+            value_boolean: outcome.value_boolean,
+            reasoning: outcome.reasoning,
+          },
+          costUsd: outcome.cost,
+          totalTokens: outcome.tokens,
+        })
         return {
           requestId: sample.requestId,
           datasetItemId: sample.datasetItemId,
           ...outcome,
         }
-      } catch {
+      } catch (err) {
+        span.end({
+          status: 'error',
+          errorMessage: err instanceof Error ? err.message : 'callJudge threw',
+        })
         return null
       }
     })
@@ -876,6 +923,11 @@ export async function runEvalRun(input: RunInput): Promise<void> {
           completed_at: new Date().toISOString(),
         })
         .eq('id', evalRunId)
+      internalTrace.end({
+        status: 'error',
+        errorMessage: 'All judge calls failed',
+        metadata: { scored_count: 0, total_samples: preparedSamples.length },
+      })
       return
     }
 
@@ -940,6 +992,15 @@ export async function runEvalRun(input: RunInput): Promise<void> {
         completed_at: new Date().toISOString(),
       })
       .eq('id', evalRunId)
+    internalTrace.end({
+      status: 'completed',
+      metadata: {
+        scored_count: scored.length,
+        total_samples: preparedSamples.length,
+        avg_score: avgScore,
+        total_cost_usd: totalCost,
+      },
+    })
   } catch (err) {
     await supabaseAdmin
       .from('eval_runs')
@@ -949,6 +1010,10 @@ export async function runEvalRun(input: RunInput): Promise<void> {
         completed_at: new Date().toISOString(),
       })
       .eq('id', evalRunId)
+    internalTrace.end({
+      status: 'error',
+      errorMessage: err instanceof Error ? err.message : 'Unknown error',
+    })
   }
 }
 

--- a/apps/server/src/lib/internal-tracing.test.ts
+++ b/apps/server/src/lib/internal-tracing.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// We isolate the module under test so we can flip `process.env` and
+// re-import to exercise both the "disabled" and "enabled" branches in
+// the same test file. Vitest's `vi.resetModules()` makes that cheap.
+
+describe('internal-tracing — disabled (no env)', () => {
+  beforeEach(() => {
+    delete process.env['SPANLENS_INTERNAL_BASE_URL']
+    delete process.env['SPANLENS_INTERNAL_API_KEY']
+    vi.resetModules()
+  })
+
+  it('startInternalTrace returns a stub handle that does not throw', async () => {
+    const mod = await import('./internal-tracing.js')
+    const trace = mod.startInternalTrace('foo')
+    expect(trace).toBeDefined()
+    expect(await trace.creationPromise).toBeNull()
+    trace.end() // no-op
+  })
+
+  it('startSpan on a disabled trace also stubs', async () => {
+    const mod = await import('./internal-tracing.js')
+    const trace = mod.startInternalTrace('foo')
+    const span = trace.startSpan('judge', { spanType: 'llm' })
+    expect(await span.creationPromise).toBeNull()
+    span.end({ status: 'completed' })
+  })
+
+  it('internalTracingEnabled() returns false', async () => {
+    const mod = await import('./internal-tracing.js')
+    expect(mod.internalTracingEnabled()).toBe(false)
+  })
+})
+
+describe('internal-tracing — enabled (env present)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    process.env['SPANLENS_INTERNAL_BASE_URL'] = 'https://example.test'
+    process.env['SPANLENS_INTERNAL_API_KEY'] = 'sl_live_test'
+    fetchMock = vi.fn()
+    // The lib reads `fetch` from the global scope; vi.stubGlobal makes
+    // the swap testable and unwinds automatically in afterEach.
+    vi.stubGlobal('fetch', fetchMock)
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    delete process.env['SPANLENS_INTERNAL_BASE_URL']
+    delete process.env['SPANLENS_INTERNAL_API_KEY']
+  })
+
+  it('POSTs to /ingest/traces with the right shape', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: true, data: { id: 'trc_1' } }), { status: 201 }),
+    )
+    const mod = await import('./internal-tracing.js')
+    const trace = mod.startInternalTrace('eval_run', { evaluator_id: 'evl_1' })
+    const id = await trace.creationPromise
+    expect(id).toBe('trc_1')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://example.test/ingest/traces')
+    const initHeaders = init.headers as Record<string, string>
+    expect(initHeaders['Authorization']).toBe('Bearer sl_live_test')
+    const body = JSON.parse(init.body as string)
+    expect(body.name).toBe('eval_run')
+    expect(body.metadata).toEqual({ evaluator_id: 'evl_1' })
+    expect(typeof body.started_at).toBe('string')
+  })
+
+  it('returns null id when the POST fails', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 500 }))
+    const mod = await import('./internal-tracing.js')
+    const trace = mod.startInternalTrace('eval_run')
+    expect(await trace.creationPromise).toBeNull()
+  })
+
+  it('returns null id when fetch throws', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network'))
+    const mod = await import('./internal-tracing.js')
+    const trace = mod.startInternalTrace('eval_run')
+    expect(await trace.creationPromise).toBeNull()
+  })
+
+  it('chains span creation behind trace creation', async () => {
+    let resolveTrace!: (v: Response) => void
+    const traceCreate = new Promise<Response>((resolve) => { resolveTrace = resolve })
+    fetchMock
+      .mockImplementationOnce(() => traceCreate)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true, data: { id: 'spn_1' } }), { status: 201 }),
+      )
+
+    const mod = await import('./internal-tracing.js')
+    const trace = mod.startInternalTrace('t')
+    const span = trace.startSpan('s', { spanType: 'llm' })
+
+    // Resolve the trace POST only after we've kicked off span creation.
+    // This proves span POST waits on the trace id rather than racing.
+    resolveTrace(
+      new Response(JSON.stringify({ success: true, data: { id: 'trc_1' } }), { status: 201 }),
+    )
+
+    const spanId = await span.creationPromise
+    expect(spanId).toBe('spn_1')
+
+    // Two POSTs total — trace then span.
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const [, spanInit] = fetchMock.mock.calls[1]
+    expect((fetchMock.mock.calls[1][0] as string)).toBe('https://example.test/ingest/traces/trc_1/spans')
+    const spanBody = JSON.parse(spanInit.body as string)
+    expect(spanBody.name).toBe('s')
+    expect(spanBody.span_type).toBe('llm')
+  })
+
+  it('end() PATCHes the trace once creation resolves', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: true, data: { id: 'trc_42' } }), { status: 201 }),
+    )
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 200 }))
+
+    const mod = await import('./internal-tracing.js')
+    const trace = mod.startInternalTrace('t')
+    await trace.creationPromise // ensure trace POST settles
+    trace.end({ status: 'completed', metadata: { ok: true } })
+
+    // Give the background end() PATCH a tick to fire.
+    await new Promise((r) => setTimeout(r, 5))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const [url, init] = fetchMock.mock.calls[1]
+    expect(url).toBe('https://example.test/ingest/traces/trc_42')
+    expect(init.method).toBe('PATCH')
+    const body = JSON.parse(init.body as string)
+    expect(body.status).toBe('completed')
+    expect(body.ended_at).toBeTypeOf('string')
+    expect(body.metadata).toEqual({ ok: true })
+  })
+
+  it('does NOT throw when end() called after a failed creation', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 500 }))
+    const mod = await import('./internal-tracing.js')
+    const trace = mod.startInternalTrace('t')
+    expect(() => trace.end({ status: 'error', errorMessage: 'boom' })).not.toThrow()
+    // No PATCH should be sent because creation returned null.
+    await new Promise((r) => setTimeout(r, 5))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/server/src/lib/internal-tracing.test.ts
+++ b/apps/server/src/lib/internal-tracing.test.ts
@@ -61,7 +61,9 @@ describe('internal-tracing — enabled (env present)', () => {
     const id = await trace.creationPromise
     expect(id).toBe('trc_1')
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    const [url, init] = fetchMock.mock.calls[0]
+    const call = fetchMock.mock.calls[0]
+    if (!call) throw new Error('fetch was not called')
+    const [url, init] = call as [string, RequestInit]
     expect(url).toBe('https://example.test/ingest/traces')
     const initHeaders = init.headers as Record<string, string>
     expect(initHeaders['Authorization']).toBe('Bearer sl_live_test')
@@ -109,8 +111,10 @@ describe('internal-tracing — enabled (env present)', () => {
 
     // Two POSTs total — trace then span.
     expect(fetchMock).toHaveBeenCalledTimes(2)
-    const [, spanInit] = fetchMock.mock.calls[1]
-    expect((fetchMock.mock.calls[1][0] as string)).toBe('https://example.test/ingest/traces/trc_1/spans')
+    const spanCall = fetchMock.mock.calls[1]
+    if (!spanCall) throw new Error('span fetch not called')
+    const [spanUrl, spanInit] = spanCall as [string, RequestInit]
+    expect(spanUrl).toBe('https://example.test/ingest/traces/trc_1/spans')
     const spanBody = JSON.parse(spanInit.body as string)
     expect(spanBody.name).toBe('s')
     expect(spanBody.span_type).toBe('llm')
@@ -131,7 +135,9 @@ describe('internal-tracing — enabled (env present)', () => {
     await new Promise((r) => setTimeout(r, 5))
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
-    const [url, init] = fetchMock.mock.calls[1]
+    const endCall = fetchMock.mock.calls[1]
+    if (!endCall) throw new Error('end PATCH not called')
+    const [url, init] = endCall as [string, RequestInit]
     expect(url).toBe('https://example.test/ingest/traces/trc_42')
     expect(init.method).toBe('PATCH')
     const body = JSON.parse(init.body as string)

--- a/apps/server/src/lib/internal-tracing.ts
+++ b/apps/server/src/lib/internal-tracing.ts
@@ -1,0 +1,257 @@
+/**
+ * Internal tracing — Spanlens instruments itself with Spanlens.
+ *
+ * Every eval / experiment / playground run on our own server posts a
+ * trace + spans to the public ingest API of a dedicated "spanlens-team"
+ * workspace, so we can see our own eval cost, latency, error rate on
+ * the same /traces view our customers use.
+ *
+ * Design constraints:
+ *
+ *   • Fail-open. If the internal API key is missing, the upstream is
+ *     down, or any single fetch errors, the runner that called us
+ *     MUST continue uninterrupted. Customer evals cannot fail because
+ *     our own observability stopped working.
+ *
+ *   • Hot-path latency must be negligible. Returning the trace/span
+ *     handle immediately while the underlying POST runs in the
+ *     background is the same trick `packages/sdk` uses (gotcha #10 in
+ *     CLAUDE.md). The handle chains its `_creationPromise` so a child
+ *     span POST waits for the parent's INSERT to commit before the
+ *     server checks ownership.
+ *
+ *   • Cron / Edge friendly. The runner is invoked via
+ *     `fireAndForget(c, runEvalRun(...))` which means the function body
+ *     keeps running after the HTTP response is sent. We do NOT use
+ *     `c.executionCtx` here because it isn't always available.
+ *
+ *   • No SDK import. The official SDK has heavier deps + a bigger
+ *     surface area. A 200-line local wrapper is faster to audit and
+ *     keeps `apps/server` cold-start lean. If the wire format changes
+ *     we only have one file to update.
+ *
+ * Env vars (read once at module load):
+ *
+ *   SPANLENS_INTERNAL_BASE_URL  https://server.spanlens.io  (or local)
+ *   SPANLENS_INTERNAL_API_KEY   sl_live_<hex>               (full-scope key
+ *                                                            of the
+ *                                                            spanlens-team
+ *                                                            workspace)
+ *
+ * When either is missing the module degrades to no-op: every public
+ * function returns a stub handle whose .end() is a no-op. This is the
+ * only safe default for local dev and CI — nobody else should ever ship
+ * traces to our internal workspace.
+ */
+
+const BASE_URL = process.env['SPANLENS_INTERNAL_BASE_URL']
+const API_KEY = process.env['SPANLENS_INTERNAL_API_KEY']
+
+/**
+ * `true` when both env vars are present. We snapshot this once so a
+ * hot-path branch is a single boolean check, not a string compare.
+ */
+const ENABLED = Boolean(BASE_URL && API_KEY)
+
+interface InternalIngestSuccess { success: true; data: { id: string } }
+interface InternalIngestError { success?: false; error?: string }
+
+async function postIngest<T>(path: string, body: Record<string, unknown>): Promise<T | null> {
+  if (!ENABLED) return null
+  try {
+    const res = await fetch(`${BASE_URL}${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${API_KEY}`,
+      },
+      body: JSON.stringify(body),
+    })
+    if (!res.ok) return null
+    return (await res.json()) as T
+  } catch {
+    return null
+  }
+}
+
+async function patchIngest(path: string, body: Record<string, unknown>): Promise<void> {
+  if (!ENABLED) return
+  try {
+    await fetch(`${BASE_URL}${path}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${API_KEY}`,
+      },
+      body: JSON.stringify(body),
+    })
+  } catch {
+    // Swallow — internal tracing must never escalate to a caller-visible error.
+  }
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+export interface InternalTraceHandle {
+  /** Chains future span POSTs behind the trace creation INSERT. */
+  readonly creationPromise: Promise<string | null>
+  startSpan(name: string, opts?: SpanOpts): InternalSpanHandle
+  end(opts?: { status?: 'completed' | 'error'; errorMessage?: string; metadata?: Record<string, unknown> }): void
+}
+
+export interface InternalSpanHandle {
+  readonly creationPromise: Promise<string | null>
+  end(opts?: SpanEndOpts): void
+}
+
+export interface SpanOpts {
+  spanType?: 'llm' | 'tool' | 'retrieval' | 'chain' | 'agent'
+  input?: unknown
+  metadata?: Record<string, unknown>
+}
+
+export interface SpanEndOpts {
+  status?: 'completed' | 'error'
+  output?: unknown
+  errorMessage?: string
+  metadata?: Record<string, unknown>
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
+  costUsd?: number
+}
+
+/**
+ * Stub handle returned when tracing is disabled or the trace POST
+ * fails. Every method is a no-op so call sites don't need to null-check.
+ */
+function stubTrace(): InternalTraceHandle {
+  const nullPromise = Promise.resolve(null)
+  return {
+    creationPromise: nullPromise,
+    startSpan(): InternalSpanHandle {
+      return { creationPromise: nullPromise, end() { /* no-op */ } }
+    },
+    end() { /* no-op */ },
+  }
+}
+
+/**
+ * Start a trace. Returns immediately with a handle whose
+ * `creationPromise` resolves to the server-assigned trace id (or null
+ * on failure). The caller never awaits us directly.
+ *
+ * @param name     Short trace name, e.g. "eval_run".
+ * @param metadata Free-form tags written on the trace row.
+ */
+export function startInternalTrace(
+  name: string,
+  metadata?: Record<string, unknown>,
+): InternalTraceHandle {
+  if (!ENABLED) return stubTrace()
+
+  const startedAt = new Date().toISOString()
+  const creationPromise = (async (): Promise<string | null> => {
+    const body: Record<string, unknown> = { name, started_at: startedAt }
+    if (metadata) body['metadata'] = metadata
+    const result = await postIngest<InternalIngestSuccess | InternalIngestError>(
+      '/ingest/traces',
+      body,
+    )
+    if (!result || !('success' in result) || !result.success) return null
+    return result.data.id
+  })()
+
+  return {
+    creationPromise,
+    startSpan(spanName, opts) {
+      return startSpanImpl(creationPromise, null, spanName, opts)
+    },
+    end(opts) {
+      // Chain the PATCH behind the trace's own creation INSERT so the
+      // server can find the row by id. We intentionally do NOT await
+      // this in the caller — it runs in the background.
+      void (async () => {
+        const traceId = await creationPromise
+        if (!traceId) return
+        const body: Record<string, unknown> = {
+          status: opts?.status ?? 'completed',
+          ended_at: new Date().toISOString(),
+        }
+        if (opts?.errorMessage) body['error_message'] = opts.errorMessage
+        if (opts?.metadata) body['metadata'] = opts.metadata
+        await patchIngest(`/ingest/traces/${traceId}`, body)
+      })()
+    },
+  }
+}
+
+/**
+ * Internal helper — implements both the trace-level and span-level
+ * `startSpan`. Parent id may be null (top-level under the trace) or a
+ * promise resolving to another span's id.
+ */
+function startSpanImpl(
+  traceIdPromise: Promise<string | null>,
+  parentIdPromise: Promise<string | null> | null,
+  name: string,
+  opts?: SpanOpts,
+): InternalSpanHandle {
+  const startedAt = new Date().toISOString()
+  const creationPromise = (async (): Promise<string | null> => {
+    const traceId = await traceIdPromise
+    if (!traceId) return null
+    const parentSpanId = parentIdPromise ? await parentIdPromise : null
+    const body: Record<string, unknown> = { name, started_at: startedAt }
+    if (parentSpanId) body['parent_span_id'] = parentSpanId
+    if (opts?.spanType) body['span_type'] = opts.spanType
+    if (opts?.input !== undefined) body['input'] = opts.input
+    if (opts?.metadata) body['metadata'] = opts.metadata
+    const result = await postIngest<InternalIngestSuccess | InternalIngestError>(
+      `/ingest/traces/${traceId}/spans`,
+      body,
+    )
+    if (!result || !('success' in result) || !result.success) return null
+    return result.data.id
+  })()
+
+  return {
+    creationPromise,
+    end(endOpts) {
+      void (async () => {
+        const spanId = await creationPromise
+        if (!spanId) return
+        const body: Record<string, unknown> = {
+          status: endOpts?.status ?? 'completed',
+          ended_at: new Date().toISOString(),
+        }
+        if (endOpts?.output !== undefined) body['output'] = endOpts.output
+        if (endOpts?.errorMessage) body['error_message'] = endOpts.errorMessage
+        if (endOpts?.metadata) body['metadata'] = endOpts.metadata
+        if (endOpts?.promptTokens != null) body['prompt_tokens'] = endOpts.promptTokens
+        if (endOpts?.completionTokens != null) body['completion_tokens'] = endOpts.completionTokens
+        if (endOpts?.totalTokens != null) body['total_tokens'] = endOpts.totalTokens
+        if (endOpts?.costUsd != null) body['cost_usd'] = endOpts.costUsd
+        await patchIngest(`/ingest/spans/${spanId}`, body)
+      })()
+    },
+  }
+}
+
+/**
+ * Test helper — re-reads the env vars and re-snapshots the ENABLED
+ * flag. Used by `internal-tracing.test.ts` to flip the state without
+ * restarting Vitest.
+ */
+export function _refreshEnabledFlagForTests(): boolean {
+  return Boolean(process.env['SPANLENS_INTERNAL_BASE_URL'] && process.env['SPANLENS_INTERNAL_API_KEY'])
+}
+
+/**
+ * Whether internal tracing is currently active. Mostly for diagnostics
+ * and the health endpoint; callers should NOT branch on this — the
+ * stub handle is designed to be safe to call unconditionally.
+ */
+export function internalTracingEnabled(): boolean {
+  return ENABLED
+}


### PR DESCRIPTION
Every eval run on our own server posts an `eval_run` trace + per-sample `llm_judge` spans to a dedicated `spanlens-team` workspace, so we see our own eval cost / latency / errors in the same /traces view our customers use.

## Safety model

- **Opt-in by env.** `SPANLENS_INTERNAL_BASE_URL` + `SPANLENS_INTERNAL_API_KEY` not set → every public function returns a stub handle whose every method is a no-op. Local dev, CI, and production-before-rollout all behave exactly like before.
- **Fail-open.** Every fetch is try/catch + status-checked. Internal tracing CANNOT throw back into eval-runner. Customer evals can never fail because our own observability stopped working.
- **No hot-path latency.** `startInternalTrace` returns immediately; the POST runs in the background. Spans chain their POSTs behind the trace's `creationPromise` (CLAUDE.md gotcha #10) so the server-side ownership check on /ingest/spans never 404s due to a race.

## Highlights

- New `lib/internal-tracing.ts` (~250 lines, no SDK dep)
- `eval-runner.runEvalRun` opens an `eval_run` trace, wraps each `callJudge` in an `llm_judge` span, ends both in all 3 terminal paths (success / allFailed / catch) — never a dangling LIVE span
- `.env.example` documents the two new vars + the no-op fallback
- 9 unit tests covering disabled path, POST shape, failure modes, span chaining race-safety, end() PATCH, end() after failed creation

## Production rollout (separate step, not in this PR)

1. Create a `spanlens-team` workspace + a project + a full-scope `sl_live_*` key
2. Register `SPANLENS_INTERNAL_BASE_URL` and `SPANLENS_INTERNAL_API_KEY` in Vercel production env
3. Trigger an eval run, watch the trace land in the `spanlens-team` /traces view

## Test plan

- [x] Server typecheck + lint clean
- [x] 693 server tests pass (+9 new)
- [ ] Local: trigger eval run, verify no errors when env unset (no-op path)
- [ ] Production: after env registered, first eval run produces a trace with N spans
- [ ] Production: confirm pre-existing eval runs continue unchanged (no schema change to eval_results)