### PR TITLE
feat(5.3 lite): events_fallback queue + replay for ClickHouse shadow writes

### DIFF
--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -19,7 +19,7 @@ import { runReconciliationCron } from '../lib/events-reconciliation.js'
 import { runLeakDetectionJob } from '../lib/leak-detection.js'
 import { sendHighConfidenceRecommendationAlerts } from '../lib/recommendation-notify.js'
 import { logCronRun } from '../lib/cron-logger.js'
-import { replayFallbackQueue } from '../lib/fallback-replay.js'
+import { replayFallbackQueue, replayEventsFallbackQueue } from '../lib/fallback-replay.js'
 import { runDowngradeCheck } from '../lib/billing-downgrade.js'
 import { executePendingDeletions } from './pendingDeletions.js'
 
@@ -477,13 +477,23 @@ cronRouter.get('/replay-fallback', async (c) => {
 
   const start = Date.now()
   try {
-    const result = await replayFallbackQueue()
+    // 5.3 lite — drain both backstop queues in one cron tick. Independent
+    // promises so a CH outage on one path doesn't block the other.
+    const [requestsResult, eventsResult] = await Promise.all([
+      replayFallbackQueue(),
+      replayEventsFallbackQueue(),
+    ])
     // Treat partial failure (some rows still queued after retry++) as success
     // for the cron infra — the rows will be retried next run. Only a top-level
     // result.error (e.g. Supabase SELECT failed) is a hard cron failure.
-    const status = result.error ? 'error' : 'ok'
-    logCronRun('replay-fallback', status, Date.now() - start, result.error).catch(console.error)
-    return c.json({ success: !result.error, ...result })
+    const topErr = requestsResult.error ?? eventsResult.error
+    const status = topErr ? 'error' : 'ok'
+    logCronRun('replay-fallback', status, Date.now() - start, topErr).catch(console.error)
+    return c.json({
+      success: !topErr,
+      requests: requestsResult,
+      events: eventsResult,
+    })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
     logCronRun('replay-fallback', 'error', Date.now() - start, msg).catch(console.error)

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -98,12 +98,15 @@ app.get('/health', (c) => c.json({ status: 'ok', timestamp: new Date().toISOStri
 // when one of them is slow.
 app.get('/health/deep', async (c) => {
   const { pingClickhouse } = await import('./lib/clickhouse.js')
-  const { fallbackQueueSize } = await import('./lib/fallback-replay.js')
+  const { fallbackQueueSize, eventsFallbackQueueSize } = await import(
+    './lib/fallback-replay.js'
+  )
 
   const start = Date.now()
-  const [chOk, fallbackQueue] = await Promise.all([
+  const [chOk, fallbackQueue, eventsFallback] = await Promise.all([
     pingClickhouse().catch(() => false),
     fallbackQueueSize().catch(() => null),
+    eventsFallbackQueueSize().catch(() => null),
   ])
   const chLatency = Date.now() - start
 
@@ -115,7 +118,7 @@ app.get('/health/deep', async (c) => {
       clickhouse: { ok: chOk, latencyMs: chLatency },
       // Null means the lookup itself failed (e.g. Supabase down) — not an
       // empty queue. Distinguish for triage.
-      fallback: { queue: fallbackQueue },
+      fallback: { queue: fallbackQueue, eventsQueue: eventsFallback },
     },
     overallOk ? 200 : 503,
   )

--- a/apps/server/src/lib/events-writer.test.ts
+++ b/apps/server/src/lib/events-writer.test.ts
@@ -11,9 +11,24 @@ vi.mock('./clickhouse.js', () => ({
     d.toISOString().replace('T', ' ').replace('Z', ''),
 }))
 
+// Mock the Supabase admin client too so the fallback enqueue path can
+// be exercised without a network call.
+const fallbackInsertMock = vi.fn().mockResolvedValue({ error: null })
+vi.mock('./db.js', () => ({
+  supabaseAdmin: {
+    from: (_table: string) => ({
+      insert: fallbackInsertMock,
+    }),
+  },
+}))
+
 import { writeRequestAsEvent, writeTraceAsEvent, writeSpanAsEvent } from './events-writer.js'
 
-afterEach(() => insertMock.mockClear())
+afterEach(() => {
+  insertMock.mockClear()
+  fallbackInsertMock.mockClear()
+  insertMock.mockResolvedValue(undefined)
+})
 
 describe('writeRequestAsEvent', () => {
   const baseData = {
@@ -148,5 +163,97 @@ describe('writeSpanAsEvent', () => {
     })
     expect(row.cost_details).toEqual({ total_cost_usd: 0.0008 })
     expect(row.total_tokens).toBe(275)
+  })
+})
+
+describe('insertEventOrQueue — 5.3 lite fallback path', () => {
+  const baseData = {
+    organizationId: 'org-1',
+    projectId: 'prj-1',
+    provider: 'openai',
+    model: 'gpt-4o-mini',
+    promptTokens: 100,
+    completionTokens: 50,
+    totalTokens: 150,
+    costUsd: 0.001,
+    latencyMs: 1200,
+    statusCode: 200,
+    requestBody: null,
+    responseBody: null,
+    errorMessage: null,
+    traceId: null,
+    spanId: null,
+  } as const
+
+  const requestRow = {
+    id: 'evt-99',
+    cost_usd: 0.001,
+    created_at: '2026-06-06 00:00:00.000',
+    request_body: '',
+    response_body: '',
+    error_message: null,
+  }
+
+  it('enqueues the row into events_fallback when ClickHouse throws', async () => {
+    insertMock.mockRejectedValueOnce(new Error('CH cold start'))
+
+    // The writer itself should still resolve — failure is contained.
+    await expect(writeRequestAsEvent(baseData, requestRow)).resolves.toBeUndefined()
+
+    expect(fallbackInsertMock).toHaveBeenCalledTimes(1)
+    const enqueued = fallbackInsertMock.mock.calls[0]?.[0] as {
+      payload: { event_id: string; event_type: string }
+      event_type: string
+      last_error: string
+    }
+    expect(enqueued.event_type).toBe('generation')
+    expect(enqueued.payload.event_id).toBe('evt-99')
+    expect(enqueued.last_error).toContain('CH cold start')
+  })
+
+  it('still resolves quietly when the Supabase enqueue itself fails (last-resort log)', async () => {
+    insertMock.mockRejectedValueOnce(new Error('CH down'))
+    fallbackInsertMock.mockRejectedValueOnce(new Error('supabase down too'))
+
+    await expect(writeRequestAsEvent(baseData, requestRow)).resolves.toBeUndefined()
+    // Row really is lost at this point — no further backstop. Test
+    // exists so a future regression that throws here is caught.
+  })
+
+  it('queues trace shadow writes when CH throws', async () => {
+    insertMock.mockRejectedValueOnce(new Error('CH unreachable'))
+
+    await writeTraceAsEvent({
+      traceId: 'trc-x',
+      organizationId: 'org-1',
+      projectId: 'prj-1',
+      name: 'eval_run',
+      startedAt: '2026-06-06T00:00:00.000Z',
+    })
+
+    expect(fallbackInsertMock).toHaveBeenCalledTimes(1)
+    expect(fallbackInsertMock.mock.calls[0]?.[0].event_type).toBe('trace')
+  })
+
+  it('queues span shadow writes when CH throws', async () => {
+    insertMock.mockRejectedValueOnce(new Error('CH unreachable'))
+
+    await writeSpanAsEvent({
+      spanId: 'spn-x',
+      traceId: 'trc-x',
+      organizationId: 'org-1',
+      projectId: 'prj-1',
+      name: 'llm_call',
+      startedAt: '2026-06-06T00:00:00.000Z',
+    })
+
+    expect(fallbackInsertMock).toHaveBeenCalledTimes(1)
+    expect(fallbackInsertMock.mock.calls[0]?.[0].event_type).toBe('span')
+  })
+
+  it('does NOT touch events_fallback on the happy path', async () => {
+    // insertMock default = resolves(undefined). No CH error.
+    await writeRequestAsEvent(baseData, requestRow)
+    expect(fallbackInsertMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/server/src/lib/events-writer.ts
+++ b/apps/server/src/lib/events-writer.ts
@@ -22,7 +22,46 @@
 
 import { randomUUID } from 'node:crypto'
 import { getClickhouse, toClickhouseTimestamp } from './clickhouse.js'
+import { supabaseAdmin } from './db.js'
 import type { RequestLogData } from './logger.js'
+
+/**
+ * Shared insert path for every events shadow write. Wraps the ClickHouse
+ * insert so that a CH-side failure (Cloud dev-tier auto-pause, transient
+ * network blip) queues the row into Supabase `events_fallback` instead of
+ * being lost. The `/cron/replay-fallback` cron drains that queue every
+ * five minutes — same retry semantics as `requests_fallback` (P2.6).
+ *
+ * Never throws. Caller treats events shadow writes as best-effort.
+ */
+async function insertEventOrQueue(row: Record<string, unknown>): Promise<void> {
+  try {
+    await getClickhouse().insert({
+      table: 'events',
+      format: 'JSONEachRow',
+      values: [row],
+    })
+  } catch (chErr) {
+    const message = chErr instanceof Error ? chErr.message : String(chErr)
+    console.error(
+      '[events-writer] CH insert failed → queueing to events_fallback:',
+      message,
+    )
+    try {
+      await supabaseAdmin.from('events_fallback').insert({
+        payload: row,
+        event_type: String(row['event_type'] ?? 'unknown'),
+        last_error: message.slice(0, 500),
+      })
+    } catch (queueErr) {
+      // Last-resort: even the Supabase enqueue failed. Surface loudly so
+      // sustained outages don't go silently. The row is genuinely lost
+      // at this point — there is no further backstop.
+      const queueMsg = queueErr instanceof Error ? queueErr.message : String(queueErr)
+      console.error('[events-writer] events_fallback enqueue failed too:', queueMsg)
+    }
+  }
+}
 
 /**
  * Shape of the row that landed in `requests`. We re-use the field
@@ -128,11 +167,7 @@ export async function writeRequestAsEvent(
     created_at: requestRow.created_at,
   }
 
-  await getClickhouse().insert({
-    table: 'events',
-    format: 'JSONEachRow',
-    values: [eventRow],
-  })
+  await insertEventOrQueue(eventRow)
 }
 
 // ── Trace + span shadow writes (used by ingest API) ──────────────────────────
@@ -194,11 +229,7 @@ export async function writeTraceAsEvent(input: TraceEventInput): Promise<void> {
     created_at: created,
   }
 
-  await getClickhouse().insert({
-    table: 'events',
-    format: 'JSONEachRow',
-    values: [eventRow],
-  })
+  await insertEventOrQueue(eventRow)
 }
 
 export interface SpanEventInput {
@@ -272,9 +303,5 @@ export async function writeSpanAsEvent(input: SpanEventInput): Promise<void> {
     created_at: created,
   }
 
-  await getClickhouse().insert({
-    table: 'events',
-    format: 'JSONEachRow',
-    values: [eventRow],
-  })
+  await insertEventOrQueue(eventRow)
 }

--- a/apps/server/src/lib/fallback-replay.ts
+++ b/apps/server/src/lib/fallback-replay.ts
@@ -142,3 +142,80 @@ export async function fallbackQueueSize(): Promise<number | null> {
   if (error) return null
   return count ?? 0
 }
+
+/**
+ * 5.3 lite — drain `events_fallback` into the ClickHouse `events` table.
+ * Mirrors `replayFallbackQueue` so the same cron endpoint can call both.
+ * Separate function (not parameterised) so the SQL stays readable and a
+ * future per-table tuning (chunk size, age) doesn't bleed across.
+ */
+export async function replayEventsFallbackQueue(): Promise<ReplayResult> {
+  const result: ReplayResult = {
+    attempted: 0,
+    replayed: 0,
+    failed: 0,
+    expired: 0,
+  }
+
+  const expiry = new Date(Date.now() - MAX_AGE_DAYS * 24 * 60 * 60 * 1000).toISOString()
+  const { count: expiredCount } = await supabaseAdmin
+    .from('events_fallback')
+    .delete({ count: 'exact' })
+    .or(`created_at.lt.${expiry},retry_count.gte.${MAX_RETRY_COUNT}`)
+  result.expired = expiredCount ?? 0
+
+  const { data: rows, error: selectError } = await supabaseAdmin
+    .from('events_fallback')
+    .select('id, payload, retry_count')
+    .order('created_at', { ascending: true })
+    .limit(REPLAY_BATCH_SIZE)
+
+  if (selectError) {
+    result.error = `select failed: ${selectError.message}`
+    return result
+  }
+
+  if (!rows || rows.length === 0) {
+    return result
+  }
+
+  result.attempted = rows.length
+
+  try {
+    await getClickhouse().insert({
+      table: 'events',
+      format: 'JSONEachRow',
+      values: rows.map((r) => r.payload as Record<string, unknown>),
+    })
+    const ids = rows.map((r) => r.id as string)
+    await supabaseAdmin.from('events_fallback').delete().in('id', ids)
+    result.replayed = rows.length
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    result.failed = rows.length
+    result.error = `clickhouse insert failed: ${message.slice(0, 300)}`
+
+    const now = new Date().toISOString()
+    for (const row of rows) {
+      await supabaseAdmin
+        .from('events_fallback')
+        .update({
+          retry_count: (row.retry_count as number) + 1,
+          last_retry_at: now,
+          last_error: message.slice(0, 500),
+        })
+        .eq('id', row.id as string)
+    }
+  }
+
+  return result
+}
+
+/** Companion size getter for `/health/deep` panels. */
+export async function eventsFallbackQueueSize(): Promise<number | null> {
+  const { count, error } = await supabaseAdmin
+    .from('events_fallback')
+    .select('id', { count: 'exact', head: true })
+  if (error) return null
+  return count ?? 0
+}

--- a/supabase/migrations/20260606100000_events_fallback.sql
+++ b/supabase/migrations/20260606100000_events_fallback.sql
@@ -1,0 +1,70 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- events_fallback — emergency queue for ClickHouse `events` shadow writes
+-- that couldn't reach ClickHouse.
+--
+-- WHY: Phase 5.1 Stage 3 made the dashboard read from the unified `events`
+-- table for every route. Stage 4 (Postgres traces/spans deprecate) needs
+-- `events` to become the single source of truth for traces and spans, so
+-- any in-flight write that fails (ClickHouse Cloud dev-tier auto-pause,
+-- transient network blip) must NOT be lost. `lib/events-writer.ts` currently
+-- swallows failures and writes them to console — fine in shadow-write mode
+-- (Postgres still has the row), insufficient once Postgres is removed.
+--
+-- DESIGN — mirrors `requests_fallback` (P2.6) on purpose:
+--   • Single Supabase table whose `payload jsonb` holds the full ClickHouse
+--     INSERT row exactly as events-writer would have sent it. Schema-opaque
+--     so this migration doesn't have to follow every `events` column add.
+--   • `event_type` surfaced as a separate column so a future operator
+--     dashboard can show queue depth per event_type (generation / trace /
+--     span) without parsing payload.
+--   • `retry_count` + `last_error` for cron back-off / poison-row detection.
+--   • RLS forbids client access — only `service_role` (server) writes.
+--   • Indexes on (created_at) for FIFO + (retry_count) for stalled-row sweep.
+--
+-- USAGE
+--   On ClickHouse insert failure → INSERT into events_fallback with the
+--   payload. The same `/cron/replay-fallback` (every 5 min) drains both
+--   `requests_fallback` AND `events_fallback` so a single endpoint handles
+--   both backstops.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS events_fallback (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- The full ClickHouse INSERT row, exactly as events-writer.ts would have
+  -- sent it. Opaque so this table doesn't need DDL changes when the
+  -- `events` ClickHouse schema evolves.
+  payload         JSONB NOT NULL,
+  -- Surfaced for cheap cron filtering and queue-depth-per-type dashboards.
+  -- Kept in sync with payload->>'event_type'.
+  event_type      TEXT NOT NULL,
+  -- Bumped by the replay cron each retry. After 7 days OR 100 retries the
+  -- cron expires the row (poison payload poisoning the queue).
+  retry_count     INTEGER NOT NULL DEFAULT 0,
+  last_error      TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_retry_at   TIMESTAMPTZ
+);
+
+-- FIFO replay + retention cleanup both want a chronological index.
+CREATE INDEX IF NOT EXISTS idx_events_fallback_created_at
+  ON events_fallback (created_at);
+
+-- Cheap scan for "stalled" rows.
+CREATE INDEX IF NOT EXISTS idx_events_fallback_retry_count
+  ON events_fallback (retry_count)
+  WHERE retry_count > 0;
+
+-- Queue-depth-per-event_type lookups (admin UI / metrics).
+CREATE INDEX IF NOT EXISTS idx_events_fallback_event_type
+  ON events_fallback (event_type);
+
+ALTER TABLE events_fallback ENABLE ROW LEVEL SECURITY;
+-- No policies = client access blocked. Server uses supabaseAdmin (service_role)
+-- which bypasses RLS by design.
+
+COMMENT ON TABLE events_fallback IS
+  'Backstop queue for ClickHouse events shadow writes that failed. Populated by lib/events-writer.ts catch path; drained by cron /replay-fallback alongside requests_fallback. Stage 4 prerequisite — events becomes single source of truth.';
+COMMENT ON COLUMN events_fallback.payload IS
+  'The full ClickHouse events INSERT row (JSONEachRow shape). Opaque so this table does not need migrations when the events CH schema changes.';
+COMMENT ON COLUMN events_fallback.event_type IS
+  'generation | trace | span. Mirrors payload->>event_type for cheap filtering.';


### PR DESCRIPTION
5.3 "lite" — closes the data-loss gap on the events shadow write path without bringing in R2 / Upstash Redis / Fly.io workers. Same pattern as `requests_fallback` (P2.6), drained by the same /cron/replay-fallback.

## Why now
Stage 4 (Postgres traces/spans deprecate) needs `events` to become single source of truth. Today every events shadow write that fails CH insert is silently dropped — fine while Postgres is primary, unsafe after.

## What
- **`supabase/migrations/20260606100000_events_fallback.sql`** — table mirrors `requests_fallback` + `event_type` column for per-type queue depth
- **`lib/events-writer.ts`** — new `insertEventOrQueue(row)` helper; 3 call sites switched. Never throws.
- **`lib/fallback-replay.ts`** — `replayEventsFallbackQueue()` + `eventsFallbackQueueSize()`
- **`/cron/replay-fallback`** — drains both queues via Promise.all
- **`/health/deep`** — `fallback.eventsQueue` alongside `fallback.queue`

## Test plan
- [x] 758 server tests passed (+5)
- [ ] Production: Supabase migration auto-applied via deploy-server.yml
- [ ] Verify `/health/deep` shows `fallback.eventsQueue: 0` after deploy
- [ ] supabase gen types regen after merge