### PR TITLE
feat(5.1): Stage 3 — /api/v1/stats/* reads via events view

### DIFF
--- a/apps/server/src/lib/stats-queries.ts
+++ b/apps/server/src/lib/stats-queries.ts
@@ -1,5 +1,6 @@
 import { getClickhouse } from './clickhouse.js'
 import { requestsScope } from './requests-query.js'
+import { statsSource } from './stats-source.js'
 
 /**
  * ClickHouse replacements for the 4 stats RPCs that used to live in Postgres:
@@ -81,7 +82,7 @@ export async function getStatsOverview(
       sum(prompt_tokens)                     AS prompt_tokens,
       sum(completion_tokens)                 AS completion_tokens,
       avg(latency_ms)                        AS avg_latency_ms
-    FROM requests
+    FROM ${statsSource()}
     WHERE ${where}`
 
   const result = await getClickhouse().query({
@@ -144,7 +145,7 @@ export async function getStatsModels(
       sum(cost_usd)                                    AS total_cost_usd,
       avg(latency_ms)                                  AS avg_latency_ms,
       avg(if(status_code >= 400, 1.0, 0.0))            AS error_rate
-    FROM requests
+    FROM ${statsSource()}
     WHERE ${where}
     GROUP BY provider, model
     ORDER BY total_cost_usd DESC`
@@ -246,7 +247,7 @@ export async function getStatsTimeseries(
       countIf(status_code >= 500)                                AS errors_5xx,
       quantile(0.5)(latency_ms)                                  AS p50_latency_ms,
       quantile(0.95)(latency_ms)                                 AS p95_latency_ms
-    FROM requests
+    FROM ${statsSource()}
     WHERE ${where}
     GROUP BY day
     ORDER BY day ASC`
@@ -312,7 +313,7 @@ export async function getTimeseriesBreakdown(
         'status' AS kind,
         toString(status_code) AS value,
         count() AS c
-      FROM requests
+      FROM ${statsSource()}
       WHERE ${where}
       GROUP BY day, value
       UNION ALL
@@ -321,7 +322,7 @@ export async function getTimeseriesBreakdown(
         'model' AS kind,
         concat(provider, ' / ', model) AS value,
         count() AS c
-      FROM requests
+      FROM ${statsSource()}
       WHERE ${where}
       GROUP BY day, value
     )
@@ -439,7 +440,7 @@ export async function getUserAnalytics(
       countIf(status_code >= 400)                      AS error_requests,
       uniqExact(model)                                 AS distinct_models,
       count() OVER ()                                  AS total_count
-    FROM requests
+    FROM ${statsSource()}
     WHERE ${where}
     GROUP BY user_id
     ORDER BY ${sortCol} ${sortDir} NULLS LAST
@@ -562,7 +563,7 @@ export async function getSessionAnalytics(
       countIf(status_code >= 400)                      AS error_requests,
       uniqExact(model)                                 AS distinct_models,
       count() OVER ()                                  AS total_count
-    FROM requests
+    FROM ${statsSource()}
     WHERE ${where}
     GROUP BY session_id
     ORDER BY ${sortCol} ${sortDir} NULLS LAST
@@ -614,7 +615,7 @@ export async function getSecuritySummary(
       JSONExtractString(flag, 'type')    AS flag_type,
       JSONExtractString(flag, 'pattern') AS pattern,
       count()                            AS count
-    FROM requests
+    FROM ${statsSource()}
     ARRAY JOIN JSONExtractArrayRaw(flags) AS flag
     WHERE ${scope.whereScope}
       AND has_security_flags = 1
@@ -672,7 +673,7 @@ export async function getLatencyPercentiles(
       quantileIf(0.95)(proxy_overhead_ms, isNotNull(proxy_overhead_ms))        AS p95_overhead,
       quantileIf(0.99)(proxy_overhead_ms, isNotNull(proxy_overhead_ms))        AS p99_overhead,
       avgIf(proxy_overhead_ms, isNotNull(proxy_overhead_ms))                   AS avg_overhead
-    FROM requests
+    FROM ${statsSource()}
     WHERE ${scope.whereScope}
       AND created_at >= parseDateTime64BestEffort({sinceTs:String})`
 

--- a/apps/server/src/lib/stats-source.test.ts
+++ b/apps/server/src/lib/stats-source.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('statsSource', () => {
+  afterEach(() => {
+    delete process.env['USE_EVENTS_FOR_REQUESTS']
+    delete process.env['EVENTS_BACKFILL_COMPLETE']
+    vi.resetModules()
+  })
+
+  it('defaults to the legacy requests table when no flag is set', async () => {
+    vi.resetModules()
+    const mod = await import('./stats-source.js')
+    expect(mod.statsSource()).toBe('requests')
+  })
+
+  it('switches to events_as_requests when both flags are 1', async () => {
+    process.env['USE_EVENTS_FOR_REQUESTS'] = '1'
+    process.env['EVENTS_BACKFILL_COMPLETE'] = '1'
+    vi.resetModules()
+    const mod = await import('./stats-source.js')
+    expect(mod.statsSource()).toBe('events_as_requests')
+  })
+
+  it('stays on requests when only the dashboard flag is set (backfill ack missing)', async () => {
+    process.env['USE_EVENTS_FOR_REQUESTS'] = '1'
+    vi.resetModules()
+    const mod = await import('./stats-source.js')
+    expect(mod.statsSource()).toBe('requests')
+  })
+})

--- a/apps/server/src/lib/stats-source.ts
+++ b/apps/server/src/lib/stats-source.ts
@@ -1,0 +1,19 @@
+/**
+ * Phase 5.1 Stage 3 — single-source-of-truth for which ClickHouse table
+ * the stats pipeline reads from.
+ *
+ * `lib/stats-queries.ts` interpolates this into every FROM clause so a
+ * Vercel env flip swaps the data source for the whole stats pipeline
+ * at once. Both `requests` and `events_as_requests` (a view defined in
+ * `clickhouse/migrations/005_create_events_as_requests_view.sql`) expose
+ * the same column shape, so the rest of each query is unchanged.
+ *
+ * Flipping back is byte-identical to today: drop the env var and
+ * redeploy.
+ */
+
+import { useEventsForRequests } from './feature-flags.js'
+
+export function statsSource(): string {
+  return useEventsForRequests ? 'events_as_requests' : 'requests'
+}

