### PR TITLE
feat(5.1): add flags/response_flags/has_security_flags/truncated to events

### DIFF
--- a/apps/server/src/lib/events-writer.ts
+++ b/apps/server/src/lib/events-writer.ts
@@ -36,6 +36,15 @@ interface RequestRowLike {
   request_body: string
   response_body: string
   error_message: string | null
+  /**
+   * Pre-computed in logger.ts and threaded straight through so events
+   * gets the same security/truncation values as `requests`. Added by
+   * migration 006.
+   */
+  flags?: string
+  response_flags?: string
+  has_security_flags?: boolean
+  truncated?: number
 }
 
 /**
@@ -65,7 +74,20 @@ export async function writeRequestAsEvent(
 
   const metadata: Record<string, string> = {}
   if (data.serviceTier) metadata['service_tier'] = data.serviceTier
+  // `truncated` used to live in the metadata map as a string; from
+  // migration 006 it has a dedicated typed column. Keep the map entry
+  // for one release cycle so older consumers don't break.
   if (data.truncated) metadata['truncated'] = 'true'
+
+  // Phase 5.1 PR-5 — the four columns added by migration 006. The
+  // logger already wrote these into the `requests` row; we read them
+  // back off `requestRow` so events stays bit-identical to what
+  // landed in `requests`. Defaults match the requests-table column
+  // defaults so a missing prop never produces a wrong value.
+  const flagsValue = requestRow.flags ?? '[]'
+  const responseFlagsValue = requestRow.response_flags ?? '{}'
+  const hasSecurityFlagsValue = requestRow.has_security_flags ?? false
+  const truncatedValue = requestRow.truncated ?? (data.truncated ? 1 : 0)
 
   const eventRow = {
     event_id: requestRow.id,
@@ -99,6 +121,10 @@ export async function writeRequestAsEvent(
     session_id: data.sessionId ?? null,
     prompt_version_id: data.promptVersionId ?? null,
     provider_key_id: data.providerKeyId ?? null,
+    flags: flagsValue,
+    response_flags: responseFlagsValue,
+    has_security_flags: hasSecurityFlagsValue,
+    truncated: truncatedValue,
     created_at: requestRow.created_at,
   }
 

--- a/clickhouse/migrations/006_add_events_security_columns.sql
+++ b/clickhouse/migrations/006_add_events_security_columns.sql
@@ -1,0 +1,49 @@
+-- 006_add_events_security_columns.sql
+-- Phase 5.1 Stage 3 — fill the column gap between `events` and `requests`
+-- so the stats pipeline can return real security/truncation values instead
+-- of the literal placeholders the events_as_requests view falls back to.
+--
+-- Adds the four columns the legacy `requests` table carries but `events`
+-- never did:
+--
+--   • flags                LowCardinality(String) DEFAULT '[]'
+--     Comma-separated PII / prompt-injection markers from the proxy.
+--   • response_flags       LowCardinality(String) DEFAULT '{}'
+--     Provider safety metadata (OpenAI's `flagged` etc).
+--   • has_security_flags   Bool DEFAULT false
+--     Pre-computed boolean: any flags set → 1. Drives the
+--     SecuritySummary aggregation and the "security badge" filter.
+--   • truncated            UInt8 DEFAULT 0
+--     1 when the stream deadline (290s) cut the response short — see
+--     CLAUDE.md gotcha #11.
+--
+-- WHY add these now, not in the original 004:
+--   Stage 1 dual-write shipped before the column gap was visible. Stage
+--   3 surfaced it: the events_as_requests view had to hard-code
+--   '[]' / '{}' / 0 / 0 to keep the SQL shape compatible, which masks
+--   real flag counts and truncation rates on the dashboard once the
+--   read switch is on.
+--
+-- BACKFILL: existing events rows default to the empty-state values
+-- above. The next dual-write (events-writer.ts) will populate the
+-- columns for new rows; the historical backfill picks them up on the
+-- next backfill-events-from-requests cron run (the SELECT side of the
+-- code-path migration needs a follow-up to thread these columns
+-- through — done in a separate PR so the schema change can deploy
+-- in isolation).
+--
+-- IDEMPOTENT (CLAUDE.md DB rule): ADD COLUMN IF NOT EXISTS so the
+-- migration is safe to apply twice. CH MergeTree adds the column
+-- lazily — no rewrite of existing parts.
+
+ALTER TABLE events
+    ADD COLUMN IF NOT EXISTS flags              LowCardinality(String) DEFAULT '[]';
+
+ALTER TABLE events
+    ADD COLUMN IF NOT EXISTS response_flags     LowCardinality(String) DEFAULT '{}';
+
+ALTER TABLE events
+    ADD COLUMN IF NOT EXISTS has_security_flags Bool                   DEFAULT false;
+
+ALTER TABLE events
+    ADD COLUMN IF NOT EXISTS truncated          UInt8                  DEFAULT 0;

--- a/clickhouse/migrations/007_rebuild_events_as_requests_view.sql
+++ b/clickhouse/migrations/007_rebuild_events_as_requests_view.sql
@@ -1,0 +1,66 @@
+-- 007_rebuild_events_as_requests_view.sql
+-- Phase 5.1 PR-5 — refresh the `events_as_requests` view to project
+-- the real `flags` / `response_flags` / `has_security_flags` / `truncated`
+-- columns that migration 006 added to `events`, instead of the
+-- literal placeholders the 005 view returned.
+--
+-- Why a separate migration: 005 has already shipped to production with
+-- the placeholder columns. CREATE VIEW IF NOT EXISTS is a no-op when
+-- the view exists, so the only way to pick up the new projection is to
+-- drop the old view and recreate it. CLAUDE.md forbids editing past
+-- migrations, so the rebuild lives here.
+--
+-- ORDER OF OPERATIONS: this migration MUST run after 006 (which adds
+-- the underlying columns). `pnpm ch:migrate` applies in lexical
+-- order, so the 006 → 007 sequence is correct as-is.
+--
+-- IDEMPOTENT: DROP IF EXISTS + CREATE OR REPLACE. Safe to re-run.
+-- ClickHouse's DROP VIEW is metadata-only and never touches the
+-- underlying `events` rows.
+
+DROP VIEW IF EXISTS events_as_requests;
+
+CREATE VIEW events_as_requests AS
+SELECT
+    event_id                                                       AS id,
+    organization_id,
+    project_id,
+    api_key_id,
+
+    provider,
+    model,
+
+    toUInt32OrZero(toString(usage_details['prompt_tokens']))       AS prompt_tokens,
+    toUInt32OrZero(toString(usage_details['completion_tokens']))   AS completion_tokens,
+    toUInt32OrZero(toString(usage_details['total_tokens']))        AS total_tokens,
+    toUInt32OrZero(toString(usage_details['cache_read_tokens']))   AS cache_read_tokens,
+    toUInt32OrZero(toString(usage_details['cache_write_tokens']))  AS cache_write_tokens,
+
+    total_cost_usd                                                 AS cost_usd,
+    duration_ms                                                    AS latency_ms,
+    CAST(NULL, 'Nullable(UInt32)')                                 AS proxy_overhead_ms,
+    status_code,
+
+    input                                                          AS request_body,
+    output                                                          AS response_body,
+    error_message,
+
+    trace_id,
+    parent_event_id                                                AS span_id,
+    prompt_version_id,
+    provider_key_id,
+
+    user_id,
+    session_id,
+
+    -- The four columns added by migration 006 — now passed through.
+    flags,
+    response_flags,
+    has_security_flags,
+    truncated,
+
+    ''                                                              AS service_tier,
+
+    created_at
+FROM events
+WHERE event_type = 'generation';


### PR DESCRIPTION
Phase 5.1 PR-5 — close the column gap between events and requests so the stats pipeline returns real security/truncation values.

## Migrations
- **006_add_events_security_columns.sql** — additive ALTER TABLE
- **007_rebuild_events_as_requests_view.sql** — DROP + CREATE view to project new columns

## Code
- events-writer.ts threads real flags/response_flags/has_security_flags/truncated values from RequestRowLike (which logger.ts already computes for requests)

## Production
Apply via `pnpm ch:migrate` against ClickHouse Cloud. 006 → 007 lexical order is correct as-is.