### PR TITLE
fix(5.1): await events shadow INSERT — fire-and-forget was being dropped

### DIFF
--- a/apps/server/src/api/ingest.ts
+++ b/apps/server/src/api/ingest.ts
@@ -96,19 +96,23 @@ ingestRouter.post('/traces', async (c) => {
     return c.json({ error: 'Failed to create trace', detail: error?.message }, 500)
   }
 
-  // Phase 5.1 dual-write to events. Best-effort — events is still
-  // the shadow store; reads come from Postgres traces.
-  void writeTraceAsEvent({
-    traceId: data.id as string,
-    organizationId,
-    projectId,
-    apiKeyId,
-    name: insert.name,
-    startedAt: (data.started_at as string) ?? new Date().toISOString(),
-    metadata: insert.metadata ?? null,
-  }).catch((err) => {
+  // Phase 5.1 dual-write to events. Best-effort — events is the shadow
+  // store; reads still come from Postgres traces. Awaited rather than
+  // fire-and-forget: an unawaited promise on Vercel Node runtime is
+  // dropped at response time (CLAUDE.md gotcha #8). ~30ms CH round trip.
+  try {
+    await writeTraceAsEvent({
+      traceId: data.id as string,
+      organizationId,
+      projectId,
+      apiKeyId,
+      name: insert.name,
+      startedAt: (data.started_at as string) ?? new Date().toISOString(),
+      metadata: insert.metadata ?? null,
+    })
+  } catch (err) {
     console.error('[ingest] trace events shadow INSERT failed:', err instanceof Error ? err.message : err)
-  })
+  }
 
   return c.json({ success: true, data }, 201)
 })
@@ -283,22 +287,25 @@ ingestRouter.post('/traces/:id/spans', async (c) => {
     return c.json({ error: 'Failed to create span', detail: error?.message }, 500)
   }
 
-  // Phase 5.1 dual-write to events.
-  void writeSpanAsEvent({
-    spanId: data.id as string,
-    traceId,
-    parentSpanId: insert.parent_span_id ?? null,
-    organizationId,
-    projectId: (insert as { project_id?: string }).project_id ?? '',
-    apiKeyId: null,
-    name: insert.name,
-    spanType: insert.span_type ?? null,
-    startedAt: (data.started_at as string) ?? new Date().toISOString(),
-    input: insert.input,
-    metadata: insert.metadata ?? null,
-  }).catch((err) => {
+  // Phase 5.1 dual-write to events — awaited for the same reason as the
+  // trace path above (CLAUDE.md gotcha #8).
+  try {
+    await writeSpanAsEvent({
+      spanId: data.id as string,
+      traceId,
+      parentSpanId: insert.parent_span_id ?? null,
+      organizationId,
+      projectId: (insert as { project_id?: string }).project_id ?? '',
+      apiKeyId: null,
+      name: insert.name,
+      spanType: insert.span_type ?? null,
+      startedAt: (data.started_at as string) ?? new Date().toISOString(),
+      input: insert.input,
+      metadata: insert.metadata ?? null,
+    })
+  } catch (err) {
     console.error('[ingest] span events shadow INSERT failed:', err instanceof Error ? err.message : err)
-  })
+  }
 
   return c.json({ success: true, data }, 201)
 })

--- a/apps/server/src/lib/logger.ts
+++ b/apps/server/src/lib/logger.ts
@@ -282,16 +282,20 @@ export async function logRequestAsync(data: RequestLogData): Promise<void> {
       values: [clickhouseRow],
     })
     // ── Phase 5.1 dual-write to events ───────────────────────────────────────
-    // Best-effort. A failure here MUST NOT roll back the requests INSERT —
-    // events is still in the "shadow" stage; reads come from requests, so
-    // a missing events row is recoverable later by backfill. We log
-    // loudly so a sustained outage gets noticed, but don't escalate.
-    void writeRequestAsEvent(data, clickhouseRow).catch((err) => {
+    // Best-effort. A failure here MUST NOT roll back the requests INSERT.
+    // Awaited rather than fire-and-forget: on Vercel Node runtime an
+    // unawaited promise inside an already-fireAndForget-wrapped
+    // function is silently dropped at response time (CLAUDE.md gotcha #8).
+    // The events INSERT round-trip is ~30ms on ClickHouse Cloud — within
+    // the waitUntil budget logRequestAsync already runs under.
+    try {
+      await writeRequestAsEvent(data, clickhouseRow)
+    } catch (err) {
       console.error(
         '[logger] events shadow INSERT failed:',
         err instanceof Error ? err.message : err,
       )
-    })
+    }
   } catch (err) {
     // ── ClickHouse fallback (P2.6) ─────────────────────────────────────────
     // CH outage / network blip / Development tier cold-start → preserve the


### PR DESCRIPTION
Production verification of #222 surfaced CLAUDE.md gotcha #8: `void writeXAsEvent(...).catch(...)` was being dropped by Vercel Node runtime at response time. The events table is empty after a successful ingest curl that returned 201, even though the source traces row landed in Postgres.

## Fix
- Await the writeRequestAsEvent / writeTraceAsEvent / writeSpanAsEvent calls (~30ms CH Cloud round trip each)
- try/catch around each so shadow writes still can't escalate a 5xx
- logger.ts is already inside a fireAndForget wrapper so latency is on the waitUntil clock
- ingest.ts adds ~30ms per POST. Within p99 budget; SDK pipelines via creationPromise so user latency unchanged

## Verification
- [x] typecheck + lint + 707 tests
- [ ] Production: trace POST followed by SELECT WHERE event_id = X returns the row