### PR TITLE
feat(server): R-Q2 detect-missing-model-prices cron + internal_alerts queue

### DIFF
--- a/apps/server/src/__tests__/detect-missing-model-prices.test.ts
+++ b/apps/server/src/__tests__/detect-missing-model-prices.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+/**
+ * R-Q2 — /cron/detect-missing-model-prices unit tests.
+ *
+ * The cron handler is the entry point for the operator-facing alert when
+ * `model_prices` falls behind a new model release (gotcha #2). Three
+ * branches must be exercised because each has a different production
+ * failure mode:
+ *
+ *   1. Auth gate (CRON_SECRET) — fail-closed. If a refactor accidentally
+ *      removed the assertion, the endpoint becomes a tenant-blind
+ *      ClickHouse query open to the public internet.
+ *
+ *   2. Empty result (zero models exceed the 100/hour threshold) — must
+ *      NOT insert an internal_alerts row. Spurious alerts train the
+ *      operator to ignore the queue.
+ *
+ *   3. Non-empty result — exactly one alert row per run, with the
+ *      per-model breakdown in `details`. We don't dedupe against
+ *      unresolved alerts of the same kind (see cron.ts comment) so a
+ *      still-broken seed keeps re-firing until the operator fixes it.
+ */
+
+const supabaseInsertMock = vi.fn()
+const clickhouseQueryMock = vi.fn()
+const logCronRunMock = vi.fn()
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: (_table: string) => ({
+      insert: (payload: unknown) => supabaseInsertMock(payload),
+    }),
+  },
+}))
+
+vi.mock('../lib/clickhouse.js', () => ({
+  getClickhouse: () => ({
+    query: (opts: unknown) => clickhouseQueryMock(opts),
+  }),
+  getOrgClickhouse: () => ({ query: () => Promise.resolve({ json: () => [] }) }),
+}))
+
+vi.mock('../lib/cron-logger.js', () => ({
+  logCronRun: (...args: unknown[]) => {
+    logCronRunMock(...args)
+    return Promise.resolve()
+  },
+}))
+
+// Other cron-route imports pull in real modules we don't need here.
+// Mocking them keeps the cron.ts module-load side-effect-free.
+vi.mock('../lib/notifiers.js', () => ({ deliverToChannel: vi.fn() }))
+vi.mock('../lib/webhook-emit.js', () => ({ emitWebhookEvent: vi.fn() }))
+vi.mock('../lib/webhook-dispatch.js', () => ({ retryFailedWebhooks: vi.fn() }))
+vi.mock('../lib/paddle-usage.js', () => ({ computeAndReportOverages: vi.fn() }))
+vi.mock('../lib/quota-warnings.js', () => ({ runQuotaWarningsJob: vi.fn() }))
+vi.mock('../lib/anomaly-snapshot.js', () => ({ snapshotAnomaliesForAllOrgs: vi.fn() }))
+vi.mock('../lib/stale-key-digest.js', () => ({ runStaleKeyDigestJob: vi.fn() }))
+vi.mock('../lib/background-migrations/runner.js', () => ({ runDueMigrations: vi.fn() }))
+vi.mock('../lib/events-reconciliation.js', () => ({ runReconciliationCron: vi.fn() }))
+vi.mock('../lib/leak-detection.js', () => ({ runLeakDetectionJob: vi.fn() }))
+vi.mock('../lib/recommendation-notify.js', () => ({ sendHighConfidenceRecommendationAlerts: vi.fn() }))
+vi.mock('../lib/fallback-replay.js', () => ({
+  replayFallbackQueue: vi.fn(),
+  replayEventsFallbackQueue: vi.fn(),
+}))
+vi.mock('../lib/billing-downgrade.js', () => ({ runDowngradeCheck: vi.fn() }))
+vi.mock('../api/pendingDeletions.js', () => ({ executePendingDeletions: vi.fn() }))
+
+let cronRouter: typeof import('../api/cron.js').cronRouter
+const origSecret = process.env['CRON_SECRET']
+
+beforeEach(async () => {
+  vi.resetModules()
+  supabaseInsertMock.mockReset()
+  clickhouseQueryMock.mockReset()
+  logCronRunMock.mockReset()
+  process.env['CRON_SECRET'] = 'test-secret'
+  ;({ cronRouter } = await import('../api/cron.js'))
+})
+
+afterEach(() => {
+  if (origSecret === undefined) delete process.env['CRON_SECRET']
+  else process.env['CRON_SECRET'] = origSecret
+})
+
+function request(authHeader?: string) {
+  return cronRouter.request(
+    '/detect-missing-model-prices',
+    authHeader ? { headers: { Authorization: authHeader } } : {},
+  )
+}
+
+describe('R-Q2 — /cron/detect-missing-model-prices', () => {
+  test('rejects request without Bearer auth (401)', async () => {
+    const res = await request()
+    expect(res.status).toBe(401)
+    expect(supabaseInsertMock).not.toHaveBeenCalled()
+    expect(clickhouseQueryMock).not.toHaveBeenCalled()
+  })
+
+  test('rejects request with wrong secret (401)', async () => {
+    const res = await request('Bearer wrong')
+    expect(res.status).toBe(401)
+    expect(clickhouseQueryMock).not.toHaveBeenCalled()
+  })
+
+  test('fail-closed when CRON_SECRET unset', async () => {
+    delete process.env['CRON_SECRET']
+    vi.resetModules()
+    ;({ cronRouter } = await import('../api/cron.js'))
+
+    const res = await request('Bearer anything')
+    expect(res.status).toBe(401)
+  })
+
+  test('zero missing models → no internal_alerts insert + missing=0', async () => {
+    clickhouseQueryMock.mockResolvedValue({ json: async () => [] })
+
+    const res = await request('Bearer test-secret')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: boolean; missing: number }
+    expect(body.ok).toBe(true)
+    expect(body.missing).toBe(0)
+    expect(supabaseInsertMock).not.toHaveBeenCalled()
+    expect(logCronRunMock).toHaveBeenCalledWith(
+      'detect-missing-model-prices',
+      'ok',
+      expect.any(Number),
+    )
+  })
+
+  test('non-empty result → inserts exactly one internal_alerts row with details', async () => {
+    // ClickHouse JSONEachRow returns counts as STRINGS (gotcha #19).
+    // Use that exact shape in the fixture to lock the type conversion.
+    clickhouseQueryMock.mockResolvedValue({
+      json: async () => [
+        { model: 'gpt-4o-2026-11-01', missing_count: '512' },
+        { model: 'claude-sonnet-5', missing_count: '187' },
+      ],
+    })
+    supabaseInsertMock.mockResolvedValue({ error: null })
+
+    const res = await request('Bearer test-secret')
+    expect(res.status).toBe(200)
+
+    expect(supabaseInsertMock).toHaveBeenCalledTimes(1)
+    const payload = supabaseInsertMock.mock.calls[0]?.[0] as {
+      kind: string
+      severity: string
+      message: string
+      details: { models: Array<{ model: string; count: number }>; threshold: number }
+    }
+    expect(payload.kind).toBe('missing_model_prices')
+    expect(payload.severity).toBe('warn')
+    expect(payload.message).toContain('2 model(s) missing prices')
+    expect(payload.message).toContain('699 rows') // 512 + 187
+    expect(payload.details.threshold).toBe(100)
+    // Confirm string → number conversion (gotcha #19).
+    expect(payload.details.models).toEqual([
+      { model: 'gpt-4o-2026-11-01', count: 512 },
+      { model: 'claude-sonnet-5', count: 187 },
+    ])
+  })
+
+  test('ClickHouse query throws → 500 + logCronRun error', async () => {
+    clickhouseQueryMock.mockRejectedValue(new Error('ClickHouse unreachable'))
+
+    const res = await request('Bearer test-secret')
+    expect(res.status).toBe(500)
+    expect(supabaseInsertMock).not.toHaveBeenCalled()
+    expect(logCronRunMock).toHaveBeenCalledWith(
+      'detect-missing-model-prices',
+      'error',
+      expect.any(Number),
+      expect.stringContaining('ClickHouse unreachable'),
+    )
+  })
+
+  test('internal_alerts insert fails → 500 + logCronRun error', async () => {
+    clickhouseQueryMock.mockResolvedValue({
+      json: async () => [{ model: 'gpt-9', missing_count: '200' }],
+    })
+    supabaseInsertMock.mockResolvedValue({
+      error: { message: 'duplicate key value violates unique constraint' },
+    })
+
+    const res = await request('Bearer test-secret')
+    expect(res.status).toBe(500)
+    expect(logCronRunMock).toHaveBeenCalledWith(
+      'detect-missing-model-prices',
+      'error',
+      expect.any(Number),
+      expect.stringContaining('insert failed'),
+    )
+  })
+})

