### PR TITLE
chore: R-Q4 lefthook pre-commit guards for supabase migrations

### DIFF
--- a/.lefthook/migration-naming.sh
+++ b/.lefthook/migration-naming.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Refuse a commit that adds a `supabase/migrations/*` file whose name
+# does not match Supabase's required `YYYYMMDDHHMMSS_<snake>.sql`
+# pattern. Supabase orders migrations by filename; a mistyped prefix
+# slots the new file out of order and tips production.
+set -e
+
+added=$(git diff --cached --name-only --diff-filter=A \
+  | grep -E '^supabase/migrations/' || true)
+
+if [ -z "$added" ]; then
+  exit 0
+fi
+
+bad=""
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  name=$(basename "$f")
+  if ! echo "$name" | grep -qE '^[0-9]{14}_[a-z0-9_]+\.sql$'; then
+    bad="${bad}  ${name}
+"
+  fi
+done <<EOF
+$added
+EOF
+
+if [ -z "$bad" ]; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+
+[lefthook/migration-naming] Migration filename invalid.
+
+Expected pattern:
+  YYYYMMDDHHMMSS_lowercase_snake.sql
+
+Offending file(s):
+${bad}
+Generate a fresh timestamp with:
+  date -u +%Y%m%d%H%M%S
+EOF
+
+exit 1

--- a/.lefthook/no-migration-edits.sh
+++ b/.lefthook/no-migration-edits.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Refuse a commit that modifies or deletes an already-tracked
+# `supabase/migrations/<ts>_<desc>.sql` file. The remote migration
+# history is keyed by file hash; editing a merged migration desyncs
+# every other dev's local DB and the deploy-server.yml migrate job.
+set -e
+
+modified=$(git diff --cached --name-only --diff-filter=MD \
+  | grep -E '^supabase/migrations/[0-9]+_.+\.sql$' || true)
+
+if [ -z "$modified" ]; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+
+[lefthook/no-migration-edits] Refusing commit.
+
+Modifying or deleting an already-tracked migration is forbidden
+(CLAUDE.md / "DB 작업 규칙"). The remote migration history depends
+on the file hash staying stable.
+
+Offending file(s):
+$(echo "$modified" | sed 's/^/  /')
+
+Fix: create a NEW migration with a fresh timestamp instead:
+  ts=\$(date -u +%Y%m%d%H%M%S)
+  cp <bad-edit>.sql supabase/migrations/\${ts}_<desc>.sql
+
+If you are intentionally editing pre-merge local work and accept the
+risk, bypass once with:
+  git commit --no-verify
+EOF
+
+exit 1

--- a/.lefthook/no-types-edit.sh
+++ b/.lefthook/no-types-edit.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Warn when `supabase/types.ts` is in the staged set but no new
+# migration accompanies it. types.ts is generated; a manual edit
+# desyncs from the committed migration set and silently breaks
+# `tsc --noEmit` on the next gen-types run.
+#
+# Warning only (exit 0) — sometimes you legitimately need to commit
+# a regenerated types.ts after pulling someone else's migration. Block
+# would be too aggressive. The author reads the message and decides.
+set -e
+
+types_modified=$(git diff --cached --name-only \
+  | grep '^supabase/types.ts$' || true)
+migration_added=$(git diff --cached --name-only --diff-filter=A \
+  | grep -E '^supabase/migrations/[0-9]+_.+\.sql$' || true)
+
+if [ -z "$types_modified" ] || [ -n "$migration_added" ]; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+
+[lefthook/no-types-edit] WARN — supabase/types.ts changed without a new
+migration file in the same commit.
+
+If the diff is the output of:
+  supabase gen types --lang typescript --local 2>/dev/null > supabase/types.ts
+…on the latest schema, this is OK.
+
+If you hand-edited the file, revert it and regenerate:
+  supabase gen types --lang typescript --local 2>/dev/null > supabase/types.ts
+
+EOF
+
+# Warning only — do not block.
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ cp apps/server/.env.example apps/server/.env  # fill in the values
 
 # Install + start dev servers
 pnpm install
