### PR TITLE
feat: 5.1 Stage 1 — events table + dual-write shadow

### DIFF
--- a/apps/server/src/__tests__/gotcha.test.ts
+++ b/apps/server/src/__tests__/gotcha.test.ts
@@ -173,7 +173,8 @@ describe('logRequestAsync — ClickHouse write path', () => {
       spanId: null,
     })
 
-    expect(mockClickhouseInsert).toHaveBeenCalledOnce()
+    // Phase 5.1 dual-write: requests + events shadow insert = 2 calls.
+    expect(mockClickhouseInsert).toHaveBeenCalledTimes(2)
     const row = getInsertedRow()
     expect(row.organization_id).toBe('org-1')
     expect(row.provider).toBe('openai')

--- a/apps/server/src/__tests__/logger-fallback.test.ts
+++ b/apps/server/src/__tests__/logger-fallback.test.ts
@@ -96,7 +96,8 @@ describe('logRequestAsync — happy path', () => {
 
     await logRequestAsync(baseLog)
 
-    expect(clickhouseInsertMock).toHaveBeenCalledOnce()
+    // Phase 5.1 dual-write: requests + events shadow insert = 2 calls.
+    expect(clickhouseInsertMock).toHaveBeenCalledTimes(2)
     expect(fallbackInsertMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/server/src/api/ingest.ts
+++ b/apps/server/src/api/ingest.ts
@@ -40,6 +40,8 @@ function computeDurationMs(startedAt: string | null, endedAt: string | null): nu
   return end - start
 }
 
+import { writeTraceAsEvent, writeSpanAsEvent } from '../lib/events-writer.js'
+
 // ── POST /ingest/traces ──────────────────────────────────────
 ingestRouter.post('/traces', async (c) => {
   const organizationId = c.get('organizationId')
@@ -93,6 +95,20 @@ ingestRouter.post('/traces', async (c) => {
   if (error || !data) {
     return c.json({ error: 'Failed to create trace', detail: error?.message }, 500)
   }
+
+  // Phase 5.1 dual-write to events. Best-effort — events is still
+  // the shadow store; reads come from Postgres traces.
+  void writeTraceAsEvent({
+    traceId: data.id as string,
+    organizationId,
+    projectId,
+    apiKeyId,
+    name: insert.name,
+    startedAt: (data.started_at as string) ?? new Date().toISOString(),
+    metadata: insert.metadata ?? null,
+  }).catch((err) => {
+    console.error('[ingest] trace events shadow INSERT failed:', err instanceof Error ? err.message : err)
+  })
 
   return c.json({ success: true, data }, 201)
 })
@@ -266,6 +282,23 @@ ingestRouter.post('/traces/:id/spans', async (c) => {
   if (error || !data) {
     return c.json({ error: 'Failed to create span', detail: error?.message }, 500)
   }
+
+  // Phase 5.1 dual-write to events.
+  void writeSpanAsEvent({
+    spanId: data.id as string,
+    traceId,
+    parentSpanId: insert.parent_span_id ?? null,
+    organizationId,
+    projectId: (insert as { project_id?: string }).project_id ?? '',
+    apiKeyId: null,
+    name: insert.name,
+    spanType: insert.span_type ?? null,
+    startedAt: (data.started_at as string) ?? new Date().toISOString(),
+    input: insert.input,
+    metadata: insert.metadata ?? null,
+  }).catch((err) => {
+    console.error('[ingest] span events shadow INSERT failed:', err instanceof Error ? err.message : err)
+  })
 
   return c.json({ success: true, data }, 201)
 })

--- a/apps/server/src/lib/events-query.ts
+++ b/apps/server/src/lib/events-query.ts
@@ -1,0 +1,117 @@
+/**
+ * Phase 5.1 events table query helpers.
+ *
+ * Mirrors the contract of `requests-query.ts` (tenant isolation +
+ * plan retention) for the new `events` table. Reads against `events`
+ * MUST go through `eventsScope()` so they:
+ *
+ *   1. Filter `organization_id` (ClickHouse has no RLS).
+ *   2. Clip the time window to the org's plan retention.
+ *
+ * NOTE: in Stage 1 nothing reads from `events` yet — this file ships
+ * with the dual-write so the eventual reading-switch PR (Stage 3) is
+ * a pure flag flip, not a "design the query layer" PR. Tests still
+ * cover the helpers so the contract is locked in.
+ */
+
+import { getClickhouse } from './clickhouse.js'
+import { LOG_RETENTION_DAYS, type Plan } from './quota.js'
+import { getOrgPlan } from './requests-query.js'
+
+export interface EventsScope {
+  /**
+   * SQL fragment that must appear at the start of every WHERE clause
+   * against `events`. No leading WHERE / AND.
+   */
+  readonly whereScope: string
+  readonly scopeParams: Readonly<{ orgId: string; retentionDays: number }>
+  readonly plan: Plan
+}
+
+export interface EventsScopeOptions {
+  /**
+   * Skip the plan retention window. Required for billing / quota / admin
+   * paths. Do NOT use for user-facing reads.
+   */
+  readonly ignoreRetention?: boolean
+}
+
+/**
+ * Resolves the org + retention WHERE scope for `events` queries.
+ */
+export async function eventsScope(
+  organizationId: string,
+  options: EventsScopeOptions = {},
+): Promise<EventsScope> {
+  const plan = await getOrgPlan(organizationId)
+  const retentionDays = LOG_RETENTION_DAYS[plan]
+  const whereScope = options.ignoreRetention
+    ? 'organization_id = {orgId:UUID}'
+    : 'organization_id = {orgId:UUID} ' +
+      'AND created_at >= now() - INTERVAL {retentionDays:UInt32} DAY'
+  return {
+    whereScope,
+    scopeParams: { orgId: organizationId, retentionDays },
+    plan,
+  }
+}
+
+/**
+ * Select rows from `events`. Same signature as `selectRequests` to make
+ * the eventual reading-switch (Stage 3) a near-mechanical replacement.
+ *
+ * `select` is interpolated raw into the SELECT clause — callers MUST
+ * keep it free of user input.
+ */
+export async function selectEvents<T>(opts: {
+  scope: EventsScope
+  select: string
+  filters?: string
+  params?: Record<string, unknown>
+  orderBy?: string
+  limit?: number
+  offset?: number
+}): Promise<T[]> {
+  const { scope, select, filters, params, orderBy, limit, offset } = opts
+
+  const whereParts = [scope.whereScope]
+  if (filters && filters.length > 0) whereParts.push(filters)
+  const where = whereParts.join(' AND ')
+
+  const tail: string[] = []
+  if (orderBy) tail.push(`ORDER BY ${orderBy}`)
+  if (typeof limit === 'number') tail.push(`LIMIT ${Math.max(0, Math.floor(limit))}`)
+  if (typeof offset === 'number') tail.push(`OFFSET ${Math.max(0, Math.floor(offset))}`)
+
+  const query = `SELECT ${select} FROM events WHERE ${where} ${tail.join(' ')}`.trim()
+
+  const res = await getClickhouse().query({
+    query,
+    query_params: { ...scope.scopeParams, ...(params ?? {}) },
+    format: 'JSONEachRow',
+  })
+  return (await res.json()) as T[]
+}
+
+/**
+ * COUNT(*) variant. Callers don't have to thread "select count(*)"
+ * through the same pipeline.
+ */
+export async function countEvents(opts: {
+  scope: EventsScope
+  filters?: string
+  params?: Record<string, unknown>
+}): Promise<number> {
+  const { scope, filters, params } = opts
+  const whereParts = [scope.whereScope]
+  if (filters && filters.length > 0) whereParts.push(filters)
+  const where = whereParts.join(' AND ')
+  const query = `SELECT count() AS c FROM events WHERE ${where}`
+  const res = await getClickhouse().query({
+    query,
+    query_params: { ...scope.scopeParams, ...(params ?? {}) },
+    format: 'JSONEachRow',
+  })
+  const rows = (await res.json()) as Array<{ c: string }>
+  return Number(rows[0]?.c ?? 0)
+}

--- a/apps/server/src/lib/events-writer.test.ts
+++ b/apps/server/src/lib/events-writer.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the ClickHouse client BEFORE importing events-writer so the
+// mock is in place when the module wires its imports.
+const insertMock = vi.fn().mockResolvedValue(undefined)
+vi.mock('./clickhouse.js', () => ({
+  getClickhouse: () => ({ insert: insertMock }),
+  // Strip 'T' / 'Z' the way the real toClickhouseTimestamp does so
+  // assertions stay deterministic.
+  toClickhouseTimestamp: (d: Date = new Date()) =>
+    d.toISOString().replace('T', ' ').replace('Z', ''),
+}))
+
+import { writeRequestAsEvent, writeTraceAsEvent, writeSpanAsEvent } from './events-writer.js'
+
+afterEach(() => insertMock.mockClear())
+
+describe('writeRequestAsEvent', () => {
+  const baseData = {
+    organizationId: 'org-1',
+    projectId: 'prj-1',
+    provider: 'openai',
+    model: 'gpt-4o-mini',
+    promptTokens: 100,
+    completionTokens: 50,
+    totalTokens: 150,
+    costUsd: 0.001,
+    latencyMs: 1200,
+    statusCode: 200,
+    requestBody: null,
+    responseBody: null,
+    errorMessage: null,
+    traceId: null,
+    spanId: null,
+  } as const
+
+  const requestRow = {
+    id: 'evt-1',
+    cost_usd: 0.001,
+    created_at: '2026-06-06 00:00:00.000',
+    request_body: '{"messages":[]}',
+    response_body: '{"choices":[]}',
+    error_message: null,
+  }
+
+  it('inserts an event_type=generation row into events', async () => {
+    await writeRequestAsEvent(baseData, requestRow)
+    expect(insertMock).toHaveBeenCalledTimes(1)
+    const call = insertMock.mock.calls[0]?.[0]
+    expect(call.table).toBe('events')
+    expect(call.values).toHaveLength(1)
+    const row = call.values[0]
+    expect(row.event_id).toBe('evt-1')
+    expect(row.event_type).toBe('generation')
+    expect(row.provider).toBe('openai')
+    expect(row.model).toBe('gpt-4o-mini')
+  })
+
+  it('synthesises trace_id when caller did not supply one', async () => {
+    await writeRequestAsEvent(baseData, requestRow)
+    const row = insertMock.mock.calls[0]?.[0].values[0]
+    // UUID v4 shape; not equal to event_id when no traceId provided.
+    expect(row.trace_id).toMatch(/^[0-9a-f-]{36}$/)
+    expect(row.trace_id).not.toBe(row.event_id)
+  })
+
+  it('preserves caller trace_id and parent span_id', async () => {
+    await writeRequestAsEvent(
+      { ...baseData, traceId: 'trc-7', spanId: 'spn-9' },
+      requestRow,
+    )
+    const row = insertMock.mock.calls[0]?.[0].values[0]
+    expect(row.trace_id).toBe('trc-7')
+    expect(row.parent_event_id).toBe('spn-9')
+  })
+
+  it('writes the usage map with historical keys + optional cache tokens', async () => {
+    await writeRequestAsEvent(
+      { ...baseData, cacheReadTokens: 7, cacheWriteTokens: 3 },
+      requestRow,
+    )
+    const row = insertMock.mock.calls[0]?.[0].values[0]
+    expect(row.usage_details).toEqual({
+      prompt_tokens: 100,
+      completion_tokens: 50,
+      total_tokens: 150,
+      cache_read_tokens: 7,
+      cache_write_tokens: 3,
+    })
+  })
+
+  it('writes cost_details only when costUsd is present', async () => {
+    await writeRequestAsEvent({ ...baseData, costUsd: null }, requestRow)
+    const row = insertMock.mock.calls[0]?.[0].values[0]
+    expect(row.cost_details).toEqual({})
+    expect(row.total_cost_usd).toBeNull()
+  })
+})
+
+describe('writeTraceAsEvent', () => {
+  it('writes a trace row with event_type=trace and equal event_id/trace_id', async () => {
+    await writeTraceAsEvent({
+      traceId: 'trc-1',
+      organizationId: 'org-1',
+      projectId: 'prj-1',
+      name: 'eval_run',
+      startedAt: '2026-06-06T00:00:00.000Z',
+      metadata: { evaluator_id: 'evl-1', source: 'production' },
+    })
+    expect(insertMock).toHaveBeenCalledTimes(1)
+    const row = insertMock.mock.calls[0]?.[0].values[0]
+    expect(row.event_id).toBe('trc-1')
+    expect(row.trace_id).toBe('trc-1')
+    expect(row.parent_event_id).toBeNull()
+    expect(row.event_type).toBe('trace')
+    expect(row.metadata['evaluator_id']).toBe('evl-1')
+    expect(row.metadata['source']).toBe('production')
+  })
+})
+
+describe('writeSpanAsEvent', () => {
+  it('writes a span row with parent_event_id pointing at the parent', async () => {
+    await writeSpanAsEvent({
+      spanId: 'spn-1',
+      traceId: 'trc-1',
+      parentSpanId: 'spn-0',
+      organizationId: 'org-1',
+      projectId: 'prj-1',
+      name: 'llm_judge',
+      spanType: 'llm',
+      startedAt: '2026-06-06T00:00:00.000Z',
+      promptTokens: 200,
+      completionTokens: 75,
+      totalTokens: 275,
+      costUsd: 0.0008,
+    })
+    expect(insertMock).toHaveBeenCalledTimes(1)
+    const row = insertMock.mock.calls[0]?.[0].values[0]
+    expect(row.event_id).toBe('spn-1')
+    expect(row.trace_id).toBe('trc-1')
+    expect(row.parent_event_id).toBe('spn-0')
+    expect(row.event_type).toBe('span')
+    expect(row.metadata['span_type']).toBe('llm')
+    expect(row.usage_details).toEqual({
+      prompt_tokens: 200,
+      completion_tokens: 75,
+      total_tokens: 275,
+    })
+    expect(row.cost_details).toEqual({ total_cost_usd: 0.0008 })
+    expect(row.total_tokens).toBe(275)
+  })
+})

--- a/apps/server/src/lib/events-writer.ts
+++ b/apps/server/src/lib/events-writer.ts
@@ -1,0 +1,254 @@
+/**
+ * Phase 5.1 dual-write — events table shadow inserts.
+ *
+ * The runtime contract:
+ *
+ *   • Reads still come from `requests` (LLM calls) and Postgres
+ *     `traces` / `spans`. `events` is a shadow store while we
+ *     dual-write, backfill, and gradually flip dashboard reads.
+ *   • Every helper here MUST NOT throw back to the caller. If the
+ *     CH INSERT fails the row is silently dropped; the source
+ *     `requests` row already landed. We log loudly so a sustained
+ *     outage is visible in Sentry but never escalate to a 5xx.
+ *   • Helpers are pure mapping + a single CH insert call. No
+ *     dependency on the request scan, security flags, fallback queue,
+ *     or webhook chain — those stay on the requests path until
+ *     reads cut over.
+ *
+ * This file is intentionally thin so we can audit the
+ * requests → events mapping in one diff. The schema lives in
+ * `clickhouse/migrations/004_create_events.sql`.
+ */
+
+import { randomUUID } from 'node:crypto'
+import { getClickhouse, toClickhouseTimestamp } from './clickhouse.js'
+import type { RequestLogData } from './logger.js'
+
+/**
+ * Shape of the row that landed in `requests`. We re-use the field
+ * names so the call site in logger.ts can pass `clickhouseRow`
+ * straight through.
+ */
+interface RequestRowLike {
+  id: string
+  cost_usd: number | null
+  created_at: string
+  request_body: string
+  response_body: string
+  error_message: string | null
+}
+
+/**
+ * Write an LLM call as an `event_type='generation'` row in events.
+ * Called from logger.ts AFTER the `requests` insert succeeds.
+ */
+export async function writeRequestAsEvent(
+  data: RequestLogData,
+  requestRow: RequestRowLike,
+): Promise<void> {
+  // `usage_details` is the open-ended token map. For backwards
+  // compatibility with the existing dashboard we include the
+  // historical keys (prompt/completion/total/cache_read/cache_write)
+  // even when zero — the lookup is cheaper than a "key missing" check
+  // on the read side.
+  const usageDetails: Record<string, number> = {
+    prompt_tokens: data.promptTokens,
+    completion_tokens: data.completionTokens,
+    total_tokens: data.totalTokens,
+    cache_read_tokens: data.cacheReadTokens ?? 0,
+    cache_write_tokens: data.cacheWriteTokens ?? 0,
+  }
+  const costDetails: Record<string, number> = {}
+  if (data.costUsd != null) {
+    costDetails['total_cost_usd'] = data.costUsd
+  }
+
+  const metadata: Record<string, string> = {}
+  if (data.serviceTier) metadata['service_tier'] = data.serviceTier
+  if (data.truncated) metadata['truncated'] = 'true'
+
+  const eventRow = {
+    event_id: requestRow.id,
+    // For an LLM call without an explicit trace we generate a
+    // synthetic trace_id so every row in events has a non-null
+    // trace_id (queries don't need a special-case null branch).
+    trace_id: data.traceId ?? randomUUID(),
+    parent_event_id: data.spanId ?? null,
+    event_type: 'generation',
+    organization_id: data.organizationId,
+    project_id: data.projectId,
+    api_key_id: data.apiKeyId ?? null,
+    name: `${data.provider}.${data.model}`,
+    provider: data.provider,
+    model: data.model,
+    start_time: requestRow.created_at,
+    end_time: requestRow.created_at,
+    // Reuse the proxy-measured latency. Faster than re-deriving from
+    // start/end (which are equal when we don't know the start).
+    duration_ms: data.latencyMs,
+    input: requestRow.request_body,
+    output: requestRow.response_body,
+    usage_details: usageDetails,
+    cost_details: costDetails,
+    total_cost_usd: data.costUsd ?? null,
+    total_tokens: data.totalTokens,
+    status_code: data.statusCode,
+    error_message: requestRow.error_message,
+    metadata,
+    user_id: data.userId ?? null,
+    session_id: data.sessionId ?? null,
+    prompt_version_id: data.promptVersionId ?? null,
+    provider_key_id: data.providerKeyId ?? null,
+    created_at: requestRow.created_at,
+  }
+
+  await getClickhouse().insert({
+    table: 'events',
+    format: 'JSONEachRow',
+    values: [eventRow],
+  })
+}
+
+// ── Trace + span shadow writes (used by ingest API) ──────────────────────────
+
+export interface TraceEventInput {
+  traceId: string
+  organizationId: string
+  projectId: string
+  apiKeyId?: string | null
+  name: string
+  startedAt: string
+  endedAt?: string | null
+  status?: string | null
+  errorMessage?: string | null
+  metadata?: Record<string, unknown> | null
+  durationMs?: number | null
+}
+
+export async function writeTraceAsEvent(input: TraceEventInput): Promise<void> {
+  const created = toClickhouseTimestamp(new Date(input.startedAt))
+  const metadata: Record<string, string> = { source: 'ingest_trace' }
+  if (input.status) metadata['status'] = input.status
+  if (input.metadata) {
+    // The ingest API stores trace metadata as JSONB. Flatten top-level
+    // string values into the events `metadata` map; nested objects go
+    // into the `input` payload as JSON so we don't lose them.
+    for (const [k, v] of Object.entries(input.metadata)) {
+      if (typeof v === 'string') metadata[k] = v
+    }
+  }
+
+  const eventRow = {
+    event_id: input.traceId,
+    trace_id: input.traceId,
+    parent_event_id: null,
+    event_type: 'trace',
+    organization_id: input.organizationId,
+    project_id: input.projectId,
+    api_key_id: input.apiKeyId ?? null,
+    name: input.name,
+    provider: '',
+    model: '',
+    start_time: created,
+    end_time: input.endedAt ? toClickhouseTimestamp(new Date(input.endedAt)) : null,
+    duration_ms: input.durationMs ?? null,
+    input: input.metadata ? JSON.stringify(input.metadata) : '',
+    output: '',
+    usage_details: {},
+    cost_details: {},
+    total_cost_usd: null,
+    total_tokens: 0,
+    status_code: 0,
+    error_message: input.errorMessage ?? null,
+    metadata,
+    user_id: null,
+    session_id: null,
+    prompt_version_id: null,
+    provider_key_id: null,
+    created_at: created,
+  }
+
+  await getClickhouse().insert({
+    table: 'events',
+    format: 'JSONEachRow',
+    values: [eventRow],
+  })
+}
+
+export interface SpanEventInput {
+  spanId: string
+  traceId: string
+  parentSpanId?: string | null
+  organizationId: string
+  projectId: string
+  apiKeyId?: string | null
+  name: string
+  spanType?: string | null
+  startedAt: string
+  endedAt?: string | null
+  durationMs?: number | null
+  status?: string | null
+  errorMessage?: string | null
+  input?: unknown
+  output?: unknown
+  metadata?: Record<string, unknown> | null
+  promptTokens?: number | null
+  completionTokens?: number | null
+  totalTokens?: number | null
+  costUsd?: number | null
+}
+
+export async function writeSpanAsEvent(input: SpanEventInput): Promise<void> {
+  const created = toClickhouseTimestamp(new Date(input.startedAt))
+  const usageDetails: Record<string, number> = {}
+  if (input.promptTokens != null) usageDetails['prompt_tokens'] = input.promptTokens
+  if (input.completionTokens != null) usageDetails['completion_tokens'] = input.completionTokens
+  if (input.totalTokens != null) usageDetails['total_tokens'] = input.totalTokens
+  const costDetails: Record<string, number> = {}
+  if (input.costUsd != null) costDetails['total_cost_usd'] = input.costUsd
+
+  const metadata: Record<string, string> = { source: 'ingest_span' }
+  if (input.spanType) metadata['span_type'] = input.spanType
+  if (input.status) metadata['status'] = input.status
+  if (input.metadata) {
+    for (const [k, v] of Object.entries(input.metadata)) {
+      if (typeof v === 'string') metadata[k] = v
+    }
+  }
+
+  const eventRow = {
+    event_id: input.spanId,
+    trace_id: input.traceId,
+    parent_event_id: input.parentSpanId ?? null,
+    event_type: 'span',
+    organization_id: input.organizationId,
+    project_id: input.projectId,
+    api_key_id: input.apiKeyId ?? null,
+    name: input.name,
+    provider: '',
+    model: '',
+    start_time: created,
+    end_time: input.endedAt ? toClickhouseTimestamp(new Date(input.endedAt)) : null,
+    duration_ms: input.durationMs ?? null,
+    input: input.input != null ? JSON.stringify(input.input) : '',
+    output: input.output != null ? JSON.stringify(input.output) : '',
+    usage_details: usageDetails,
+    cost_details: costDetails,
+    total_cost_usd: input.costUsd ?? null,
+    total_tokens: input.totalTokens ?? 0,
+    status_code: 0,
+    error_message: input.errorMessage ?? null,
+    metadata,
+    user_id: null,
+    session_id: null,
+    prompt_version_id: null,
+    provider_key_id: null,
+    created_at: created,
+  }
+
+  await getClickhouse().insert({
+    table: 'events',
+    format: 'JSONEachRow',
+    values: [eventRow],
+  })
+}

--- a/apps/server/src/lib/logger.ts
+++ b/apps/server/src/lib/logger.ts
@@ -5,6 +5,7 @@ import { maskApiKeysInBody, maskApiKeys } from './pii-mask.js'
 import { scanAll, type SecurityFlag } from './security-scan.js'
 import { sendEmail, renderSecurityAlertEmail } from './resend.js'
 import { emitWebhookEvent } from './webhook-emit.js'
+import { writeRequestAsEvent } from './events-writer.js'
 
 /**
  * Customer-controlled body logging mode (sent via the `x-spanlens-log-body`
@@ -279,6 +280,17 @@ export async function logRequestAsync(data: RequestLogData): Promise<void> {
       table: 'requests',
       format: 'JSONEachRow',
       values: [clickhouseRow],
+    })
+    // ── Phase 5.1 dual-write to events ───────────────────────────────────────
+    // Best-effort. A failure here MUST NOT roll back the requests INSERT —
+    // events is still in the "shadow" stage; reads come from requests, so
+    // a missing events row is recoverable later by backfill. We log
+    // loudly so a sustained outage gets noticed, but don't escalate.
+    void writeRequestAsEvent(data, clickhouseRow).catch((err) => {
+      console.error(
+        '[logger] events shadow INSERT failed:',
+        err instanceof Error ? err.message : err,
+      )
     })
   } catch (err) {
     // ── ClickHouse fallback (P2.6) ─────────────────────────────────────────

--- a/clickhouse/migrations/004_create_events.sql
+++ b/clickhouse/migrations/004_create_events.sql
@@ -1,0 +1,113 @@
+-- 004_create_events.sql
+-- Unified event store. Stage 1 of Phase 5.1.
+--
+-- WHY a separate `events` table when we already have `requests`:
+--
+--   * `requests` is one row per LLM call. A user-facing "trace" is
+--     reconstructed by joining requests + traces + spans across
+--     ClickHouse and Postgres. Dashboards do this join on every
+--     pageview.
+--   * Langfuse (and PostHog, and Datadog APM) found that a single
+--     append-only `events` table — where a trace, span, and LLM
+--     generation are all variants of the same row shape — is far
+--     simpler to query and roughly 3x faster than the join.
+--   * `usage_details` as a Map lets future token kinds (vision,
+--     reasoning, cache-write tiers) land without a column migration.
+--   * Same for `cost_details` — different providers split cost
+--     differently (input/output/cache/reasoning) and a Map keeps
+--     the per-call breakdown without a wide table.
+--
+-- ROLLOUT (do NOT cut over reads until all 3 stages land):
+--
+--   Stage 1 (this PR): create the table + dual-write from logger
+--     and ingest. Reads still come from `requests` / Postgres
+--     traces. Risk-controlled — events being broken doesn't break
+--     production.
+--   Stage 2: background-migration backfill 6 months of requests
+--     into events.
+--   Stage 3: feature-flag reads per dashboard route. Roll back to
+--     `requests` if a single route mismatches.
+--
+-- The schema deliberately mirrors `requests` field naming where it
+-- can so the backfill is a straight SELECT … INSERT.
+
+CREATE TABLE IF NOT EXISTS events (
+    -- Identity. event_id is per-row; trace_id groups by trace;
+    -- parent_event_id chains spans. For type='trace' the trace_id
+    -- equals event_id and parent_event_id is empty.
+    event_id            UUID,
+    trace_id            UUID,
+    parent_event_id     Nullable(UUID),
+
+    -- Discriminator. We accept a wider value set than today (just
+    -- 'generation', 'trace', 'span') so future event kinds (eval
+    -- run, embedding, tool call, observation) don't need a column
+    -- migration. LowCardinality keeps the dictionary tight.
+    event_type          LowCardinality(String),
+
+    -- Tenant + project + caller key. organization_id is the first
+    -- sort key so single-tenant scans hit one (or a few) parts.
+    organization_id     UUID,
+    project_id          UUID,
+    api_key_id          Nullable(UUID),
+
+    -- Human label ("openai.chat.completions" for LLM calls,
+    -- "trace_name" for traces, span name for spans).
+    name                LowCardinality(String),
+
+    -- Provider + model. Empty for non-LLM events.
+    provider            LowCardinality(String) DEFAULT '',
+    model               LowCardinality(String) DEFAULT '',
+
+    -- Per-event start + end. duration_ms is denormalised so range
+    -- aggregations don't need a per-row computation.
+    start_time          DateTime64(3, 'UTC') DEFAULT now64(3),
+    end_time            Nullable(DateTime64(3, 'UTC')),
+    duration_ms         Nullable(UInt32),
+
+    -- Body columns. ZSTD-compressed strings, same trade-off as
+    -- requests. Empty string when logBody=meta/none.
+    input               String DEFAULT '' CODEC(ZSTD(3)),
+    output              String DEFAULT '' CODEC(ZSTD(3)),
+
+    -- Open-ended numeric details. Adding a new key (e.g.
+    -- "vision_input_tokens") doesn't need a column migration —
+    -- we just start writing the new key and every dashboard query
+    -- that wants it does a single map lookup.
+    usage_details       Map(String, UInt64),
+    cost_details        Map(String, Decimal(18, 8)),
+
+    -- Total cost flattened out for the common "spend over time" query
+    -- — saves the dashboard from summing the map on every row.
+    total_cost_usd      Nullable(Decimal(18, 8)),
+    total_tokens        UInt32 DEFAULT 0,
+
+    -- HTTP-style status for LLM calls (matches `requests.status_code`).
+    -- 0 for non-LLM events.
+    status_code         UInt16 DEFAULT 0,
+    error_message       Nullable(String),
+
+    -- Free-form tags. String values only so it stays cheap; complex
+    -- metadata can live in input/output JSON.
+    metadata            Map(String, String),
+
+    -- End-user / session identifiers — same semantics as
+    -- `requests.user_id` / `session_id`.
+    user_id             Nullable(String),
+    session_id          Nullable(String),
+
+    -- Optional cross-references the dashboard already cares about.
+    prompt_version_id   Nullable(UUID),
+    provider_key_id     Nullable(UUID),
+
+    created_at          DateTime64(3, 'UTC') DEFAULT now64(3)
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(created_at)
+-- Same prefix as requests (organization_id, project_id, created_at)
+-- so multitenant range scans stay fast. trace_id last so per-trace
+-- "show me all spans" queries hit the right primary-key skip.
+ORDER BY (organization_id, project_id, created_at, trace_id, event_id)
+-- Match requests' 365d TTL so we don't accidentally retain events
+-- longer than the source LLM call.
+TTL toDateTime(created_at) + INTERVAL 365 DAY;


### PR DESCRIPTION
Phase 5.1 Stage 1 of the Langfuse-style events unification. Lands the new ClickHouse `events` table and dual-writes from every LLM proxy call (via logger.ts) and every /ingest/traces or /ingest/spans call. Reads still come from the existing `requests` table and Postgres `traces` / `spans` — Stage 1 is a pure shadow write so a broken events row can never affect production.

## Rollout plan
- **Stage 1 (this PR)** — dual-write; reads unchanged.
- **Stage 2** — background-migration backfill 6 months from requests.
- **Stage 3** — feature-flag reads per dashboard route.

## Highlights
- New ClickHouse `events` table with `usage_details` / `cost_details` Map columns (future token kinds don't need a column migration)
- `lib/events-writer.ts` — 3 best-effort helpers (LLM call / trace / span), never throws back to caller
- `lib/events-query.ts` — eventsScope + selectEvents + countEvents, contract-compatible with requests-query
- 7 new unit tests + updated 2 existing logger tests for the dual-write count

## Safety model
- Events write happens AFTER the requests insert succeeds
- Detached promise + explicit `.catch` so a thrown event write cannot break the requests path
- The CH `requests_fallback` queue is unchanged — events is intentionally NOT in the fallback path because reads don't depend on it yet

## ClickHouse migration
- Apply on staging/production via `pnpm ch:migrate` (idempotent CREATE IF NOT EXISTS pattern, matches the project convention)

## Test plan
- [x] Server typecheck + lint clean
- [x] 707 server tests pass (+7 new events-writer tests; updated 2 logger assertions for 2-insert count)
- [x] Local ClickHouse migration applied
- [ ] Production: `pnpm ch:migrate` on ClickHouse Cloud after merge
- [ ] Production: monitor next 24h for `[logger] events shadow INSERT failed` log lines
- [ ] Production: cross-check 1h sample — row count in `events WHERE event_type='generation'` ≈ row count in `requests`