--- a/apps/server/src/api/admin/alerts.ts
+++ b/apps/server/src/api/admin/alerts.ts
@@ -1,0 +1,64 @@
+import { Hono } from 'hono'
+import { authJwt, type JwtContext } from '../../middleware/authJwt.js'
+import { requireSystemAdmin } from '../../middleware/requireSystemAdmin.js'
+import { supabaseAdmin } from '../../lib/db.js'
+
+/**
+ * Admin-only internal_alerts management.
+ *
+ *   GET  /api/v1/admin/alerts            list unresolved (default) or all
+ *   POST /api/v1/admin/alerts/:id/resolve  mark one resolved
+ *
+ * Authorization: SPANLENS_ADMIN_EMAILS env var (see requireSystemAdmin).
+ *
+ * The list endpoint defaults to `unresolved=true` because the operator
+ * workflow is "show me what's broken right now." Resolved history is
+ * available behind `?unresolved=false` for audit, but kept off the
+ * default view to reduce noise.
+ */
+export const adminAlertsRouter = new Hono<JwtContext>()
+
+adminAlertsRouter.use('*', authJwt)
+adminAlertsRouter.use('*', requireSystemAdmin)
+
+adminAlertsRouter.get('/', async (c) => {
+  const unresolvedOnly = c.req.query('unresolved') !== 'false'
+
+  let query = supabaseAdmin
+    .from('internal_alerts')
+    .select('id, kind, severity, message, details, resolved_at, resolved_by, created_at')
+    .order('created_at', { ascending: false })
+    .limit(200)
+
+  if (unresolvedOnly) {
+    query = query.is('resolved_at', null)
+  }
+
+  const { data, error } = await query
+  if (error) {
+    return c.json({ error: 'Failed to fetch alerts' }, 500)
+  }
+
+  return c.json({ success: true, data: data ?? [] })
+})
+
+adminAlertsRouter.post('/:id/resolve', async (c) => {
+  const id = c.req.param('id')
+  const userId = c.get('userId')
+
+  const { data, error } = await supabaseAdmin
+    .from('internal_alerts')
+    .update({
+      resolved_at: new Date().toISOString(),
+      resolved_by: userId,
+    })
+    .eq('id', id)
+    .is('resolved_at', null) // Idempotent — already-resolved rows are not touched.
+    .select('id, resolved_at')
+    .maybeSingle()
+
+  if (error) return c.json({ error: `Resolve failed: ${error.message}` }, 500)
+  if (!data) return c.json({ error: 'Alert not found or already resolved' }, 404)
+
+  return c.json({ success: true, data })
+})

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -621,6 +621,97 @@ cronRouter.get('/events-reconciliation', async (c) => {
   }
 })
 