+pnpm exec lefthook install   # pre-commit guards for supabase migrations
 pnpm dev                # web :3000, server :3001
 
 # Apply migrations
@@ -113,7 +114,17 @@ Smaller scopes:
 - ClickHouse: `clickhouse/migrations/NNN_description.sql`. **Idempotent only**
   (`CREATE IF NOT EXISTS`, `ALTER … ADD COLUMN IF NOT EXISTS`).
 - Always run `supabase gen types` after a Postgres migration so
-  `supabase/types.ts` stays in sync.
+  `supabase/types.ts` stays in sync. Pipe stderr to `/dev/null` — the CLI
+  leaks warning lines onto stdout that, if captured into the file, break
+  `tsc`:
+  ```
+  supabase gen types --lang typescript --local 2>/dev/null > supabase/types.ts
+  ```
+- These conventions are enforced locally by [`lefthook`](./lefthook.yml).
+  Run `pnpm exec lefthook install` once per clone to wire up the
+  `pre-commit` guards (rejects edits to merged migrations, rejects
+  off-pattern filenames, warns when `supabase/types.ts` changes without a
+  paired migration).
 
 ---
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,44 @@
+# lefthook — git hook orchestrator
+#
+# Local-only guards on the migration workflow. Repository conventions
+# (CLAUDE.md "DB 작업 규칙") forbid:
+#
+#   1. Editing or deleting an already-merged migration file. The
+#      remote migration history is hash-keyed; editing a committed
+#      migration breaks `db push` on every other dev's machine and on
+#      the deploy-server.yml migrate job.
+#
+#   2. Migrations named outside the YYYYMMDDHHMMSS_lowercase_snake.sql
+#      pattern. Supabase orders by filename; a mistyped prefix lands
+#      the new migration in the wrong slot and tips production.
+#
+#   3. Hand-editing supabase/types.ts. Always regenerate via
+#      `supabase gen types --lang typescript --local 2>/dev/null > supabase/types.ts`
+#      so the file matches the committed migration set. The hook
+#      warns but does not block: a regenerated types.ts is sometimes
+#      a legitimate solo change after pulling someone else's
+#      migration.
+#
+# Install once per clone:    `pnpm exec lefthook install`
+# Uninstall:                  `pnpm exec lefthook uninstall`
+# Bypass a single commit:     `git commit --no-verify`
+#
+# Multi-line shell snippets here would be re-quoted by lefthook before
+# `sh -c` ran them and broke on the first nested $variable. Each rule
+# lives in `.lefthook/<name>.sh` instead, where the shell can read the
+# script straight off disk.
+
+pre-commit:
+  parallel: true
+  commands:
+    no-migration-edits:
+      tags: db
+      run: bash .lefthook/no-migration-edits.sh
+
+    migration-naming:
+      tags: db
+      run: bash .lefthook/migration-naming.sh
+
+    no-types-edit:
+      tags: db
+      run: bash .lefthook/no-types-edit.sh

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "ch:migrate": "pnpm --filter server exec tsx ../../clickhouse/apply.ts"
   },
   "devDependencies": {
-    "typescript": "^6.0.3",
+    "eslint": "^9",
+    "lefthook": "^2.1.9",
     "prettier": "^3.3.3",
-    "eslint": "^9"
+    "typescript": "^6.0.3"
   },
   "packageManager": "pnpm@10.33.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.7.0)
+      lefthook:
+        specifier: ^2.1.9
+        version: 2.1.9
       prettier:
         specifier: ^3.3.3
         version: 3.8.3
