### PR TITLE
feat: 5.1 Stage 3 — feature-flagged read switch for /api/v1/requests

### DIFF
--- a/apps/server/src/api/requests.ts
+++ b/apps/server/src/api/requests.ts
@@ -13,6 +13,12 @@ import {
   countRequests,
   fetchProviderKeyNames,
 } from '../lib/requests-query.js'
+import {
+  eventsScope,
+  selectGenerationsAsRequests,
+  countGenerations,
+} from '../lib/events-query.js'
+import { useEventsForRequests } from '../lib/feature-flags.js'
 import { fromClickhouseTimestamp } from '../lib/clickhouse.js'
 
 export const requestsRouter = new Hono<JwtContext>()
@@ -113,19 +119,40 @@ requestsRouter.get('/', async (c) => {
   const combinedFilters = filters.length > 0 ? filters.join(' AND ') : undefined
 
   try {
-    const scope = await requestsScope(orgId)
-    const [rows, total] = await Promise.all([
-      selectRequests<RequestRow>({
-        scope,
-        select: LIST_COLUMNS,
-        filters: combinedFilters,
-        orderBy,
-        limit,
-        offset,
-        params,
-      }),
-      countRequests({ scope, filters: combinedFilters, params }),
-    ])
+    let rows: RequestRow[]
+    let total: number
+
+    if (useEventsForRequests) {
+      // Phase 5.1 Stage 3 — read from the unified events table. The
+      // helper projects events columns into the same shape selectRequests
+      // returns so the downstream mapping below works unchanged.
+      const eventsScopeResolved = await eventsScope(orgId)
+      ;[rows, total] = await Promise.all([
+        selectGenerationsAsRequests<RequestRow>({
+          scope: eventsScopeResolved,
+          filters: combinedFilters,
+          orderBy,
+          limit,
+          offset,
+          params,
+        }),
+        countGenerations({ scope: eventsScopeResolved, filters: combinedFilters, params }),
+      ])
+    } else {
+      const scope = await requestsScope(orgId)
+      ;[rows, total] = await Promise.all([
+        selectRequests<RequestRow>({
+          scope,
+          select: LIST_COLUMNS,
+          filters: combinedFilters,
+          orderBy,
+          limit,
+          offset,
+          params,
+        }),
+        countRequests({ scope, filters: combinedFilters, params }),
+      ])
+    }
 
     // App-layer replacement for Supabase's `provider_keys ( name )` nested select.
     const keyMap = await fetchProviderKeyNames(orgId, rows.map((r) => r.provider_key_id))

--- a/apps/server/src/lib/events-query.test.ts
+++ b/apps/server/src/lib/events-query.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Stub ClickHouse + the requests-query plan lookup. selectGenerationsAsRequests
+// goes through eventsScope() which calls getOrgPlan() — return 'team' so the
+// retention clip is the longest non-Enterprise value.
+const queryMock = vi.fn()
+vi.mock('./clickhouse.js', () => ({
+  getClickhouse: () => ({ query: queryMock }),
+}))
+vi.mock('./requests-query.js', async () => {
+  const actual = await vi.importActual<typeof import('./requests-query.js')>('./requests-query.js')
+  return {
+    ...actual,
+    getOrgPlan: async () => 'team',
+  }
+})
+
+import { eventsScope, selectGenerationsAsRequests, countGenerations } from './events-query.js'
+
+afterEach(() => queryMock.mockReset())
+
+function jsonRes<T>(rows: T[]) {
+  return { json: async () => rows as unknown }
+}
+
+describe('eventsScope', () => {
+  it('returns the multitenant + retention WHERE fragment with team retention', async () => {
+    const scope = await eventsScope('org-1')
+    expect(scope.whereScope).toMatch(/organization_id = \{orgId:UUID\}/)
+    expect(scope.whereScope).toMatch(/INTERVAL \{retentionDays:UInt32\} DAY/)
+    expect(scope.scopeParams.retentionDays).toBe(365)
+    expect(scope.scopeParams.orgId).toBe('org-1')
+    expect(scope.plan).toBe('team')
+  })
+
+  it('skips the retention clip when ignoreRetention is set', async () => {
+    const scope = await eventsScope('org-1', { ignoreRetention: true })
+    expect(scope.whereScope).toBe('organization_id = {orgId:UUID}')
+  })
+})
+
+describe('selectGenerationsAsRequests — read-side shim for /api/v1/requests', () => {
+  it("filters by event_type = 'generation' in addition to the scope WHERE", async () => {
+    queryMock.mockResolvedValueOnce(jsonRes([]))
+    const scope = await eventsScope('org-1')
+    await selectGenerationsAsRequests({ scope })
+
+    const call = queryMock.mock.calls[0]?.[0] as { query: string; query_params: Record<string, unknown> }
+    expect(call.query).toContain("event_type = 'generation'")
+    expect(call.query).toContain('organization_id = {orgId:UUID}')
+    expect(call.query_params['orgId']).toBe('org-1')
+  })
+
+  it('projects the events columns into the same shape selectRequests returns', async () => {
+    queryMock.mockResolvedValueOnce(jsonRes([]))
+    const scope = await eventsScope('org-1')
+    await selectGenerationsAsRequests({ scope })
+
+    const call = queryMock.mock.calls[0]?.[0] as { query: string }
+    // Spot-check every alias the dashboard relies on.
+    expect(call.query).toMatch(/event_id\).*AS id/s)
+    expect(call.query).toMatch(/total_cost_usd\s+AS cost_usd/)
+    expect(call.query).toMatch(/duration_ms\s+AS latency_ms/)
+    expect(call.query).toMatch(/input\s+AS request_body/)
+    expect(call.query).toMatch(/output\s+AS response_body/)
+    expect(call.query).toMatch(/parent_event_id\s+AS span_id/)
+  })
+
+  it("substitutes neutral defaults for columns that don't exist on events yet", async () => {
+    queryMock.mockResolvedValueOnce(jsonRes([]))
+    const scope = await eventsScope('org-1')
+    await selectGenerationsAsRequests({ scope })
+
+    const call = queryMock.mock.calls[0]?.[0] as { query: string }
+    // flags / response_flags / has_security_flags / truncated are
+    // surfaced as empty / 0 so the dashboard's badges stay quiet.
+    expect(call.query).toMatch(/'' +AS flags/)
+    expect(call.query).toMatch(/'{}' +AS response_flags/)
+    expect(call.query).toMatch(/0 +AS has_security_flags/)
+    expect(call.query).toMatch(/0 +AS truncated/)
+  })
+
+  it('passes caller filters / orderBy / limit / offset through', async () => {
+    queryMock.mockResolvedValueOnce(jsonRes([]))
+    const scope = await eventsScope('org-1')
+    await selectGenerationsAsRequests({
+      scope,
+      filters: 'status_code >= 400',
+      orderBy: 'created_at DESC',
+      limit: 50,
+      offset: 100,
+    })
+
+    const call = queryMock.mock.calls[0]?.[0] as { query: string }
+    expect(call.query).toContain('status_code >= 400')
+    expect(call.query).toContain('ORDER BY created_at DESC')
+    expect(call.query).toContain('LIMIT 50')
+    expect(call.query).toContain('OFFSET 100')
+  })
+
+  it('returns the rows the query produced (no transformation)', async () => {
+    const fakeRow = { id: 'evt-1', provider: 'openai', model: 'gpt-4o' }
+    queryMock.mockResolvedValueOnce(jsonRes([fakeRow]))
+    const scope = await eventsScope('org-1')
+    const rows = await selectGenerationsAsRequests<typeof fakeRow>({ scope })
+    expect(rows).toEqual([fakeRow])
+  })
+})
+
+describe('countGenerations', () => {
+  it("counts rows in events with event_type = 'generation'", async () => {
+    queryMock.mockResolvedValueOnce(jsonRes([{ c: '42' }]))
+    const scope = await eventsScope('org-1')
+    const total = await countGenerations({ scope })
+    expect(total).toBe(42)
+    const call = queryMock.mock.calls[0]?.[0] as { query: string }
+    expect(call.query).toContain("event_type = 'generation'")
+  })
+})

--- a/apps/server/src/lib/events-query.ts
+++ b/apps/server/src/lib/events-query.ts
@@ -66,11 +66,11 @@ export async function eventsScope(
 export async function selectEvents<T>(opts: {
   scope: EventsScope
   select: string
-  filters?: string
-  params?: Record<string, unknown>
-  orderBy?: string
-  limit?: number
-  offset?: number
+  filters?: string | undefined
+  params?: Record<string, unknown> | undefined
+  orderBy?: string | undefined
+  limit?: number | undefined
+  offset?: number | undefined
 }): Promise<T[]> {
   const { scope, select, filters, params, orderBy, limit, offset } = opts
 
@@ -99,11 +99,111 @@ export async function selectEvents<T>(opts: {
  */
 export async function countEvents(opts: {
   scope: EventsScope
-  filters?: string
-  params?: Record<string, unknown>
+  filters?: string | undefined
+  params?: Record<string, unknown> | undefined
 }): Promise<number> {
   const { scope, filters, params } = opts
   const whereParts = [scope.whereScope]
+  if (filters && filters.length > 0) whereParts.push(filters)
+  const where = whereParts.join(' AND ')
+  const query = `SELECT count() AS c FROM events WHERE ${where}`
+  const res = await getClickhouse().query({
+    query,
+    query_params: { ...scope.scopeParams, ...(params ?? {}) },
+    format: 'JSONEachRow',
+  })
+  const rows = (await res.json()) as Array<{ c: string }>
+  return Number(rows[0]?.c ?? 0)
+}
+
+/**
+ * Phase 5.1 Stage 3 — read-side compatibility shim for the
+ * `/api/v1/requests` list endpoint.
+ *
+ * Selects `event_type='generation'` rows from `events` and projects
+ * the columns into the shape the requests router already returns to
+ * the dashboard. Columns the events table doesn't carry (security
+ * flags, truncation marker) fall back to neutral defaults so the
+ * dashboard's badges stay consistent — Stage 3 is a read switch,
+ * not a feature regression.
+ *
+ * `extraFilters` is concatenated with AND to the events-scoped
+ * WHERE. Callers should NOT include `event_type` themselves; this
+ * helper adds it.
+ */
+export async function selectGenerationsAsRequests<T>(opts: {
+  scope: EventsScope
+  filters?: string | undefined
+  params?: Record<string, unknown> | undefined
+  orderBy?: string | undefined
+  limit?: number | undefined
+  offset?: number | undefined
+}): Promise<T[]> {
+  const { scope, filters, params, orderBy, limit, offset } = opts
+
+  const whereParts = [scope.whereScope, "event_type = 'generation'"]
+  if (filters && filters.length > 0) whereParts.push(filters)
+  const where = whereParts.join(' AND ')
+
+  const tail: string[] = []
+  if (orderBy) tail.push(`ORDER BY ${orderBy}`)
+  if (typeof limit === 'number') tail.push(`LIMIT ${Math.max(0, Math.floor(limit))}`)
+  if (typeof offset === 'number') tail.push(`OFFSET ${Math.max(0, Math.floor(offset))}`)
+
+  // Column aliases match the existing requests-router SELECT exactly
+  // so the post-query mapping (cost coercion, key-name lookup, etc.)
+  // works unchanged. usage_details map lookups default to 0 when the
+  // key is absent.
+  const query = `
+    SELECT
+      toString(event_id)                          AS id,
+      provider,
+      model,
+      toUInt32OrZero(toString(usage_details['prompt_tokens']))     AS prompt_tokens,
+      toUInt32OrZero(toString(usage_details['completion_tokens'])) AS completion_tokens,
+      toUInt32OrZero(toString(usage_details['total_tokens']))      AS total_tokens,
+      toUInt32OrZero(toString(usage_details['cache_read_tokens'])) AS cache_read_tokens,
+      toUInt32OrZero(toString(usage_details['cache_write_tokens']))AS cache_write_tokens,
+      total_cost_usd                              AS cost_usd,
+      duration_ms                                 AS latency_ms,
+      status_code,
+      input                                       AS request_body,
+      output                                      AS response_body,
+      error_message,
+      trace_id,
+      parent_event_id                             AS span_id,
+      provider_key_id,
+      user_id,
+      session_id,
+      -- Security flags and truncation live only in \`requests\`; surface
+      -- empty defaults so dashboard badges (no flag → no badge) stay
+      -- consistent until those columns land on \`events\`.
+      ''                                          AS flags,
+      '{}'                                        AS response_flags,
+      0                                           AS has_security_flags,
+      0                                           AS truncated,
+      toString(created_at)                        AS created_at
+    FROM events
+    WHERE ${where}
+    ${tail.join(' ')}
+  `.trim()
+
+  const res = await getClickhouse().query({
+    query,
+    query_params: { ...scope.scopeParams, ...(params ?? {}) },
+    format: 'JSONEachRow',
+  })
+  return (await res.json()) as T[]
+}
+
+/** Companion COUNT used by the same flag branch in /api/v1/requests. */
+export async function countGenerations(opts: {
+  scope: EventsScope
+  filters?: string | undefined
+  params?: Record<string, unknown> | undefined
+}): Promise<number> {
+  const { scope, filters, params } = opts
+  const whereParts = [scope.whereScope, "event_type = 'generation'"]
   if (filters && filters.length > 0) whereParts.push(filters)
   const where = whereParts.join(' AND ')
   const query = `SELECT count() AS c FROM events WHERE ${where}`

--- a/apps/server/src/lib/feature-flags.test.ts
+++ b/apps/server/src/lib/feature-flags.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The feature-flags module reads env vars once at import time. Tests
+ * use vi.resetModules() so each describe block sees a fresh snapshot.
+ */
+describe('feature-flags', () => {
+  afterEach(() => {
+    delete process.env['USE_EVENTS_FOR_REQUESTS']
+    vi.resetModules()
+  })
+
+  it('defaults USE_EVENTS_FOR_REQUESTS to false when the env var is missing', async () => {
+    delete process.env['USE_EVENTS_FOR_REQUESTS']
+    vi.resetModules()
+    const mod = await import('./feature-flags.js')
+    expect(mod.useEventsForRequests).toBe(false)
+  })
+
+  it('enables USE_EVENTS_FOR_REQUESTS only when the env var is the literal "1"', async () => {
+    process.env['USE_EVENTS_FOR_REQUESTS'] = '1'
+    vi.resetModules()
+    const mod = await import('./feature-flags.js')
+    expect(mod.useEventsForRequests).toBe(true)
+  })
+
+  it('rejects truthy-looking strings other than "1" so dev / CI / prod stay consistent', async () => {
+    for (const v of ['true', 'TRUE', 'yes', 'on', '2']) {
+      process.env['USE_EVENTS_FOR_REQUESTS'] = v
+      vi.resetModules()
+      const mod = await import('./feature-flags.js')
+      expect(mod.useEventsForRequests, `expected ${v} to be rejected`).toBe(false)
+    }
+  })
+
+  it('snapshotFlags surfaces every flag for /health/deep', async () => {
+    process.env['USE_EVENTS_FOR_REQUESTS'] = '1'
+    vi.resetModules()
+    const mod = await import('./feature-flags.js')
+    expect(mod.snapshotFlags()).toEqual({ USE_EVENTS_FOR_REQUESTS: true })
+  })
+})

--- a/apps/server/src/lib/feature-flags.ts
+++ b/apps/server/src/lib/feature-flags.ts
@@ -1,0 +1,42 @@
+/**
+ * Server-side feature flags.
+ *
+ * Env-var-backed boolean toggles read once at module load. Two design
+ * choices worth flagging:
+ *
+ *   1. Read at module load (not per-call) — flips require a redeploy
+ *      to take effect. We accept that cost for the operational simplicity
+ *      of "no live wire to the flag service". When we need at-runtime
+ *      flips for a specific feature we'll wire that flag into Upstash
+ *      or LaunchDarkly individually.
+ *
+ *   2. Strict truthy check — only the literal string "1" enables a
+ *      flag. We reject "true" / "TRUE" / "yes" to keep behaviour
+ *      identical across dev machines, CI, and production. A missing
+ *      var is always disabled.
+ *
+ * Add new flags as exported constants here so a `git grep` from a code
+ * review finds every flag the server reads.
+ */
+
+function envBool(name: string): boolean {
+  return process.env[name] === '1'
+}
+
+/**
+ * Phase 5.1 Stage 3 — when set, `/api/v1/requests` reads from the
+ * new unified `events` table (event_type='generation') instead of
+ * `requests`. Turning the flag off must remain a safe operation that
+ * falls all the way back to the original code path; we don't drop
+ * `requests` writes until Stage 4 (post-cutover).
+ *
+ * Activation env var: `USE_EVENTS_FOR_REQUESTS=1`
+ */
+export const useEventsForRequests = envBool('USE_EVENTS_FOR_REQUESTS')
+
+/** Diagnostics view — used by `/health/deep` to surface what's on. */
+export function snapshotFlags(): Record<string, boolean> {
+  return {
+    USE_EVENTS_FOR_REQUESTS: useEventsForRequests,
+  }
+}


### PR DESCRIPTION
First Stage 3 PR. Flips a single dashboard route — the list endpoint behind `/api/v1/requests` — to read from the unified `events` table when `USE_EVENTS_FOR_REQUESTS=1` is set. Existing `requests`-table path stays the default.

## Why one route at a time
Stage 3's whole point is incremental. Flipping every read simultaneously couples the rollout to a single deploy and removes the per-route abort. Subsequent PRs extend the same pattern to `/api/v1/stats/*` and `/api/v1/traces`.

## Highlights
- New `feature-flags.ts` module — strict env-var (only literal `1` enables)
- `selectGenerationsAsRequests` + `countGenerations` shim helpers — events columns aliased to match `selectRequests` output exactly
- `requests.ts` list endpoint wraps the data fetch in `if (useEventsForRequests)`
- Downstream mapping unchanged so the dashboard sees identical rows

## Activation
Set `USE_EVENTS_FOR_REQUESTS=1` on Vercel production env. Roll back by removing the var (or setting it to anything other than `1`) and redeploying.

## Test plan
- [x] Server typecheck + lint + 730 tests (+12)
- [ ] Production: set flag to 1, /api/v1/requests returns identical row shape
- [ ] Production: cross-check 1h sample — list endpoint returns the same rows from both paths
- [ ] Production: remove flag, list endpoint reverts cleanly