### PR TITLE
fix(5.1): remove non-existent service_tier column from backfill SELECT

### DIFF
--- a/apps/server/src/lib/background-migrations/registry/migrations/backfill-events-from-requests.ts
+++ b/apps/server/src/lib/background-migrations/registry/migrations/backfill-events-from-requests.ts
@@ -67,7 +67,6 @@ interface RequestRow {
   provider_key_id: string | null
   user_id: string | null
   session_id: string | null
-  service_tier: string
   created_at: string
 }
 
@@ -124,7 +123,6 @@ function mapRequestToEventRow(r: RequestRow): Record<string, unknown> {
   }
 
   const metadata: Record<string, string> = { source: 'backfill_requests' }
-  if (r.service_tier) metadata['service_tier'] = r.service_tier
 
   // ClickHouse SELECT can return non-null Nullable(UUID) as the
   // string '00000000-...' when DEFAULT was applied — treat that as
@@ -218,7 +216,6 @@ export const backfillEventsFromRequests: BackgroundMigration = {
           toString(provider_key_id) AS provider_key_id,
           user_id,
           session_id,
-          service_tier,
           toString(created_at) AS created_at
         FROM requests
         WHERE (created_at, id) > (parseDateTime64BestEffort({cursor_ts:String}), {cursor_id:UUID})


### PR DESCRIPTION
Production run of the backfill migration failed with:
```
Unknown expression identifier 'service_tier' in scope SELECT ...
```

The actual `requests` table schema has never had a `service_tier` column. I assumed it existed based on a stale mental model. ClickHouse rejected the SELECT immediately, so the migration flipped to `status='failed'`.

User impact contained: Stage 2 was already backfilled out-of-band via direct `INSERT … SELECT` in SQL console (54 generations + 1 trace verified). The DB row is marked 'completed' with a note pointing here.

This fix is so the cron path is correct for the NEXT backfill (spans, traces, future schema-add migrations).