### PR TITLE
feat: 4B.2b experiment-runner + playground also dogfood via internal-tracing

### DIFF
--- a/apps/server/src/api/prompts-playground.ts
+++ b/apps/server/src/api/prompts-playground.ts
@@ -4,6 +4,7 @@ import { supabaseAdmin } from '../lib/db.js'
 import { aes256Decrypt } from '../lib/crypto.js'
 import { calculateCost } from '../lib/cost.js'
 import { interpolate, inferProvider, buildOpenAIBody } from '../lib/playground-runner.js'
+import { startInternalTrace } from '../lib/internal-tracing.js'
 
 export const promptsPlaygroundRouter = new Hono<JwtContext>()
 
@@ -106,6 +107,23 @@ promptsPlaygroundRouter.post('/run', async (c) => {
 
   const { result: interpolated, missingVars } = interpolate(pv.content, variables)
 
+  // 4B.2b — dogfood ourselves. Each playground run posts a
+  // `playground_call` trace + a single `llm` span to the spanlens-team
+  // workspace so we can audit our own model/temperature/maxTokens
+  // choices alongside customer traffic.
+  const internalTrace = startInternalTrace('playground_call', {
+    organization_id: orgId,
+    prompt_version_id: promptVersionId,
+    model,
+    provider: modelProvider,
+    temperature,
+    max_tokens: maxTokens,
+  })
+  const span = internalTrace.startSpan('llm', {
+    spanType: 'llm',
+    metadata: { model, provider: modelProvider },
+  })
+
   const startMs = Date.now()
 
   if (modelProvider === 'openai') {
@@ -126,6 +144,8 @@ promptsPlaygroundRouter.post('/run', async (c) => {
 
     if (!upstreamRes.ok) {
       const text = await upstreamRes.text().catch(() => '')
+      span.end({ status: 'error', errorMessage: `OpenAI ${upstreamRes.status}` })
+      internalTrace.end({ status: 'error', errorMessage: `OpenAI ${upstreamRes.status}` })
       return c.json({ error: `OpenAI error: ${text}`, upstreamStatus: upstreamRes.status }, 502)
     }
 
@@ -140,6 +160,19 @@ promptsPlaygroundRouter.post('/run', async (c) => {
     const completionTokens = json.usage?.completion_tokens ?? 0
     const resolvedModel = json.model ?? model
     const cost = calculateCost('openai', resolvedModel, { promptTokens, completionTokens })
+
+    span.end({
+      status: 'completed',
+      ...(cost?.totalCost != null ? { costUsd: cost.totalCost } : {}),
+      promptTokens,
+      completionTokens,
+      totalTokens: promptTokens + completionTokens,
+      metadata: { resolved_model: resolvedModel, latency_ms: latencyMs },
+    })
+    internalTrace.end({
+      status: 'completed',
+      metadata: { latency_ms: latencyMs, cost_usd: cost?.totalCost ?? null },
+    })
 
     return c.json({
       success: true,
@@ -176,6 +209,8 @@ promptsPlaygroundRouter.post('/run', async (c) => {
 
   if (!upstreamRes.ok) {
     const text = await upstreamRes.text().catch(() => '')
+    span.end({ status: 'error', errorMessage: `Anthropic ${upstreamRes.status}` })
+    internalTrace.end({ status: 'error', errorMessage: `Anthropic ${upstreamRes.status}` })
     return c.json({ error: `Anthropic error: ${text}`, upstreamStatus: upstreamRes.status }, 502)
   }
 
@@ -190,6 +225,19 @@ promptsPlaygroundRouter.post('/run', async (c) => {
   const completionTokens = json.usage?.output_tokens ?? 0
   const resolvedModel = json.model ?? model
   const cost = calculateCost('anthropic', resolvedModel, { promptTokens, completionTokens })
+
+  span.end({
+    status: 'completed',
+    ...(cost?.totalCost != null ? { costUsd: cost.totalCost } : {}),
+    promptTokens,
+    completionTokens,
+    totalTokens: promptTokens + completionTokens,
+    metadata: { resolved_model: resolvedModel, latency_ms: latencyMs },
+  })
+  internalTrace.end({
+    status: 'completed',
+    metadata: { latency_ms: latencyMs, cost_usd: cost?.totalCost ?? null },
+  })
 
   return c.json({
     success: true,

--- a/apps/server/src/lib/experiment-runner.ts
+++ b/apps/server/src/lib/experiment-runner.ts
@@ -15,6 +15,7 @@ import { supabaseAdmin } from './db.js'
 import { aes256Decrypt } from './crypto.js'
 import { calculateCost } from './cost.js'
 import { interpolate, buildOpenAIBody } from './playground-runner.js'
+import { startInternalTrace } from './internal-tracing.js'
 
 const ITEM_CONCURRENCY = 3
 const MAX_TOKENS = 1024
@@ -386,6 +387,24 @@ export async function runExperiment(input: RunInput): Promise<void> {
     .update({ status: 'running' })
     .eq('id', experimentId)
 
+  // 4B.2b — dogfood ourselves. Every A/B experiment posts an
+  // `ab_experiment` trace to the spanlens-team workspace so we can see
+  // our own per-arm cost and judge agreement in /traces. Each dataset
+  // item becomes one `ab_item` span — we keep both arms inside a single
+  // span (with arm details in metadata) rather than spamming two spans
+  // per item, since the trace UI groups by name and a 100-item dataset
+  // would otherwise create 200 sibling spans that are hard to scan.
+  const internalTrace = startInternalTrace('ab_experiment', {
+    experiment_id: experimentId,
+    organization_id: organizationId,
+    version_a_id: versionAId,
+    version_b_id: versionBId,
+    dataset_id: datasetId,
+    evaluator_id: evaluatorId ?? null,
+    run_provider: runProvider,
+    run_model: runModel,
+  })
+
   try {
     // Load both prompt versions
     const { data: versions, error: vErr } = await supabaseAdmin
@@ -482,49 +501,81 @@ export async function runExperiment(input: RunInput): Promise<void> {
     }
 
     const outcomes = await pool(items as DatasetItemRow[], ITEM_CONCURRENCY, async (item): Promise<ItemOutcome> => {
-      // Run both arms in parallel
-      const [aResult, bResult] = await Promise.all([
-        runPrompt(versionA.content, item, runProvider, runModel, runApiKey),
-        runPrompt(versionB.content, item, runProvider, runModel, runApiKey),
-      ])
+      // One span per item covering both A/B arms + the optional judge
+      // call. End-state is decided once we know if either arm errored.
+      const itemSpan = internalTrace.startSpan('ab_item', {
+        spanType: 'chain',
+        metadata: { dataset_item_id: item.id },
+      })
 
-      const outcome: ItemOutcome = {
-        datasetItemId: item.id,
-        outputA: 'output' in aResult ? aResult.output : null,
-        outputB: 'output' in bResult ? bResult.output : null,
-        costA: 'cost' in aResult ? aResult.cost : 0,
-        costB: 'cost' in bResult ? bResult.cost : 0,
-        latencyA: 'latencyMs' in aResult ? aResult.latencyMs : null,
-        latencyB: 'latencyMs' in bResult ? bResult.latencyMs : null,
-        tokensA: 'tokens' in aResult ? aResult.tokens : 0,
-        tokensB: 'tokens' in bResult ? bResult.tokens : 0,
-        scoreA: null, scoreB: null,
-        reasoningA: null, reasoningB: null,
-        errorA: 'error' in aResult ? aResult.error : null,
-        errorB: 'error' in bResult ? bResult.error : null,
-      }
+      try {
+        // Run both arms in parallel
+        const [aResult, bResult] = await Promise.all([
+          runPrompt(versionA.content, item, runProvider, runModel, runApiKey),
+          runPrompt(versionB.content, item, runProvider, runModel, runApiKey),
+        ])
 
-      // Optionally judge both outputs
-      if (evaluatorConfig && judgeApiKey) {
-        if (outcome.outputA) {
-          const j = await callJudge(evaluatorConfig, outcome.outputA, judgeApiKey)
-          if (j) {
-            outcome.scoreA = j.score
-            outcome.reasoningA = j.reasoning
-            outcome.costA += j.cost
+        const outcome: ItemOutcome = {
+          datasetItemId: item.id,
+          outputA: 'output' in aResult ? aResult.output : null,
+          outputB: 'output' in bResult ? bResult.output : null,
+          costA: 'cost' in aResult ? aResult.cost : 0,
+          costB: 'cost' in bResult ? bResult.cost : 0,
+          latencyA: 'latencyMs' in aResult ? aResult.latencyMs : null,
+          latencyB: 'latencyMs' in bResult ? bResult.latencyMs : null,
+          tokensA: 'tokens' in aResult ? aResult.tokens : 0,
+          tokensB: 'tokens' in bResult ? bResult.tokens : 0,
+          scoreA: null, scoreB: null,
+          reasoningA: null, reasoningB: null,
+          errorA: 'error' in aResult ? aResult.error : null,
+          errorB: 'error' in bResult ? bResult.error : null,
+        }
+
+        // Optionally judge both outputs
+        if (evaluatorConfig && judgeApiKey) {
+          if (outcome.outputA) {
+            const j = await callJudge(evaluatorConfig, outcome.outputA, judgeApiKey)
+            if (j) {
+              outcome.scoreA = j.score
+              outcome.reasoningA = j.reasoning
+              outcome.costA += j.cost
+            }
+          }
+          if (outcome.outputB) {
+            const j = await callJudge(evaluatorConfig, outcome.outputB, judgeApiKey)
+            if (j) {
+              outcome.scoreB = j.score
+              outcome.reasoningB = j.reasoning
+              outcome.costB += j.cost
+            }
           }
         }
-        if (outcome.outputB) {
-          const j = await callJudge(evaluatorConfig, outcome.outputB, judgeApiKey)
-          if (j) {
-            outcome.scoreB = j.score
-            outcome.reasoningB = j.reasoning
-            outcome.costB += j.cost
-          }
-        }
-      }
 
-      return outcome
+        // Both arms ok-ish? Even partial success counts — error_a /
+        // error_b on the row is the per-arm detail.
+        const bothErrored = outcome.errorA && outcome.errorB
+        itemSpan.end({
+          status: bothErrored ? 'error' : 'completed',
+          output: {
+            cost_a_usd: outcome.costA,
+            cost_b_usd: outcome.costB,
+            score_a: outcome.scoreA,
+            score_b: outcome.scoreB,
+          },
+          costUsd: outcome.costA + outcome.costB,
+          totalTokens: outcome.tokensA + outcome.tokensB,
+          ...(bothErrored
+            ? { errorMessage: `A: ${outcome.errorA} · B: ${outcome.errorB}` }
+            : {}),
+        })
+        return outcome
+      } catch (err) {
+        itemSpan.end({
+          status: 'error',
+          errorMessage: err instanceof Error ? err.message : 'item processing threw',
+        })
+        throw err
+      }
     })
 
     // Persist results
@@ -571,6 +622,15 @@ export async function runExperiment(input: RunInput): Promise<void> {
         completed_at: new Date().toISOString(),
       })
       .eq('id', experimentId)
+    internalTrace.end({
+      status: 'completed',
+      metadata: {
+        completed_items: outcomes.length,
+        avg_score_a: avgA,
+        avg_score_b: avgB,
+        total_cost_usd: totalCost,
+      },
+    })
   } catch (err) {
     await supabaseAdmin
       .from('experiments')
@@ -580,5 +640,9 @@ export async function runExperiment(input: RunInput): Promise<void> {
         completed_at: new Date().toISOString(),
       })
       .eq('id', experimentId)
+    internalTrace.end({
+      status: 'error',
+      errorMessage: err instanceof Error ? err.message : 'Unknown error',
+    })
   }
 }


### PR DESCRIPTION
Extends #215 — every A/B experiment now posts an `ab_experiment` trace with one `ab_item` span per dataset item, and every Playground call posts a `playground_call` trace + a single `llm` span. Mirrors the eval-runner integration shipped earlier.

Same fail-open helper, so this PR is a no-op until SPANLENS_INTERNAL_* env vars are set on the deployment.

## Test plan
- [x] Server typecheck + lint + 693 tests
- [x] No schema change, no test fixture update
- [ ] Production (env already registered in #215): trigger an A/B experiment, confirm `ab_experiment` trace + N `ab_item` spans land in /traces
- [ ] Production: open Playground, run one prompt, confirm `playground_call` trace appears