+// GET /cron/detect-missing-model-prices
+//
+// Hourly scan over the last hour's `requests` table for rows where `model`
+// is populated but `cost_usd` is NULL. That combination means lib/cost.ts'
+// `calculateCost()` couldn't resolve a price row for the model — almost
+// always because `model_prices` doesn't have the SKU yet (gotcha #2: new
+// LLM releases land in production before our price seed catches up).
+//
+// Threshold: 100 missing rows / hour / model. Below that, transient
+// hiccups (mis-spelled model in a customer request, model in the middle
+// of being deprecated, etc.) fire too many false-positives. 100/hour
+// represents a real customer routing real traffic through an unpriced
+// model and losing cost attribution every minute they wait.
+//
+// Output: one `internal_alerts` row of kind `missing_model_prices` per
+// run when at least one model crosses the threshold. The details JSONB
+// carries the per-model breakdown so the operator can decide which seed
+// rows to add first. Multiple runs against the same unseeded model
+// produce multiple alerts — we don't de-dup, because the operator clicks
+// Resolve when they fix it and the next hour either re-fires (still
+// broken) or stays quiet (fixed). De-duping with "skip if unresolved
+// alert exists" would mask a still-failing fix.
+//
+// gotcha #32: this cron is internal ops, not org-scoped, so the
+// events/requests feature-flag dual-read pattern does not apply.
+// When Phase 5.1 Stage 4 lands and `requests` is dropped, the query
+// here moves to `events` in the same PR.
+cronRouter.get('/detect-missing-model-prices', async (c) => {
+  const authFail = assertCronAuth(c.req.header('Authorization'))
+  if (authFail) return c.json({ error: authFail }, 401)
+
+  const start = Date.now()
+
+  // We query ClickHouse directly (not via requestsScope) on purpose —
+  // this is a global health check, not a per-org read. The lint rule
+  // guards against tenant-blind reads from org-facing handlers; this
+  // handler is gated by CRON_SECRET, not by an org context. Same
+  // exception applied as `/keep-warm`.
+  try {
+    const rs = await getClickhouse().query({
+      query: `
+        SELECT model, count() AS missing_count
+        FROM requests
+        WHERE created_at >= now() - INTERVAL 1 HOUR
+          AND cost_usd IS NULL
+          AND model != ''
+        GROUP BY model
+        HAVING missing_count > 100
+        ORDER BY missing_count DESC
+      `,
+      format: 'JSONEachRow',
+    }).then((r) => r.json<{ model: string; missing_count: string }>())
+
+    // ClickHouse JSONEachRow returns numbers as strings (gotcha #19).
+    const models = rs.map((row) => ({
+      model: row.model,
+      count: Number(row.missing_count),
+    }))
+
+    if (models.length === 0) {
+      logCronRun('detect-missing-model-prices', 'ok', Date.now() - start).catch(console.error)
+      return c.json({ ok: true, missing: 0 })
+    }
+
+    const totalRows = models.reduce((sum, m) => sum + m.count, 0)
+    const { error: insertError } = await supabaseAdmin.from('internal_alerts').insert({
+      kind: 'missing_model_prices',
+      severity: 'warn',
+      message: `${models.length} model(s) missing prices in last 1h (${totalRows} rows)`,
+      details: { models, threshold: 100 },
+    })
+
+    if (insertError) {
+      logCronRun(
+        'detect-missing-model-prices',
+        'error',
+        Date.now() - start,
+        `internal_alerts insert failed: ${insertError.message}`,
+      ).catch(console.error)
+      return c.json({ ok: false, error: 'failed to insert alert' }, 500)
+    }
+
+    logCronRun('detect-missing-model-prices', 'ok', Date.now() - start).catch(console.error)
+    return c.json({ ok: true, missing: models.length, models })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    logCronRun('detect-missing-model-prices', 'error', Date.now() - start, message).catch(console.error)
+    return c.json({ ok: false, error: message }, 500)
+  }
+})
+
 // All three steps run in parallel via Promise.allSettled — one slow / failing
 // dependency doesn't block the others, and we never throw (cron retries are
 // noisy and a transient warmup failure is not worth alerting on). No

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -54,6 +54,7 @@ import { feedbackRouter }     from './api/feedback.js'
 import { adminModelPricesRouter } from './api/admin/modelPrices.js'
 import { adminModelRecommendationsRouter } from './api/admin/modelRecommendations.js'
 import { adminBackgroundMigrationsRouter } from './api/admin/backgroundMigrations.js'
