### PR TITLE
feat(5.1): daily events vs requests reconciliation cron

### DIFF
--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -15,6 +15,7 @@ import { runQuotaWarningsJob } from '../lib/quota-warnings.js'
 import { snapshotAnomaliesForAllOrgs } from '../lib/anomaly-snapshot.js'
 import { runStaleKeyDigestJob } from '../lib/stale-key-digest.js'
 import { runDueMigrations } from '../lib/background-migrations/runner.js'
+import { runReconciliationCron } from '../lib/events-reconciliation.js'
 import { runLeakDetectionJob } from '../lib/leak-detection.js'
 import { sendHighConfidenceRecommendationAlerts } from '../lib/recommendation-notify.js'
 import { logCronRun } from '../lib/cron-logger.js'
@@ -584,6 +585,30 @@ cronRouter.get('/run-background-migrations', async (c) => {
     durationMs,
     ...result,
   })
+})
+
+// GET /cron/events-reconciliation
+// Phase 5.1 Stage 3 — daily integrity check that the dual-write hasn't
+// drifted. Compares the row count of `requests` vs `events` (filtered
+// to event_type='generation') over a recent 24h window. Out-of-tolerance
+// drift (>1%) marks the cron run failed so it surfaces in Vercel logs
+// and the cron_job_runs table. Schedule: 02:00 UTC daily so it runs
+// after the day's traffic has settled but before the operator's
+// morning dashboard glance.
+cronRouter.get('/events-reconciliation', async (c) => {
+  const authFail = assertCronAuth(c.req.header('Authorization'))
+  if (authFail) return c.json({ error: authFail }, 401)
+
+  const started = Date.now()
+  try {
+    const result = await runReconciliationCron()
+    await logCronRun('events-reconciliation', 'ok', Date.now() - started)
+    return c.json({ ok: true, ts: new Date().toISOString(), ...result })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'unknown error'
+    await logCronRun('events-reconciliation', 'error', Date.now() - started, message)
+    return c.json({ ok: false, ts: new Date().toISOString(), error: message }, 200)
+  }
 })
 
 // All three steps run in parallel via Promise.allSettled — one slow / failing

--- a/apps/server/src/lib/events-reconciliation.test.ts
+++ b/apps/server/src/lib/events-reconciliation.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const queryMock = vi.fn()
+vi.mock('./clickhouse.js', () => ({
+  getClickhouse: () => ({ query: queryMock }),
+}))
+
+import { computeReconciliation, runReconciliationCron } from './events-reconciliation.js'
+
+afterEach(() => queryMock.mockReset())
+
+function res<T>(rows: T[]) {
+  return { json: async () => rows as unknown }
+}
+
+describe('computeReconciliation', () => {
+  it('returns withinTolerance=true when counts match exactly', async () => {
+    queryMock
+      .mockResolvedValueOnce(res([{ c: '1000' }]))
+      .mockResolvedValueOnce(res([{ c: '1000' }]))
+
+    const r = await computeReconciliation()
+    expect(r.requestsCount).toBe(1000)
+    expect(r.eventsCount).toBe(1000)
+    expect(r.absDiff).toBe(0)
+    expect(r.ratio).toBe(0)
+    expect(r.withinTolerance).toBe(true)
+  })
+
+  it('returns withinTolerance=true when both counts are zero (off-peak)', async () => {
+    queryMock
+      .mockResolvedValueOnce(res([{ c: '0' }]))
+      .mockResolvedValueOnce(res([{ c: '0' }]))
+
+    const r = await computeReconciliation()
+    expect(r.ratio).toBe(0)
+    expect(r.withinTolerance).toBe(true)
+  })
+
+  it('returns withinTolerance=true when diff is at the 1% threshold', async () => {
+    queryMock
+      .mockResolvedValueOnce(res([{ c: '100' }]))
+      .mockResolvedValueOnce(res([{ c: '99' }]))
+
+    const r = await computeReconciliation()
+    expect(r.absDiff).toBe(1)
+    expect(r.ratio).toBeCloseTo(0.01, 4)
+    expect(r.withinTolerance).toBe(true)
+  })
+
+  it('returns withinTolerance=false when diff exceeds 1%', async () => {
+    queryMock
+      .mockResolvedValueOnce(res([{ c: '1000' }]))
+      .mockResolvedValueOnce(res([{ c: '950' }]))
+
+    const r = await computeReconciliation()
+    expect(r.absDiff).toBe(50)
+    expect(r.ratio).toBe(0.05)
+    expect(r.withinTolerance).toBe(false)
+  })
+
+  it('clips the window to end an hour before now so in-flight writes do not skew it', async () => {
+    queryMock
+      .mockResolvedValueOnce(res([{ c: '0' }]))
+      .mockResolvedValueOnce(res([{ c: '0' }]))
+
+    const before = Date.now()
+    const r = await computeReconciliation()
+    const after = Date.now()
+
+    const toMs = new Date(r.windowToUtc).getTime()
+    const fromMs = new Date(r.windowFromUtc).getTime()
+
+    // windowTo should be ~1h ago, windowFrom should be ~25h ago.
+    expect(toMs).toBeLessThanOrEqual(after - 3_500_000)
+    expect(toMs).toBeGreaterThanOrEqual(before - 3_700_000)
+    expect(toMs - fromMs).toBe(24 * 3_600_000)
+  })
+
+  it('throws via runReconciliationCron when out of tolerance', async () => {
+    queryMock
+      .mockResolvedValueOnce(res([{ c: '100' }]))
+      .mockResolvedValueOnce(res([{ c: '50' }]))
+
+    await expect(runReconciliationCron()).rejects.toThrow(/drift.*>.*1%/)
+  })
+
+  it('resolves cleanly via runReconciliationCron when within tolerance', async () => {
+    queryMock
+      .mockResolvedValueOnce(res([{ c: '100' }]))
+      .mockResolvedValueOnce(res([{ c: '100' }]))
+
+    const r = await runReconciliationCron()
+    expect(r.withinTolerance).toBe(true)
+  })
+})

