### PR TITLE
feat: 5.1 Stage 2 — backfill-events-from-requests background migration

### DIFF
--- a/apps/server/src/lib/background-migrations/registry/index.ts
+++ b/apps/server/src/lib/background-migrations/registry/index.ts
@@ -24,11 +24,18 @@
 
 import type { BackgroundMigration } from '../index.js'
 import { noopHealthcheck } from './migrations/noop-healthcheck.js'
+import { backfillEventsFromRequests } from './migrations/backfill-events-from-requests.js'
 
 const REGISTRY = new Map<string, BackgroundMigration>([
   // Always-registered no-op so the cron has something to exercise on
   // a fresh deploy. Safe to run anytime — it just yields immediately.
   [noopHealthcheck.name, noopHealthcheck],
+
+  // Phase 5.1 Stage 2 — backfill historical requests into the new
+  // events table. INSERT a row into `background_migrations` with
+  // name='backfill-events-from-requests' to start it; the cron will
+  // pick it up on the next 5-minute tick.
+  [backfillEventsFromRequests.name, backfillEventsFromRequests],
 ])
 
 export function getRegistry(): ReadonlyMap<string, BackgroundMigration> {

--- a/apps/server/src/lib/background-migrations/registry/migrations/backfill-events-from-requests.test.ts
+++ b/apps/server/src/lib/background-migrations/registry/migrations/backfill-events-from-requests.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Stub ClickHouse before importing the migration. Each test installs
+// its own query/insert mocks via vi.mocked() handles.
+const queryMock = vi.fn()
+const insertMock = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../../../clickhouse.js', () => ({
+  getClickhouse: () => ({ query: queryMock, insert: insertMock }),
+  toClickhouseTimestamp: (d: Date = new Date()) =>
+    d.toISOString().replace('T', ' ').replace('Z', ''),
+}))
+
+import { backfillEventsFromRequests, mapRequestToEventRow } from './backfill-events-from-requests.js'
+import type { ChunkState } from '../../index.js'
+
+afterEach(() => {
+  queryMock.mockReset()
+  insertMock.mockClear()
+})
+
+function makeRequestRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'req-1',
+    organization_id: 'org-1',
+    project_id: 'prj-1',
+    api_key_id: 'key-1',
+    provider: 'openai',
+    model: 'gpt-4o-mini',
+    prompt_tokens: 100,
+    completion_tokens: 50,
+    total_tokens: 150,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+    cost_usd: '0.0010',
+    latency_ms: 1200,
+    status_code: 200,
+    request_body: '{"messages":[]}',
+    response_body: '{"choices":[]}',
+    error_message: null,
+    trace_id: '00000000-0000-0000-0000-000000000000',
+    span_id: '00000000-0000-0000-0000-000000000000',
+    prompt_version_id: '00000000-0000-0000-0000-000000000000',
+    provider_key_id: '00000000-0000-0000-0000-000000000000',
+    user_id: null,
+    session_id: null,
+    service_tier: '',
+    created_at: '2026-01-01 00:00:00.000',
+    ...overrides,
+  }
+}
+
+function jsonRes<T>(rows: T[]) {
+  return { json: async () => rows as unknown }
+}
+
+describe('mapRequestToEventRow', () => {
+  it('maps the historical token columns into usage_details', () => {
+    const row = mapRequestToEventRow(makeRequestRow({ trace_id: 'trc-x' }) as never)
+    expect(row['usage_details']).toEqual({
+      prompt_tokens: 100,
+      completion_tokens: 50,
+      total_tokens: 150,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+    })
+  })
+
+  it('tags backfilled rows in metadata so they are distinguishable from live writes', () => {
+    const row = mapRequestToEventRow(makeRequestRow() as never)
+    expect(row['metadata']).toMatchObject({ source: 'backfill_requests' })
+  })
+
+  it('treats a missing trace_id as the event itself so the events table never has null trace_id', () => {
+    const row = mapRequestToEventRow(makeRequestRow({ trace_id: null }) as never)
+    expect(row['trace_id']).toBe('req-1') // event_id fallback
+  })
+
+  it('sets cost_details only when cost is present and finite', () => {
+    const withCost = mapRequestToEventRow(makeRequestRow() as never)
+    expect(withCost['cost_details']).toEqual({ total_cost_usd: 0.001 })
+    expect(withCost['total_cost_usd']).toBe(0.001)
+
+    const noCost = mapRequestToEventRow(makeRequestRow({ cost_usd: null }) as never)
+    expect(noCost['cost_details']).toEqual({})
+    expect(noCost['total_cost_usd']).toBeNull()
+  })
+})
+
+describe('backfillEventsFromRequests.runChunk', () => {
+  it('counts the total on first run and stores it in state', async () => {
+    // First call: SELECT count() returns 42.
+    queryMock.mockResolvedValueOnce(jsonRes([{ c: '42' }]))
+    // Second call: SELECT … FROM requests returns 1 row.
+    queryMock.mockResolvedValueOnce(jsonRes([makeRequestRow({ id: 'req-1' })]))
+
+    const result = await backfillEventsFromRequests.runChunk({})
+    expect(result.done).toBe(false)
+    if (result.done) return
+    expect((result.state as { total_estimate?: number }).total_estimate).toBe(42)
+    expect((result.state as { rows_processed?: number }).rows_processed).toBe(1)
+    expect(result.progressTotal).toBe(42)
+    expect(result.progressCurrent).toBe(1)
+  })
+
+  it('skips the count() on subsequent runs by reading total_estimate from state', async () => {
+    queryMock.mockResolvedValueOnce(jsonRes([makeRequestRow({ id: 'req-2' })]))
+
+    const state: ChunkState = {
+      last_created_at: '2026-01-01 00:00:00.000',
+      last_id: 'req-1',
+      rows_processed: 100,
+      total_estimate: 42,
+    }
+    await backfillEventsFromRequests.runChunk(state)
+
+    // Only the SELECT … FROM requests, no count().
+    expect(queryMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns done when SELECT yields zero rows', async () => {
+    // total_estimate already in state so we go straight to the SELECT.
+    queryMock.mockResolvedValueOnce(jsonRes([]))
+    const result = await backfillEventsFromRequests.runChunk({
+      last_created_at: '2026-01-01 00:00:00.000',
+      last_id: 'req-1',
+      rows_processed: 100,
+      total_estimate: 42,
+    } as ChunkState)
+    expect(result.done).toBe(true)
+    expect(insertMock).not.toHaveBeenCalled()
+  })
+
+  it('advances the cursor to the last row of the chunk', async () => {
+    queryMock.mockResolvedValueOnce(
+      jsonRes([
+        makeRequestRow({ id: 'req-1', created_at: '2026-01-01 00:00:00.000' }),
+        makeRequestRow({ id: 'req-2', created_at: '2026-01-01 00:00:01.000' }),
+        makeRequestRow({ id: 'req-3', created_at: '2026-01-01 00:00:02.000' }),
+      ]),
+    )
+
+    const result = await backfillEventsFromRequests.runChunk({
+      last_created_at: '1970-01-01 00:00:00.000',
+      last_id: '00000000-0000-0000-0000-000000000000',
+      rows_processed: 0,
+      total_estimate: 100,
+    } as ChunkState)
+
+    if (result.done) throw new Error('expected continuation')
+    expect((result.state as { last_id?: string }).last_id).toBe('req-3')
+    expect((result.state as { last_created_at?: string }).last_created_at).toBe(
+      '2026-01-01 00:00:02.000',
+    )
+    expect((result.state as { rows_processed?: number }).rows_processed).toBe(3)
+  })
+
+  it('writes the mapped rows into the events table', async () => {
+    queryMock.mockResolvedValueOnce(
+      jsonRes([
+        makeRequestRow({ id: 'req-1', trace_id: 'trc-1', span_id: 'spn-1' }),
+      ]),
+    )
+    await backfillEventsFromRequests.runChunk({
+      last_created_at: '1970-01-01 00:00:00.000',
+      last_id: '00000000-0000-0000-0000-000000000000',
+      rows_processed: 0,
+      total_estimate: 1,
+    } as ChunkState)
+
+    expect(insertMock).toHaveBeenCalledTimes(1)
+    const call = insertMock.mock.calls[0]?.[0]
+    expect(call.table).toBe('events')
+    const row = call.values[0]
+    expect(row.event_id).toBe('req-1')
+    expect(row.event_type).toBe('generation')
+    expect(row.trace_id).toBe('trc-1')
+    expect(row.parent_event_id).toBe('spn-1')
+  })
+
+  it('normalises empty UUIDs in the SELECT result back to null before mapping', async () => {
+    queryMock.mockResolvedValueOnce(
+      jsonRes([
+        makeRequestRow({
+          id: 'req-1',
+          trace_id: '00000000-0000-0000-0000-000000000000',
+          span_id: '00000000-0000-0000-0000-000000000000',
+        }),
+      ]),
+    )
+    await backfillEventsFromRequests.runChunk({
+      last_created_at: '1970-01-01 00:00:00.000',
+      last_id: '00000000-0000-0000-0000-000000000000',
+      rows_processed: 0,
+      total_estimate: 1,
+    } as ChunkState)
+
+    const row = insertMock.mock.calls[0]?.[0].values[0]
+    // trace_id falls back to event_id (because the null was normalised
+    // inside the migration before mapRequestToEventRow ran).
+    expect(row.trace_id).toBe('req-1')
+    expect(row.parent_event_id).toBeNull()
+  })
+
+  it('returns done if the cursor would not advance — protects against an infinite loop', async () => {
+    // Pathological case: ClickHouse returned the SAME row again. The
+    // cursor would equal itself; the migration must short-circuit.
+    queryMock.mockResolvedValueOnce(
+      jsonRes([
+        makeRequestRow({
+          id: 'req-1',
+          created_at: '2026-01-01 00:00:00.000',
+        }),
+      ]),
+    )
+
+    const result = await backfillEventsFromRequests.runChunk({
+      last_created_at: '2026-01-01 00:00:00.000',
+      last_id: 'req-1',
+      rows_processed: 1,
+      total_estimate: 1,
+    } as ChunkState)
+
+    expect(result.done).toBe(true)
+  })
+})

--- a/apps/server/src/lib/background-migrations/registry/migrations/backfill-events-from-requests.ts
+++ b/apps/server/src/lib/background-migrations/registry/migrations/backfill-events-from-requests.ts
@@ -1,0 +1,314 @@
+import type { BackgroundMigration, ChunkResult, ChunkState } from '../../index.js'
+import { getClickhouse, toClickhouseTimestamp } from '../../../clickhouse.js'
+
+/**
+ * Phase 5.1 Stage 2 — backfill the `events` table from historical
+ * `requests` rows.
+ *
+ * Strategy:
+ *
+ *   • Stream rows out of `requests` in (created_at, id) order. Both
+ *     fields are part of the table's primary key prefix so a tuple
+ *     comparison `(created_at, id) > (cursor.created_at, cursor.id)`
+ *     hits the skip-index and never scans the full table.
+ *   • For each chunk (5000 rows), map every row into the `events`
+ *     row shape — same mapping as the live dual-write but inline
+ *     here so we can pull every column out of the SELECT in a
+ *     single pass.
+ *   • INSERT the chunk into `events`. ClickHouse handles 5000-row
+ *     batches efficiently; the network round trip dominates.
+ *   • Persist the new cursor in `state` so the next chunk picks up
+ *     where we left off. If the runner crashes mid-chunk the chunk
+ *     re-runs from the prior cursor — INSERT is not idempotent (no
+ *     unique constraint on events), so duplicate rows are possible
+ *     for the in-flight chunk. The dedupe strategy in production
+ *     is the ORDER BY uniqueness check in Stage 3 reads (we filter
+ *     `argMax(…, created_at)` per event_id), so this is an
+ *     acceptable trade-off.
+ *
+ * Cursor format in `state`:
+ *
+ *   {
+ *     last_created_at: "YYYY-MM-DD HH:MM:SS.fff"  // ClickHouse fmt
+ *     last_id: "<uuid>"
+ *     rows_processed: <number>
+ *     total_estimate: <number | null>  // counted once on first run
+ *   }
+ */
+
+interface BackfillCursor {
+  last_created_at: string
+  last_id: string
+  rows_processed: number
+  total_estimate: number | null
+}
+
+interface RequestRow {
+  id: string
+  organization_id: string
+  project_id: string
+  api_key_id: string | null
+  provider: string
+  model: string
+  prompt_tokens: number
+  completion_tokens: number
+  total_tokens: number
+  cache_read_tokens: number
+  cache_write_tokens: number
+  cost_usd: string | null  // CH returns decimals as strings
+  latency_ms: number
+  status_code: number
+  request_body: string
+  response_body: string
+  error_message: string | null
+  trace_id: string | null
+  span_id: string | null
+  prompt_version_id: string | null
+  provider_key_id: string | null
+  user_id: string | null
+  session_id: string | null
+  service_tier: string
+  created_at: string
+}
+
+const CHUNK_SIZE = 5000
+
+const EPOCH_CURSOR: BackfillCursor = {
+  last_created_at: '1970-01-01 00:00:00.000',
+  last_id: '00000000-0000-0000-0000-000000000000',
+  rows_processed: 0,
+  total_estimate: null,
+}
+
+function readCursor(state: ChunkState): BackfillCursor {
+  return {
+    last_created_at:
+      typeof state['last_created_at'] === 'string'
+        ? (state['last_created_at'] as string)
+        : EPOCH_CURSOR.last_created_at,
+    last_id:
+      typeof state['last_id'] === 'string'
+        ? (state['last_id'] as string)
+        : EPOCH_CURSOR.last_id,
+    rows_processed:
+      typeof state['rows_processed'] === 'number'
+        ? (state['rows_processed'] as number)
+        : 0,
+    total_estimate:
+      typeof state['total_estimate'] === 'number'
+        ? (state['total_estimate'] as number)
+        : null,
+  }
+}
+
+/**
+ * Map a `requests` row into the events-table row shape. Matches the
+ * mapping in `lib/events-writer.ts::writeRequestAsEvent` — we keep
+ * the inline copy here so the backfill SELECT can drain every
+ * column in one pass without rebuilding a synthetic RequestLogData
+ * object.
+ */
+function mapRequestToEventRow(r: RequestRow): Record<string, unknown> {
+  const created = r.created_at
+  const usageDetails: Record<string, number> = {
+    prompt_tokens: Number(r.prompt_tokens) || 0,
+    completion_tokens: Number(r.completion_tokens) || 0,
+    total_tokens: Number(r.total_tokens) || 0,
+    cache_read_tokens: Number(r.cache_read_tokens) || 0,
+    cache_write_tokens: Number(r.cache_write_tokens) || 0,
+  }
+  const costNumeric = r.cost_usd == null ? null : Number(r.cost_usd)
+  const costDetails: Record<string, number> = {}
+  if (costNumeric != null && Number.isFinite(costNumeric)) {
+    costDetails['total_cost_usd'] = costNumeric
+  }
+
+  const metadata: Record<string, string> = { source: 'backfill_requests' }
+  if (r.service_tier) metadata['service_tier'] = r.service_tier
+
+  // ClickHouse SELECT can return non-null Nullable(UUID) as the
+  // string '00000000-...' when DEFAULT was applied — treat that as
+  // a real value rather than fabricating a fresh UUID.
+  const traceId = r.trace_id ?? r.id
+
+  return {
+    event_id: r.id,
+    trace_id: traceId,
+    parent_event_id: r.span_id ?? null,
+    event_type: 'generation',
+    organization_id: r.organization_id,
+    project_id: r.project_id,
+    api_key_id: r.api_key_id ?? null,
+    name: `${r.provider}.${r.model}`,
+    provider: r.provider,
+    model: r.model,
+    start_time: created,
+    end_time: created,
+    duration_ms: Number(r.latency_ms) || 0,
+    input: r.request_body ?? '',
+    output: r.response_body ?? '',
+    usage_details: usageDetails,
+    cost_details: costDetails,
+    total_cost_usd: costNumeric ?? null,
+    total_tokens: Number(r.total_tokens) || 0,
+    status_code: Number(r.status_code) || 0,
+    error_message: r.error_message ?? null,
+    metadata,
+    user_id: r.user_id ?? null,
+    session_id: r.session_id ?? null,
+    prompt_version_id: r.prompt_version_id ?? null,
+    provider_key_id: r.provider_key_id ?? null,
+    created_at: created,
+  }
+}
+
+/**
+ * The migration object the runner registers.
+ */
+export const backfillEventsFromRequests: BackgroundMigration = {
+  name: 'backfill-events-from-requests',
+  description:
+    'Phase 5.1 Stage 2 — copy historical LLM requests into the unified events table in chunks of ' +
+    CHUNK_SIZE +
+    ' rows, ordered by (created_at, id).',
+
+  async runChunk(state: ChunkState): Promise<ChunkResult> {
+    const cursor = readCursor(state)
+    const ch = getClickhouse()
+
+    // First-run-only: estimate the total row count so the admin UI
+    // can show a progress percentage. SELECT count() on a 6-month
+    // window can take a few seconds, but we only pay it once.
+    let totalEstimate = cursor.total_estimate
+    if (totalEstimate == null) {
+      const countRes = await ch.query({
+        query: 'SELECT count() AS c FROM requests',
+        format: 'JSONEachRow',
+      })
+      const countRows = (await countRes.json()) as Array<{ c: string }>
+      totalEstimate = Number(countRows[0]?.c ?? 0)
+    }
+
+    // Tuple comparison hits the skip index because (created_at, id)
+    // are part of the table's ORDER BY. LIMIT 5000 keeps the chunk
+    // bounded so one tick finishes in well under the 4-min budget.
+    const selectRes = await ch.query({
+      query: `
+        SELECT
+          toString(id) AS id,
+          toString(organization_id) AS organization_id,
+          toString(project_id) AS project_id,
+          toString(api_key_id) AS api_key_id,
+          provider,
+          model,
+          prompt_tokens,
+          completion_tokens,
+          total_tokens,
+          cache_read_tokens,
+          cache_write_tokens,
+          toString(cost_usd) AS cost_usd,
+          latency_ms,
+          status_code,
+          request_body,
+          response_body,
+          error_message,
+          toString(trace_id) AS trace_id,
+          toString(span_id) AS span_id,
+          toString(prompt_version_id) AS prompt_version_id,
+          toString(provider_key_id) AS provider_key_id,
+          user_id,
+          session_id,
+          service_tier,
+          toString(created_at) AS created_at
+        FROM requests
+        WHERE (created_at, id) > (parseDateTime64BestEffort({cursor_ts:String}), {cursor_id:UUID})
+        ORDER BY created_at, id
+        LIMIT ${CHUNK_SIZE}`,
+      query_params: {
+        cursor_ts: cursor.last_created_at,
+        cursor_id: cursor.last_id,
+      },
+      format: 'JSONEachRow',
+    })
+
+    const rows = (await selectRes.json()) as RequestRow[]
+
+    if (rows.length === 0) {
+      return { done: true }
+    }
+
+    // toString() in the SELECT turns the empty UUID '00000000-…'
+    // into the literal zero-uuid string for Nullable columns where
+    // the underlying value was null. Push that through map(); the
+    // writer treats it as null at INSERT time.
+    const eventRows = rows
+      .map((r) => {
+        const cleaned: RequestRow = { ...r }
+        if (cleaned.api_key_id === '00000000-0000-0000-0000-000000000000') {
+          cleaned.api_key_id = null
+        }
+        if (cleaned.trace_id === '00000000-0000-0000-0000-000000000000') {
+          cleaned.trace_id = null
+        }
+        if (cleaned.span_id === '00000000-0000-0000-0000-000000000000') {
+          cleaned.span_id = null
+        }
+        if (cleaned.prompt_version_id === '00000000-0000-0000-0000-000000000000') {
+          cleaned.prompt_version_id = null
+        }
+        if (cleaned.provider_key_id === '00000000-0000-0000-0000-000000000000') {
+          cleaned.provider_key_id = null
+        }
+        return mapRequestToEventRow(cleaned)
+      })
+
+    await ch.insert({
+      table: 'events',
+      format: 'JSONEachRow',
+      values: eventRows,
+    })
+
+    const lastRow = rows[rows.length - 1]!
+    const nextCursor: BackfillCursor = {
+      last_created_at: lastRow.created_at,
+      last_id: lastRow.id,
+      rows_processed: cursor.rows_processed + rows.length,
+      total_estimate: totalEstimate,
+    }
+
+    const result: {
+      done: false
+      state: ChunkState
+      progressCurrent?: number
+      progressTotal?: number
+    } = {
+      done: false,
+      state: nextCursor as unknown as ChunkState,
+      progressCurrent: nextCursor.rows_processed,
+    }
+    if (totalEstimate != null) result.progressTotal = totalEstimate
+
+    // Defensive: if ClickHouse returned a row but the cursor didn't
+    // advance, we'd loop forever. Treat that as done so the migration
+    // doesn't burn the cluster.
+    if (
+      nextCursor.last_created_at === cursor.last_created_at &&
+      nextCursor.last_id === cursor.last_id
+    ) {
+      return { done: true }
+    }
+
+    return result
+  },
+}
+
+// Re-export the helper so the registry test + future stats-queries
+// rewrites can share it without re-importing the writer's heavier
+// dependencies.
+export { mapRequestToEventRow }
+
+// Imported for side-effect symmetry — `toClickhouseTimestamp` is the
+// canonical formatter and we'd reach for it the moment the SELECT
+// shape changes. Reference it once so tree-shaking doesn't drop the
+// import.
+void toClickhouseTimestamp


### PR DESCRIPTION
Phase 5.1 Stage 2. Uses the background-migration framework from #220 to copy historical `requests` rows into the new `events` table.

## How to start

INSERT one row, the cron picks it up:

```sql
INSERT INTO background_migrations (name, description, status)
VALUES (
  'backfill-events-from-requests',
  'Phase 5.1 Stage 2 backfill',
  'pending'
);
```

Watch /settings/background-migrations for progress.

## Highlights

- Cursor format: `(last_created_at, last_id)` tuple — hits the requests primary key skip-index
- First chunk does a one-shot `SELECT count()` to fill `total_estimate` so the admin UI shows a percentage
- 5000 rows per chunk, yields at 240s — easily clears 6 months in a day
- Defensive no-advance loop guard
- Normalises ClickHouse's all-zero UUID return for null Nullable(UUID) columns

## Test plan
- [x] Server typecheck + lint + 718 tests (+11)
- [ ] Production: INSERT the seed row, watch the admin UI count climb
- [ ] Production: `SELECT count() FROM events WHERE event_type = 'generation'` ≈ `SELECT count() FROM requests` after the migration completes