### PR TITLE
fix(web): docs TableOfContents hydration mismatch + script-tag warning

### DIFF
--- a/apps/web/app/docs/_components/table-of-contents.tsx
+++ b/apps/web/app/docs/_components/table-of-contents.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useSyncExternalStore } from 'react'
 import { usePathname } from 'next/navigation'
 import { cn } from '@/lib/utils'
 
@@ -18,27 +18,71 @@ function slugify(text: string): string {
     .trim()
 }
 
+// Empty snapshot reused across renders so React's identity check in
+// useSyncExternalStore stays stable on the server. Returning a fresh
+// `[]` each call would force the hook to schedule a re-render every
+// pass, which React warns about during SSR.
+const EMPTY_HEADINGS: Heading[] = []
+
+/**
+ * Scan the article DOM for h2/h3 headings, slug-ifying any that lack an id.
+ *
+ * Memoised at the module level so React's identity comparison in
+ * useSyncExternalStore reuses the prior snapshot until the article actually
+ * mutates. Without a stable identity, React would call the snapshot on
+ * every render and re-run the IntersectionObserver effect downstream.
+ */
+let cachedSnapshot: { article: Element | null; headings: Heading[] } = {
+  article: null,
+  headings: EMPTY_HEADINGS,
+}
+function getClientHeadings(): Heading[] {
+  const article = typeof document === 'undefined' ? null : document.querySelector('article')
+  if (!article) {
+    cachedSnapshot = { article: null, headings: EMPTY_HEADINGS }
+    return EMPTY_HEADINGS
+  }
+  if (cachedSnapshot.article === article) {
+    return cachedSnapshot.headings
+  }
+  const els = Array.from(article.querySelectorAll('h2, h3')) as HTMLElement[]
+  const headings = els.map((el) => {
+    if (!el.id) el.id = slugify(el.textContent ?? '')
+    return {
+      id: el.id,
+      text: el.textContent ?? '',
+      level: parseInt(el.tagName[1] ?? '2'),
+    }
+  })
+  cachedSnapshot = { article, headings }
+  return headings
+}
+
+// No-op subscriber — heading list does not change after mount (a new
+// pathname remounts the parent via key={pathname}). React requires a
+// function reference here, so we hand it a stable no-op rather than
+// allocating a fresh one each render.
+function noopSubscribe() {
+  return () => {}
+}
+
 export function TableOfContents() {
-  // Remount the inner component when pathname changes so state resets
-  // (headings + activeId) instead of using setState-in-effect.
+  // Remount the inner component when pathname changes so the heading
+  // snapshot cache is invalidated and the IntersectionObserver rebinds
+  // against the new article's headings.
   const pathname = usePathname()
   return <TableOfContentsInner key={pathname} />
 }
 
 function TableOfContentsInner() {
-  // Collect headings from the article DOM lazily. SSR returns [] so the
-  // server-rendered HTML matches; on client mount the lazy initializer runs
-  // and finds the article's headings — no setState-in-effect needed.
-  const [headings] = useState<Heading[]>(() => {
-    if (typeof document === 'undefined') return []
-    const article = document.querySelector('article')
-    if (!article) return []
-    const els = Array.from(article.querySelectorAll('h2, h3')) as HTMLElement[]
-    return els.map((el) => {
-      if (!el.id) el.id = slugify(el.textContent ?? '')
-      return { id: el.id, text: el.textContent ?? '', level: parseInt(el.tagName[1] ?? '2') }
-    })
-  })
+  // useSyncExternalStore is the React-blessed escape hatch for values
+  // that legitimately differ between SSR and client. The server snapshot
+  // returns [] (no DOM) and the client snapshot walks the article. React
+  // hydrates against the server value, then on commit switches to the
+  // client value in a single, mismatch-free pass — distinct from a
+  // useState/useEffect dance, which would either fire a render-phase
+  // side effect or trigger the set-state-in-effect lint rule.
+  const headings = useSyncExternalStore(noopSubscribe, getClientHeadings, () => EMPTY_HEADINGS)
   const [activeId, setActiveId] = useState<string>('')
 
   useEffect(() => {


### PR DESCRIPTION
## What

Every docs page (`/docs/sdk`, `/docs/cli`, `/docs/quick-start`, `/docs/why`, …) logged two React warnings on first paint:

> Encountered a script tag while rendering React component.
> Hydration failed because the server rendered HTML didn't match the client.

This PR fixes the layout-level shared component that triggered them.

## Why

`TableOfContentsInner` used a `useState` lazy initializer that branched on `typeof document`. The intent was "SSR returns `[]`, client returns the heading list," but React runs lazy initializers on **both** the SSR pass and the first client render. SSR saw `document === undefined` and returned `[]`; the first client render saw the document and returned the populated heading list — so the first paint produced a `<nav>` element the SSR HTML didn't have, and React tore down the surrounding subtree to rebuild it. The lazy initializer was also mutating the article DOM (assigning `id` to headings missing one), which trips React's "render-phase code must be pure" guarantee.

## Changes

Switched to `useSyncExternalStore` — the React-blessed hook for values that legitimately differ between SSR and client. The server snapshot returns the shared `EMPTY_HEADINGS` constant; the client snapshot walks the article and caches the result against the article element identity so React's snapshot identity comparison stays stable.

The straightforward "set state inside useEffect" rewrite was rejected by the `react-hooks/set-state-in-effect` lint rule in React 19. `useSyncExternalStore` is the explicit escape hatch for this pattern.

## Verification

- ✅ `/docs/sdk`, `/docs/quick-start`, `/docs/why` all load with console clean
- ✅ TOC renders identically after the article mounts (no visual change)
- ✅ `pnpm --filter web typecheck && pnpm --filter web lint` pass
- ✅ No hydration tear-down on first paint anymore

## Notes for reviewers

This is independent of the Sprint 0 R-Q PR series (also up for review). It can land before or after them; the Sprint 0 R-Q3 (CLI docs) branch already cherry-picks this commit because the bug shows up on the new `/docs/cli` page too.