### PR TITLE
fix(5.1): double-gate useEventsForRequests on backfill completion

### DIFF
--- a/apps/server/src/lib/feature-flags.test.ts
+++ b/apps/server/src/lib/feature-flags.test.ts
@@ -7,18 +7,33 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 describe('feature-flags', () => {
   afterEach(() => {
     delete process.env['USE_EVENTS_FOR_REQUESTS']
+    delete process.env['EVENTS_BACKFILL_COMPLETE']
     vi.resetModules()
   })
 
-  it('defaults USE_EVENTS_FOR_REQUESTS to false when the env var is missing', async () => {
-    delete process.env['USE_EVENTS_FOR_REQUESTS']
+  it('defaults useEventsForRequests to false when both env vars are missing', async () => {
     vi.resetModules()
     const mod = await import('./feature-flags.js')
     expect(mod.useEventsForRequests).toBe(false)
   })
 
-  it('enables USE_EVENTS_FOR_REQUESTS only when the env var is the literal "1"', async () => {
+  it('stays disabled when only USE_EVENTS_FOR_REQUESTS=1 (backfill ack missing)', async () => {
     process.env['USE_EVENTS_FOR_REQUESTS'] = '1'
+    vi.resetModules()
+    const mod = await import('./feature-flags.js')
+    expect(mod.useEventsForRequests).toBe(false)
+  })
+
+  it('stays disabled when only EVENTS_BACKFILL_COMPLETE=1 (rollout not asked for)', async () => {
+    process.env['EVENTS_BACKFILL_COMPLETE'] = '1'
+    vi.resetModules()
+    const mod = await import('./feature-flags.js')
+    expect(mod.useEventsForRequests).toBe(false)
+  })
+
+  it('enables useEventsForRequests only when BOTH env vars are the literal "1"', async () => {
+    process.env['USE_EVENTS_FOR_REQUESTS'] = '1'
+    process.env['EVENTS_BACKFILL_COMPLETE'] = '1'
     vi.resetModules()
     const mod = await import('./feature-flags.js')
     expect(mod.useEventsForRequests).toBe(true)
@@ -27,6 +42,7 @@ describe('feature-flags', () => {
   it('rejects truthy-looking strings other than "1" so dev / CI / prod stay consistent', async () => {
     for (const v of ['true', 'TRUE', 'yes', 'on', '2']) {
       process.env['USE_EVENTS_FOR_REQUESTS'] = v
+      process.env['EVENTS_BACKFILL_COMPLETE'] = v
       vi.resetModules()
       const mod = await import('./feature-flags.js')
       expect(mod.useEventsForRequests, `expected ${v} to be rejected`).toBe(false)
@@ -35,8 +51,13 @@ describe('feature-flags', () => {
 
   it('snapshotFlags surfaces every flag for /health/deep', async () => {
     process.env['USE_EVENTS_FOR_REQUESTS'] = '1'
+    process.env['EVENTS_BACKFILL_COMPLETE'] = '1'
     vi.resetModules()
     const mod = await import('./feature-flags.js')
-    expect(mod.snapshotFlags()).toEqual({ USE_EVENTS_FOR_REQUESTS: true })
+    expect(mod.snapshotFlags()).toEqual({
+      USE_EVENTS_FOR_REQUESTS: true,
+      EVENTS_BACKFILL_COMPLETE: true,
+      useEventsForRequests: true,
+    })
   })
 })

--- a/apps/server/src/lib/feature-flags.ts
+++ b/apps/server/src/lib/feature-flags.ts
@@ -31,12 +31,24 @@ function envBool(name: string): boolean {
  * `requests` writes until Stage 4 (post-cutover).
  *
  * Activation env var: `USE_EVENTS_FOR_REQUESTS=1`
+ *
+ * Operational guard: also requires `EVENTS_BACKFILL_COMPLETE=1`.
+ * Activating the read switch BEFORE the backfill finishes shows an
+ * empty list to the operator (events only has rows from the
+ * dual-write start onward, so 99% of `requests` is missing).
+ * Production hit this footgun once already during the rollout —
+ * the double-gate prevents an env-flip from going live without
+ * the matching "I confirmed the backfill" acknowledgement.
  */
-export const useEventsForRequests = envBool('USE_EVENTS_FOR_REQUESTS')
+export const useEventsForRequests =
+  envBool('USE_EVENTS_FOR_REQUESTS') && envBool('EVENTS_BACKFILL_COMPLETE')
 
 /** Diagnostics view — used by `/health/deep` to surface what's on. */
 export function snapshotFlags(): Record<string, boolean> {
   return {
-    USE_EVENTS_FOR_REQUESTS: useEventsForRequests,
+    USE_EVENTS_FOR_REQUESTS: envBool('USE_EVENTS_FOR_REQUESTS'),
+    EVENTS_BACKFILL_COMPLETE: envBool('EVENTS_BACKFILL_COMPLETE'),
+    /** The composed flag the requests router actually branches on. */
+    useEventsForRequests,
   }
 }


### PR DESCRIPTION
Production rollout of #226 hit the obvious footgun: setting `USE_EVENTS_FOR_REQUESTS=1` before the backfill finishes flips the read switch to a near-empty events table. Dashboard list shows 'No requests yet' even though stats (which still reads from `requests`) shows 49.

Add second guard `EVENTS_BACKFILL_COMPLETE=1`. Composed flag:
`useEventsForRequests = USE_EVENTS_FOR_REQUESTS=1 && EVENTS_BACKFILL_COMPLETE=1`

Auto-disables current production deploy since EVENTS_BACKFILL_COMPLETE was never set.