### PR TITLE
feat(5.1): PR-7a — backfill traces+spans to events + traces/spans views

### DIFF
--- a/apps/server/src/lib/background-migrations/registry/index.ts
+++ b/apps/server/src/lib/background-migrations/registry/index.ts
@@ -25,6 +25,8 @@
 import type { BackgroundMigration } from '../index.js'
 import { noopHealthcheck } from './migrations/noop-healthcheck.js'
 import { backfillEventsFromRequests } from './migrations/backfill-events-from-requests.js'
+import { backfillTracesFromSupabase } from './migrations/backfill-traces-from-supabase.js'
+import { backfillSpansFromSupabase } from './migrations/backfill-spans-from-supabase.js'
 
 const REGISTRY = new Map<string, BackgroundMigration>([
   // Always-registered no-op so the cron has something to exercise on
@@ -36,6 +38,14 @@ const REGISTRY = new Map<string, BackgroundMigration>([
   // name='backfill-events-from-requests' to start it; the cron will
   // pick it up on the next 5-minute tick.
   [backfillEventsFromRequests.name, backfillEventsFromRequests],
+
+  // Phase 5.1 PR-7a — backfill historical traces and spans from
+  // Postgres into the unified events table. Run traces first (parent
+  // rows) then spans. INSERT one row per migration:
+  //   name='backfill-traces-from-supabase'
+  //   name='backfill-spans-from-supabase'
+  [backfillTracesFromSupabase.name, backfillTracesFromSupabase],
+  [backfillSpansFromSupabase.name, backfillSpansFromSupabase],
 ])
 
 export function getRegistry(): ReadonlyMap<string, BackgroundMigration> {

--- a/apps/server/src/lib/background-migrations/registry/migrations/backfill-spans-from-supabase.test.ts
+++ b/apps/server/src/lib/background-migrations/registry/migrations/backfill-spans-from-supabase.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { mapSpanToEventRow } from './backfill-spans-from-supabase.js'
+
+function span(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'spn-1',
+    trace_id: 'trc-1',
+    parent_span_id: 'spn-0',
+    organization_id: 'org-1',
+    name: 'llm_judge',
+    span_type: 'llm',
+    status: 'success',
+    started_at: '2026-06-06T00:00:00.000Z',
+    ended_at: '2026-06-06T00:00:00.500Z',
+    duration_ms: 500,
+    input: { prompt: 'Rate this output.' },
+    output: { rating: 4 },
+    metadata: { judge_model: 'gpt-4o' },
+    error_message: null,
+    prompt_tokens: 100,
+    completion_tokens: 25,
+    total_tokens: 125,
+    cost_usd: '0.0008',
+    created_at: '2026-06-06T00:00:00.000Z',
+    ...overrides,
+  } as never
+}
+
+describe('mapSpanToEventRow', () => {
+  it('emits an event_type=span row that links to its trace + parent', () => {
+    const row = mapSpanToEventRow(span())
+    expect(row['event_id']).toBe('spn-1')
+    expect(row['trace_id']).toBe('trc-1')
+    expect(row['parent_event_id']).toBe('spn-0')
+    expect(row['event_type']).toBe('span')
+  })
+
+  it('rolls span_type and status into metadata so the view can read them out', () => {
+    const row = mapSpanToEventRow(span())
+    expect(row['metadata']).toMatchObject({
+      source: 'backfill_spans_from_supabase',
+      status: 'success',
+      span_type: 'llm',
+      judge_model: 'gpt-4o',
+    })
+  })
+
+  it('writes the historical token map even when one count is zero', () => {
+    const row = mapSpanToEventRow(span({ completion_tokens: 0 }))
+    expect(row['usage_details']).toEqual({
+      prompt_tokens: 100,
+      completion_tokens: 0,
+      total_tokens: 125,
+    })
+  })
+
+  it('serialises jsonb input/output to JSON strings for CH', () => {
+    const row = mapSpanToEventRow(span())
+    expect(row['input']).toBe(JSON.stringify({ prompt: 'Rate this output.' }))
+    expect(row['output']).toBe(JSON.stringify({ rating: 4 }))
+  })
+
+  it('handles null input/output gracefully (empty string)', () => {
+    const row = mapSpanToEventRow(span({ input: null, output: null }))
+    expect(row['input']).toBe('')
+    expect(row['output']).toBe('')
+  })
+
+  it('produces cost_details only when cost is present', () => {
+    const noCost = mapSpanToEventRow(span({ cost_usd: null }))
+    expect(noCost['total_cost_usd']).toBeNull()
+    expect(noCost['cost_details']).toEqual({})
+
+    const withCost = mapSpanToEventRow(span())
+    expect(withCost['total_cost_usd']).toBe(0.0008)
+    expect(withCost['cost_details']).toEqual({ total_cost_usd: 0.0008 })
+  })
+})

--- a/apps/server/src/lib/background-migrations/registry/migrations/backfill-spans-from-supabase.ts
+++ b/apps/server/src/lib/background-migrations/registry/migrations/backfill-spans-from-supabase.ts
@@ -1,0 +1,206 @@
+import type { BackgroundMigration, ChunkResult, ChunkState } from '../../index.js'
+import { getClickhouse, toClickhouseTimestamp } from '../../../clickhouse.js'
+import { supabaseAdmin } from '../../../db.js'
+
+/**
+ * Phase 5.1 PR-7a — copy historical Supabase `spans` rows into the
+ * unified `events` table (event_type='span').
+ *
+ * Runs AFTER backfill-traces-from-supabase finishes so the parent
+ * traces are already on `events` when their children land.
+ *
+ * Chunk size: 500 rows. Spans carry input/output JSONB so payload
+ * per row is bigger than traces, but at this fleet size the network
+ * RTT still dominates.
+ */
+
+interface BackfillCursor {
+  last_created_at: string
+  last_id: string
+  rows_processed: number
+  total_estimate: number | null
+}
+
+const CHUNK_SIZE = 500
+
+function readCursor(state: ChunkState): BackfillCursor {
+  return {
+    last_created_at:
+      typeof state['last_created_at'] === 'string'
+        ? (state['last_created_at'] as string)
+        : '1970-01-01T00:00:00.000Z',
+    last_id:
+      typeof state['last_id'] === 'string'
+        ? (state['last_id'] as string)
+        : '00000000-0000-0000-0000-000000000000',
+    rows_processed:
+      typeof state['rows_processed'] === 'number'
+        ? (state['rows_processed'] as number)
+        : 0,
+    total_estimate:
+      typeof state['total_estimate'] === 'number'
+        ? (state['total_estimate'] as number)
+        : null,
+  }
+}
+
+interface SpanRow {
+  id: string
+  trace_id: string
+  parent_span_id: string | null
+  organization_id: string
+  name: string
+  span_type: string
+  status: string
+  started_at: string
+  ended_at: string | null
+  duration_ms: number | null
+  input: unknown
+  output: unknown
+  metadata: Record<string, unknown> | null
+  error_message: string | null
+  prompt_tokens: number
+  completion_tokens: number
+  total_tokens: number
+  cost_usd: number | string | null
+  created_at: string
+}
+
+function flattenMetadata(
+  meta: Record<string, unknown> | null,
+  status: string,
+  spanType: string,
+): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (meta) {
+    for (const [k, v] of Object.entries(meta)) {
+      if (typeof v === 'string') out[k] = v
+    }
+  }
+  // Always wins so a customer payload can't shadow the backfill
+  // marker, status, or span_type.
+  out['source'] = 'backfill_spans_from_supabase'
+  out['status'] = status
+  out['span_type'] = spanType
+  return out
+}
+
+function mapSpanToEventRow(s: SpanRow): Record<string, unknown> {
+  const startedAt = toClickhouseTimestamp(new Date(s.started_at))
+  const endedAt = s.ended_at ? toClickhouseTimestamp(new Date(s.ended_at)) : null
+  const created = toClickhouseTimestamp(new Date(s.created_at))
+  const inputStr = s.input == null ? '' : JSON.stringify(s.input)
+  const outputStr = s.output == null ? '' : JSON.stringify(s.output)
+  const costNum = s.cost_usd != null ? Number(s.cost_usd) : null
+  return {
+    event_id: s.id,
+    trace_id: s.trace_id,
+    parent_event_id: s.parent_span_id,
+    event_type: 'span',
+    organization_id: s.organization_id,
+    project_id: '00000000-0000-0000-0000-000000000000', // spans table has no project_id; events column is NOT NULL UUID
+    api_key_id: null,
+    name: s.name,
+    provider: '',
+    model: '',
+    start_time: startedAt,
+    end_time: endedAt,
+    duration_ms: s.duration_ms,
+    input: inputStr,
+    output: outputStr,
+    usage_details: {
+      prompt_tokens: s.prompt_tokens,
+      completion_tokens: s.completion_tokens,
+      total_tokens: s.total_tokens,
+    },
+    cost_details: costNum != null ? { total_cost_usd: costNum } : {},
+    total_cost_usd: costNum,
+    total_tokens: s.total_tokens,
+    status_code: 0,
+    error_message: s.error_message,
+    metadata: flattenMetadata(s.metadata, s.status, s.span_type),
+    user_id: null,
+    session_id: null,
+    prompt_version_id: null,
+    provider_key_id: null,
+    flags: '[]',
+    response_flags: '{}',
+    has_security_flags: false,
+    truncated: 0,
+    created_at: created,
+  }
+}
+
+export const backfillSpansFromSupabase: BackgroundMigration = {
+  name: 'backfill-spans-from-supabase',
+  description:
+    'Phase 5.1 PR-7a — copy historical spans from Postgres into the unified events table, chunks of ' +
+    CHUNK_SIZE +
+    ' rows.',
+
+  async runChunk(state: ChunkState): Promise<ChunkResult> {
+    const cursor = readCursor(state)
+
+    let totalEstimate = cursor.total_estimate
+    if (totalEstimate == null) {
+      const { count } = await supabaseAdmin
+        .from('spans')
+        .select('id', { count: 'planned', head: true })
+      totalEstimate = count ?? 0
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from('spans')
+      .select(
+        'id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms, input, output, metadata, error_message, prompt_tokens, completion_tokens, total_tokens, cost_usd, created_at',
+      )
+      .or(
+        `created_at.gt.${cursor.last_created_at},and(created_at.eq.${cursor.last_created_at},id.gt.${cursor.last_id})`,
+      )
+      .order('created_at', { ascending: true })
+      .order('id', { ascending: true })
+      .limit(CHUNK_SIZE)
+
+    if (error) {
+      throw new Error(`supabase spans select failed: ${error.message}`)
+    }
+
+    const rows = (data ?? []) as SpanRow[]
+    if (rows.length === 0) return { done: true }
+
+    const eventRows = rows.map(mapSpanToEventRow)
+    await getClickhouse().insert({
+      table: 'events',
+      format: 'JSONEachRow',
+      values: eventRows,
+    })
+
+    const lastRow = rows[rows.length - 1]!
+    const nextCursor: BackfillCursor = {
+      last_created_at: lastRow.created_at,
+      last_id: lastRow.id,
+      rows_processed: cursor.rows_processed + rows.length,
+      total_estimate: totalEstimate,
+    }
+
+    const result: ChunkResult = {
+      done: false,
+      state: nextCursor as unknown as ChunkState,
+      progressCurrent: nextCursor.rows_processed,
+    }
+    if (totalEstimate != null) {
+      ;(result as { progressTotal?: number }).progressTotal = totalEstimate
+    }
+
+    if (
+      nextCursor.last_created_at === cursor.last_created_at &&
+      nextCursor.last_id === cursor.last_id
+    ) {
+      return { done: true }
+    }
+
+    return result
+  },
+}
+
+export { mapSpanToEventRow }

--- a/apps/server/src/lib/background-migrations/registry/migrations/backfill-traces-from-supabase.test.ts
+++ b/apps/server/src/lib/background-migrations/registry/migrations/backfill-traces-from-supabase.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { mapTraceToEventRow } from './backfill-traces-from-supabase.js'
+
+function trace(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'trc-1',
+    organization_id: 'org-1',
+    project_id: 'prj-1',
+    api_key_id: 'key-1',
+    name: 'eval_run',
+    status: 'success',
+    started_at: '2026-06-06T00:00:00.000Z',
+    ended_at: '2026-06-06T00:00:01.000Z',
+    duration_ms: 1000,
+    metadata: { source: 'production', evaluator_id: 'evl-1' },
+    error_message: null,
+    total_tokens: 1500,
+    total_cost_usd: '0.0025',
+    created_at: '2026-06-06T00:00:00.000Z',
+    external_trace_id: null,
+    ...overrides,
+  } as never
+}
+
+describe('mapTraceToEventRow', () => {
+  it('emits an event_type=trace row with event_id == trace_id', () => {
+    const row = mapTraceToEventRow(trace())
+    expect(row['event_id']).toBe('trc-1')
+    expect(row['trace_id']).toBe('trc-1')
+    expect(row['parent_event_id']).toBeNull()
+    expect(row['event_type']).toBe('trace')
+  })
+
+  it('tags the metadata source so live writes are distinguishable from backfill', () => {
+    const row = mapTraceToEventRow(trace())
+    expect(row['metadata']).toMatchObject({
+      source: 'backfill_traces_from_supabase',
+      status: 'success',
+      evaluator_id: 'evl-1',
+    })
+  })
+
+  it('coerces cost_usd from CH-style string to JS number', () => {
+    const row = mapTraceToEventRow(trace({ total_cost_usd: '0.0042' }))
+    expect(row['total_cost_usd']).toBe(0.0042)
+  })
+
+  it('treats null metadata gracefully', () => {
+    const row = mapTraceToEventRow(trace({ metadata: null }))
+    expect(row['metadata']).toEqual({
+      source: 'backfill_traces_from_supabase',
+      status: 'success',
+    })
+    expect(row['input']).toBe('')
+  })
+
+  it('formats start/end times into the CH-friendly shape', () => {
+    const row = mapTraceToEventRow(trace())
+    expect(row['start_time']).toMatch(/^2026-06-06 00:00:00/)
+    expect(row['end_time']).toMatch(/^2026-06-06 00:00:01/)
+  })
+})

--- a/apps/server/src/lib/background-migrations/registry/migrations/backfill-traces-from-supabase.ts
+++ b/apps/server/src/lib/background-migrations/registry/migrations/backfill-traces-from-supabase.ts
@@ -1,0 +1,199 @@
+import type { BackgroundMigration, ChunkResult, ChunkState } from '../../index.js'
+import { getClickhouse, toClickhouseTimestamp } from '../../../clickhouse.js'
+import { supabaseAdmin } from '../../../db.js'
+
+/**
+ * Phase 5.1 PR-7a — copy historical Supabase `traces` rows into the
+ * unified `events` table (event_type='trace').
+ *
+ * Pairs with backfill-spans-from-supabase. We backfill traces first
+ * so the events table's parent rows exist before child spans land —
+ * keeps the data dependency obvious if either backfill is paused.
+ *
+ * Cursor: (last_created_at, last_id). Supabase indexes `created_at`
+ * and `id` on `traces`, so the cursor lookup hits a btree scan.
+ *
+ * Chunk size: 500 rows. Traces are small (no body payloads on the
+ * trace row itself) so the round trip is dominated by network.
+ */
+
+interface BackfillCursor {
+  last_created_at: string
+  last_id: string
+  rows_processed: number
+  total_estimate: number | null
+}
+
+const CHUNK_SIZE = 500
+
+function readCursor(state: ChunkState): BackfillCursor {
+  return {
+    last_created_at:
+      typeof state['last_created_at'] === 'string'
+        ? (state['last_created_at'] as string)
+        : '1970-01-01T00:00:00.000Z',
+    last_id:
+      typeof state['last_id'] === 'string'
+        ? (state['last_id'] as string)
+        : '00000000-0000-0000-0000-000000000000',
+    rows_processed:
+      typeof state['rows_processed'] === 'number'
+        ? (state['rows_processed'] as number)
+        : 0,
+    total_estimate:
+      typeof state['total_estimate'] === 'number'
+        ? (state['total_estimate'] as number)
+        : null,
+  }
+}
+
+interface TraceRow {
+  id: string
+  organization_id: string
+  project_id: string
+  api_key_id: string | null
+  name: string
+  status: string
+  started_at: string
+  ended_at: string | null
+  duration_ms: number | null
+  metadata: Record<string, unknown> | null
+  error_message: string | null
+  total_tokens: number
+  total_cost_usd: number | string
+  created_at: string
+  external_trace_id: string | null
+}
+
+function flattenMetadata(meta: Record<string, unknown> | null, status: string): Record<string, string> {
+  // Start with the trace-level metadata so the backfill marker and
+  // the legacy status can't be overwritten if a customer payload
+  // contains a clashing `source` or `status` key.
+  const out: Record<string, string> = {}
+  if (meta) {
+    for (const [k, v] of Object.entries(meta)) {
+      if (typeof v === 'string') out[k] = v
+    }
+  }
+  out['source'] = 'backfill_traces_from_supabase'
+  out['status'] = status
+  return out
+}
+
+function mapTraceToEventRow(t: TraceRow): Record<string, unknown> {
+  const startedAt = toClickhouseTimestamp(new Date(t.started_at))
+  const endedAt = t.ended_at ? toClickhouseTimestamp(new Date(t.ended_at)) : null
+  const created = toClickhouseTimestamp(new Date(t.created_at))
+  return {
+    event_id: t.id,
+    trace_id: t.id,
+    parent_event_id: null,
+    event_type: 'trace',
+    organization_id: t.organization_id,
+    project_id: t.project_id,
+    api_key_id: t.api_key_id,
+    name: t.name,
+    provider: '',
+    model: '',
+    start_time: startedAt,
+    end_time: endedAt,
+    duration_ms: t.duration_ms,
+    input: t.metadata ? JSON.stringify(t.metadata) : '',
+    output: '',
+    usage_details: { total_tokens: t.total_tokens },
+    cost_details: {},
+    total_cost_usd: t.total_cost_usd != null ? Number(t.total_cost_usd) : null,
+    total_tokens: t.total_tokens,
+    status_code: 0,
+    error_message: t.error_message,
+    metadata: flattenMetadata(t.metadata, t.status),
+    user_id: null,
+    session_id: null,
+    prompt_version_id: null,
+    provider_key_id: null,
+    flags: '[]',
+    response_flags: '{}',
+    has_security_flags: false,
+    truncated: 0,
+    created_at: created,
+  }
+}
+
+export const backfillTracesFromSupabase: BackgroundMigration = {
+  name: 'backfill-traces-from-supabase',
+  description:
+    'Phase 5.1 PR-7a — copy historical traces from Postgres into the unified events table, chunks of ' +
+    CHUNK_SIZE +
+    ' rows.',
+
+  async runChunk(state: ChunkState): Promise<ChunkResult> {
+    const cursor = readCursor(state)
+
+    let totalEstimate = cursor.total_estimate
+    if (totalEstimate == null) {
+      const { count } = await supabaseAdmin
+        .from('traces')
+        .select('id', { count: 'planned', head: true })
+      totalEstimate = count ?? 0
+    }
+
+    // Supabase doesn't support tuple comparison; we approximate with
+    // `(created_at > cursor) OR (created_at == cursor AND id > cursor)`.
+    // For our 115-row dataset that's fine. At 100k+ traces we'd want
+    // a single-column cursor and a TIESBREAKER ORDER BY.
+    const { data, error } = await supabaseAdmin
+      .from('traces')
+      .select(
+        'id, organization_id, project_id, api_key_id, name, status, started_at, ended_at, duration_ms, metadata, error_message, total_tokens, total_cost_usd, created_at, external_trace_id',
+      )
+      .or(
+        `created_at.gt.${cursor.last_created_at},and(created_at.eq.${cursor.last_created_at},id.gt.${cursor.last_id})`,
+      )
+      .order('created_at', { ascending: true })
+      .order('id', { ascending: true })
+      .limit(CHUNK_SIZE)
+
+    if (error) {
+      throw new Error(`supabase traces select failed: ${error.message}`)
+    }
+
+    const rows = (data ?? []) as TraceRow[]
+    if (rows.length === 0) return { done: true }
+
+    const eventRows = rows.map(mapTraceToEventRow)
+    await getClickhouse().insert({
+      table: 'events',
+      format: 'JSONEachRow',
+      values: eventRows,
+    })
+
+    const lastRow = rows[rows.length - 1]!
+    const nextCursor: BackfillCursor = {
+      last_created_at: lastRow.created_at,
+      last_id: lastRow.id,
+      rows_processed: cursor.rows_processed + rows.length,
+      total_estimate: totalEstimate,
+    }
+
+    const result: ChunkResult = {
+      done: false,
+      state: nextCursor as unknown as ChunkState,
+      progressCurrent: nextCursor.rows_processed,
+    }
+    if (totalEstimate != null) {
+      ;(result as { progressTotal?: number }).progressTotal = totalEstimate
+    }
+
+    // Defensive: cursor didn't advance → stop.
+    if (
+      nextCursor.last_created_at === cursor.last_created_at &&
+      nextCursor.last_id === cursor.last_id
+    ) {
+      return { done: true }
+    }
+
+    return result
+  },
+}
+
+export { mapTraceToEventRow }

--- a/clickhouse/migrations/008_create_trace_and_span_views.sql
+++ b/clickhouse/migrations/008_create_trace_and_span_views.sql
@@ -1,0 +1,81 @@
+-- 008_create_trace_and_span_views.sql
+-- Phase 5.1 Stage 3 / PR-7a — projection views for trace + span rows.
+--
+-- The legacy `/api/v1/traces` handler reads from Supabase `traces`
+-- and `spans` tables. To flip it to read from the unified `events`
+-- table, we expose two views that match the Postgres column shape
+-- exactly so the handler can do a single FROM-clause substitution.
+--
+-- WHY two views and not one: the dashboard renders traces as the
+-- parent row (list + detail header) and spans as the nested tree
+-- in the detail view. Two views keep each SELECT cheap (each filters
+-- on event_type at the view definition, so the engine pushes the
+-- predicate down) and the handler code stays close to today's shape.
+--
+-- WHY hardcoded literal defaults for columns events doesn't carry:
+--   • external_trace_id / external_span_id / external_parent_span_id
+--     — populated by OTLP ingest in Postgres. Until events has them
+--     as first-class columns, we surface NULL.
+--   • span_count / total_tokens / total_cost_usd on traces — these
+--     are pre-aggregated in Postgres; the events shape would need a
+--     subquery per row. Stage 3 returns them computed at SELECT
+--     time via a single GROUP BY (handler responsibility), so the
+--     view returns 0 placeholders.
+--   • request_id on spans — references the legacy `requests` table.
+--     We expose the parent event's id as a stand-in.
+--
+-- IDEMPOTENT: CREATE VIEW IF NOT EXISTS.
+
+CREATE VIEW IF NOT EXISTS traces_view AS
+SELECT
+    event_id                                    AS id,
+    organization_id,
+    project_id,
+    api_key_id,
+    name,
+    coalesce(metadata['status'], '')            AS status,
+    start_time                                  AS started_at,
+    end_time                                    AS ended_at,
+    duration_ms,
+    error_message,
+    CAST(NULL, 'Nullable(String)')              AS external_trace_id,
+    -- These three are pre-aggregated on the Postgres traces table.
+    -- The handler re-derives them per-row from spans when serving
+    -- list responses (cheap LEFT JOIN ON trace_id under 1k traces).
+    CAST(0, 'UInt32')                           AS span_count,
+    CAST(0, 'UInt32')                           AS total_tokens,
+    CAST(0, 'Decimal(18, 8)')                   AS total_cost_usd,
+    metadata,
+    created_at,
+    created_at                                  AS updated_at
+FROM events
+WHERE event_type = 'trace';
+
+CREATE VIEW IF NOT EXISTS spans_view AS
+SELECT
+    event_id                                    AS id,
+    trace_id,
+    parent_event_id                             AS parent_span_id,
+    organization_id,
+    name,
+    coalesce(metadata['span_type'], '')         AS span_type,
+    coalesce(metadata['status'], '')            AS status,
+    start_time                                  AS started_at,
+    end_time                                    AS ended_at,
+    duration_ms,
+    input,
+    output,
+    metadata,
+    error_message,
+    -- `request_id` references the Postgres requests table; events
+    -- carries the parent context via parent_event_id already.
+    CAST(NULL, 'Nullable(UUID)')                AS request_id,
+    toUInt32OrZero(toString(usage_details['prompt_tokens']))     AS prompt_tokens,
+    toUInt32OrZero(toString(usage_details['completion_tokens'])) AS completion_tokens,
+    toUInt32OrZero(toString(usage_details['total_tokens']))      AS total_tokens,
+    total_cost_usd                              AS cost_usd,
+    CAST(NULL, 'Nullable(String)')              AS external_span_id,
+    CAST(NULL, 'Nullable(String)')              AS external_parent_span_id,
+    created_at
+FROM events
+WHERE event_type = 'span';


### PR DESCRIPTION
Phase 5.1 PR-7a. Lands the schema + migration plumbing the /api/v1/traces read switch (PR-7b) will flip to. No router change yet; production behavior unchanged.