### PR TITLE
docs(web): R-Q3 CLI docs page + landing + sidebar wiring

### DIFF
--- a/apps/server/src/__tests__/detect-missing-model-prices.test.ts
+++ b/apps/server/src/__tests__/detect-missing-model-prices.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+/**
+ * R-Q2 — /cron/detect-missing-model-prices unit tests.
+ *
+ * The cron handler is the entry point for the operator-facing alert when
+ * `model_prices` falls behind a new model release (gotcha #2). Three
+ * branches must be exercised because each has a different production
+ * failure mode:
+ *
+ *   1. Auth gate (CRON_SECRET) — fail-closed. If a refactor accidentally
+ *      removed the assertion, the endpoint becomes a tenant-blind
+ *      ClickHouse query open to the public internet.
+ *
+ *   2. Empty result (zero models exceed the 100/hour threshold) — must
+ *      NOT insert an internal_alerts row. Spurious alerts train the
+ *      operator to ignore the queue.
+ *
+ *   3. Non-empty result — exactly one alert row per run, with the
+ *      per-model breakdown in `details`. We don't dedupe against
+ *      unresolved alerts of the same kind (see cron.ts comment) so a
+ *      still-broken seed keeps re-firing until the operator fixes it.
+ */
+
+const supabaseInsertMock = vi.fn()
+const clickhouseQueryMock = vi.fn()
+const logCronRunMock = vi.fn()
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: (_table: string) => ({
+      insert: (payload: unknown) => supabaseInsertMock(payload),
+    }),
+  },
+}))
+
+vi.mock('../lib/clickhouse.js', () => ({
+  getClickhouse: () => ({
+    query: (opts: unknown) => clickhouseQueryMock(opts),
+  }),
+  getOrgClickhouse: () => ({ query: () => Promise.resolve({ json: () => [] }) }),
+}))
+
+vi.mock('../lib/cron-logger.js', () => ({
+  logCronRun: (...args: unknown[]) => {
+    logCronRunMock(...args)
+    return Promise.resolve()
+  },
+}))
+
+// Other cron-route imports pull in real modules we don't need here.
+// Mocking them keeps the cron.ts module-load side-effect-free.
+vi.mock('../lib/notifiers.js', () => ({ deliverToChannel: vi.fn() }))
+vi.mock('../lib/webhook-emit.js', () => ({ emitWebhookEvent: vi.fn() }))
+vi.mock('../lib/webhook-dispatch.js', () => ({ retryFailedWebhooks: vi.fn() }))
+vi.mock('../lib/paddle-usage.js', () => ({ computeAndReportOverages: vi.fn() }))
+vi.mock('../lib/quota-warnings.js', () => ({ runQuotaWarningsJob: vi.fn() }))
+vi.mock('../lib/anomaly-snapshot.js', () => ({ snapshotAnomaliesForAllOrgs: vi.fn() }))
+vi.mock('../lib/stale-key-digest.js', () => ({ runStaleKeyDigestJob: vi.fn() }))
+vi.mock('../lib/background-migrations/runner.js', () => ({ runDueMigrations: vi.fn() }))
+vi.mock('../lib/events-reconciliation.js', () => ({ runReconciliationCron: vi.fn() }))
+vi.mock('../lib/leak-detection.js', () => ({ runLeakDetectionJob: vi.fn() }))
+vi.mock('../lib/recommendation-notify.js', () => ({ sendHighConfidenceRecommendationAlerts: vi.fn() }))
+vi.mock('../lib/fallback-replay.js', () => ({
+  replayFallbackQueue: vi.fn(),
+  replayEventsFallbackQueue: vi.fn(),
+}))
+vi.mock('../lib/billing-downgrade.js', () => ({ runDowngradeCheck: vi.fn() }))
+vi.mock('../api/pendingDeletions.js', () => ({ executePendingDeletions: vi.fn() }))
+
+let cronRouter: typeof import('../api/cron.js').cronRouter
+const origSecret = process.env['CRON_SECRET']
+
+beforeEach(async () => {
+  vi.resetModules()
+  supabaseInsertMock.mockReset()
+  clickhouseQueryMock.mockReset()
+  logCronRunMock.mockReset()
+  process.env['CRON_SECRET'] = 'test-secret'
+  ;({ cronRouter } = await import('../api/cron.js'))
+})
+
+afterEach(() => {
+  if (origSecret === undefined) delete process.env['CRON_SECRET']
+  else process.env['CRON_SECRET'] = origSecret
+})
+
+function request(authHeader?: string) {
+  return cronRouter.request(
+    '/detect-missing-model-prices',
+    authHeader ? { headers: { Authorization: authHeader } } : {},
+  )
+}
+
+describe('R-Q2 — /cron/detect-missing-model-prices', () => {
+  test('rejects request without Bearer auth (401)', async () => {
+    const res = await request()
+    expect(res.status).toBe(401)
+    expect(supabaseInsertMock).not.toHaveBeenCalled()
+    expect(clickhouseQueryMock).not.toHaveBeenCalled()
+  })
+
+  test('rejects request with wrong secret (401)', async () => {
+    const res = await request('Bearer wrong')
+    expect(res.status).toBe(401)
+    expect(clickhouseQueryMock).not.toHaveBeenCalled()
+  })
+
+  test('fail-closed when CRON_SECRET unset', async () => {
+    delete process.env['CRON_SECRET']
+    vi.resetModules()
+    ;({ cronRouter } = await import('../api/cron.js'))
+
+    const res = await request('Bearer anything')
+    expect(res.status).toBe(401)
+  })
+
+  test('zero missing models → no internal_alerts insert + missing=0', async () => {
+    clickhouseQueryMock.mockResolvedValue({ json: async () => [] })
+
+    const res = await request('Bearer test-secret')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: boolean; missing: number }
+    expect(body.ok).toBe(true)
+    expect(body.missing).toBe(0)
+    expect(supabaseInsertMock).not.toHaveBeenCalled()
+    expect(logCronRunMock).toHaveBeenCalledWith(
+      'detect-missing-model-prices',
+      'ok',
+      expect.any(Number),
+    )
+  })
+
+  test('non-empty result → inserts exactly one internal_alerts row with details', async () => {
+    // ClickHouse JSONEachRow returns counts as STRINGS (gotcha #19).
+    // Use that exact shape in the fixture to lock the type conversion.
+    clickhouseQueryMock.mockResolvedValue({
+      json: async () => [
+        { model: 'gpt-4o-2026-11-01', missing_count: '512' },
+        { model: 'claude-sonnet-5', missing_count: '187' },
+      ],
+    })
+    supabaseInsertMock.mockResolvedValue({ error: null })
+
+    const res = await request('Bearer test-secret')
+    expect(res.status).toBe(200)
+
+    expect(supabaseInsertMock).toHaveBeenCalledTimes(1)
+    const payload = supabaseInsertMock.mock.calls[0]?.[0] as {
+      kind: string
+      severity: string
+      message: string
+      details: { models: Array<{ model: string; count: number }>; threshold: number }
+    }
+    expect(payload.kind).toBe('missing_model_prices')
+    expect(payload.severity).toBe('warn')
+    expect(payload.message).toContain('2 model(s) missing prices')
+    expect(payload.message).toContain('699 rows') // 512 + 187
+    expect(payload.details.threshold).toBe(100)
+    // Confirm string → number conversion (gotcha #19).
+    expect(payload.details.models).toEqual([
+      { model: 'gpt-4o-2026-11-01', count: 512 },
+      { model: 'claude-sonnet-5', count: 187 },
+    ])
+  })
+
+  test('ClickHouse query throws → 500 + logCronRun error', async () => {
+    clickhouseQueryMock.mockRejectedValue(new Error('ClickHouse unreachable'))
+
+    const res = await request('Bearer test-secret')
+    expect(res.status).toBe(500)
+    expect(supabaseInsertMock).not.toHaveBeenCalled()
+    expect(logCronRunMock).toHaveBeenCalledWith(
+      'detect-missing-model-prices',
+      'error',
+      expect.any(Number),
+      expect.stringContaining('ClickHouse unreachable'),
+    )
+  })
+
+  test('internal_alerts insert fails → 500 + logCronRun error', async () => {
+    clickhouseQueryMock.mockResolvedValue({
+      json: async () => [{ model: 'gpt-9', missing_count: '200' }],
+    })
+    supabaseInsertMock.mockResolvedValue({
+      error: { message: 'duplicate key value violates unique constraint' },
+    })
+
+    const res = await request('Bearer test-secret')
+    expect(res.status).toBe(500)
+    expect(logCronRunMock).toHaveBeenCalledWith(
+      'detect-missing-model-prices',
+      'error',
+      expect.any(Number),
+      expect.stringContaining('insert failed'),
+    )
+  })
+})