@@ -3674,6 +3677,60 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
+
+  lefthook-darwin-arm64@2.1.9:
+    resolution: {integrity: sha512-119HryNcvr4nqn0wUIrNPgpMEPn9yMQzEcW/lezRsnb56PCJriJB92+MCySPVcWDxJnZef7o0T3jdnPNiSH7Qg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.9:
+    resolution: {integrity: sha512-dwo5Tke2XcQCM56DGHgFKBfRbJIL6xs2wZ0zG1TUVZgl4t4mQUt6LiZ4V/ZQfYHTZF9qywvXoIlR5N35qOaiVQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.9:
+    resolution: {integrity: sha512-+09PVap6nl6xsaHch5JLtq7WvIR++U1Q2MzA2ai0M4uB/VP3AqrvKqHw6+9hjyKnIH+HHL83uqi77EAY+LaxLA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.9:
+    resolution: {integrity: sha512-8XresjKIYpkE9ARgCtBEZgJZxAU3T4MIqzj4zNy15XRT59I1Us+QdqXTNm+pkZ41Yd2X/nxs2Pkvbq3NWWlIGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.9:
+    resolution: {integrity: sha512-1oNIQfwrPe6rgU2KcDM3aF6+hpZDCKx1TmawQKpXUY5gVsbZ7MqX0Sk/1lnnWxqPm+kQQ5f6J2dpFWd+4xH8jg==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.9:
+    resolution: {integrity: sha512-fT+7Q+BJyGp+CslFQkNXmdFRgyVXsPHPi9NAsDX0a6QOyNnoORByAsvx6zeAKuF5rL3BBgNfho1/v2RuGxGy9w==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.9:
+    resolution: {integrity: sha512-4bVuafBk3dddVNo0+3hMbjcJs4mqYAstxpPMmX2ufkudSTYFNIhWoqwuGVQV/SS/xdcOKJAldW4qayAzed2ysw==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.9:
+    resolution: {integrity: sha512-PmPoMmLP/wQQWcQ9u2YH86bTZ3UCfBsxuEmVTEyPU2U8R1qSTp5r/Gs3G8cN5Mxo91XB9oBERtF1n+xD3W6aVA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.9:
+    resolution: {integrity: sha512-KphfkBKmwBnmolyrdhIl3lrBaOyTcCgXBT2AB/9OHnEXhOLvv5uTCUkrD4YRAxXPtFKq6UvnapIeoL3GZq0bdA==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.9:
+    resolution: {integrity: sha512-2qlUtkJHZ3MyUxgV5XTEmcrIoNZA07iwaquoswAcqv/1MeBFXlD+O+koFRfrzWng2O5WYEbpJnd8tvaYnV8fTA==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.9:
+    resolution: {integrity: sha512-bwDaIOViTktE8kJLf9jP0p+H2/RDTlFFlc43Am2YgUsX22hI6Sq4RbzsrecwzY5y+MHTipOH7WsmWSEniePHWQ==}
+    hasBin: true
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -7522,8 +7579,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.7
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -7545,7 +7602,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7556,22 +7613,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7582,7 +7639,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -8293,6 +8350,49 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
+
+  lefthook-darwin-arm64@2.1.9:
+    optional: true
+
+  lefthook-darwin-x64@2.1.9:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.9:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.9:
+    optional: true
+
+  lefthook-linux-arm64@2.1.9:
+    optional: true
+
+  lefthook-linux-x64@2.1.9:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.9:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.9:
+    optional: true
+
+  lefthook-windows-arm64@2.1.9:
+    optional: true
+
+  lefthook-windows-x64@2.1.9:
+    optional: true
+
+  lefthook@2.1.9:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.9
+      lefthook-darwin-x64: 2.1.9
+      lefthook-freebsd-arm64: 2.1.9
+      lefthook-freebsd-x64: 2.1.9
+      lefthook-linux-arm64: 2.1.9
+      lefthook-linux-x64: 2.1.9
+      lefthook-openbsd-arm64: 2.1.9
+      lefthook-openbsd-x64: 2.1.9
+      lefthook-windows-arm64: 2.1.9
+      lefthook-windows-x64: 2.1.9
 
   levn@0.4.1:
     dependencies:


### PR DESCRIPTION
Originally PR #244 — auto-closed when R-Q3 base branch was deleted. Same code, rebased onto main.

Local pre-commit guards: no-migration-edits (reject), migration-naming (reject), no-types-edit (warn). External `.lefthook/*.sh` scripts because YAML re-quoting breaks nested $variables.

Verified: edit-existing reject, bad-name reject, valid pass, types-alone warn-pass. CONTRIBUTING.md updated with install instruction.