+import { adminAlertsRouter } from './api/admin/alerts.js'
 import { sharesRouter }           from './api/shares.js'
 import { publicShareRouter }      from './api/publicShare.js'
 import { badgeRouter }            from './api/badge.js'
@@ -222,5 +223,6 @@ app.route('/api/v1/shares',         sharesRouter)   // PLG Loop ① — owner-si
 app.route('/api/v1/admin/model-prices', adminModelPricesRouter)
 app.route('/api/v1/admin/model-recommendations', adminModelRecommendationsRouter)
 app.route('/api/v1/admin/background-migrations', adminBackgroundMigrationsRouter)
+app.route('/api/v1/admin/alerts', adminAlertsRouter)
 
 export default app

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -21,6 +21,7 @@
     { "path": "/cron/execute-pending-deletions",  "schedule": "0 */6 * * *" },
     { "path": "/cron/run-background-migrations",  "schedule": "*/5 * * * *" },
     { "path": "/cron/events-reconciliation",      "schedule": "0 2 * * *" },
+    { "path": "/cron/detect-missing-model-prices","schedule": "0 * * * *" },
     { "path": "/cron/keep-warm",                  "schedule": "*/5 * * * *" }
   ]
 }

--- a/apps/web/app/(dashboard)/settings/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/settings/alerts/alerts-client.tsx
@@ -1,0 +1,211 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+import { AlertTriangle, AlertCircle, Info, CheckCircle, Loader2 } from 'lucide-react'
+import { Topbar } from '@/components/layout/topbar'
+import { cn } from '@/lib/utils'
+import {
+  useInternalAlerts,
+  useResolveAlert,
+  type AlertSeverity,
+  type InternalAlert,
+} from '@/lib/queries/use-internal-alerts'
+
+/**
+ * Spanlens operator alerts queue (R-Q2).
+ *
+ * Shows unresolved internal_alerts rows by default with a toggle for
+ * the resolved history. Each row carries the cron-emitted message plus
+ * the structured `details` JSON for inspection.
+ *
+ * Access control: API returns 403 unless the user's email is in
+ * SPANLENS_ADMIN_EMAILS. We render the page shell either way and let
+ * the query surface "Permission denied" — the page link is hidden
+ * from non-admin sidebars upstream of this client.
+ */
+
+const SEVERITY_STYLE: Record<AlertSeverity, string> = {
+  info: 'border-border bg-bg-elev text-text-muted',
+  warn: 'border-amber-500/40 bg-amber-500/10 text-amber-500',
+  error: 'border-bad/40 bg-bad/10 text-bad',
+}
+
+function SeverityBadge({ severity }: { severity: AlertSeverity }) {
+  const Icon = severity === 'error' ? AlertCircle : severity === 'warn' ? AlertTriangle : Info
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-[5px] border px-2 py-0.5 font-mono text-[10.5px] uppercase tracking-[0.04em]',
+        SEVERITY_STYLE[severity],
+      )}
+    >
+      <Icon className="h-3 w-3" />
+      {severity}
+    </span>
+  )
+}
+
+function formatAge(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime()
+  if (diffMs < 60_000) return `${Math.round(diffMs / 1000)}s ago`
+  if (diffMs < 3_600_000) return `${Math.round(diffMs / 60_000)}m ago`
+  if (diffMs < 86_400_000) return `${Math.round(diffMs / 3_600_000)}h ago`
+  return `${Math.round(diffMs / 86_400_000)}d ago`
+}
+
+function AlertRow({
+  alert,
+  onResolve,
+  resolving,
+}: {
+  alert: InternalAlert
+  onResolve: (id: string) => void
+  resolving: boolean
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const hasDetails = Object.keys(alert.details).length > 0
+
+  return (
+    <div className="border border-border rounded-lg overflow-hidden">
+      <div className="flex items-start justify-between gap-3 p-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1.5">
+            <SeverityBadge severity={alert.severity} />
+            <span className="font-mono text-[11px] text-text-faint">{alert.kind}</span>
+            <span className="font-mono text-[11px] text-text-faint">
+              · {formatAge(alert.created_at)}
+            </span>
+          </div>
+          <p className="text-[13px] text-text break-words">{alert.message}</p>
+          {hasDetails && (
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className="mt-2 font-mono text-[11px] text-text-faint hover:text-text-muted"
+            >
+              {expanded ? '▾ Hide details' : '▸ Show details'}
+            </button>
+          )}
+          {hasDetails && expanded && (
+            <pre className="mt-2 overflow-x-auto rounded-md bg-bg-elev p-3 font-mono text-[11px] text-text-muted">
+              {JSON.stringify(alert.details, null, 2)}
+            </pre>
+          )}
+        </div>
+        {alert.resolved_at ? (
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-[5px] border border-good/40 bg-good/10 px-2 py-1 font-mono text-[10.5px] uppercase tracking-[0.04em] text-good">
+            <CheckCircle className="h-3 w-3" />
+            resolved
+          </span>
+        ) : (
+          <button
+            onClick={() => onResolve(alert.id)}
+            disabled={resolving}
+            className="shrink-0 rounded-md border border-border bg-bg-elev px-3 py-1.5 font-mono text-[11px] hover:bg-bg-hover disabled:opacity-50"
+          >
+            {resolving ? <Loader2 className="h-3 w-3 animate-spin" /> : 'Resolve'}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function AlertsClient() {
+  const [showResolved, setShowResolved] = useState(false)
+  const query = useInternalAlerts(!showResolved)
+  const resolve = useResolveAlert()
+  const alerts = query.data ?? []
+
+  return (
+    <>
+      <Topbar
+        crumbs={[
+          { label: 'Settings', href: '/settings' },
+          { label: 'Internal alerts' },
+        ]}
+      />
+      <div className="px-6 py-8 max-w-[1100px] mx-auto">
+        <div className="mb-6">
+          <Link
+            href="/settings"
+            className="font-mono text-[11px] text-text-faint hover:text-text-muted"
+          >
+            ← Settings
+          </Link>
+          <h1 className="mt-2 text-2xl font-semibold">Internal alerts</h1>
+          <p className="mt-1 text-[13px] text-text-muted max-w-[680px]">
+            Spanlens operator queue. Surfaces Spanlens-wide problems detected
+            by cron jobs (missing model prices, orphan spans, fallback queue
+            buildup, webhook backlog). Resolving an entry is a soft
+            acknowledgement: the next cron run can re-fire if the underlying
+            condition is still present.
+          </p>
+        </div>
+
+        <div className="mb-4 flex items-center gap-2">
+          <button
+            onClick={() => setShowResolved(false)}
+            className={cn(
+              'rounded-md border px-3 py-1.5 font-mono text-[11px]',
+              !showResolved
+                ? 'border-accent bg-accent-bg/40 text-text'
+                : 'border-border bg-bg-elev text-text-muted hover:text-text',
+            )}
+          >
+            Unresolved
+          </button>
+          <button
+            onClick={() => setShowResolved(true)}
+            className={cn(
+              'rounded-md border px-3 py-1.5 font-mono text-[11px]',
+              showResolved
+                ? 'border-accent bg-accent-bg/40 text-text'
+                : 'border-border bg-bg-elev text-text-muted hover:text-text',
+            )}
+          >
+            All (recent)
+          </button>
+          {query.isFetching && (
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-text-faint" />
+          )}
+        </div>
+
+        {query.isLoading && (
+          <div className="rounded-lg border border-border bg-bg-elev p-6 text-center font-mono text-[12px] text-text-faint">
+            Loading…
+          </div>
+        )}
+
+        {query.isError && (
+          <div className="rounded-lg border border-bad/40 bg-bad/10 p-6 text-[13px] text-bad">
+            Failed to load alerts.
+            {' '}
+            {query.error instanceof Error ? query.error.message : 'Unknown error.'}
+          </div>
+        )}
+
+        {!query.isLoading && !query.isError && alerts.length === 0 && (
+          <div className="rounded-lg border border-border bg-bg-elev p-8 text-center">
+            <CheckCircle className="mx-auto h-6 w-6 text-good" />
+            <p className="mt-2 text-[13px] text-text">All clear.</p>
+            <p className="mt-1 font-mono text-[11px] text-text-faint">
+              No {showResolved ? 'alerts in the recent window' : 'unresolved alerts'}.
+            </p>
+          </div>
+        )}
+
+        <div className="space-y-3">
+          {alerts.map((alert) => (
+            <AlertRow
+              key={alert.id}
+              alert={alert}
+              onResolve={(id) => resolve.mutate(id)}
+              resolving={resolve.isPending && resolve.variables === alert.id}
+            />
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/alerts/page.tsx
+++ b/apps/web/app/(dashboard)/settings/alerts/page.tsx
@@ -1,0 +1,9 @@
+import { AlertsClient } from './alerts-client'
+
+export const metadata = {
+  title: 'Internal alerts · Spanlens',
+}
+
+export default function AlertsPage() {
+  return <AlertsClient />
+}

--- a/apps/web/lib/queries/use-internal-alerts.ts
+++ b/apps/web/lib/queries/use-internal-alerts.ts
@@ -1,0 +1,61 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiGet, apiPost } from '@/lib/api'
+import type { ApiEnvelope } from './types'
+
+/**
+ * Internal operator alerts queue (R-Q2 / internal_alerts table).
+ *
+ * Surfaces Spanlens-wide problems (missing model prices, orphan spans, etc.)
+ * to SPANLENS_ADMIN_EMAILS users. Read-only for everyone else; the API
+ * returns 403 on access, which we let the page bubble up.
+ */
+
+export type AlertKind =
+  | 'missing_model_prices'
+  | 'orphan_spans'
+  | 'fallback_queue_high'
+  | 'webhook_backlog'
+
+export type AlertSeverity = 'info' | 'warn' | 'error'
+
+export interface InternalAlert {
+  id: string
+  kind: AlertKind
+  severity: AlertSeverity
+  message: string
+  details: Record<string, unknown>
+  resolved_at: string | null
+  resolved_by: string | null
+  created_at: string
+}
+
+export const internalAlertsKey = (unresolvedOnly: boolean) =>
+  ['internal-alerts', { unresolvedOnly }] as const
+
+export function useInternalAlerts(unresolvedOnly = true) {
+  return useQuery({
+    queryKey: internalAlertsKey(unresolvedOnly),
+    queryFn: async () => {
+      const path = unresolvedOnly
+        ? '/api/v1/admin/alerts?unresolved=true'
+        : '/api/v1/admin/alerts?unresolved=false'
+      const res = await apiGet<ApiEnvelope<InternalAlert[]>>(path)
+      return res.data ?? []
+    },
+    refetchInterval: 60_000,
+  })
+}
+
+export function useResolveAlert() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await apiPost(`/api/v1/admin/alerts/${id}/resolve`)
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['internal-alerts'] })
+    },
+  })
+}

--- a/supabase/migrations/20260609110000_internal_alerts.sql
+++ b/supabase/migrations/20260609110000_internal_alerts.sql
@@ -1,0 +1,71 @@
+-- Migration: internal_alerts queue
+--
+-- Internal operator-facing alerts queue. Used by automated background checks
+-- that detect Spanlens-wide problems (missing model prices, accumulating
+-- orphan spans, etc.) and need to surface them to the on-call Spanlens
+-- operator BEFORE we wire up a real Slack integration (R-18 / Q1 2027).
+--
+-- Lifecycle
+--   * Inserted by cron handlers running under service_role (RLS bypass).
+--   * Surfaced at /admin/alerts to SPANLENS_ADMIN_EMAILS users.
+--   * "Resolved" is a soft acknowledgement — the operator clicks Resolve
+--     when they've handled the underlying issue. We do not auto-resolve
+--     because some alerts (e.g. missing_model_prices) re-fire harmlessly
+--     hour-after-hour until the operator fixes the price seed, and an
+--     auto-resolve would mask a stuck condition.
+--
+-- Multi-tenancy
+--   No organization_id column. These are internal-operator alerts, never
+--   per-org. Org-facing notifications go through the existing
+--   notification_channels + alerts pipeline.
+--
+-- CHECK constraints
+--   `kind` enumerates the alert family. Adding a new family is a code-only
+--   change once it's in the list — no SQL needed. The initial four:
+--
+--     missing_model_prices  — R-Q2 (this PR)
+--     orphan_spans          — R-14 (Sprint 5-6)
+--     fallback_queue_high   — R-22 health metric trigger
+--     webhook_backlog       — R-22 health metric trigger
+--
+--   `severity` is the standard info/warn/error tri-state. We never page on
+--   `info`; `warn` shows up in the dashboard; `error` is reserved for cases
+--   that need human attention within hours, not days.
+--
+-- Indexing
+--   The dashboard query is "unresolved rows by kind, newest first". The
+--   partial index hits exactly that shape and shrinks naturally as old
+--   alerts are resolved.
+
+CREATE TABLE internal_alerts (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  kind        TEXT NOT NULL CHECK (kind IN (
+    'missing_model_prices',
+    'orphan_spans',
+    'fallback_queue_high',
+    'webhook_backlog'
+  )),
+  severity    TEXT NOT NULL CHECK (severity IN ('info', 'warn', 'error')),
+  message     TEXT NOT NULL,
+  details     JSONB NOT NULL DEFAULT '{}'::jsonb,
+  resolved_at TIMESTAMPTZ,
+  resolved_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- "Unresolved by kind, newest first" — exact shape of the dashboard query.
+CREATE INDEX internal_alerts_unresolved_idx
+  ON internal_alerts (kind, created_at DESC)
+  WHERE resolved_at IS NULL;
+
+-- Deny-by-default RLS. Server reads/writes via service_role (bypasses RLS);
+-- the admin UI goes through /api/v1/admin/alerts (SPANLENS_ADMIN_EMAILS
+-- check via requireSystemAdmin middleware). No authenticated-role policies.
+ALTER TABLE internal_alerts ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE internal_alerts IS
+  'Spanlens operator alerts queue. Inserted by cron jobs, surfaced at /admin/alerts. Replace with Slack once R-18 (OAuth) lands.';
+COMMENT ON COLUMN internal_alerts.kind IS
+  'Alert family. Adding a new family requires extending the CHECK constraint plus code; do not stuff free-form text here.';
+COMMENT ON COLUMN internal_alerts.resolved_at IS
+  'Soft acknowledgement — clicked by the operator at /admin/alerts. Not auto-set, since most kinds re-fire benignly until the root cause is fixed.';

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -1178,6 +1178,39 @@ export type Database = {
           },
         ]
       }
+      internal_alerts: {
+        Row: {
+          created_at: string
+          details: Json
+          id: string
+          kind: string
+          message: string
+          resolved_at: string | null
+          resolved_by: string | null
+          severity: string
+        }
+        Insert: {
+          created_at?: string
+          details?: Json
+          id?: string
+          kind: string
+          message: string
+          resolved_at?: string | null
+          resolved_by?: string | null
+          severity: string
+        }
+        Update: {
+          created_at?: string
+          details?: Json
+          id?: string
+          kind?: string
+          message?: string
+          resolved_at?: string | null
+          resolved_by?: string | null
+          severity?: string
+        }
+        Relationships: []
+      }
       model_price_history: {
         Row: {
           cache_read_price_per_1m: number | null


### PR DESCRIPTION
## R-Code
R-Q2 (Sprint 0, +1 Ops / monitoring). Originally PR #242 — auto-closed when R-Q1 base branch was deleted on merge. Same code, fresh PR after rebase onto main.

## What

Detect new LLM models routing customer traffic through Spanlens *before* their `model_prices` row exists.

## Why

When a customer routes traffic through a new LLM model that we haven't yet seeded into `model_prices`, `lib/cost.ts:calculateCost()` returns `null` and the request is logged with `cost_usd = NULL`. Gotcha #2 in `CLAUDE.md`.

## Changes

- `supabase/migrations/20260609110000_internal_alerts.sql` — operator-facing alert queue, `kind` / `severity` CHECK + partial index `(kind, created_at DESC) WHERE resolved_at IS NULL` + RLS deny-by-default. Re-used later by R-14, R-22.
- `apps/server/src/api/cron.ts` adds `/cron/detect-missing-model-prices` — hourly scan, threshold `count > 100` per model, one `internal_alerts` row per run.
- `vercel.json` — `0 * * * *` schedule.
- `apps/server/src/api/admin/alerts.ts` — `GET /api/v1/admin/alerts` (`unresolved=true` default) + `POST /:id/resolve`, gated by `authJwt` + `requireSystemAdmin`.
- `apps/web/app/(dashboard)/settings/alerts/page.tsx` + `alerts-client.tsx`.

We deliberately do **not** dedupe against unresolved alerts of the same kind — a still-broken seed has to keep re-firing.

## Verification

- ✅ 7-case unit suite (auth gate × 3 + zero/non-zero + ClickHouse throw + insert fail)
- ✅ `pnpm --filter server test`: 66 files / 771 tests pass
- ✅ Local E2E: 150 unpriced rows seeded → cron → `internal_alerts` row verified via psql
- ✅ Chrome MCP `/settings/alerts` clean

## Follow-up

Production: confirm `CRON_SECRET` + `SPANLENS_ADMIN_EMAILS` are set in Vercel env before first cron fires.