--- a/clickhouse/migrations/005_create_events_as_requests_view.sql
+++ b/clickhouse/migrations/005_create_events_as_requests_view.sql
@@ -1,0 +1,73 @@
+-- 005_create_events_as_requests_view.sql
+-- Phase 5.1 Stage 3 — projection view that exposes the `events` table
+-- in the column shape the legacy `stats-queries.ts` already expects from
+-- `requests`.
+--
+-- WHY a VIEW rather than per-call CTEs:
+--   The stats pipeline has nine separate functions, each with its own
+--   hand-rolled SQL string and 'FROM requests' baked in. Wrapping every
+--   query in a CTE would touch every function and bloat the SQL by
+--   ~30 lines per call site. A view keeps the per-function diff to a
+--   single 'FROM requests' → 'FROM events_as_requests' string swap,
+--   and reuses ClickHouse's query planner on the underlying table.
+--
+-- WHY column-by-column aliasing:
+--   `events` is the canonical Langfuse-style schema with
+--   `total_cost_usd`, `duration_ms`, `usage_details Map`, `input`,
+--   `output`. The legacy stats queries reference the historical
+--   names. The view bridges the two so the feature flag flip in
+--   `lib/stats-source.ts` is a one-line behaviour change.
+--
+-- WHY hard-coded literals for flags/response_flags/has_security_flags/
+-- truncated:
+--   These four columns live on `requests` but never made it onto
+--   `events` (gap to be closed by a follow-up migration). The legacy
+--   SecuritySummary and truncated-row stats need them, so the view
+--   returns neutral defaults. Once `events` carries them natively
+--   the literals are swapped for the real columns.
+--
+-- IDEMPOTENT: CREATE VIEW IF NOT EXISTS. Drop + recreate by hand if
+-- the projection changes.
+
+CREATE VIEW IF NOT EXISTS events_as_requests AS
+SELECT
+    event_id                                                       AS id,
+    organization_id,
+    project_id,
+    api_key_id,
+
+    provider,
+    model,
+
+    toUInt32OrZero(toString(usage_details['prompt_tokens']))       AS prompt_tokens,
+    toUInt32OrZero(toString(usage_details['completion_tokens']))   AS completion_tokens,
+    toUInt32OrZero(toString(usage_details['total_tokens']))        AS total_tokens,
+    toUInt32OrZero(toString(usage_details['cache_read_tokens']))   AS cache_read_tokens,
+    toUInt32OrZero(toString(usage_details['cache_write_tokens']))  AS cache_write_tokens,
+
+    total_cost_usd                                                 AS cost_usd,
+    duration_ms                                                    AS latency_ms,
+    CAST(NULL, 'Nullable(UInt32)')                                 AS proxy_overhead_ms,
+    status_code,
+
+    input                                                          AS request_body,
+    output                                                          AS response_body,
+    error_message,
+
+    trace_id,
+    parent_event_id                                                AS span_id,
+    prompt_version_id,
+    provider_key_id,
+
+    user_id,
+    session_id,
+
+    '[]'                                                            AS flags,
+    '{}'                                                            AS response_flags,
+    CAST(0, 'Bool')                                                 AS has_security_flags,
+    CAST(0, 'UInt8')                                                AS truncated,
+    ''                                                              AS service_tier,
+
+    created_at
+FROM events
+WHERE event_type = 'generation';


### PR DESCRIPTION
Phase 5.1 Stage 3 second route. Flips every stats endpoint (overview, models, timeseries, timeseries-breakdown, user-analytics, session-analytics, security-summary, latency percentiles) to read from `events` via a column-shape view.

## Highlights
- **clickhouse/migrations/005_create_events_as_requests_view.sql** — `CREATE VIEW IF NOT EXISTS events_as_requests AS SELECT … FROM events WHERE event_type='generation'`. Aliases events columns to the historical `requests` shape (event_id→id, duration_ms→latency_ms, usage_details map→tokens, total_cost_usd→cost_usd, …) so the legacy stats SQL works unchanged.
- **lib/stats-source.ts** — `statsSource()` returns 'requests' or 'events_as_requests' based on the double-gated flag. 3 unit tests.
- **lib/stats-queries.ts** — 9 `FROM requests` → `FROM ${statsSource()}` swaps.

## Activation
Same flags as /api/v1/requests (`USE_EVENTS_FOR_REQUESTS=1` + `EVENTS_BACKFILL_COMPLETE=1`). No new env var.

## Production checklist
- [ ] Apply migration 005 against ClickHouse Cloud
- [ ] Verify dashboard /overview cards still match
- [ ] Verify traffic chart still renders

## Test plan
- [x] 735 server tests (+3)
- [ ] /dashboard 전체 카드 + chart 정상 표시
- [ ] /security summary 정상
- [ ] /users page 정상