--- a/apps/server/src/__tests__/eval-results-null-score.test.ts
+++ b/apps/server/src/__tests__/eval-results-null-score.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, expectTypeOf } from 'vitest'
+import { validateScore, type ScoreConfig, type NormalizedScoreFields } from '../lib/score-validation.js'
+
+/**
+ * R-Q1 regression suite.
+ *
+ * Pins three invariants after the `eval_results.score DROP NOT NULL`
+ * migration (20260609100000):
+ *
+ *   1. `NormalizedScoreFields.score` is `number | null` at the type level.
+ *      `validateScore()` is the only path that builds the insert payload
+ *      for typed score columns, so if this widens or narrows in a way
+ *      incompatible with the new schema, the typecheck fails before
+ *      runtime sees it. The `supabase/types.ts` Row/Insert type is
+ *      verified by the typecheck of the routes that perform the actual
+ *      INSERT (eval-runner.ts, evals.ts) — re-importing it here would
+ *      reach outside `rootDir`.
+ *
+ *   2. `validateScore()` for CATEGORICAL / BOOLEAN / TEXT configs returns
+ *      `fields.score === null`. The migration only matters if the writer
+ *      actually emits null for non-numeric configs; this confirms it does.
+ *
+ *   3. NUMERIC configs keep mirroring the legacy `score` column from
+ *      `value_number`, so dashboards reading `AVG(score)` stay unaffected
+ *      by the migration. This is the backward-compat invariant.
+ *
+ * The migration itself is exercised by `supabase db push` and observable
+ * through `information_schema.columns.is_nullable = YES`; the full DB
+ * integration would need a real `eval_results` row, which is overkill for
+ * a column-nullability change.
+ */
+
+function makeConfig(overrides: Partial<ScoreConfig> = {}): ScoreConfig {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    data_type: 'NUMERIC',
+    min_value: 0,
+    max_value: 1,
+    categories: null,
+    bool_true_label: null,
+    bool_false_label: null,
+    ...overrides,
+  }
+}
+
+describe('R-Q1 — eval_results.score nullable', () => {
+  it('NormalizedScoreFields.score is nullable at the type level', () => {
+    expectTypeOf<NormalizedScoreFields['score']>().toEqualTypeOf<number | null>()
+  })
+
+  it('CATEGORICAL evaluator emits score=null + value_string set', () => {
+    const config = makeConfig({
+      data_type: 'CATEGORICAL',
+      categories: ['accepted', 'rejected'],
+      min_value: null,
+      max_value: null,
+    })
+
+    const r = validateScore(config, 'accepted')
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.fields.score).toBeNull()
+    expect(r.fields.value_string).toBe('accepted')
+    expect(r.fields.value_number).toBeNull()
+    expect(r.fields.value_boolean).toBeNull()
+  })
+
+  it('BOOLEAN evaluator emits score=null + value_boolean set', () => {
+    const config = makeConfig({
+      data_type: 'BOOLEAN',
+      min_value: null,
+      max_value: null,
+    })
+
+    const r = validateScore(config, true)
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.fields.score).toBeNull()
+    expect(r.fields.value_boolean).toBe(true)
+    expect(r.fields.value_number).toBeNull()
+    expect(r.fields.value_string).toBeNull()
+  })
+
+  it('TEXT evaluator emits score=null + value_string set', () => {
+    const config = makeConfig({
+      data_type: 'TEXT',
+      min_value: null,
+      max_value: null,
+    })
+
+    const r = validateScore(config, 'free-form judge reasoning')
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.fields.score).toBeNull()
+    expect(r.fields.value_string).toBe('free-form judge reasoning')
+    expect(r.fields.value_number).toBeNull()
+    expect(r.fields.value_boolean).toBeNull()
+  })
+
+  it('NUMERIC evaluator keeps mirroring score=value_number (backward compat)', () => {
+    const config = makeConfig({
+      data_type: 'NUMERIC',
+      min_value: 0,
+      max_value: 1,
+    })
+
+    const r = validateScore(config, 0.85)
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.fields.score).toBe(0.85)
+    expect(r.fields.value_number).toBe(0.85)
+    // Pre-migration dashboards that read AVG(score) still see 0.85.
+  })
+
+  it('Exactly one typed value column is non-null across all 4 score types', () => {
+    // Invariant: typed-value columns are mutually exclusive (lib/score-validation
+    // contract). If a future change accidentally fills two, downstream
+    // aggregations could double-count.
+    const cases: Array<[ScoreConfig, unknown]> = [
+      [makeConfig({ data_type: 'NUMERIC', min_value: 0, max_value: 1 }), 0.5],
+      [
+        makeConfig({
+          data_type: 'CATEGORICAL',
+          categories: ['ok'],
+          min_value: null,
+          max_value: null,
+        }),
+        'ok',
+      ],
+      [makeConfig({ data_type: 'BOOLEAN', min_value: null, max_value: null }), false],
+      [makeConfig({ data_type: 'TEXT', min_value: null, max_value: null }), 'note'],
+    ]
+
+    for (const [config, value] of cases) {
+      const r = validateScore(config, value)
+      if (!r.ok) throw new Error(`fixture ${config.data_type} should validate`)
+      const filled = [
+        r.fields.value_number,
+        r.fields.value_string,
+        r.fields.value_boolean,
+      ].filter((v) => v !== null).length
+      expect(filled, `${config.data_type} must fill exactly 1 typed column`).toBe(1)
+    }
+  })
+})

