### PR TITLE
feat(db): R-Q1 drop NOT NULL on eval_results.score for typed scores

### DIFF
--- a/apps/server/src/__tests__/eval-results-null-score.test.ts
+++ b/apps/server/src/__tests__/eval-results-null-score.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, expectTypeOf } from 'vitest'
+import { validateScore, type ScoreConfig, type NormalizedScoreFields } from '../lib/score-validation.js'
+
+/**
+ * R-Q1 regression suite.
+ *
+ * Pins three invariants after the `eval_results.score DROP NOT NULL`
+ * migration (20260609100000):
+ *
+ *   1. `NormalizedScoreFields.score` is `number | null` at the type level.
+ *      `validateScore()` is the only path that builds the insert payload
+ *      for typed score columns, so if this widens or narrows in a way
+ *      incompatible with the new schema, the typecheck fails before
+ *      runtime sees it. The `supabase/types.ts` Row/Insert type is
+ *      verified by the typecheck of the routes that perform the actual
+ *      INSERT (eval-runner.ts, evals.ts) — re-importing it here would
+ *      reach outside `rootDir`.
+ *
+ *   2. `validateScore()` for CATEGORICAL / BOOLEAN / TEXT configs returns
+ *      `fields.score === null`. The migration only matters if the writer
+ *      actually emits null for non-numeric configs; this confirms it does.
+ *
+ *   3. NUMERIC configs keep mirroring the legacy `score` column from
+ *      `value_number`, so dashboards reading `AVG(score)` stay unaffected
+ *      by the migration. This is the backward-compat invariant.
+ *
+ * The migration itself is exercised by `supabase db push` and observable
+ * through `information_schema.columns.is_nullable = YES`; the full DB
+ * integration would need a real `eval_results` row, which is overkill for
+ * a column-nullability change.
+ */
+
+function makeConfig(overrides: Partial<ScoreConfig> = {}): ScoreConfig {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    data_type: 'NUMERIC',
+    min_value: 0,
+    max_value: 1,
+    categories: null,
+    bool_true_label: null,
+    bool_false_label: null,
+    ...overrides,
+  }
+}
+
+describe('R-Q1 — eval_results.score nullable', () => {
+  it('NormalizedScoreFields.score is nullable at the type level', () => {
+    expectTypeOf<NormalizedScoreFields['score']>().toEqualTypeOf<number | null>()
+  })
+
+  it('CATEGORICAL evaluator emits score=null + value_string set', () => {
+    const config = makeConfig({
+      data_type: 'CATEGORICAL',
+      categories: ['accepted', 'rejected'],
+      min_value: null,
+      max_value: null,
+    })
+
+    const r = validateScore(config, 'accepted')
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.fields.score).toBeNull()
+    expect(r.fields.value_string).toBe('accepted')
+    expect(r.fields.value_number).toBeNull()
+    expect(r.fields.value_boolean).toBeNull()
+  })
+
+  it('BOOLEAN evaluator emits score=null + value_boolean set', () => {
+    const config = makeConfig({
+      data_type: 'BOOLEAN',
+      min_value: null,
+      max_value: null,
+    })
+
+    const r = validateScore(config, true)
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.fields.score).toBeNull()
+    expect(r.fields.value_boolean).toBe(true)
+    expect(r.fields.value_number).toBeNull()
+    expect(r.fields.value_string).toBeNull()
+  })
+
+  it('TEXT evaluator emits score=null + value_string set', () => {
+    const config = makeConfig({
+      data_type: 'TEXT',
+      min_value: null,
+      max_value: null,
+    })
+
+    const r = validateScore(config, 'free-form judge reasoning')
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.fields.score).toBeNull()
+    expect(r.fields.value_string).toBe('free-form judge reasoning')
+    expect(r.fields.value_number).toBeNull()
+    expect(r.fields.value_boolean).toBeNull()
+  })
+
+  it('NUMERIC evaluator keeps mirroring score=value_number (backward compat)', () => {
+    const config = makeConfig({
+      data_type: 'NUMERIC',
+      min_value: 0,
+      max_value: 1,
+    })
+
+    const r = validateScore(config, 0.85)
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.fields.score).toBe(0.85)
+    expect(r.fields.value_number).toBe(0.85)
+    // Pre-migration dashboards that read AVG(score) still see 0.85.
+  })
+
+  it('Exactly one typed value column is non-null across all 4 score types', () => {
+    // Invariant: typed-value columns are mutually exclusive (lib/score-validation
+    // contract). If a future change accidentally fills two, downstream
+    // aggregations could double-count.
+    const cases: Array<[ScoreConfig, unknown]> = [
+      [makeConfig({ data_type: 'NUMERIC', min_value: 0, max_value: 1 }), 0.5],
+      [
+        makeConfig({
+          data_type: 'CATEGORICAL',
+          categories: ['ok'],
+          min_value: null,
+          max_value: null,
+        }),
+        'ok',
+      ],
+      [makeConfig({ data_type: 'BOOLEAN', min_value: null, max_value: null }), false],
+      [makeConfig({ data_type: 'TEXT', min_value: null, max_value: null }), 'note'],
+    ]
+
+    for (const [config, value] of cases) {
+      const r = validateScore(config, value)
+      if (!r.ok) throw new Error(`fixture ${config.data_type} should validate`)
+      const filled = [
+        r.fields.value_number,
+        r.fields.value_string,
+        r.fields.value_boolean,
+      ].filter((v) => v !== null).length
+      expect(filled, `${config.data_type} must fill exactly 1 typed column`).toBe(1)
+    }
+  })
+})

