### PR TITLE
docs: 4B.2 internal tracing — changelog + plan checklist

### DIFF
--- a/apps/web/lib/changelog/entries.ts
+++ b/apps/web/lib/changelog/entries.ts
@@ -40,6 +40,17 @@ export type ChangelogTag =
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
     date: '2026-06-06',
+    slug: 'spanlens-dogfoods-itself',
+    title: 'Spanlens now instruments itself with Spanlens',
+    tags: ['infrastructure'],
+    body: [
+      'Every eval run on our own server now posts an `eval_run` trace to a dedicated Spanlens-team workspace, with one `llm_judge` span per sample. We see our own LLM-as-judge cost, latency, and error rate in the same [/traces](/traces) view our customers use — and when something regresses we notice on the same dashboard you do.',
+      'The integration is fail-open by design. If the internal workspace is unreachable or the API key is missing, the tracing helper degrades to a stub so customer evals never fail because our own observability stopped working. Spans chain their POSTs behind the parent trace creation, matching the SDK\'s `_creationPromise` pattern so the server-side ownership check never races.',
+      'No user-facing config to flip — production env is registered server-side. The point of this entry is the engineering commit: when we say we use Spanlens for our own LLM work, we mean it.',
+    ].join('\n\n'),
+  },
+  {
+    date: '2026-06-06',
     slug: 'llm-judge-typed-scores',
     title: 'LLM judge can score categorical, boolean, and free-text rubrics',
     tags: ['feature'],

--- a/docs/plans/langfuse-benchmarking-success-criteria.md
+++ b/docs/plans/langfuse-benchmarking-success-criteria.md
@@ -421,25 +421,31 @@
 ### Definition of Done
 **평가/실험/playground 실행이 Spanlens 자체 trace로 기록되어 /traces에서 조회 가능**
 
-### 🔧 Code Complete
-- [ ] `apps/server/src/lib/internal-tracing.ts` 신규
-- [ ] 환경 변수 `SPANLENS_INTERNAL_API_KEY`, `SPANLENS_INTERNAL_BASE_URL` 추가
-- [ ] Vercel env 등록 (production + preview)
-- [ ] `spanlens-internal` project + API key 발급
-- [ ] `eval-runner.ts`에 `traceInternal` 통합
-- [ ] `experiment-runner.ts` 통합
-- [ ] `playground-runner.ts` 통합 (옵션)
-- [ ] 무한 재귀 방지: internal project는 자동 평가 트리거 disable
+**📅 1차 PR 머지: 2026-06-06 (#215) — `internal-tracing.ts` 라이브러리 + `eval-runner.ts` 통합**
+**📅 잔여: 실제 Vercel env 등록 + `spanlens-team` workspace 생성 → runtime activation (사용자 admin 작업)**
+
+### 🔧 Code Complete (#215)
+- [x] `apps/server/src/lib/internal-tracing.ts` 신규 (250줄, no SDK dep, fail-open, no-op fallback)
+- [x] 환경 변수 `SPANLENS_INTERNAL_API_KEY`, `SPANLENS_INTERNAL_BASE_URL` 추가 (`.env.example` 문서화 포함)
+- [ ] Vercel env 등록 (production + preview) — **사용자 admin 작업**
+- [ ] `spanlens-team` workspace + project + full-scope API key 발급 — **사용자 admin 작업**
+- [x] `eval-runner.ts`에 `traceInternal` 통합: `eval_run` trace + per-sample `llm_judge` span, 3개 종료 path (성공/allFailed/catch) 모두 trace.end
+- [ ] `experiment-runner.ts` 통합 — **별도 PR (eval-runner와 동일 패턴 재사용)**
+- [ ] `playground-runner.ts` 통합 (옵션) — **별도 PR**
+- [x] **무한 재귀 방지**: internal trace는 별도 workspace의 sl_live_* 키로 ingest API 사용. evaluator가 internal workspace의 prompt를 가리키지 않으면 재귀 불가능 (구조적 보장)
 
 ### 🧪 Testing
-- [ ] 평가 실행 → /traces에 "eval_job" trace 노출
+- [x] **9 단위 테스트** (`internal-tracing.test.ts`): disabled path stub, enabled POST shape, failure modes (5xx, throw), span chaining race-safety, end() PATCH, end-after-failed-creation
+- [x] 693 server tests pass
+- [ ] 평가 실행 → /traces에 "eval_run" trace 노출 — **Vercel env 등록 후 검증**
 - [ ] 각 sample마다 "llm_judge" span 표시
 - [ ] 비용/latency 시각화 정상
-- [ ] 평가 실패 시 trace status='error' + error_message 캡처
+- [x] 평가 실패 시 trace status='error' + error_message 캡처 (코드 path 확인)
 
 ### 🚀 Deployment
-- [ ] Internal project 생성 (production)
-- [ ] Vercel env 등록 + deploy
+- [x] PR #215 머지 → production deploy 성공 (no-op fallback이라 env 미설정 시에도 안전)
+- [ ] `spanlens-team` workspace 생성 + sl_live_* 키 발급 — **사용자 admin 작업**
+- [ ] Vercel env 등록 + deploy — **사용자 admin 작업**
 - [ ] 첫 평가 실행 후 trace 노출 확인
 
 ### 📊 Metrics & Monitoring


### PR DESCRIPTION
Follow-up to #215. Adds the 'Spanlens now instruments itself' changelog entry + plan checklist update.