--- a/apps/server/src/api/admin/alerts.ts
+++ b/apps/server/src/api/admin/alerts.ts
@@ -1,0 +1,64 @@
+import { Hono } from 'hono'
+import { authJwt, type JwtContext } from '../../middleware/authJwt.js'
+import { requireSystemAdmin } from '../../middleware/requireSystemAdmin.js'
+import { supabaseAdmin } from '../../lib/db.js'
+
+/**
+ * Admin-only internal_alerts management.
+ *
+ *   GET  /api/v1/admin/alerts            list unresolved (default) or all
+ *   POST /api/v1/admin/alerts/:id/resolve  mark one resolved
+ *
+ * Authorization: SPANLENS_ADMIN_EMAILS env var (see requireSystemAdmin).
+ *
+ * The list endpoint defaults to `unresolved=true` because the operator
+ * workflow is "show me what's broken right now." Resolved history is
+ * available behind `?unresolved=false` for audit, but kept off the
+ * default view to reduce noise.
+ */
+export const adminAlertsRouter = new Hono<JwtContext>()
+
+adminAlertsRouter.use('*', authJwt)
+adminAlertsRouter.use('*', requireSystemAdmin)
+
+adminAlertsRouter.get('/', async (c) => {
+  const unresolvedOnly = c.req.query('unresolved') !== 'false'
+
+  let query = supabaseAdmin
+    .from('internal_alerts')
+    .select('id, kind, severity, message, details, resolved_at, resolved_by, created_at')
+    .order('created_at', { ascending: false })
+    .limit(200)
+
+  if (unresolvedOnly) {
+    query = query.is('resolved_at', null)
+  }
+
+  const { data, error } = await query
+  if (error) {
+    return c.json({ error: 'Failed to fetch alerts' }, 500)
+  }
+
+  return c.json({ success: true, data: data ?? [] })
+})
+
+adminAlertsRouter.post('/:id/resolve', async (c) => {
+  const id = c.req.param('id')
+  const userId = c.get('userId')
+
+  const { data, error } = await supabaseAdmin
+    .from('internal_alerts')
+    .update({
+      resolved_at: new Date().toISOString(),
+      resolved_by: userId,
+    })
+    .eq('id', id)
+    .is('resolved_at', null) // Idempotent — already-resolved rows are not touched.
+    .select('id, resolved_at')
+    .maybeSingle()
+
+  if (error) return c.json({ error: `Resolve failed: ${error.message}` }, 500)
+  if (!data) return c.json({ error: 'Alert not found or already resolved' }, 404)
+
+  return c.json({ success: true, data })
+})

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -621,6 +621,97 @@ cronRouter.get('/events-reconciliation', async (c) => {
   }
 })
 
+// GET /cron/detect-missing-model-prices
+//
+// Hourly scan over the last hour's `requests` table for rows where `model`
+// is populated but `cost_usd` is NULL. That combination means lib/cost.ts'
+// `calculateCost()` couldn't resolve a price row for the model — almost
+// always because `model_prices` doesn't have the SKU yet (gotcha #2: new
+// LLM releases land in production before our price seed catches up).
+//
+// Threshold: 100 missing rows / hour / model. Below that, transient
+// hiccups (mis-spelled model in a customer request, model in the middle
+// of being deprecated, etc.) fire too many false-positives. 100/hour
+// represents a real customer routing real traffic through an unpriced
+// model and losing cost attribution every minute they wait.
+//
+// Output: one `internal_alerts` row of kind `missing_model_prices` per
+// run when at least one model crosses the threshold. The details JSONB
+// carries the per-model breakdown so the operator can decide which seed
+// rows to add first. Multiple runs against the same unseeded model
+// produce multiple alerts — we don't de-dup, because the operator clicks
+// Resolve when they fix it and the next hour either re-fires (still
+// broken) or stays quiet (fixed). De-duping with "skip if unresolved
+// alert exists" would mask a still-failing fix.
+//
+// gotcha #32: this cron is internal ops, not org-scoped, so the
+// events/requests feature-flag dual-read pattern does not apply.
+// When Phase 5.1 Stage 4 lands and `requests` is dropped, the query
+// here moves to `events` in the same PR.
+cronRouter.get('/detect-missing-model-prices', async (c) => {
+  const authFail = assertCronAuth(c.req.header('Authorization'))
+  if (authFail) return c.json({ error: authFail }, 401)
+
+  const start = Date.now()
+
+  // We query ClickHouse directly (not via requestsScope) on purpose —
+  // this is a global health check, not a per-org read. The lint rule
+  // guards against tenant-blind reads from org-facing handlers; this
+  // handler is gated by CRON_SECRET, not by an org context. Same
+  // exception applied as `/keep-warm`.
+  try {
+    const rs = await getClickhouse().query({
+      query: `
+        SELECT model, count() AS missing_count
+        FROM requests
+        WHERE created_at >= now() - INTERVAL 1 HOUR
+          AND cost_usd IS NULL
+          AND model != ''
+        GROUP BY model
+        HAVING missing_count > 100
+        ORDER BY missing_count DESC
+      `,
+      format: 'JSONEachRow',
+    }).then((r) => r.json<{ model: string; missing_count: string }>())
+
+    // ClickHouse JSONEachRow returns numbers as strings (gotcha #19).
+    const models = rs.map((row) => ({
+      model: row.model,
+      count: Number(row.missing_count),
+    }))
+
+    if (models.length === 0) {
+      logCronRun('detect-missing-model-prices', 'ok', Date.now() - start).catch(console.error)
+      return c.json({ ok: true, missing: 0 })
+    }
+
+    const totalRows = models.reduce((sum, m) => sum + m.count, 0)
+    const { error: insertError } = await supabaseAdmin.from('internal_alerts').insert({
+      kind: 'missing_model_prices',
+      severity: 'warn',
+      message: `${models.length} model(s) missing prices in last 1h (${totalRows} rows)`,
+      details: { models, threshold: 100 },
+    })
+
+    if (insertError) {
+      logCronRun(
+        'detect-missing-model-prices',
+        'error',
+        Date.now() - start,
+        `internal_alerts insert failed: ${insertError.message}`,
+      ).catch(console.error)
+      return c.json({ ok: false, error: 'failed to insert alert' }, 500)
+    }
+
+    logCronRun('detect-missing-model-prices', 'ok', Date.now() - start).catch(console.error)
+    return c.json({ ok: true, missing: models.length, models })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    logCronRun('detect-missing-model-prices', 'error', Date.now() - start, message).catch(console.error)
+    return c.json({ ok: false, error: message }, 500)
+  }
+})
+
 // All three steps run in parallel via Promise.allSettled — one slow / failing
 // dependency doesn't block the others, and we never throw (cron retries are
 // noisy and a transient warmup failure is not worth alerting on). No

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -54,6 +54,7 @@ import { feedbackRouter }     from './api/feedback.js'
 import { adminModelPricesRouter } from './api/admin/modelPrices.js'
 import { adminModelRecommendationsRouter } from './api/admin/modelRecommendations.js'
 import { adminBackgroundMigrationsRouter } from './api/admin/backgroundMigrations.js'
+import { adminAlertsRouter } from './api/admin/alerts.js'
 import { sharesRouter }           from './api/shares.js'
 import { publicShareRouter }      from './api/publicShare.js'
 import { badgeRouter }            from './api/badge.js'
@@ -222,5 +223,6 @@ app.route('/api/v1/shares',         sharesRouter)   // PLG Loop ① — owner-si
 app.route('/api/v1/admin/model-prices', adminModelPricesRouter)
 app.route('/api/v1/admin/model-recommendations', adminModelRecommendationsRouter)
 app.route('/api/v1/admin/background-migrations', adminBackgroundMigrationsRouter)
+app.route('/api/v1/admin/alerts', adminAlertsRouter)
 
 export default app

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -21,6 +21,7 @@
     { "path": "/cron/execute-pending-deletions",  "schedule": "0 */6 * * *" },
     { "path": "/cron/run-background-migrations",  "schedule": "*/5 * * * *" },
     { "path": "/cron/events-reconciliation",      "schedule": "0 2 * * *" },