--- a/supabase/migrations/20260609100000_eval_results_score_nullable.sql
+++ b/supabase/migrations/20260609100000_eval_results_score_nullable.sql
@@ -1,0 +1,28 @@
+-- Migration: eval_results.score DROP NOT NULL
+--
+-- The score-type system (20260608010000 / 20260608020000) introduced four
+-- typed value columns: value_number / value_string / value_boolean (and the
+-- legacy numeric score). For NUMERIC configs the legacy score column is
+-- mirrored from value_number; but CATEGORICAL / BOOLEAN / TEXT results have
+-- no meaningful number to put in score, and writers had to fill a sentinel
+-- (0) just to satisfy the NOT NULL constraint. That sentinel was indistinct
+-- from a real "score = 0" answer and broke any downstream consumer that
+-- treated score as the source of truth.
+--
+-- The companion column on human_evals was already made nullable in
+-- 20260608010000. This migration mirrors that on eval_results so the typed
+-- pathway can land cleanly. validateScore() in lib/score-validation.ts
+-- guarantees that exactly one of (score / value_number / value_string /
+-- value_boolean) is non-null per row, so downstream readers that previously
+-- assumed score IS NOT NULL must now check the score_config_id + typed
+-- value columns instead.
+--
+-- Backward compatibility: NUMERIC evaluators (the only kind in production
+-- before the score-type rollout) keep writing both score and value_number,
+-- so dashboards that read score directly stay unaffected. Only the new
+-- CATEGORICAL / BOOLEAN / TEXT inserts produce score=NULL rows.
+
+ALTER TABLE eval_results ALTER COLUMN score DROP NOT NULL;
+
+COMMENT ON COLUMN eval_results.score IS
+  'Legacy numeric score. Mirrored from value_number for NUMERIC score_configs; NULL for CATEGORICAL/BOOLEAN/TEXT (see lib/score-validation.ts).';

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -584,7 +584,7 @@ export type Database = {
           organization_id: string
           reasoning: string | null
           request_id: string | null
-          score: number
+          score: number | null
           score_config_id: string | null
           value_boolean: boolean | null
           value_number: number | null
@@ -600,7 +600,7 @@ export type Database = {
           organization_id: string
           reasoning?: string | null
           request_id?: string | null
-          score: number
+          score?: number | null
           score_config_id?: string | null
           value_boolean?: boolean | null
           value_number?: number | null
@@ -616,7 +616,7 @@ export type Database = {
           organization_id?: string
           reasoning?: string | null
           request_id?: string | null
-          score?: number
+          score?: number | null
           score_config_id?: string | null
           value_boolean?: boolean | null
           value_number?: number | null
@@ -837,6 +837,36 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      events_fallback: {
+        Row: {
+          created_at: string
+          event_type: string
+          id: string
+          last_error: string | null
+          last_retry_at: string | null
+          payload: Json
+          retry_count: number
+        }
+        Insert: {
+          created_at?: string
+          event_type: string
+          id?: string
+          last_error?: string | null
+          last_retry_at?: string | null
+          payload: Json
+          retry_count?: number
+        }
+        Update: {
+          created_at?: string
+          event_type?: string
+          id?: string
+          last_error?: string | null
+          last_retry_at?: string | null
+          payload?: Json
+          retry_count?: number
+        }
+        Relationships: []
       }
       experiment_results: {
         Row: {
@@ -2855,3 +2885,4 @@ export const Constants = {
     },
   },
 } as const
+


### PR DESCRIPTION
## R-Code
R-Q1 (Sprint 0, +4 Eval area)

## What

`eval_results.score` becomes nullable so `CATEGORICAL` / `BOOLEAN` / `TEXT` evaluator results can stop filling a sentinel `0`.

## Why

The score-type system (`20260608010000` + `20260608020000`) introduced four typed value columns (`value_number` / `value_string` / `value_boolean`) so an evaluator can return a category, boolean, or free-form text instead of just a number. `human_evals.score` was made nullable in the same series; `eval_results.score` was missed, forcing writers of non-numeric results to fill a sentinel `0` that downstream readers could not distinguish from a real "score = 0" answer.

## Changes

- `supabase/migrations/20260609100000_eval_results_score_nullable.sql` — `ALTER TABLE eval_results ALTER COLUMN score DROP NOT NULL`
- `supabase/types.ts` — regenerated (`score: number | null`)
- `apps/server/src/__tests__/eval-results-null-score.test.ts` — 6-case regression suite pinning:
  - `NormalizedScoreFields.score` is `number | null` at the type level
  - CATEGORICAL / BOOLEAN / TEXT validators emit `score = null`
  - NUMERIC keeps mirroring `score = value_number` (backward compat)
  - typed value columns are mutually exclusive (exactly one non-null per row)

## Backward compatibility

`validateScore()` in `lib/score-validation.ts` still mirrors `score = value_number` for NUMERIC configs, so dashboards reading `AVG(score)` keep working unchanged. Only CATEGORICAL / BOOLEAN / TEXT inserts produce `score = NULL` rows from this point on.

## Verification

- ✅ `supabase db push --include-all` applies cleanly; `information_schema.columns.is_nullable = YES`
- ✅ `pnpm --filter server typecheck` clean
- ✅ `pnpm --filter server test`: 66 files / 771 tests pass (new regression: 6/6)
- ✅ Chrome MCP regression on `/evals`: existing NUMERIC evaluators render unchanged (90.0 / 77.0 / 82.0), console errors 0
- ⏳ Production migrate + 24h `/api/v1/evals/runs/*` monitoring (post-merge)

## Sprint 0 PR series

This is PR 1/6 of the Sprint 0 R-Q stack. Subsequent PRs (R-Q2 ~ R-Q6) target this branch as their base — see the GitHub project board for the chain.