--- a/apps/server/src/lib/events-reconciliation.ts
+++ b/apps/server/src/lib/events-reconciliation.ts
@@ -1,0 +1,130 @@
+/**
+ * Phase 5.1 Stage 3 — events vs requests reconciliation.
+ *
+ * Runs daily from /cron/events-reconciliation. Compares the row counts
+ * over a recent window and reports the absolute diff + ratio. The
+ * cron logs the result through `withCronLog`, so:
+ *
+ *   • A drift inside threshold → status='ok', stays out of /health/deep
+ *     and only shows up in cron_job_runs for trend inspection.
+ *   • A drift above threshold → console.error (Vercel logs pick it up)
+ *     AND the cron call itself throws to mark the run 'error' in
+ *     cron_job_runs.
+ *
+ * The window deliberately ends 1 hour ago so we don't compare counts
+ * mid-write — the dual-write path can race with the comparison
+ * window otherwise. (events writes 30ms after `requests`; an
+ * in-flight call would skew the diff toward "events smaller".)
+ *
+ * Threshold (`DIFF_TOLERANCE_RATIO = 0.01`, i.e. 1%) is the value
+ * called out in docs/plans/langfuse-benchmarking-success-criteria.md
+ * §Metrics. Bump it once we get a few days of baseline data and know
+ * the natural noise floor.
+ */
+
+import { getClickhouse } from './clickhouse.js'
+
+const RECON_WINDOW_HOURS = 24
+const RECON_END_LAG_HOURS = 1
+const DIFF_TOLERANCE_RATIO = 0.01
+
+export interface ReconciliationResult {
+  windowFromUtc: string
+  windowToUtc: string
+  requestsCount: number
+  eventsCount: number
+  absDiff: number
+  ratio: number
+  withinTolerance: boolean
+}
+
+/**
+ * Read one count from the shared CH client. Throws on transport
+ * error so the caller can mark the cron run failed.
+ */
+async function singleCount(query: string, params: Record<string, unknown>): Promise<number> {
+  const res = await getClickhouse().query({
+    query,
+    query_params: params,
+    format: 'JSONEachRow',
+  })
+  const rows = (await res.json()) as Array<{ c: string }>
+  return Number(rows[0]?.c ?? 0)
+}
+
+/**
+ * Compute the diff between `requests` and `events`-with-generation
+ * over the reconciliation window. Caller decides whether to throw on
+ * an out-of-tolerance result.
+ */
+export async function computeReconciliation(): Promise<ReconciliationResult> {
+  const now = new Date()
+  const windowToUtc = new Date(now.getTime() - RECON_END_LAG_HOURS * 3_600_000)
+  const windowFromUtc = new Date(windowToUtc.getTime() - RECON_WINDOW_HOURS * 3_600_000)
+
+  // CH expects 'YYYY-MM-DD HH:MM:SS.fff' — gotcha #18.
+  const fmt = (d: Date): string => d.toISOString().replace('T', ' ').replace('Z', '')
+
+  const params = {
+    from_ts: fmt(windowFromUtc),
+    to_ts: fmt(windowToUtc),
+  }
+
+  const [requestsCount, eventsCount] = await Promise.all([
+    singleCount(
+      `SELECT count() AS c FROM requests
+       WHERE created_at >= parseDateTime64BestEffort({from_ts:String})
+         AND created_at <  parseDateTime64BestEffort({to_ts:String})`,
+      params,
+    ),
+    singleCount(
+      `SELECT count() AS c FROM events
+       WHERE event_type = 'generation'
+         AND created_at >= parseDateTime64BestEffort({from_ts:String})
+         AND created_at <  parseDateTime64BestEffort({to_ts:String})`,
+      params,
+    ),
+  ])
+
+  const absDiff = Math.abs(requestsCount - eventsCount)
+  // If both counts are zero (off-peak / quiet org) we treat the ratio
+  // as 0 to avoid a divide-by-zero and a false alarm.
+  const denom = Math.max(requestsCount, eventsCount)
+  const ratio = denom === 0 ? 0 : absDiff / denom
+
+  return {
+    windowFromUtc: windowFromUtc.toISOString(),
+    windowToUtc: windowToUtc.toISOString(),
+    requestsCount,
+    eventsCount,
+    absDiff,
+    ratio,
+    withinTolerance: ratio <= DIFF_TOLERANCE_RATIO,
+  }
+}
+
+/**
+ * Cron handler — runs the reconciliation, throws when out of
+ * tolerance so the cron-log marks the run failed. Returns the
+ * full result on success for the JSON response.
+ */
+export async function runReconciliationCron(): Promise<ReconciliationResult> {
+  const result = await computeReconciliation()
+  if (!result.withinTolerance) {
+    // Logged loudly so Vercel runtime logs surface it even if the
+    // throw is later caught somewhere upstream.
+    console.error('[events-reconciliation] drift above threshold:', result)
+    throw new Error(
+      `events vs requests drift ${(result.ratio * 100).toFixed(2)}% > ${
+        DIFF_TOLERANCE_RATIO * 100
+      }% (requests=${result.requestsCount}, events=${result.eventsCount})`,
+    )
+  }
+  return result
+}
+
+export const _internalForTesting = {
+  DIFF_TOLERANCE_RATIO,
+  RECON_WINDOW_HOURS,
+  RECON_END_LAG_HOURS,
+}

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -20,6 +20,7 @@
     { "path": "/cron/check-past-due-downgrades",  "schedule": "0 10 * * *" },
     { "path": "/cron/execute-pending-deletions",  "schedule": "0 */6 * * *" },
     { "path": "/cron/run-background-migrations",  "schedule": "*/5 * * * *" },
+    { "path": "/cron/events-reconciliation",      "schedule": "0 2 * * *" },
     { "path": "/cron/keep-warm",                  "schedule": "*/5 * * * *" }
   ]
 }


### PR DESCRIPTION
Phase 5.1 PR-6 — closes the Stage 3 metrics gap from success criteria plan.

## What
- `lib/events-reconciliation.ts` (new) — counts requests vs events over 24h window ending 1h ago, threshold 1% absolute diff
- `/cron/events-reconciliation` endpoint — daily at 02:00 UTC
- Out-of-tolerance → `console.error` + `cron_job_runs` status='error' so Vercel logs surface drift

## Test
- [x] 7 new unit tests, 742 server tests total