+    { "path": "/cron/detect-missing-model-prices","schedule": "0 * * * *" },
     { "path": "/cron/keep-warm",                  "schedule": "*/5 * * * *" }
   ]
 }

--- a/apps/web/app/(dashboard)/settings/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/settings/alerts/alerts-client.tsx
@@ -1,0 +1,211 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+import { AlertTriangle, AlertCircle, Info, CheckCircle, Loader2 } from 'lucide-react'
+import { Topbar } from '@/components/layout/topbar'
+import { cn } from '@/lib/utils'
+import {
+  useInternalAlerts,
+  useResolveAlert,
+  type AlertSeverity,
+  type InternalAlert,
+} from '@/lib/queries/use-internal-alerts'
+
+/**
+ * Spanlens operator alerts queue (R-Q2).
+ *
+ * Shows unresolved internal_alerts rows by default with a toggle for
+ * the resolved history. Each row carries the cron-emitted message plus
+ * the structured `details` JSON for inspection.
+ *
+ * Access control: API returns 403 unless the user's email is in
+ * SPANLENS_ADMIN_EMAILS. We render the page shell either way and let
+ * the query surface "Permission denied" — the page link is hidden
+ * from non-admin sidebars upstream of this client.
+ */
+
+const SEVERITY_STYLE: Record<AlertSeverity, string> = {
+  info: 'border-border bg-bg-elev text-text-muted',
+  warn: 'border-amber-500/40 bg-amber-500/10 text-amber-500',
+  error: 'border-bad/40 bg-bad/10 text-bad',
+}
+
+function SeverityBadge({ severity }: { severity: AlertSeverity }) {
+  const Icon = severity === 'error' ? AlertCircle : severity === 'warn' ? AlertTriangle : Info
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-[5px] border px-2 py-0.5 font-mono text-[10.5px] uppercase tracking-[0.04em]',
+        SEVERITY_STYLE[severity],
+      )}
+    >
+      <Icon className="h-3 w-3" />
+      {severity}
+    </span>
+  )
+}
+
+function formatAge(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime()
+  if (diffMs < 60_000) return `${Math.round(diffMs / 1000)}s ago`
+  if (diffMs < 3_600_000) return `${Math.round(diffMs / 60_000)}m ago`
+  if (diffMs < 86_400_000) return `${Math.round(diffMs / 3_600_000)}h ago`
+  return `${Math.round(diffMs / 86_400_000)}d ago`
+}
+
+function AlertRow({
+  alert,
+  onResolve,
+  resolving,
+}: {
+  alert: InternalAlert
+  onResolve: (id: string) => void
+  resolving: boolean
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const hasDetails = Object.keys(alert.details).length > 0
+
+  return (
+    <div className="border border-border rounded-lg overflow-hidden">
+      <div className="flex items-start justify-between gap-3 p-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1.5">
+            <SeverityBadge severity={alert.severity} />
+            <span className="font-mono text-[11px] text-text-faint">{alert.kind}</span>
+            <span className="font-mono text-[11px] text-text-faint">
+              · {formatAge(alert.created_at)}
+            </span>
+          </div>
+          <p className="text-[13px] text-text break-words">{alert.message}</p>
+          {hasDetails && (
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className="mt-2 font-mono text-[11px] text-text-faint hover:text-text-muted"
+            >
+              {expanded ? '▾ Hide details' : '▸ Show details'}
+            </button>
+          )}
+          {hasDetails && expanded && (
+            <pre className="mt-2 overflow-x-auto rounded-md bg-bg-elev p-3 font-mono text-[11px] text-text-muted">
+              {JSON.stringify(alert.details, null, 2)}
+            </pre>
+          )}
+        </div>
+        {alert.resolved_at ? (
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-[5px] border border-good/40 bg-good/10 px-2 py-1 font-mono text-[10.5px] uppercase tracking-[0.04em] text-good">
+            <CheckCircle className="h-3 w-3" />
+            resolved
+          </span>
+        ) : (
+          <button
+            onClick={() => onResolve(alert.id)}
+            disabled={resolving}
+            className="shrink-0 rounded-md border border-border bg-bg-elev px-3 py-1.5 font-mono text-[11px] hover:bg-bg-hover disabled:opacity-50"
+          >
+            {resolving ? <Loader2 className="h-3 w-3 animate-spin" /> : 'Resolve'}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function AlertsClient() {
+  const [showResolved, setShowResolved] = useState(false)
+  const query = useInternalAlerts(!showResolved)
+  const resolve = useResolveAlert()
+  const alerts = query.data ?? []
+
+  return (
+    <>
+      <Topbar
+        crumbs={[
+          { label: 'Settings', href: '/settings' },
+          { label: 'Internal alerts' },
+        ]}
+      />
+      <div className="px-6 py-8 max-w-[1100px] mx-auto">
+        <div className="mb-6">
+          <Link
+            href="/settings"
+            className="font-mono text-[11px] text-text-faint hover:text-text-muted"
+          >
+            ← Settings
+          </Link>
+          <h1 className="mt-2 text-2xl font-semibold">Internal alerts</h1>
+          <p className="mt-1 text-[13px] text-text-muted max-w-[680px]">
+            Spanlens operator queue. Surfaces Spanlens-wide problems detected
+            by cron jobs (missing model prices, orphan spans, fallback queue
+            buildup, webhook backlog). Resolving an entry is a soft
+            acknowledgement: the next cron run can re-fire if the underlying
+            condition is still present.
+          </p>
+        </div>
+
+        <div className="mb-4 flex items-center gap-2">
+          <button
+            onClick={() => setShowResolved(false)}
+            className={cn(
+              'rounded-md border px-3 py-1.5 font-mono text-[11px]',
+              !showResolved
+                ? 'border-accent bg-accent-bg/40 text-text'
+                : 'border-border bg-bg-elev text-text-muted hover:text-text',
+            )}
+          >
+            Unresolved
+          </button>
+          <button
+            onClick={() => setShowResolved(true)}
+            className={cn(
+              'rounded-md border px-3 py-1.5 font-mono text-[11px]',
+              showResolved
+                ? 'border-accent bg-accent-bg/40 text-text'
+                : 'border-border bg-bg-elev text-text-muted hover:text-text',
+            )}
+          >
+            All (recent)
+          </button>
+          {query.isFetching && (
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-text-faint" />
+          )}
+        </div>
+
+        {query.isLoading && (
+          <div className="rounded-lg border border-border bg-bg-elev p-6 text-center font-mono text-[12px] text-text-faint">
+            Loading…
+          </div>
+        )}
+
+        {query.isError && (
+          <div className="rounded-lg border border-bad/40 bg-bad/10 p-6 text-[13px] text-bad">
+            Failed to load alerts.
+            {' '}
+            {query.error instanceof Error ? query.error.message : 'Unknown error.'}
+          </div>
+        )}
+
+        {!query.isLoading && !query.isError && alerts.length === 0 && (
+          <div className="rounded-lg border border-border bg-bg-elev p-8 text-center">
+            <CheckCircle className="mx-auto h-6 w-6 text-good" />
+            <p className="mt-2 text-[13px] text-text">All clear.</p>
+            <p className="mt-1 font-mono text-[11px] text-text-faint">
+              No {showResolved ? 'alerts in the recent window' : 'unresolved alerts'}.
+            </p>
+          </div>
+        )}
+
+        <div className="space-y-3">
+          {alerts.map((alert) => (
+            <AlertRow
+              key={alert.id}
+              alert={alert}
+              onResolve={(id) => resolve.mutate(id)}
+              resolving={resolve.isPending && resolve.variables === alert.id}
+            />
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/alerts/page.tsx
+++ b/apps/web/app/(dashboard)/settings/alerts/page.tsx
@@ -1,0 +1,9 @@
+import { AlertsClient } from './alerts-client'
+
+export const metadata = {
+  title: 'Internal alerts · Spanlens',
+}
+
+export default function AlertsPage() {
+  return <AlertsClient />
+}

--- a/apps/web/app/docs/_components/sidebar.tsx
+++ b/apps/web/app/docs/_components/sidebar.tsx
@@ -91,6 +91,7 @@ const NAV: NavGroup[] = [
     title: 'SDK & integrations',
     items: [
       { title: '@spanlens/sdk', href: '/docs/sdk' },
+      { title: '@spanlens/cli', href: '/docs/cli' },
       { title: 'LangGraph', href: '/docs/integrations/langgraph' },
       { title: 'LangChain', href: '/docs/sdk#langchain' },
       { title: 'Vercel AI SDK', href: '/docs/sdk#vercel-ai' },

--- a/apps/web/app/docs/_components/table-of-contents.tsx
+++ b/apps/web/app/docs/_components/table-of-contents.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useSyncExternalStore } from 'react'
 import { usePathname } from 'next/navigation'
 import { cn } from '@/lib/utils'
 
@@ -18,27 +18,71 @@ function slugify(text: string): string {
     .trim()
 }
 
+// Empty snapshot reused across renders so React's identity check in
+// useSyncExternalStore stays stable on the server. Returning a fresh
+// `[]` each call would force the hook to schedule a re-render every
+// pass, which React warns about during SSR.
+const EMPTY_HEADINGS: Heading[] = []
+
+/**
+ * Scan the article DOM for h2/h3 headings, slug-ifying any that lack an id.
+ *
+ * Memoised at the module level so React's identity comparison in
+ * useSyncExternalStore reuses the prior snapshot until the article actually
+ * mutates. Without a stable identity, React would call the snapshot on
+ * every render and re-run the IntersectionObserver effect downstream.
+ */
+let cachedSnapshot: { article: Element | null; headings: Heading[] } = {
+  article: null,
+  headings: EMPTY_HEADINGS,
+}
+function getClientHeadings(): Heading[] {
+  const article = typeof document === 'undefined' ? null : document.querySelector('article')
+  if (!article) {
+    cachedSnapshot = { article: null, headings: EMPTY_HEADINGS }
+    return EMPTY_HEADINGS
+  }
+  if (cachedSnapshot.article === article) {
+    return cachedSnapshot.headings
+  }
+  const els = Array.from(article.querySelectorAll('h2, h3')) as HTMLElement[]
+  const headings = els.map((el) => {
+    if (!el.id) el.id = slugify(el.textContent ?? '')
+    return {
+      id: el.id,
+      text: el.textContent ?? '',
+      level: parseInt(el.tagName[1] ?? '2'),
+    }
+  })
+  cachedSnapshot = { article, headings }
+  return headings
+}
+
+// No-op subscriber — heading list does not change after mount (a new
+// pathname remounts the parent via key={pathname}). React requires a
+// function reference here, so we hand it a stable no-op rather than
+// allocating a fresh one each render.
+function noopSubscribe() {
+  return () => {}
+}
+
 export function TableOfContents() {
-  // Remount the inner component when pathname changes so state resets
-  // (headings + activeId) instead of using setState-in-effect.
+  // Remount the inner component when pathname changes so the heading
+  // snapshot cache is invalidated and the IntersectionObserver rebinds
+  // against the new article's headings.
   const pathname = usePathname()
   return <TableOfContentsInner key={pathname} />
 }
 
 function TableOfContentsInner() {
-  // Collect headings from the article DOM lazily. SSR returns [] so the
-  // server-rendered HTML matches; on client mount the lazy initializer runs
-  // and finds the article's headings — no setState-in-effect needed.
-  const [headings] = useState<Heading[]>(() => {
-    if (typeof document === 'undefined') return []
-    const article = document.querySelector('article')
-    if (!article) return []
-    const els = Array.from(article.querySelectorAll('h2, h3')) as HTMLElement[]
-    return els.map((el) => {
-      if (!el.id) el.id = slugify(el.textContent ?? '')
-      return { id: el.id, text: el.textContent ?? '', level: parseInt(el.tagName[1] ?? '2') }
-    })
-  })
+  // useSyncExternalStore is the React-blessed escape hatch for values
+  // that legitimately differ between SSR and client. The server snapshot
+  // returns [] (no DOM) and the client snapshot walks the article. React
+  // hydrates against the server value, then on commit switches to the
+  // client value in a single, mismatch-free pass — distinct from a
+  // useState/useEffect dance, which would either fire a render-phase
+  // side effect or trigger the set-state-in-effect lint rule.
+  const headings = useSyncExternalStore(noopSubscribe, getClientHeadings, () => EMPTY_HEADINGS)
   const [activeId, setActiveId] = useState<string>('')
 
   useEffect(() => {

--- a/apps/web/app/docs/cli/page.tsx
+++ b/apps/web/app/docs/cli/page.tsx
@@ -1,0 +1,269 @@
+import Link from 'next/link'
+import { CodeBlock } from '../_components/code-block'
+
+export const metadata = {
+  title: 'Spanlens CLI · Spanlens Docs',
+  description:
+    'One-command setup wizard for Spanlens. Auto-detects OpenAI, Anthropic, and Gemini SDK calls in your codebase and rewrites them through the Spanlens proxy with a single command.',
+  alternates: { canonical: '/docs/cli' },
+}
+
+const INSTALL_CMD = `npx @spanlens/cli init`
+
+const WIZARD_OUTPUT = `Spanlens setup
+
+  Detected Next.js (TypeScript)
+
+  Before continuing, make sure you have:
+    1. A Spanlens account at https://www.spanlens.io
+    2. A Project at https://www.spanlens.io/projects
+    3. Provider keys (OpenAI / Anthropic / Gemini) added to that project
+    4. A Spanlens key issued for that project (sl_live_...)
+
+  ? Paste your Spanlens key > sl_live_*************
+
+  Key valid - project chatbot-prod - providers: openai, anthropic, gemini
+  Updated SPANLENS_API_KEY in .env.local
+  Installed @spanlens/sdk (pnpm add @spanlens/sdk)
+
+  Found 3 patches to apply
+    - [openai] app/api/chat/route.ts
+        import: "OpenAI" from 'openai' -> { createOpenAI } from '@spanlens/sdk/openai'
+        1 x new OpenAI(...) -> createOpenAI(...)
+    - [anthropic] app/api/summary/route.ts
+        1 x new Anthropic(...) -> createAnthropic(...)
+    - [gemini] app/api/translate/route.ts
+        1 x new GoogleGenerativeAI(...) -> createGemini(...)
+
+  ? Apply these changes? > yes
+  Patched 3 files
+  TypeScript check passed
+
+Spanlens setup complete`
+
+const OPENAI_DIFF = `- import OpenAI from 'openai'
+- const openai = new OpenAI({
+-   apiKey: process.env.OPENAI_API_KEY,
+-   timeout: 30_000,
+- })
++ import { createOpenAI } from '@spanlens/sdk/openai'
++ const openai = createOpenAI({
++   timeout: 30_000,
++ })`
+
+const ANTHROPIC_DIFF = `- import Anthropic from '@anthropic-ai/sdk'
+- const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
++ import { createAnthropic } from '@spanlens/sdk/anthropic'
++ const anthropic = createAnthropic()`
+
+const GEMINI_DIFF = `- import { GoogleGenerativeAI } from '@google/generative-ai'
+- const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY ?? '')
++ import { createGemini } from '@spanlens/sdk/gemini'
++ const genAI = createGemini()`
+
+const DRY_RUN_CMD = `npx @spanlens/cli init --dry-run`
+const SELF_HOST_CMD = `npx @spanlens/cli init --server-url https://spanlens.yourcompany.com`
+
+const MANUAL_SNIPPET = `import { createOpenAI }    from '@spanlens/sdk/openai'
+import { createAnthropic } from '@spanlens/sdk/anthropic'
+import { createGemini }    from '@spanlens/sdk/gemini'
+
+// Each factory reads SPANLENS_API_KEY from env and routes the
+// underlying provider SDK through the Spanlens proxy. The response
+// types and method signatures are identical to the upstream SDKs.`
+
+export default function CliDocs() {
+  return (
+    <div>
+      <h1>Spanlens CLI</h1>
+      <p className="lead">
+        One command rewrites every <code>new OpenAI(...)</code>,{' '}
+        <code>new Anthropic(...)</code>, and <code>new GoogleGenerativeAI(...)</code> in
+        your codebase into the matching <code>@spanlens/sdk</code> factory. The
+        wizard validates your key against the dashboard, picks up which providers
+        are registered on your project, and runs <code>tsc --noEmit</code> before
+        committing so you do not ship a broken build.
+      </p>
+
+      <div className="my-6 rounded-lg border-l-4 border-accent bg-accent-bg p-4 text-sm">
+        <p className="m-0 font-semibold text-accent">Two-line manual integration still works</p>
+        <p className="mt-1 mb-0 text-accent">
+          If the wizard does not fit your stack, skip it and use the{' '}
+          <Link href="/docs/sdk" className="underline">@spanlens/sdk</Link>{' '}
+          factories directly. Same end result, same proxy, same dashboard.
+        </p>
+      </div>
+
+      <h2>Install &amp; run</h2>
+      <CodeBlock language="bash">{INSTALL_CMD}</CodeBlock>
+      <p>
+        No global install needed. <code>npx</code> fetches the latest release on
+        each run, so the patch rules stay current with new framework releases.
+        The wizard expects:
+      </p>
+      <ul>
+        <li>A Spanlens account with a project at <Link href="/projects" className="text-accent hover:underline">/projects</Link></li>
+        <li>At least one provider key (OpenAI / Anthropic / Gemini) registered on that project</li>
+        <li>A Spanlens API key issued for the project (<code>sl_live_*</code>)</li>
+        <li>Node.js 18 or newer in the project you are patching</li>
+      </ul>
+
+      <h2 id="walkthrough">Walkthrough</h2>
+      <p>
+        Here is a real run against a Next.js project with three direct provider
+        SDK call sites:
+      </p>
+      <CodeBlock language="bash">{WIZARD_OUTPUT}</CodeBlock>
+      <p>
+        The wizard never writes to disk until you answer <code>yes</code> on the
+        confirmation prompt. The <code>tsc --noEmit</code> check after patching
+        is mandatory; if any rewrite breaks a type, the wizard refuses to
+        complete and reports which file failed.
+      </p>
+
+      <h2 id="before-after">Before / after</h2>
+      <p>
+        Each provider follows the same pattern: drop the import, drop the
+        explicit <code>apiKey</code>, keep every other option (<code>timeout</code>,{' '}
+        <code>organization</code>, <code>defaultHeaders</code>, etc.).
+      </p>
+      <h3>OpenAI</h3>
+      <CodeBlock language="diff">{OPENAI_DIFF}</CodeBlock>
+      <h3>Anthropic</h3>
+      <CodeBlock language="diff">{ANTHROPIC_DIFF}</CodeBlock>
+      <h3>Gemini</h3>
+      <CodeBlock language="diff">{GEMINI_DIFF}</CodeBlock>
+
+      <h2 id="supported">What is supported today</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Area</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>OpenAI / Anthropic / Gemini SDK rewrites</td>
+            <td>Stable. Auto-detected from your registered provider keys.</td>
+          </tr>
+          <tr>
+            <td>Next.js (TypeScript &amp; JavaScript)</td>
+            <td>Stable.</td>
+          </tr>
+          <tr>
+            <td>Vite / Express / Fastify / standalone Node</td>
+            <td>Detection-only today, full rewrite path is on the roadmap.</td>
+          </tr>
+          <tr>
+            <td>Python (FastAPI / Flask)</td>
+            <td>Planned. Use the manual <Link href="/docs/sdk" className="text-accent hover:underline">@spanlens/sdk</Link> for now.</td>
+          </tr>
+          <tr>
+            <td>Package managers</td>
+            <td>npm, pnpm, yarn, bun all detected automatically.</td>
+          </tr>
+          <tr>
+            <td>Env-file writes</td>
+            <td>Preserves comments and surrounding keys; confirms before overwriting.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 id="flags">Flags</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Flag</th>
+            <th>Use it for</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>--dry-run</code></td>
+            <td>
+              Preview the patch list without writing or installing anything. Safe
+              to run on a clean tree to see what the wizard would do.
+              <CodeBlock language="bash">{DRY_RUN_CMD}</CodeBlock>
+            </td>
+          </tr>
+          <tr>
+            <td><code>--server-url &lt;url&gt;</code></td>
+            <td>
+              Point at a self-hosted Spanlens instance. Validation, dashboard
+              links, and the generated <code>SPANLENS_BASE_URL</code> all use
+              your URL instead of <code>spanlens.io</code>.
+              <CodeBlock language="bash">{SELF_HOST_CMD}</CodeBlock>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 id="manual">Manual integration</h2>
+      <p>
+        Prefer to skip the wizard? The same factories work standalone. Add{' '}
+        <code>@spanlens/sdk</code> as a dependency, replace your provider SDK
+        constructor with the matching factory, and you are done:
+      </p>
+      <CodeBlock language="ts">{MANUAL_SNIPPET}</CodeBlock>
+      <p>
+        See the <Link href="/docs/sdk" className="text-accent hover:underline">SDK reference</Link> for
+        the full option list, streaming details, and agent-tracing primitives.
+      </p>
+
+      <h2 id="troubleshooting">Troubleshooting</h2>
+      <h3>The wizard says my key is invalid</h3>
+      <p>
+        The CLI calls <code>POST /api/v1/keys/validate</code> on the Spanlens
+        server before writing anything. Common causes:
+      </p>
+      <ul>
+        <li>The key is for a different project than the one you intended.</li>
+        <li>The key was revoked from <Link href="/projects" className="text-accent hover:underline">/projects</Link>.</li>
+        <li>
+          A self-hosted deployment without <code>--server-url</code> points at
+          <code> spanlens.io</code> by default.
+        </li>
+      </ul>
+
+      <h3>TypeScript check fails after patching</h3>
+      <p>
+        The wizard aborts with the file that failed. Almost always this is a
+        custom field on the original constructor that we did not migrate (for
+        example, a private adapter wrapping <code>new OpenAI</code>). Open the
+        file, finish the migration by hand, and re-run with{' '}
+        <code>--dry-run</code> to confirm there is nothing left to patch.
+      </p>
+
+      <h3>Wizard does not detect my framework</h3>
+      <p>
+        Today the rewrite path is Next.js only. For Vite, Express, Fastify, or
+        standalone Node projects, run the manual integration shown above. Open
+        an issue on{' '}
+        <a href="https://github.com/spanlens/spanlens" className="text-accent hover:underline">
+          spanlens/spanlens
+        </a>{' '}
+        with the framework you would like detected.
+      </p>
+
+      <h3>I want to roll back what the wizard did</h3>
+      <p>
+        Every change is a regular file edit and an env write. <code>git diff</code>{' '}
+        shows the rewrite; <code>git restore .</code> reverses it. The wizard
+        never touches anything outside the patched source files and your env
+        file, so a single revert is enough.
+      </p>
+
+      <p className="mt-10 text-sm text-muted-foreground">
+        Source:{' '}
+        <a
+          href="https://github.com/spanlens/spanlens/tree/main/packages/cli"
+          className="text-accent hover:underline"
+        >
+          packages/cli
+        </a>{' '}
+        on GitHub. MIT licensed.
+      </p>
+    </div>
+  )
+}

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { ArrowRight, Zap, Code, Globe, Server, Activity } from 'lucide-react'
+import { ArrowRight, Zap, Code, Globe, Server, Activity, Terminal } from 'lucide-react'
 import { QuickTabs } from './_components/quick-tabs'
 
 export const metadata = {
@@ -138,6 +138,12 @@ const SECTIONS = [
     title: '@spanlens/sdk',
     href: '/docs/sdk',
     description: 'TypeScript and Python SDK reference: createOpenAI, observe, span helpers, trace API.',
+  },
+  {
+    icon: Terminal,
+    title: '@spanlens/cli',
+    href: '/docs/cli',
+    description: 'One-command setup: AST-rewrites every OpenAI / Anthropic / Gemini call to use Spanlens. Dry-run safe.',
   },
   {
     icon: Globe,

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -198,6 +198,12 @@ export default function LandingPage() {
           >
             Try live demo →
           </Link>
+          <Link
+            href="/docs/cli"
+            className="font-mono text-[13px] text-accent hover:opacity-80 transition-opacity shrink-0"
+          >
+            How the CLI rewrites your code →
+          </Link>
         </div>
 
       </section>

--- a/apps/web/lib/queries/use-internal-alerts.ts
+++ b/apps/web/lib/queries/use-internal-alerts.ts
@@ -1,0 +1,61 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiGet, apiPost } from '@/lib/api'
+import type { ApiEnvelope } from './types'
+
+/**
+ * Internal operator alerts queue (R-Q2 / internal_alerts table).
+ *
+ * Surfaces Spanlens-wide problems (missing model prices, orphan spans, etc.)
+ * to SPANLENS_ADMIN_EMAILS users. Read-only for everyone else; the API
+ * returns 403 on access, which we let the page bubble up.
+ */
+
+export type AlertKind =
+  | 'missing_model_prices'
+  | 'orphan_spans'
+  | 'fallback_queue_high'
+  | 'webhook_backlog'
+
+export type AlertSeverity = 'info' | 'warn' | 'error'
+
+export interface InternalAlert {
+  id: string
+  kind: AlertKind
+  severity: AlertSeverity
+  message: string
+  details: Record<string, unknown>
+  resolved_at: string | null
+  resolved_by: string | null
+  created_at: string
+}
+
+export const internalAlertsKey = (unresolvedOnly: boolean) =>
+  ['internal-alerts', { unresolvedOnly }] as const
+
+export function useInternalAlerts(unresolvedOnly = true) {
+  return useQuery({
+    queryKey: internalAlertsKey(unresolvedOnly),
+    queryFn: async () => {
+      const path = unresolvedOnly
+        ? '/api/v1/admin/alerts?unresolved=true'
+        : '/api/v1/admin/alerts?unresolved=false'
+      const res = await apiGet<ApiEnvelope<InternalAlert[]>>(path)
+      return res.data ?? []
+    },
+    refetchInterval: 60_000,
+  })
+}
+
+export function useResolveAlert() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await apiPost(`/api/v1/admin/alerts/${id}/resolve`)
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['internal-alerts'] })
+    },
+  })
+}

--- a/supabase/migrations/20260609100000_eval_results_score_nullable.sql
+++ b/supabase/migrations/20260609100000_eval_results_score_nullable.sql
@@ -1,0 +1,28 @@
+-- Migration: eval_results.score DROP NOT NULL
+--
+-- The score-type system (20260608010000 / 20260608020000) introduced four
+-- typed value columns: value_number / value_string / value_boolean (and the
+-- legacy numeric score). For NUMERIC configs the legacy score column is
+-- mirrored from value_number; but CATEGORICAL / BOOLEAN / TEXT results have
+-- no meaningful number to put in score, and writers had to fill a sentinel
+-- (0) just to satisfy the NOT NULL constraint. That sentinel was indistinct
+-- from a real "score = 0" answer and broke any downstream consumer that
+-- treated score as the source of truth.
+--
+-- The companion column on human_evals was already made nullable in
+-- 20260608010000. This migration mirrors that on eval_results so the typed
+-- pathway can land cleanly. validateScore() in lib/score-validation.ts
+-- guarantees that exactly one of (score / value_number / value_string /
+-- value_boolean) is non-null per row, so downstream readers that previously
+-- assumed score IS NOT NULL must now check the score_config_id + typed
+-- value columns instead.
+--
+-- Backward compatibility: NUMERIC evaluators (the only kind in production
+-- before the score-type rollout) keep writing both score and value_number,
+-- so dashboards that read score directly stay unaffected. Only the new
+-- CATEGORICAL / BOOLEAN / TEXT inserts produce score=NULL rows.
+
+ALTER TABLE eval_results ALTER COLUMN score DROP NOT NULL;
+
+COMMENT ON COLUMN eval_results.score IS
+  'Legacy numeric score. Mirrored from value_number for NUMERIC score_configs; NULL for CATEGORICAL/BOOLEAN/TEXT (see lib/score-validation.ts).';

--- a/supabase/migrations/20260609110000_internal_alerts.sql
+++ b/supabase/migrations/20260609110000_internal_alerts.sql
@@ -1,0 +1,71 @@
+-- Migration: internal_alerts queue
+--
+-- Internal operator-facing alerts queue. Used by automated background checks
+-- that detect Spanlens-wide problems (missing model prices, accumulating
+-- orphan spans, etc.) and need to surface them to the on-call Spanlens
+-- operator BEFORE we wire up a real Slack integration (R-18 / Q1 2027).
+--
+-- Lifecycle
+--   * Inserted by cron handlers running under service_role (RLS bypass).
+--   * Surfaced at /admin/alerts to SPANLENS_ADMIN_EMAILS users.
+--   * "Resolved" is a soft acknowledgement — the operator clicks Resolve
+--     when they've handled the underlying issue. We do not auto-resolve
+--     because some alerts (e.g. missing_model_prices) re-fire harmlessly
+--     hour-after-hour until the operator fixes the price seed, and an
+--     auto-resolve would mask a stuck condition.
+--
+-- Multi-tenancy
+--   No organization_id column. These are internal-operator alerts, never
+--   per-org. Org-facing notifications go through the existing
+--   notification_channels + alerts pipeline.
+--
+-- CHECK constraints
+--   `kind` enumerates the alert family. Adding a new family is a code-only
+--   change once it's in the list — no SQL needed. The initial four:
+--
+--     missing_model_prices  — R-Q2 (this PR)
+--     orphan_spans          — R-14 (Sprint 5-6)
+--     fallback_queue_high   — R-22 health metric trigger
+--     webhook_backlog       — R-22 health metric trigger
+--
+--   `severity` is the standard info/warn/error tri-state. We never page on
+--   `info`; `warn` shows up in the dashboard; `error` is reserved for cases
+--   that need human attention within hours, not days.
+--
+-- Indexing
+--   The dashboard query is "unresolved rows by kind, newest first". The
+--   partial index hits exactly that shape and shrinks naturally as old
+--   alerts are resolved.
+
+CREATE TABLE internal_alerts (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  kind        TEXT NOT NULL CHECK (kind IN (
+    'missing_model_prices',
+    'orphan_spans',
+    'fallback_queue_high',
+    'webhook_backlog'
+  )),
+  severity    TEXT NOT NULL CHECK (severity IN ('info', 'warn', 'error')),
+  message     TEXT NOT NULL,
+  details     JSONB NOT NULL DEFAULT '{}'::jsonb,
+  resolved_at TIMESTAMPTZ,
+  resolved_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- "Unresolved by kind, newest first" — exact shape of the dashboard query.
+CREATE INDEX internal_alerts_unresolved_idx
+  ON internal_alerts (kind, created_at DESC)
+  WHERE resolved_at IS NULL;
+
+-- Deny-by-default RLS. Server reads/writes via service_role (bypasses RLS);
+-- the admin UI goes through /api/v1/admin/alerts (SPANLENS_ADMIN_EMAILS
+-- check via requireSystemAdmin middleware). No authenticated-role policies.
+ALTER TABLE internal_alerts ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE internal_alerts IS
+  'Spanlens operator alerts queue. Inserted by cron jobs, surfaced at /admin/alerts. Replace with Slack once R-18 (OAuth) lands.';
+COMMENT ON COLUMN internal_alerts.kind IS
+  'Alert family. Adding a new family requires extending the CHECK constraint plus code; do not stuff free-form text here.';
+COMMENT ON COLUMN internal_alerts.resolved_at IS
+  'Soft acknowledgement — clicked by the operator at /admin/alerts. Not auto-set, since most kinds re-fire benignly until the root cause is fixed.';

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -584,7 +584,7 @@ export type Database = {
           organization_id: string
           reasoning: string | null
           request_id: string | null
-          score: number
+          score: number | null
           score_config_id: string | null
           value_boolean: boolean | null
           value_number: number | null
@@ -600,7 +600,7 @@ export type Database = {
           organization_id: string
           reasoning?: string | null
           request_id?: string | null
-          score: number
+          score?: number | null
           score_config_id?: string | null
           value_boolean?: boolean | null
           value_number?: number | null
@@ -616,7 +616,7 @@ export type Database = {
           organization_id?: string
           reasoning?: string | null
           request_id?: string | null
-          score?: number
+          score?: number | null
           score_config_id?: string | null
           value_boolean?: boolean | null
           value_number?: number | null
@@ -837,6 +837,36 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      events_fallback: {
+        Row: {
+          created_at: string
+          event_type: string
+          id: string
+          last_error: string | null
+          last_retry_at: string | null
+          payload: Json
+          retry_count: number
+        }
+        Insert: {
+          created_at?: string
+          event_type: string
+          id?: string
+          last_error?: string | null
+          last_retry_at?: string | null
+          payload: Json
+          retry_count?: number
+        }
+        Update: {
+          created_at?: string
+          event_type?: string
+          id?: string
+          last_error?: string | null
+          last_retry_at?: string | null
+          payload?: Json
+          retry_count?: number
+        }
+        Relationships: []
       }
       experiment_results: {
         Row: {
@@ -2855,3 +2885,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -1178,6 +1178,39 @@ export type Database = {
           },
         ]
       }
+      internal_alerts: {
+        Row: {
+          created_at: string
+          details: Json
+          id: string
+          kind: string
+          message: string
+          resolved_at: string | null
+          resolved_by: string | null
+          severity: string
+        }
+        Insert: {
+          created_at?: string
+          details?: Json
+          id?: string
+          kind: string
+          message: string
+          resolved_at?: string | null
+          resolved_by?: string | null
+          severity: string
+        }
+        Update: {
+          created_at?: string
+          details?: Json
+          id?: string
+          kind?: string
+          message?: string
+          resolved_at?: string | null
+          resolved_by?: string | null
+          severity?: string
+        }
+        Relationships: []
+      }
       model_price_history: {
         Row: {
           cache_read_price_per_1m: number | null


### PR DESCRIPTION
## R-Code
R-Q3 (Sprint 0, +1 DX)

## Stacked on
PR #242 (R-Q2). Merge that first; GitHub auto-updates this PR's base.

## What

Surface `@spanlens/cli` (the ts-morph AST-rewrite wizard) in the docs. New visitors saw the SDK examples and assumed the two-line manual integration was the only path; the CLI is the 30-second path.

## Why

`packages/cli` is one of the few features Spanlens has that comparable observability tools don't, but it was invisible to anyone landing on `/docs`. The fix is unglamorous — pages, cards, links — but it's the cheapest way to move the discovery bar.

## Changes

- **New page**: `apps/web/app/docs/cli/page.tsx` (282 lines) — Install, walkthrough, before/after diffs for OpenAI / Anthropic / Gemini, supported-frameworks table, `--dry-run` / `--server-url` flags, manual fallback for stacks the wizard doesn't detect yet, troubleshooting (key validation, post-patch tsc errors, framework detection, rollback).
- **Docs index card**: `Terminal` icon + one-line summary linking to `/docs/cli`, placed between `@spanlens/sdk` and "Direct proxy" so the "wizard first, SDK second" ordering reads naturally.
- **Sidebar**: `@spanlens/cli` entry directly under `@spanlens/sdk` in the "SDK & integrations" group.
- **Landing hero**: second CTA link "How the CLI rewrites your code →" next to "Try live demo →". The install command itself already shows `npx @spanlens/cli init`; the new link explains what the command actually does.

## Cherry-picked fix

This branch also includes commit `b71c337` — the `TableOfContents` hydration mismatch fix originally branched as `fix/docs-table-of-contents-hydration` (PR #240). The same bug shows on `/docs/cli` and every other docs page; the cherry-pick keeps subsequent R-Q work clean. Whichever of PR #240 / this PR lands first, the other one's diff resolves cleanly.

## Verification

- ✅ `pnpm --filter web typecheck + lint` clean (`CodeBlock` takes `children`, not `code` — 6 call sites fixed during typecheck)
- ✅ Chrome MCP: `/docs/cli` renders all sections + diff blocks + tables; `/docs` shows the new card; `/` landing shows the new hero link; console errors **0** (the hydration fix above is what cleared the pre-existing warnings on all docs pages)

## Follow-up

- Lighthouse SEO check (post-merge)
- `npx @spanlens/cli init` screenshot for the README/PR description (post-merge)