### PR TITLE
refactor(server): R-Q6 rename getClickhouse → unscopedClickhouse + tighten import guard

### DIFF
--- a/.lefthook/migration-naming.sh
+++ b/.lefthook/migration-naming.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Refuse a commit that adds a `supabase/migrations/*` file whose name
+# does not match Supabase's required `YYYYMMDDHHMMSS_<snake>.sql`
+# pattern. Supabase orders migrations by filename; a mistyped prefix
+# slots the new file out of order and tips production.
+set -e
+
+added=$(git diff --cached --name-only --diff-filter=A \
+  | grep -E '^supabase/migrations/' || true)
+
+if [ -z "$added" ]; then
+  exit 0
+fi
+
+bad=""
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  name=$(basename "$f")
+  if ! echo "$name" | grep -qE '^[0-9]{14}_[a-z0-9_]+\.sql$'; then
+    bad="${bad}  ${name}
+"
+  fi
+done <<EOF
+$added
+EOF
+
+if [ -z "$bad" ]; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+
+[lefthook/migration-naming] Migration filename invalid.
+
+Expected pattern:
+  YYYYMMDDHHMMSS_lowercase_snake.sql
+
+Offending file(s):
+${bad}
+Generate a fresh timestamp with:
+  date -u +%Y%m%d%H%M%S
+EOF
+
+exit 1

--- a/.lefthook/no-migration-edits.sh
+++ b/.lefthook/no-migration-edits.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Refuse a commit that modifies or deletes an already-tracked
+# `supabase/migrations/<ts>_<desc>.sql` file. The remote migration
+# history is keyed by file hash; editing a merged migration desyncs
+# every other dev's local DB and the deploy-server.yml migrate job.
+set -e
+
+modified=$(git diff --cached --name-only --diff-filter=MD \
+  | grep -E '^supabase/migrations/[0-9]+_.+\.sql$' || true)
+
+if [ -z "$modified" ]; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+
+[lefthook/no-migration-edits] Refusing commit.
+
+Modifying or deleting an already-tracked migration is forbidden
+(CLAUDE.md / "DB 작업 규칙"). The remote migration history depends
+on the file hash staying stable.
+
+Offending file(s):
+$(echo "$modified" | sed 's/^/  /')
+
+Fix: create a NEW migration with a fresh timestamp instead:
+  ts=\$(date -u +%Y%m%d%H%M%S)
+  cp <bad-edit>.sql supabase/migrations/\${ts}_<desc>.sql
+
+If you are intentionally editing pre-merge local work and accept the
+risk, bypass once with:
+  git commit --no-verify
+EOF
+
+exit 1

--- a/.lefthook/no-types-edit.sh
+++ b/.lefthook/no-types-edit.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Warn when `supabase/types.ts` is in the staged set but no new
+# migration accompanies it. types.ts is generated; a manual edit
+# desyncs from the committed migration set and silently breaks
+# `tsc --noEmit` on the next gen-types run.
+#
+# Warning only (exit 0) — sometimes you legitimately need to commit
+# a regenerated types.ts after pulling someone else's migration. Block
+# would be too aggressive. The author reads the message and decides.
+set -e
+
+types_modified=$(git diff --cached --name-only \
+  | grep '^supabase/types.ts$' || true)
+migration_added=$(git diff --cached --name-only --diff-filter=A \
+  | grep -E '^supabase/migrations/[0-9]+_.+\.sql$' || true)
+
+if [ -z "$types_modified" ] || [ -n "$migration_added" ]; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+
+[lefthook/no-types-edit] WARN — supabase/types.ts changed without a new
+migration file in the same commit.
+
+If the diff is the output of:
+  supabase gen types --lang typescript --local 2>/dev/null > supabase/types.ts
+…on the latest schema, this is OK.
+
+If you hand-edited the file, revert it and regenerate:
+  supabase gen types --lang typescript --local 2>/dev/null > supabase/types.ts
+
+EOF
+
+# Warning only — do not block.
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ cp apps/server/.env.example apps/server/.env  # fill in the values
 
 # Install + start dev servers
 pnpm install
+pnpm exec lefthook install   # pre-commit guards for supabase migrations
 pnpm dev                # web :3000, server :3001
 
 # Apply migrations
@@ -113,7 +114,17 @@ Smaller scopes:
 - ClickHouse: `clickhouse/migrations/NNN_description.sql`. **Idempotent only**
   (`CREATE IF NOT EXISTS`, `ALTER … ADD COLUMN IF NOT EXISTS`).
 - Always run `supabase gen types` after a Postgres migration so
-  `supabase/types.ts` stays in sync.
+  `supabase/types.ts` stays in sync. Pipe stderr to `/dev/null` — the CLI
+  leaks warning lines onto stdout that, if captured into the file, break
+  `tsc`:
+  ```
+  supabase gen types --lang typescript --local 2>/dev/null > supabase/types.ts
+  ```
+- These conventions are enforced locally by [`lefthook`](./lefthook.yml).
+  Run `pnpm exec lefthook install` once per clone to wire up the
+  `pre-commit` guards (rejects edits to merged migrations, rejects
+  off-pattern filenames, warns when `supabase/types.ts` changes without a
+  paired migration).
 
 ---
 

--- a/apps/server/eslint.config.mjs
+++ b/apps/server/eslint.config.mjs
@@ -1,5 +1,6 @@
 import tsParser from '@typescript-eslint/parser'
 import tsPlugin from '@typescript-eslint/eslint-plugin'
+import spanlensPlugin from '@spanlens/eslint-plugin'
 import globals from 'globals'
 
 const restrictedClickhouse = {
@@ -38,6 +39,7 @@ const config = [
     },
     plugins: {
       '@typescript-eslint': tsPlugin,
+      '@spanlens': spanlensPlugin,
     },
     rules: {
       ...tsPlugin.configs.recommended.rules,
@@ -45,12 +47,24 @@ const config = [
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       '@typescript-eslint/no-explicit-any': 'warn',
       'no-restricted-imports': ['error', restrictedClickhouse],
+      // R-Q5: aes256Decrypt returns '' on every failure mode; missing
+      // checks silently send empty Authorization headers upstream.
+      '@spanlens/aes-decrypt-must-be-checked': 'error',
     },
   },
   {
     files: ['src/lib/**/*.ts', 'src/__tests__/**/*.ts'],
     rules: {
       'no-restricted-imports': 'off',
+    },
+  },
+  {
+    // The decrypt rule is for production code only. Test files
+    // intentionally call aes256Decrypt() with malformed inputs and
+    // assert the empty-string return — that IS the test.
+    files: ['src/__tests__/**/*.ts'],
+    rules: {
+      '@spanlens/aes-decrypt-must-be-checked': 'off',
     },
   },
 ]

--- a/apps/server/eslint.config.mjs
+++ b/apps/server/eslint.config.mjs
@@ -3,19 +3,32 @@ import tsPlugin from '@typescript-eslint/eslint-plugin'
 import spanlensPlugin from '@spanlens/eslint-plugin'
 import globals from 'globals'
 
+// R-Q6: `unscopedClickhouse` (renamed from `getClickhouse`) returns the
+// raw ClickHouse client with no organization scoping. Importing it from
+// API/middleware code is a cross-tenant leak waiting to happen because
+// ClickHouse has no row-level security; every read MUST filter on
+// organization_id at the application layer. The org-scoped helpers in
+// `lib/requests-query.ts` / `lib/events-query.ts` (and `getOrgClickhouse`)
+// thread the org id through automatically.
+//
+// The block targets both the function name and the legacy alias so a
+// pre-R-Q6 stash that still says `getClickhouse` is also rejected — the
+// alias does not exist anymore, but a stale auto-import in someone's
+// editor could try to add it back, and the explicit message is clearer
+// than a "module not found" error.
 const restrictedClickhouse = {
   paths: [
     {
       name: '../lib/clickhouse.js',
-      importNames: ['getClickhouse'],
+      importNames: ['unscopedClickhouse', 'getClickhouse'],
       message:
-        'Use getOrgClickhouse(orgId) from lib/clickhouse.ts or the helpers in lib/requests-query.ts instead of getClickhouse() directly.',
+        'Use getOrgClickhouse(orgId) from lib/clickhouse.ts (or the helpers in lib/requests-query.ts / lib/events-query.ts) instead. For health checks use pingClickhouse(). unscopedClickhouse() is for lib/** internals only.',
     },
     {
       name: '../../lib/clickhouse.js',
-      importNames: ['getClickhouse'],
+      importNames: ['unscopedClickhouse', 'getClickhouse'],
       message:
-        'Use getOrgClickhouse(orgId) from lib/clickhouse.ts or the helpers in lib/requests-query.ts instead of getClickhouse() directly.',
+        'Use getOrgClickhouse(orgId) from lib/clickhouse.ts (or the helpers in lib/requests-query.ts / lib/events-query.ts) instead. For health checks use pingClickhouse(). unscopedClickhouse() is for lib/** internals only.',
     },
   ],
 }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,6 +28,7 @@
     "hono": "^4.12.23"
   },
   "devDependencies": {
+    "@spanlens/eslint-plugin": "workspace:*",
     "@types/node": "^25.8.0",
     "@typescript-eslint/eslint-plugin": "^8.60.1",
     "@typescript-eslint/parser": "^8.60.1",

--- a/apps/server/src/__tests__/anomaly-confidence.test.ts
+++ b/apps/server/src/__tests__/anomaly-confidence.test.ts
@@ -13,7 +13,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 const clickhouseQueryMock = vi.fn()
 
 vi.mock('../lib/clickhouse.js', () => ({
-  getClickhouse: () => ({
+  unscopedClickhouse: () => ({
     query: (opts: unknown) => clickhouseQueryMock(opts),
   }),
 }))

--- a/apps/server/src/__tests__/anomaly-detect.test.ts
+++ b/apps/server/src/__tests__/anomaly-detect.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // detectAnomalies now queries ClickHouse directly (was a Postgres RPC).
-// Mock getClickhouse() so tests run without a real container; the test
+// Mock unscopedClickhouse() so tests run without a real container; the test
 // helpers below shape the response the way @clickhouse/client returns it
 // (a ResultSet whose .json() resolves to an array of plain rows).
 const mockChQuery = vi.hoisted(() => vi.fn())
 vi.mock('../lib/clickhouse.js', () => ({
-  getClickhouse: () => ({ query: mockChQuery }),
+  unscopedClickhouse: () => ({ query: mockChQuery }),
 }))
 
 import { detectAnomalies } from '../lib/anomaly.js'

--- a/apps/server/src/__tests__/anomaly-snapshot.test.ts
+++ b/apps/server/src/__tests__/anomaly-snapshot.test.ts
@@ -9,7 +9,7 @@ vi.mock('../lib/db.js', () => ({
 // of Supabase. Tests control which orgs come back via setActiveOrgsForCH.
 const mockChQuery = vi.hoisted(() => vi.fn())
 vi.mock('../lib/clickhouse.js', () => ({
-  getClickhouse: () => ({ query: mockChQuery }),
+  unscopedClickhouse: () => ({ query: mockChQuery }),
 }))
 
 function setActiveOrgsForCH(orgIds: string[]): void {

--- a/apps/server/src/__tests__/detect-missing-model-prices.test.ts
+++ b/apps/server/src/__tests__/detect-missing-model-prices.test.ts
@@ -35,7 +35,7 @@ vi.mock('../lib/db.js', () => ({
 }))
 
 vi.mock('../lib/clickhouse.js', () => ({
-  getClickhouse: () => ({
+  unscopedClickhouse: () => ({
     query: (opts: unknown) => clickhouseQueryMock(opts),
   }),
   getOrgClickhouse: () => ({ query: () => Promise.resolve({ json: () => [] }) }),

--- a/apps/server/src/__tests__/exports-stream.test.ts
+++ b/apps/server/src/__tests__/exports-stream.test.ts
@@ -205,7 +205,7 @@ vi.mock('../lib/clickhouse.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../lib/clickhouse.js')>()
   return {
     ...actual,
-    getClickhouse: () => ({
+    unscopedClickhouse: () => ({
       query: (opts: unknown) => clickhouseQueryMock(opts),
     }),
   }

--- a/apps/server/src/__tests__/fallback-replay.test.ts
+++ b/apps/server/src/__tests__/fallback-replay.test.ts
@@ -26,7 +26,7 @@ vi.mock('../lib/db.js', () => ({
 }))
 
 vi.mock('../lib/clickhouse.js', () => ({
-  getClickhouse: () => ({
+  unscopedClickhouse: () => ({
     insert: (opts: unknown) => clickhouseInsertMock(opts),
   }),
 }))

--- a/apps/server/src/__tests__/gotcha.test.ts
+++ b/apps/server/src/__tests__/gotcha.test.ts
@@ -46,7 +46,7 @@ vi.mock('../lib/db.js', () => {
 // ClickHouse client mock — logger.ts now writes here instead of Supabase.
 const mockClickhouseInsert = vi.fn().mockResolvedValue({ executed: true })
 vi.mock('../lib/clickhouse.js', () => ({
-  getClickhouse: () => ({ insert: mockClickhouseInsert }),
+  unscopedClickhouse: () => ({ insert: mockClickhouseInsert }),
   // logger.ts also imports toClickhouseTimestamp — return a deterministic
   // value so test assertions on row contents stay stable.
   toClickhouseTimestamp: () => '2026-05-16 11:49:23.749',
@@ -129,7 +129,7 @@ describe('getDecryptedProviderKey — Gotcha #5 (decryption empty string → nul
 // Original Gotcha #3 covered "logger must use supabaseAdmin so RLS doesn't
 // block the insert". After the ClickHouse migration the requests table no
 // longer lives in Supabase, so the test asserts the new contract:
-//   1. logger writes to ClickHouse via getClickhouse().insert(...)
+//   1. logger writes to ClickHouse via unscopedClickhouse().insert(...)
 //   2. body columns are mask-scrubbed before insert (no leaked API keys)
 //   3. > 64KB bodies are truncated to keep rows bounded
 //   4. ClickHouse failures don't throw (fire-and-forget contract)

--- a/apps/server/src/__tests__/integration/helpers.ts
+++ b/apps/server/src/__tests__/integration/helpers.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { supabaseAdmin } from '../../lib/db.js'
-import { getClickhouse } from '../../lib/clickhouse.js'
+import { unscopedClickhouse } from '../../lib/clickhouse.js'
 
 export interface InsertRequestsArgs {
   orgId: string
@@ -57,13 +57,13 @@ export async function insertRequests(args: InsertRequestsArgs): Promise<void> {
     has_security_flags: false,
     created_at: createdAt,
   }))
-  await getClickhouse().insert({ table: 'requests', format: 'JSONEachRow', values: rows })
+  await unscopedClickhouse().insert({ table: 'requests', format: 'JSONEachRow', values: rows })
 }
 
 export async function cleanupRequests(orgId: string): Promise<void> {
   // ClickHouse mutations (ALTER ... DELETE) are async on disk but synchronous
   // from the client's perspective for our test sizes — safe to await.
-  await getClickhouse().command({
+  await unscopedClickhouse().command({
     query: 'ALTER TABLE requests DELETE WHERE organization_id = {orgId:UUID}',
     query_params: { orgId },
   })

--- a/apps/server/src/__tests__/logger-fallback.test.ts
+++ b/apps/server/src/__tests__/logger-fallback.test.ts
@@ -17,7 +17,7 @@ vi.mock('../lib/clickhouse.js', async () => {
   )
   return {
     ...actual,
-    getClickhouse: () => ({
+    unscopedClickhouse: () => ({
       insert: (opts: unknown) => clickhouseInsertMock(opts),
     }),
   }

--- a/apps/server/src/__tests__/multi-tenant-isolation.test.ts
+++ b/apps/server/src/__tests__/multi-tenant-isolation.test.ts
@@ -56,7 +56,7 @@ let stubbedRows: unknown[] = []
 
 vi.mock('../lib/clickhouse.js', () => {
   return {
-    getClickhouse: () => ({
+    unscopedClickhouse: () => ({
       query: async (opts: CapturedQuery) => {
         captured.push({
           query: opts.query,

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -1,12 +1,16 @@
 import { Hono } from 'hono'
 import { supabaseAdmin } from '../lib/db.js'
-// `getClickhouse` is used by the /cron/keep-warm handler below to run
-// `SELECT 1` with no org context. The lint rule guards against multi-tenant
-// leaks via tenant-blind reads; this call site can't leak because it returns
-// no rows. The org-scoped helpers all require an orgId we don't have at
-// warmup time, so this is the only viable client for the warmup ping.
+// `unscopedClickhouse` is used by /cron/detect-missing-model-prices below
+// to GROUP BY model across all tenants — that scan is the entire point of
+// the alert and cannot be done per-org. The lint rule guards against
+// tenant-blind reads from request handlers; this is operator-facing cron
+// gated by CRON_SECRET, so the exception is intentional.
+//
+// /cron/keep-warm previously used unscopedClickhouse().query('SELECT 1')
+// to warm the HTTP pool. We now use pingClickhouse() instead — same warmup
+// effect, no need to reach for the raw client. See R-Q6.
 // eslint-disable-next-line no-restricted-imports
-import { getClickhouse, getOrgClickhouse } from '../lib/clickhouse.js'
+import { unscopedClickhouse, getOrgClickhouse, pingClickhouse } from '../lib/clickhouse.js'
 import { deliverToChannel, type AlertNotification } from '../lib/notifiers.js'
 import { emitWebhookEvent } from '../lib/webhook-emit.js'
 import { retryFailedWebhooks } from '../lib/webhook-dispatch.js'
@@ -660,7 +664,7 @@ cronRouter.get('/detect-missing-model-prices', async (c) => {
   // handler is gated by CRON_SECRET, not by an org context. Same
   // exception applied as `/keep-warm`.
   try {
-    const rs = await getClickhouse().query({
+    const rs = await unscopedClickhouse().query({
       query: `
         SELECT model, count() AS missing_count
         FROM requests
@@ -726,15 +730,20 @@ cronRouter.get('/keep-warm', async (c) => {
     // `head: true` skips the row body, so the request is HEAD-shaped and
     // doesn't transfer payload — just warms the pool.
     supabaseAdmin.from('organizations').select('id', { count: 'exact', head: true }).limit(1),
-    // ClickHouse: `SELECT 1` is the canonical no-op query. Bypasses any
-    // table cache but exercises HTTP keep-alive, auth, and the cluster's
-    // query parser. Format `JSONEachRow` matches our normal calls so the
-    // shared client doesn't switch modes on the first real call.
-    getClickhouse().query({ query: 'SELECT 1 AS ok', format: 'JSONEachRow' }).then((r) => r.json()),
+    // ClickHouse: pingClickhouse() under the hood runs `.ping()` against
+    // the singleton client, which exercises HTTP keep-alive, auth, and
+    // the client's connection pool — exactly what keep-warm needs. Less
+    // verbose than a synthetic SELECT and survives the no-restricted-imports
+    // tightening from R-Q6.
+    pingClickhouse(),
   ])
 
   const supabaseOk = results[0].status === 'fulfilled'
-  const clickhouseOk = results[1].status === 'fulfilled'
+  // pingClickhouse() swallows its own errors and resolves to false, so the
+  // outer settled-status is always 'fulfilled'. Look at the resolved value
+  // instead — that's where the actual reachability signal lives.
+  const clickhouseOk =
+    results[1].status === 'fulfilled' && results[1].value === true
   return c.json({
     ok: supabaseOk && clickhouseOk,
     ts: new Date().toISOString(),

--- a/apps/server/src/lib/anomaly-snapshot.ts
+++ b/apps/server/src/lib/anomaly-snapshot.ts
@@ -1,5 +1,5 @@
 import { supabaseAdmin } from './db.js'
-import { getClickhouse } from './clickhouse.js'
+import { unscopedClickhouse } from './clickhouse.js'
 import { detectAnomalies, ANOMALY_DEFAULTS, type AnomalyBucket } from './anomaly.js'
 import { deliverToChannel, type AlertNotification, type NotificationChannelRow } from './notifiers.js'
 
@@ -37,7 +37,7 @@ export async function snapshotAnomaliesForAllOrgs(
     .replace('Z', '')
   let uniqueOrgIds: string[]
   try {
-    const result = await getClickhouse().query({
+    const result = await unscopedClickhouse().query({
       query:
         'SELECT DISTINCT organization_id ' +
         'FROM requests ' +

--- a/apps/server/src/lib/anomaly.ts
+++ b/apps/server/src/lib/anomaly.ts
@@ -1,4 +1,4 @@
-import { getClickhouse } from './clickhouse.js'
+import { unscopedClickhouse } from './clickhouse.js'
 
 /**
  * Anomaly detection over recent `requests` rows.
@@ -203,7 +203,7 @@ export async function detectAnomalies(
 
   let data: AnomalyStatsRow[]
   try {
-    const result = await getClickhouse().query({
+    const result = await unscopedClickhouse().query({
       query: sql,
       query_params: params,
       format: 'JSONEachRow',
@@ -393,7 +393,7 @@ export async function fetchContributingFactors(
     LIMIT 5`
 
   try {
-    const ch = getClickhouse()
+    const ch = unscopedClickhouse()
     const [tokensResult, errorsResult] = await Promise.all([
       ch.query({ query: tokensSql, query_params: baseParams, format: 'JSONEachRow' }),
       ch.query({ query: errorsSql, query_params: baseParams, format: 'JSONEachRow' }),

--- a/apps/server/src/lib/background-migrations/registry/migrations/backfill-events-from-requests.test.ts
+++ b/apps/server/src/lib/background-migrations/registry/migrations/backfill-events-from-requests.test.ts
@@ -6,7 +6,7 @@ const queryMock = vi.fn()
 const insertMock = vi.fn().mockResolvedValue(undefined)
 
 vi.mock('../../../clickhouse.js', () => ({
-  getClickhouse: () => ({ query: queryMock, insert: insertMock }),
+  unscopedClickhouse: () => ({ query: queryMock, insert: insertMock }),
   toClickhouseTimestamp: (d: Date = new Date()) =>
     d.toISOString().replace('T', ' ').replace('Z', ''),
 }))

--- a/apps/server/src/lib/background-migrations/registry/migrations/backfill-events-from-requests.ts
+++ b/apps/server/src/lib/background-migrations/registry/migrations/backfill-events-from-requests.ts
@@ -1,5 +1,5 @@
 import type { BackgroundMigration, ChunkResult, ChunkState } from '../../index.js'
-import { getClickhouse, toClickhouseTimestamp } from '../../../clickhouse.js'
+import { unscopedClickhouse, toClickhouseTimestamp } from '../../../clickhouse.js'
 
 /**
  * Phase 5.1 Stage 2 — backfill the `events` table from historical
@@ -172,7 +172,7 @@ export const backfillEventsFromRequests: BackgroundMigration = {
 
   async runChunk(state: ChunkState): Promise<ChunkResult> {
     const cursor = readCursor(state)
-    const ch = getClickhouse()
+    const ch = unscopedClickhouse()
 
     // First-run-only: estimate the total row count so the admin UI
     // can show a progress percentage. SELECT count() on a 6-month

--- a/apps/server/src/lib/background-migrations/registry/migrations/backfill-spans-from-supabase.ts
+++ b/apps/server/src/lib/background-migrations/registry/migrations/backfill-spans-from-supabase.ts
@@ -1,5 +1,5 @@
 import type { BackgroundMigration, ChunkResult, ChunkState } from '../../index.js'
-import { getClickhouse, toClickhouseTimestamp } from '../../../clickhouse.js'
+import { unscopedClickhouse, toClickhouseTimestamp } from '../../../clickhouse.js'
 import { supabaseAdmin } from '../../../db.js'
 
 /**
@@ -169,7 +169,7 @@ export const backfillSpansFromSupabase: BackgroundMigration = {
     if (rows.length === 0) return { done: true }
 
     const eventRows = rows.map(mapSpanToEventRow)
-    await getClickhouse().insert({
+    await unscopedClickhouse().insert({
       table: 'events',
       format: 'JSONEachRow',
       values: eventRows,

--- a/apps/server/src/lib/background-migrations/registry/migrations/backfill-traces-from-supabase.ts
+++ b/apps/server/src/lib/background-migrations/registry/migrations/backfill-traces-from-supabase.ts
@@ -1,5 +1,5 @@
 import type { BackgroundMigration, ChunkResult, ChunkState } from '../../index.js'
-import { getClickhouse, toClickhouseTimestamp } from '../../../clickhouse.js'
+import { unscopedClickhouse, toClickhouseTimestamp } from '../../../clickhouse.js'
 import { supabaseAdmin } from '../../../db.js'
 
 /**
@@ -161,7 +161,7 @@ export const backfillTracesFromSupabase: BackgroundMigration = {
     if (rows.length === 0) return { done: true }
 
     const eventRows = rows.map(mapTraceToEventRow)
-    await getClickhouse().insert({
+    await unscopedClickhouse().insert({
       table: 'events',
       format: 'JSONEachRow',
       values: eventRows,

--- a/apps/server/src/lib/clickhouse.ts
+++ b/apps/server/src/lib/clickhouse.ts
@@ -36,7 +36,37 @@ function readEnv(): ClickhouseEnv {
   return { url, username, password, database }
 }
 
-export function getClickhouse(): ClickHouseClient {
+/**
+ * Return the singleton ClickHouse client without any organization scoping.
+ *
+ * **Do not call this from request handlers.** ClickHouse has no row-level
+ * security; every read MUST filter on `organization_id` before any user
+ * sees the result. The org-scoped helpers in `lib/requests-query.ts` /
+ * `lib/events-query.ts` (and `getOrgClickhouse` below) thread the org
+ * id through automatically. A tenant-blind call from a handler is a
+ * cross-tenant leak waiting to happen.
+ *
+ * Legitimate callers — all in `apps/server/src/lib/**` — are:
+ *
+ *   - The query helpers themselves (requests-query, events-query,
+ *     stats-queries, anomaly, etc.) which take an `orgId` argument and
+ *     interpolate it into every WHERE clause.
+ *   - The fallback replay (`fallback-replay.ts`) which writes rows
+ *     queued in Supabase back into ClickHouse — the orgId travels with
+ *     the row, not with the client.
+ *   - The reconciliation cron (`events-reconciliation.ts`) which counts
+ *     across tenants by design (operator-facing diagnostic).
+ *   - The schema inspectors (`clickhouse.test.ts`).
+ *
+ * Anything outside `lib/` is blocked by the ESLint
+ * `no-restricted-imports` rule on this export name.
+ *
+ * Renamed from `getClickhouse` in R-Q6 (2026-06-08). The old name was
+ * a footgun: it read as "get me a ClickHouse client" with no warning
+ * that the caller now owns the multi-tenant filter. The new name
+ * forces every code reader to ask "scoped to what?"
+ */
+export function unscopedClickhouse(): ClickHouseClient {
   if (_client) return _client
   const env = readEnv()
   _client = createClient({
@@ -83,7 +113,7 @@ export function resetClickhouseClient(): void {
  */
 export async function pingClickhouse(): Promise<boolean> {
   try {
-    const result = await getClickhouse().ping()
+    const result = await unscopedClickhouse().ping()
     return result.success
   } catch {
     return false
@@ -93,7 +123,7 @@ export async function pingClickhouse(): Promise<boolean> {
 /**
  * Returns the raw ClickHouse client scoped to a specific organization.
  *
- * This is a thin helper that pairs `getClickhouse()` with the caller's
+ * This is a thin helper that pairs `unscopedClickhouse()` with the caller's
  * `organizationId` so API/middleware code must explicitly declare the org
  * rather than calling the bare singleton. It does NOT automatically inject
  * the WHERE clause — callers still write `organization_id = {orgId:UUID}` —
@@ -112,7 +142,7 @@ export async function pingClickhouse(): Promise<boolean> {
  *   })
  */
 export function getOrgClickhouse(organizationId: string): { client: ClickHouseClient; orgId: string } {
-  return { client: getClickhouse(), orgId: organizationId }
+  return { client: unscopedClickhouse(), orgId: organizationId }
 }
 
 /**

--- a/apps/server/src/lib/events-query.test.ts
+++ b/apps/server/src/lib/events-query.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 // retention clip is the longest non-Enterprise value.
 const queryMock = vi.fn()
 vi.mock('./clickhouse.js', () => ({
-  getClickhouse: () => ({ query: queryMock }),
+  unscopedClickhouse: () => ({ query: queryMock }),
 }))
 vi.mock('./requests-query.js', async () => {
   const actual = await vi.importActual<typeof import('./requests-query.js')>('./requests-query.js')

--- a/apps/server/src/lib/events-query.ts
+++ b/apps/server/src/lib/events-query.ts
@@ -14,7 +14,7 @@
  * cover the helpers so the contract is locked in.
  */
 
-import { getClickhouse } from './clickhouse.js'
+import { unscopedClickhouse } from './clickhouse.js'
 import { LOG_RETENTION_DAYS, type Plan } from './quota.js'
 import { getOrgPlan } from './requests-query.js'
 
@@ -85,7 +85,7 @@ export async function selectEvents<T>(opts: {
 
   const query = `SELECT ${select} FROM events WHERE ${where} ${tail.join(' ')}`.trim()
 
-  const res = await getClickhouse().query({
+  const res = await unscopedClickhouse().query({
     query,
     query_params: { ...scope.scopeParams, ...(params ?? {}) },
     format: 'JSONEachRow',
@@ -107,7 +107,7 @@ export async function countEvents(opts: {
   if (filters && filters.length > 0) whereParts.push(filters)
   const where = whereParts.join(' AND ')
   const query = `SELECT count() AS c FROM events WHERE ${where}`
-  const res = await getClickhouse().query({
+  const res = await unscopedClickhouse().query({
     query,
     query_params: { ...scope.scopeParams, ...(params ?? {}) },
     format: 'JSONEachRow',
@@ -189,7 +189,7 @@ export async function selectGenerationsAsRequests<T>(opts: {
   `.trim()
 
   try {
-    const res = await getClickhouse().query({
+    const res = await unscopedClickhouse().query({
       query,
       query_params: { ...scope.scopeParams, ...(params ?? {}) },
       format: 'JSONEachRow',
@@ -226,7 +226,7 @@ export async function countGenerations(opts: {
   const where = whereParts.join(' AND ')
   const query = `SELECT count() AS c FROM events WHERE ${where}`
   try {
-    const res = await getClickhouse().query({
+    const res = await unscopedClickhouse().query({
       query,
       query_params: { ...scope.scopeParams, ...(params ?? {}) },
       format: 'JSONEachRow',

--- a/apps/server/src/lib/events-reconciliation.test.ts
+++ b/apps/server/src/lib/events-reconciliation.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const queryMock = vi.fn()
 vi.mock('./clickhouse.js', () => ({
-  getClickhouse: () => ({ query: queryMock }),
+  unscopedClickhouse: () => ({ query: queryMock }),
 }))
 
 import { computeReconciliation, runReconciliationCron } from './events-reconciliation.js'

--- a/apps/server/src/lib/events-reconciliation.ts
+++ b/apps/server/src/lib/events-reconciliation.ts
@@ -21,7 +21,7 @@
  * have a few days of baseline data and know the natural noise floor.
  */
 
-import { getClickhouse } from './clickhouse.js'
+import { unscopedClickhouse } from './clickhouse.js'
 
 const RECON_WINDOW_HOURS = 24
 const RECON_END_LAG_HOURS = 1
@@ -42,7 +42,7 @@ export interface ReconciliationResult {
  * error so the caller can mark the cron run failed.
  */
 async function singleCount(query: string, params: Record<string, unknown>): Promise<number> {
-  const res = await getClickhouse().query({
+  const res = await unscopedClickhouse().query({
     query,
     query_params: params,
     format: 'JSONEachRow',

--- a/apps/server/src/lib/events-writer.test.ts
+++ b/apps/server/src/lib/events-writer.test.ts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 // mock is in place when the module wires its imports.
 const insertMock = vi.fn().mockResolvedValue(undefined)
 vi.mock('./clickhouse.js', () => ({
-  getClickhouse: () => ({ insert: insertMock }),
+  unscopedClickhouse: () => ({ insert: insertMock }),
   // Strip 'T' / 'Z' the way the real toClickhouseTimestamp does so
   // assertions stay deterministic.
   toClickhouseTimestamp: (d: Date = new Date()) =>

--- a/apps/server/src/lib/events-writer.ts
+++ b/apps/server/src/lib/events-writer.ts
@@ -21,7 +21,7 @@
  */
 
 import { randomUUID } from 'node:crypto'
-import { getClickhouse, toClickhouseTimestamp } from './clickhouse.js'
+import { unscopedClickhouse, toClickhouseTimestamp } from './clickhouse.js'
 import { supabaseAdmin } from './db.js'
 import type { RequestLogData } from './logger.js'
 
@@ -36,7 +36,7 @@ import type { RequestLogData } from './logger.js'
  */
 async function insertEventOrQueue(row: Record<string, unknown>): Promise<void> {
   try {
-    await getClickhouse().insert({
+    await unscopedClickhouse().insert({
       table: 'events',
       format: 'JSONEachRow',
       values: [row],

--- a/apps/server/src/lib/fallback-replay.ts
+++ b/apps/server/src/lib/fallback-replay.ts
@@ -25,7 +25,7 @@
 //     data and is poisoning the queue; surface and drop.
 // ─────────────────────────────────────────────────────────────────────────────
 
-import { getClickhouse } from './clickhouse.js'
+import { unscopedClickhouse } from './clickhouse.js'
 import { supabaseAdmin } from './db.js'
 
 /** Max rows replayed per cron invocation. Bounded so a stuck cron can't run away. */
@@ -89,7 +89,7 @@ export async function replayFallbackQueue(): Promise<ReplayResult> {
   // 3. Bulk INSERT the entire batch. ClickHouse JSONEachRow accepts arrays —
   //    one round trip for the whole batch instead of N.
   try {
-    await getClickhouse().insert({
+    await unscopedClickhouse().insert({
       table: 'requests',
       format: 'JSONEachRow',
       values: rows.map((r) => r.payload as Record<string, unknown>),
@@ -182,7 +182,7 @@ export async function replayEventsFallbackQueue(): Promise<ReplayResult> {
   result.attempted = rows.length
 
   try {
-    await getClickhouse().insert({
+    await unscopedClickhouse().insert({
       table: 'events',
       format: 'JSONEachRow',
       values: rows.map((r) => r.payload as Record<string, unknown>),

--- a/apps/server/src/lib/logger.ts
+++ b/apps/server/src/lib/logger.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { supabaseAdmin } from './db.js'
-import { getClickhouse, toClickhouseTimestamp } from './clickhouse.js'
+import { unscopedClickhouse, toClickhouseTimestamp } from './clickhouse.js'
 import { maskApiKeysInBody, maskApiKeys } from './pii-mask.js'
 import { scanAll, type SecurityFlag } from './security-scan.js'
 import { sendEmail, renderSecurityAlertEmail } from './resend.js'
@@ -276,7 +276,7 @@ export async function logRequestAsync(data: RequestLogData): Promise<void> {
   }
 
   try {
-    await getClickhouse().insert({
+    await unscopedClickhouse().insert({
       table: 'requests',
       format: 'JSONEachRow',
       values: [clickhouseRow],

--- a/apps/server/src/lib/model-recommend.ts
+++ b/apps/server/src/lib/model-recommend.ts
@@ -1,4 +1,4 @@
-import { getClickhouse, toClickhouseTimestamp } from './clickhouse.js'
+import { unscopedClickhouse, toClickhouseTimestamp } from './clickhouse.js'
 import { requestsScope } from './requests-query.js'
 // Import from the cache module directly — `model-recommend-rules.ts` no
 // longer re-exports `matchSubstitute` because doing so created a circular
@@ -100,7 +100,7 @@ export async function recommendModelSwaps(
   // ── Phase 1: current-window aggregates ───────────────────────────────────
   let data: AggregateRow[] = []
   try {
-    const res = await getClickhouse().query({
+    const res = await unscopedClickhouse().query({
       query: `
         SELECT
           provider,
@@ -183,7 +183,7 @@ export async function recommendModelSwaps(
   async function fetchPriorCost(provider: string, model: string): Promise<number> {
     try {
       interface CostRow { total_cost_usd: string | null }
-      const res = await getClickhouse().query({
+      const res = await unscopedClickhouse().query({
         query: `
           SELECT sum(cost_usd) AS total_cost_usd
           FROM requests

--- a/apps/server/src/lib/quota.ts
+++ b/apps/server/src/lib/quota.ts
@@ -1,5 +1,5 @@
 import { supabaseAdmin } from './db.js'
-import { getClickhouse } from './clickhouse.js'
+import { unscopedClickhouse } from './clickhouse.js'
 
 /**
  * Monthly request quota per plan tier. Checked in the proxy middleware
@@ -128,7 +128,7 @@ export async function countMonthlyRequests(
     where += ' AND created_at < parseDateTime64BestEffort({until:String})'
   }
 
-  const result = await getClickhouse().query({
+  const result = await unscopedClickhouse().query({
     query: `SELECT count() AS n FROM requests WHERE ${where}`,
     query_params: params,
     format: 'JSONEachRow',

--- a/apps/server/src/lib/requests-query.ts
+++ b/apps/server/src/lib/requests-query.ts
@@ -1,4 +1,4 @@
-import { getClickhouse } from './clickhouse.js'
+import { unscopedClickhouse } from './clickhouse.js'
 import { supabaseAdmin } from './db.js'
 import { LOG_RETENTION_DAYS, type Plan } from './quota.js'
 
@@ -109,7 +109,7 @@ export interface RequestsScopeOptions {
  *
  * Example:
  *   const { whereScope, scopeParams } = await requestsScope(orgId)
- *   const result = await getClickhouse().query({
+ *   const result = await unscopedClickhouse().query({
  *     query: `SELECT id FROM requests WHERE ${whereScope} AND provider = {provider:String}`,
  *     query_params: { ...scopeParams, provider: 'openai' },
  *     format: 'JSONEachRow',
@@ -241,7 +241,7 @@ export async function selectRequests<T>(opts: {
   if (limit != null) sql += ` LIMIT ${Number(limit)}`
   if (offset != null) sql += ` OFFSET ${Number(offset)}`
 
-  const result = await getClickhouse().query({
+  const result = await unscopedClickhouse().query({
     query: sql,
     query_params: { ...scope.scopeParams, ...params },
     format: 'JSONEachRow',
@@ -283,7 +283,7 @@ export async function* streamRequests<T>(opts: {
   if (orderBy) sql += ` ORDER BY ${orderBy}`
   if (limit != null) sql += ` LIMIT ${Number(limit)}`
 
-  const result = await getClickhouse().query({
+  const result = await unscopedClickhouse().query({
     query: sql,
     query_params: { ...scope.scopeParams, ...params },
     format: 'JSONEachRow',
@@ -320,7 +320,7 @@ export async function countRequests(opts: {
 }): Promise<number> {
   const { scope, filters, params = {} } = opts
   const where = filters ? `${scope.whereScope} AND ${filters}` : scope.whereScope
-  const result = await getClickhouse().query({
+  const result = await unscopedClickhouse().query({
     query: `SELECT count() AS n FROM requests WHERE ${where}`,
     query_params: { ...scope.scopeParams, ...params },
     format: 'JSONEachRow',

--- a/apps/server/src/lib/stale-key-digest.ts
+++ b/apps/server/src/lib/stale-key-digest.ts
@@ -11,7 +11,7 @@
  */
 
 import { supabaseAdmin } from './db.js'
-import { getClickhouse } from './clickhouse.js'
+import { unscopedClickhouse } from './clickhouse.js'
 import { sendEmail, renderStaleKeyDigestEmail } from './resend.js'
 import { getAdminEmails } from './admin-emails.js'
 
@@ -64,7 +64,7 @@ async function findStaleKeysForOrg(
   const lastUsedMap = new Map<string, string>()
   if (keyIds.length > 0) {
     try {
-      const result = await getClickhouse().query({
+      const result = await unscopedClickhouse().query({
         query:
           'SELECT provider_key_id AS id, max(created_at) AS last_used_at ' +
           'FROM requests ' +

--- a/apps/server/src/lib/stats-queries.ts
+++ b/apps/server/src/lib/stats-queries.ts
@@ -1,4 +1,4 @@
-import { getClickhouse } from './clickhouse.js'
+import { unscopedClickhouse } from './clickhouse.js'
 import { requestsScope } from './requests-query.js'
 import { statsSource } from './stats-source.js'
 
@@ -85,7 +85,7 @@ export async function getStatsOverview(
     FROM ${statsSource()}
     WHERE ${where}`
 
-  const result = await getClickhouse().query({
+  const result = await unscopedClickhouse().query({
     query: sql,
     query_params: params,
     format: 'JSONEachRow',
@@ -150,7 +150,7 @@ export async function getStatsModels(
     GROUP BY provider, model
     ORDER BY total_cost_usd DESC`
 
-  const result = await getClickhouse().query({
+  const result = await unscopedClickhouse().query({
     query: sql,
     query_params: params,
     format: 'JSONEachRow',
@@ -252,7 +252,7 @@ export async function getStatsTimeseries(
     GROUP BY day
     ORDER BY day ASC`
 
-  const result = await getClickhouse().query({
+  const result = await unscopedClickhouse().query({
     query: sql,
     query_params: params,
     format: 'JSONEachRow',
@@ -328,7 +328,7 @@ export async function getTimeseriesBreakdown(
     )
     ORDER BY day ASC, kind ASC, c DESC`
 
-  const result = await getClickhouse().query({
+  const result = await unscopedClickhouse().query({
     query: sql,
     query_params: params,
     format: 'JSONEachRow',
@@ -449,7 +449,7 @@ export async function getUserAnalytics(
   params['limit'] = options.limit
   params['offset'] = options.offset
 
-  const result = await getClickhouse().query({
+  const result = await unscopedClickhouse().query({
     query: sql,
     query_params: params,
     format: 'JSONEachRow',
@@ -572,7 +572,7 @@ export async function getSessionAnalytics(
   params['limit'] = options.limit
   params['offset'] = options.offset
 
-  const result = await getClickhouse().query({
+  const result = await unscopedClickhouse().query({
     query: sql,
     query_params: params,
     format: 'JSONEachRow',
@@ -623,7 +623,7 @@ export async function getSecuritySummary(
     GROUP BY flag_type, pattern
     ORDER BY count DESC`
 
-  const result = await getClickhouse().query({
+  const result = await unscopedClickhouse().query({
     query: sql,
     query_params: { ...scope.scopeParams, hours },
     format: 'JSONEachRow',
@@ -677,7 +677,7 @@ export async function getLatencyPercentiles(
     WHERE ${scope.whereScope}
       AND created_at >= parseDateTime64BestEffort({sinceTs:String})`
 
-  const result = await getClickhouse().query({
+  const result = await unscopedClickhouse().query({
     query: sql,
     query_params: { ...scope.scopeParams, sinceTs },
     format: 'JSONEachRow',

--- a/apps/server/src/lib/traces-events-queries.ts
+++ b/apps/server/src/lib/traces-events-queries.ts
@@ -19,7 +19,7 @@
  * doesn't carry them as first-class columns.
  */
 
-import { getClickhouse } from './clickhouse.js'
+import { unscopedClickhouse } from './clickhouse.js'
 
 export interface TraceListOptions {
   organizationId: string
@@ -133,7 +133,7 @@ export async function listTracesFromEvents(opts: TraceListOptions): Promise<Trac
 
   const countQuery = `SELECT count() AS c FROM traces_view t WHERE ${where}`
 
-  const ch = getClickhouse()
+  const ch = unscopedClickhouse()
   const [listRes, countRes] = await Promise.all([
     ch.query({
       query: listQuery,
@@ -207,7 +207,7 @@ export async function getTraceWithSpansFromEvents(
   traceId: string,
   organizationId: string,
 ): Promise<TraceDetailResult> {
-  const ch = getClickhouse()
+  const ch = unscopedClickhouse()
 
   const params = { traceId, orgId: organizationId }
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,44 @@
+# lefthook — git hook orchestrator
+#
+# Local-only guards on the migration workflow. Repository conventions
+# (CLAUDE.md "DB 작업 규칙") forbid:
+#
+#   1. Editing or deleting an already-merged migration file. The
+#      remote migration history is hash-keyed; editing a committed
+#      migration breaks `db push` on every other dev's machine and on
+#      the deploy-server.yml migrate job.
+#
+#   2. Migrations named outside the YYYYMMDDHHMMSS_lowercase_snake.sql
+#      pattern. Supabase orders by filename; a mistyped prefix lands
+#      the new migration in the wrong slot and tips production.
+#
+#   3. Hand-editing supabase/types.ts. Always regenerate via
+#      `supabase gen types --lang typescript --local 2>/dev/null > supabase/types.ts`
+#      so the file matches the committed migration set. The hook
+#      warns but does not block: a regenerated types.ts is sometimes
+#      a legitimate solo change after pulling someone else's
+#      migration.
+#
+# Install once per clone:    `pnpm exec lefthook install`
+# Uninstall:                  `pnpm exec lefthook uninstall`
+# Bypass a single commit:     `git commit --no-verify`
+#
+# Multi-line shell snippets here would be re-quoted by lefthook before
+# `sh -c` ran them and broke on the first nested $variable. Each rule
+# lives in `.lefthook/<name>.sh` instead, where the shell can read the
+# script straight off disk.
+
+pre-commit:
+  parallel: true
+  commands:
+    no-migration-edits:
+      tags: db
+      run: bash .lefthook/no-migration-edits.sh
+
+    migration-naming:
+      tags: db
+      run: bash .lefthook/migration-naming.sh
+
+    no-types-edit:
+      tags: db
+      run: bash .lefthook/no-types-edit.sh

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "ch:migrate": "pnpm --filter server exec tsx ../../clickhouse/apply.ts"
   },
   "devDependencies": {
-    "typescript": "^6.0.3",
+    "eslint": "^9",
+    "lefthook": "^2.1.9",
     "prettier": "^3.3.3",
-    "eslint": "^9"
+    "typescript": "^6.0.3"
   },
   "packageManager": "pnpm@10.33.0",
   "engines": {

--- a/packages/eslint-plugin/RULES.md
+++ b/packages/eslint-plugin/RULES.md
@@ -1,0 +1,102 @@
+# @spanlens/eslint-plugin rules
+
+Spanlens-internal ESLint rules. Each rule guards a silent-data-loss
+pattern the TypeScript type system cannot catch on its own.
+
+---
+
+## `aes-decrypt-must-be-checked`
+
+**Type**: problem · **Level**: error · **Auto-fixable**: no
+
+`apps/server/src/lib/crypto.ts:aes256Decrypt()` is a `Promise<string>`
+that returns the empty string `""` on every failure mode (wrong key,
+tampered ciphertext, malformed input, etc.) instead of throwing. The
+design is intentional — a thrown error inside the proxy hot path
+would crash a request that the upstream provider could still serve
+with a different key — but it means every caller has to **explicitly
+check for the empty string** before using the result. A missed check
+silently sends an empty `Authorization` header to OpenAI and produces
+a 401 the customer has no way to debug.
+
+### What the rule enforces
+
+For every `await aes256Decrypt(...)` expression, the rule requires one
+of these patterns within the same block, in the next three
+statements:
+
+```ts
+// 1. truthy check + throw / return / continue
+const key = await aes256Decrypt(cipher)
+if (!key) throw new Error('decrypt failed')
+useKey(key)
+```
+
+```ts
+// 2. length-zero check + early return
+const key = await aes256Decrypt(cipher)
+if (key.length === 0) return null
+useKey(key)
+```
+
+```ts
+// 3. strict-equal empty string
+const key = await aes256Decrypt(cipher)
+if (key === '') return null
+useKey(key)
+```
+
+```ts
+// 4. combined boolean
+const key = await aes256Decrypt(cipher)
+if (!key || key.length === 0) {
+  throw new Error('decrypt failed')
+}
+useKey(key)
+```
+
+### What the rule rejects
+
+```ts
+// MISSING check — fails the rule
+const key = await aes256Decrypt(cipher)
+useKey(key) // ← rule fires on the await above
+```
+
+```ts
+// Discarding the result — fails the rule
+await aes256Decrypt(cipher)
+// nothing to check; the rule cannot prove the caller looked at the
+// return value, so it conservatively rejects.
+```
+
+### Why so strict?
+
+This rule is intentionally conservative. False positives ("I had a
+check three statements down") are fixable in one line; false
+negatives leak production decryption failures into customer 401s
+with no error log. The cost is asymmetric.
+
+If a call site truly does not care about the return value (e.g. a
+sanity test where the empty string is the expected output), wrap the
+call in a `// eslint-disable-next-line @spanlens/aes-decrypt-must-be-checked`
+comment and explain why in the comment body. Searchable trail, opt-out
+visible in review.
+
+### Escape hatch for tests
+
+`*.test.ts` and `__tests__/` files are exempt — the rule is scoped to
+production code via the host config's `files: ['src/**/*.ts']`
+override. If you add a new test directory layout, mirror that override
+or the rule will fire on assertion-style calls
+(`expect(await aes256Decrypt(...)).toBe('')`).
+
+### Rationale
+
+`crypto.ts:aes256Decrypt` is one of the most footgun-prone primitives
+in the codebase. The function comment warns about it; CLAUDE.md
+mentions it (`apps/server/src/lib/crypto.ts:81-105` returns empty
+string silently); reviewers catch the missing check most of the time.
+But "most of the time" is the wrong reliability bar for a primitive
+that decrypts production provider keys, so we encode the convention
+as a lint rule instead of a tradition.

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@spanlens/eslint-plugin",
+  "version": "0.0.1",
+  "description": "Spanlens-internal ESLint rules. Guards against silent-data-loss patterns the type system cannot catch (empty-string decrypt fallthrough, etc.).",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "RULES.md"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --clean",
+    "dev": "tsup src/index.ts --format esm --dts --watch",
+    "lint": "echo 'noop'",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@typescript-eslint/utils": "^8.60.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "@typescript-eslint/rule-tester": "^8.60.1",
+    "tsup": "^8.3.5",
+    "typescript": "^6.0.3",
+    "vitest": "^3.2.4"
+  },
+  "peerDependencies": {
+    "eslint": ">=9.0.0"
+  }
+}

--- a/packages/eslint-plugin/src/__tests__/aes-decrypt-must-be-checked.test.ts
+++ b/packages/eslint-plugin/src/__tests__/aes-decrypt-must-be-checked.test.ts
@@ -1,0 +1,168 @@
+import { RuleTester } from '@typescript-eslint/rule-tester'
+import { afterAll, describe, it } from 'vitest'
+
+import { aesDecryptMustBeChecked } from '../rules/aes-decrypt-must-be-checked.js'
+
+// RuleTester hooks into the test runner's lifecycle. Wiring vitest's
+// describe/it/afterAll explicitly is required when not running under jest.
+RuleTester.afterAll = afterAll
+RuleTester.describe = describe
+RuleTester.it = it
+RuleTester.itOnly = it.only
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('aes-decrypt-must-be-checked', aesDecryptMustBeChecked, {
+  valid: [
+    // Pattern 1: truthy check + throw (matches eval-runner.ts, experiment-runner.ts).
+    {
+      code: `
+async function f() {
+  const key = await aes256Decrypt(cipher)
+  if (!key) throw new Error('decrypt failed')
+  useKey(key)
+}
+      `,
+    },
+    // Pattern 2: length === 0 check + early return (matches proxy/utils.ts).
+    {
+      code: `
+async function f() {
+  const decrypted = await aes256Decrypt(data.encrypted_key)
+  if (decrypted.length === 0) return null
+  useKey(decrypted)
+}
+      `,
+    },
+    // Pattern 3: strict-equal empty string.
+    {
+      code: `
+async function f() {
+  const k = await aes256Decrypt(x)
+  if (k === '') return null
+  useKey(k)
+}
+      `,
+    },
+    // Pattern 4: combined boolean.
+    {
+      code: `
+async function f() {
+  const k = await aes256Decrypt(x)
+  if (!k || k.length === 0) {
+    throw new Error('decrypt failed')
+  }
+  useKey(k)
+}
+      `,
+    },
+    // Pattern 5: check three statements down (still inside the window).
+    {
+      code: `
+async function f() {
+  const k = await aes256Decrypt(x)
+  log('decrypted')
+  metric.inc('decrypt-attempts')
+  if (!k) return null
+  useKey(k)
+}
+      `,
+    },
+    // Pattern 6: !key.length unary on member expression.
+    {
+      code: `
+async function f() {
+  const k = await aes256Decrypt(x)
+  if (!k.length) return null
+  useKey(k)
+}
+      `,
+    },
+    // Pattern 7: reassignment with subsequent check (matches experiment-runner.ts:473).
+    {
+      code: `
+async function f() {
+  let judgeApiKey = ''
+  if (jk) {
+    judgeApiKey = await aes256Decrypt(jk.encrypted_key)
+    if (!judgeApiKey) throw new Error('Failed to decrypt judge key')
+  }
+}
+      `,
+    },
+    // Pattern 8: nested check inside if block (matches leak-detection.ts:120).
+    {
+      code: `
+async function f() {
+  const plaintext = await aes256Decrypt(key.encrypted_key)
+  if (!plaintext) {
+    throw new Error('decryption returned empty string')
+  }
+  return plaintext
+}
+      `,
+    },
+  ],
+  invalid: [
+    // Missing check entirely.
+    {
+      code: `
+async function f() {
+  const key = await aes256Decrypt(cipher)
+  useKey(key)
+}
+      `,
+      errors: [{ messageId: 'missingCheck' }],
+    },
+    // Discarded await (no binding at all).
+    {
+      code: `
+async function f() {
+  await aes256Decrypt(cipher)
+}
+      `,
+      errors: [{ messageId: 'noBinding' }],
+    },
+    // Check too far away — outside the 3-statement window.
+    {
+      code: `
+async function f() {
+  const k = await aes256Decrypt(x)
+  log('a')
+  log('b')
+  log('c')
+  log('d')
+  if (!k) return null
+  useKey(k)
+}
+      `,
+      errors: [{ messageId: 'missingCheck' }],
+    },
+    // Wrong variable checked.
+    {
+      code: `
+async function f() {
+  const k = await aes256Decrypt(x)
+  const other = 'a'
+  if (!other) return null
+  useKey(k)
+}
+      `,
+      errors: [{ messageId: 'missingCheck' }],
+    },
+    // Truthy assertion (if (k)) is NOT a valid check — that's "use only if
+    // non-empty," but the convention is to bail on empty, not to silently
+    // skip.
+    {
+      code: `
+async function f() {
+  const k = await aes256Decrypt(x)
+  if (k) {
+    useKey(k)
+  }
+}
+      `,
+      errors: [{ messageId: 'missingCheck' }],
+    },
+  ],
+})

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,0 +1,20 @@
+import { aesDecryptMustBeChecked } from './rules/aes-decrypt-must-be-checked.js'
+
+/**
+ * @spanlens/eslint-plugin — internal ESLint rules.
+ *
+ * Each rule guards a silent-data-loss pattern the TypeScript type system
+ * cannot catch on its own. See RULES.md for the per-rule rationale.
+ */
+const plugin = {
+  meta: {
+    name: '@spanlens/eslint-plugin',
+    version: '0.0.1',
+  },
+  rules: {
+    'aes-decrypt-must-be-checked': aesDecryptMustBeChecked,
+  },
+}
+
+export default plugin
+export const rules = plugin.rules

--- a/packages/eslint-plugin/src/rules/aes-decrypt-must-be-checked.ts
+++ b/packages/eslint-plugin/src/rules/aes-decrypt-must-be-checked.ts
@@ -1,0 +1,239 @@
+import { ESLintUtils, AST_NODE_TYPES, type TSESTree } from '@typescript-eslint/utils'
+
+/**
+ * Require an emptiness check after `await aes256Decrypt(...)`.
+ *
+ * `apps/server/src/lib/crypto.ts:aes256Decrypt` returns "" on every failure
+ * mode (wrong key, tampered ciphertext, malformed input). A caller that
+ * forgets to check produces a silent empty Authorization header upstream.
+ *
+ * The rule fires on the await expression. Recognised valid follow-ups,
+ * looked at within the next three statements of the enclosing block:
+ *
+ *   if (!result) ...
+ *   if (result.length === 0) ...
+ *   if (result === '') ...
+ *   if (!result || result.length === 0) ...
+ *   if (result == '') / result == "" / result === "" (loose & strict)
+ *
+ * Anything else, including discarding the result via a non-VariableDeclarator
+ * parent, is reported.
+ */
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/spanlens/spanlens/blob/main/packages/eslint-plugin/RULES.md#${name}`,
+)
+
+const DECRYPT_FUNCTION_NAME = 'aes256Decrypt'
+const STATEMENTS_TO_INSPECT = 3
+
+type AwaitWithCallee = TSESTree.AwaitExpression & {
+  argument: TSESTree.CallExpression & {
+    callee: TSESTree.Identifier
+  }
+}
+
+function isDecryptAwait(node: TSESTree.AwaitExpression): node is AwaitWithCallee {
+  return (
+    node.argument.type === AST_NODE_TYPES.CallExpression &&
+    node.argument.callee.type === AST_NODE_TYPES.Identifier &&
+    node.argument.callee.name === DECRYPT_FUNCTION_NAME
+  )
+}
+
+/**
+ * Walk outward from the AwaitExpression until we find either a
+ * VariableDeclarator (the result was named) or a Statement (the result
+ * was discarded). Returns the VariableDeclarator + its declaring
+ * VariableDeclaration if found, otherwise null.
+ */
+function findOwningDeclaration(await_: TSESTree.AwaitExpression): {
+  varName: string
+  declaration: TSESTree.VariableDeclaration
+} | null {
+  let cur: TSESTree.Node | undefined = await_.parent
+  while (cur) {
+    if (cur.type === AST_NODE_TYPES.VariableDeclarator) {
+      if (cur.id.type !== AST_NODE_TYPES.Identifier) return null
+      const parent = cur.parent
+      if (!parent || parent.type !== AST_NODE_TYPES.VariableDeclaration) return null
+      return { varName: cur.id.name, declaration: parent }
+    }
+    if (cur.type === AST_NODE_TYPES.AssignmentExpression) {
+      if (cur.left.type !== AST_NODE_TYPES.Identifier) return null
+      // Reassignment (`judgeApiKey = await ...`) — we treat the LHS the
+      // same as a fresh binding for purposes of the next-3-statements
+      // scan. Cast the enclosing ExpressionStatement to a Declaration-ish
+      // sentinel by returning the surrounding statement as `declaration`.
+      let stmt: TSESTree.Node | undefined = cur.parent
+      while (stmt && stmt.type !== AST_NODE_TYPES.ExpressionStatement) {
+        stmt = stmt.parent
+      }
+      if (!stmt) return null
+      return {
+        varName: cur.left.name,
+        declaration: stmt as unknown as TSESTree.VariableDeclaration,
+      }
+    }
+    if (
+      cur.type === AST_NODE_TYPES.ExpressionStatement ||
+      cur.type === AST_NODE_TYPES.IfStatement ||
+      cur.type === AST_NODE_TYPES.ReturnStatement
+    ) {
+      return null
+    }
+    cur = cur.parent
+  }
+  return null
+}
+
+/**
+ * Does this IfStatement test a known emptiness condition against `varName`?
+ *
+ * Recognised:
+ *   !varName
+ *   varName.length === 0   (also ==)
+ *   varName === ''         (also ==, "")
+ *   !varName.length
+ *   varName.length < 1
+ *   any LogicalExpression composed of the above (||, &&)
+ *
+ * The IfStatement consequent does NOT have to be a throw/return — any
+ * branch the user took is fine, because the lint goal is "you explicitly
+ * looked at the value." Encoding "the branch must throw" makes the rule
+ * trip over legitimate `if (!key) { metrics.inc('decrypt-fail'); return null }`
+ * patterns.
+ */
+function testChecksVar(node: TSESTree.Expression, varName: string): boolean {
+  // !varName
+  if (
+    node.type === AST_NODE_TYPES.UnaryExpression &&
+    node.operator === '!' &&
+    node.argument.type === AST_NODE_TYPES.Identifier &&
+    node.argument.name === varName
+  ) {
+    return true
+  }
+
+  // varName === '' / varName == ''
+  if (
+    node.type === AST_NODE_TYPES.BinaryExpression &&
+    (node.operator === '===' || node.operator === '==')
+  ) {
+    const left = node.left
+    const right = node.right
+    const isEmpty = (n: TSESTree.Node): boolean =>
+      n.type === AST_NODE_TYPES.Literal && (n.value === '' || n.value === 0)
+    const isVar = (n: TSESTree.Node): boolean =>
+      n.type === AST_NODE_TYPES.Identifier && n.name === varName
+    const isLengthOfVar = (n: TSESTree.Node): boolean =>
+      n.type === AST_NODE_TYPES.MemberExpression &&
+      n.object.type === AST_NODE_TYPES.Identifier &&
+      n.object.name === varName &&
+      n.property.type === AST_NODE_TYPES.Identifier &&
+      n.property.name === 'length'
+    if ((isVar(left) && isEmpty(right)) || (isEmpty(left) && isVar(right))) return true
+    if ((isLengthOfVar(left) && isEmpty(right)) || (isEmpty(left) && isLengthOfVar(right)))
+      return true
+  }
+
+  // varName.length < 1   (also <=, !==)
+  if (
+    node.type === AST_NODE_TYPES.BinaryExpression &&
+    (node.operator === '<' || node.operator === '<=') &&
+    node.left.type === AST_NODE_TYPES.MemberExpression &&
+    node.left.object.type === AST_NODE_TYPES.Identifier &&
+    node.left.object.name === varName &&
+    node.left.property.type === AST_NODE_TYPES.Identifier &&
+    node.left.property.name === 'length' &&
+    node.right.type === AST_NODE_TYPES.Literal &&
+    typeof node.right.value === 'number' &&
+    node.right.value <= 1
+  ) {
+    return true
+  }
+
+  // !varName.length
+  if (
+    node.type === AST_NODE_TYPES.UnaryExpression &&
+    node.operator === '!' &&
+    node.argument.type === AST_NODE_TYPES.MemberExpression &&
+    node.argument.object.type === AST_NODE_TYPES.Identifier &&
+    node.argument.object.name === varName &&
+    node.argument.property.type === AST_NODE_TYPES.Identifier &&
+    node.argument.property.name === 'length'
+  ) {
+    return true
+  }
+
+  // LogicalExpression ( ... || ... ) / ( ... && ... ) — recurse
+  if (
+    node.type === AST_NODE_TYPES.LogicalExpression &&
+    (node.operator === '||' || node.operator === '&&')
+  ) {
+    return testChecksVar(node.left, varName) || testChecksVar(node.right, varName)
+  }
+
+  return false
+}
+
+export const aesDecryptMustBeChecked = createRule({
+  name: 'aes-decrypt-must-be-checked',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require an empty-string check after `await aes256Decrypt(...)` to prevent silent fallthrough on decryption failure.',
+    },
+    schema: [],
+    messages: {
+      missingCheck:
+        "aes256Decrypt() returns '' on every failure mode. Add an explicit check (`if (!{{ varName }}) ...`, `if ({{ varName }}.length === 0) ...`, or equivalent) within the next 3 statements before using the value.",
+      noBinding:
+        "aes256Decrypt() returns '' on every failure mode. Capture the result in a variable and check it before use — discarding the await result is almost certainly a bug.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      AwaitExpression(node) {
+        if (!isDecryptAwait(node)) return
+
+        const owning = findOwningDeclaration(node)
+        if (!owning) {
+          context.report({ node, messageId: 'noBinding' })
+          return
+        }
+
+        const { varName, declaration } = owning
+
+        // Find the enclosing block-like node so we can look at the next
+        // statements. Both BlockStatement and Program have a `body` array.
+        const block = declaration.parent
+        if (
+          !block ||
+          (block.type !== AST_NODE_TYPES.BlockStatement &&
+            block.type !== AST_NODE_TYPES.Program)
+        ) {
+          context.report({ node, messageId: 'missingCheck', data: { varName } })
+          return
+        }
+
+        const idx = block.body.indexOf(declaration as unknown as TSESTree.Statement)
+        if (idx === -1) {
+          context.report({ node, messageId: 'missingCheck', data: { varName } })
+          return
+        }
+
+        const next = block.body.slice(idx + 1, idx + 1 + STATEMENTS_TO_INSPECT)
+        for (const stmt of next) {
+          if (stmt.type !== AST_NODE_TYPES.IfStatement) continue
+          if (testChecksVar(stmt.test, varName)) return
+        }
+
+        context.report({ node, messageId: 'missingCheck', data: { varName } })
+      },
+    }
+  },
+})

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": true,
+    "rootDir": "src",
+    "types": ["node"],
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.7.0)
+      lefthook:
+        specifier: ^2.1.9
+        version: 2.1.9
       prettier:
         specifier: ^3.3.3
         version: 3.8.3
@@ -3674,6 +3677,60 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
+
+  lefthook-darwin-arm64@2.1.9:
+    resolution: {integrity: sha512-119HryNcvr4nqn0wUIrNPgpMEPn9yMQzEcW/lezRsnb56PCJriJB92+MCySPVcWDxJnZef7o0T3jdnPNiSH7Qg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.9:
+    resolution: {integrity: sha512-dwo5Tke2XcQCM56DGHgFKBfRbJIL6xs2wZ0zG1TUVZgl4t4mQUt6LiZ4V/ZQfYHTZF9qywvXoIlR5N35qOaiVQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.9:
+    resolution: {integrity: sha512-+09PVap6nl6xsaHch5JLtq7WvIR++U1Q2MzA2ai0M4uB/VP3AqrvKqHw6+9hjyKnIH+HHL83uqi77EAY+LaxLA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.9:
+    resolution: {integrity: sha512-8XresjKIYpkE9ARgCtBEZgJZxAU3T4MIqzj4zNy15XRT59I1Us+QdqXTNm+pkZ41Yd2X/nxs2Pkvbq3NWWlIGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.9:
+    resolution: {integrity: sha512-1oNIQfwrPe6rgU2KcDM3aF6+hpZDCKx1TmawQKpXUY5gVsbZ7MqX0Sk/1lnnWxqPm+kQQ5f6J2dpFWd+4xH8jg==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.9:
+    resolution: {integrity: sha512-fT+7Q+BJyGp+CslFQkNXmdFRgyVXsPHPi9NAsDX0a6QOyNnoORByAsvx6zeAKuF5rL3BBgNfho1/v2RuGxGy9w==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.9:
+    resolution: {integrity: sha512-4bVuafBk3dddVNo0+3hMbjcJs4mqYAstxpPMmX2ufkudSTYFNIhWoqwuGVQV/SS/xdcOKJAldW4qayAzed2ysw==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.9:
+    resolution: {integrity: sha512-PmPoMmLP/wQQWcQ9u2YH86bTZ3UCfBsxuEmVTEyPU2U8R1qSTp5r/Gs3G8cN5Mxo91XB9oBERtF1n+xD3W6aVA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.9:
+    resolution: {integrity: sha512-KphfkBKmwBnmolyrdhIl3lrBaOyTcCgXBT2AB/9OHnEXhOLvv5uTCUkrD4YRAxXPtFKq6UvnapIeoL3GZq0bdA==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.9:
+    resolution: {integrity: sha512-2qlUtkJHZ3MyUxgV5XTEmcrIoNZA07iwaquoswAcqv/1MeBFXlD+O+koFRfrzWng2O5WYEbpJnd8tvaYnV8fTA==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.9:
+    resolution: {integrity: sha512-bwDaIOViTktE8kJLf9jP0p+H2/RDTlFFlc43Am2YgUsX22hI6Sq4RbzsrecwzY5y+MHTipOH7WsmWSEniePHWQ==}
+    hasBin: true
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -7522,8 +7579,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.7
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -7545,7 +7602,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7556,22 +7613,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7582,7 +7639,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -8293,6 +8350,49 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
+
+  lefthook-darwin-arm64@2.1.9:
+    optional: true
+
+  lefthook-darwin-x64@2.1.9:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.9:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.9:
+    optional: true
+
+  lefthook-linux-arm64@2.1.9:
+    optional: true
+
+  lefthook-linux-x64@2.1.9:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.9:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.9:
+    optional: true
+
+  lefthook-windows-arm64@2.1.9:
+    optional: true
+
+  lefthook-windows-x64@2.1.9:
+    optional: true
+
+  lefthook@2.1.9:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.9
+      lefthook-darwin-x64: 2.1.9
+      lefthook-freebsd-arm64: 2.1.9
+      lefthook-freebsd-x64: 2.1.9
+      lefthook-linux-arm64: 2.1.9
+      lefthook-linux-x64: 2.1.9
+      lefthook-openbsd-arm64: 2.1.9
+      lefthook-openbsd-x64: 2.1.9
+      lefthook-windows-arm64: 2.1.9
+      lefthook-windows-x64: 2.1.9
 
   levn@0.4.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
         specifier: ^4.12.23
         version: 4.12.23
     devDependencies:
+      '@spanlens/eslint-plugin':
+        specifier: workspace:*
+        version: link:../../packages/eslint-plugin
       '@types/node':
         specifier: ^25.8.0
         version: 25.8.0
@@ -227,6 +230,31 @@ importers:
       vitest:
         specifier: ^3.2.6
         version: 3.2.6(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
+
+  packages/eslint-plugin:
+    dependencies:
+      '@typescript-eslint/utils':
+        specifier: ^8.60.1
+        version: 8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      eslint:
+        specifier: '>=9.0.0'
+        version: 9.39.4(jiti@2.7.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.19
+      '@typescript-eslint/rule-tester':
+        specifier: ^8.60.1
+        version: 8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.6(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
 
   packages/mcp-server:
     dependencies:
@@ -2075,9 +2103,6 @@ packages:
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
 
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -2126,6 +2151,13 @@ packages:
     resolution: {integrity: sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/rule-tester@8.60.1':
+    resolution: {integrity: sha512-ly/WFKd5EwhTpuFbgQ81Z+67o4DRnlgKy+yHTuHWTy/u8yb0nEVPjDKqVUkJ1545vX2aAW1TELNSPPs+AOC+KA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/scope-manager@8.60.1':
@@ -2528,6 +2560,9 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2635,6 +2670,12 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -2673,6 +2714,10 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -2713,6 +2758,10 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
@@ -2722,6 +2771,13 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -3231,6 +3287,9 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -3618,6 +3677,10 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -3810,6 +3873,17 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   loader-runner@4.3.2:
     resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
@@ -3906,6 +3980,9 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
@@ -3915,6 +3992,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -4117,13 +4197,38 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
@@ -4236,6 +4341,10 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   recharts@3.8.1:
     resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
     engines: {node: '>=18'}
@@ -4274,6 +4383,10 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -4409,6 +4522,10 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -4500,6 +4617,11 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -4574,6 +4696,13 @@ packages:
     resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
     engines: {node: '>=18'}
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -4614,6 +4743,10 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
@@ -4623,6 +4756,9 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
   ts-morph@28.0.0:
     resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
 
@@ -4631,6 +4767,25 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   tsx@4.22.4:
     resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
@@ -4681,6 +4836,9 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -6527,8 +6685,6 @@ snapshots:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
 
-  '@types/estree@1.0.8': {}
-
   '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
@@ -6590,6 +6746,20 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.60.1
       debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/rule-tester@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/parser': 8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      ajv: 6.14.0
+      eslint: 9.39.4(jiti@2.7.0)
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      semver: 7.8.1
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -6994,6 +7164,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  any-promise@1.3.0: {}
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -7136,6 +7308,11 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -7176,6 +7353,10 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   chrome-trace-event@1.0.4: {}
 
   cjs-module-lexer@2.2.0: {}
@@ -7212,11 +7393,17 @@ snapshots:
 
   commander@2.20.3: {}
 
+  commander@4.1.1: {}
+
   commander@7.2.0: {}
 
   commondir@1.0.1: {}
 
   concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
 
   content-disposition@1.1.0: {}
 
@@ -7738,7 +7925,7 @@ snapshots:
       '@humanfs/node': 0.16.8
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -7915,6 +8102,12 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.61.1
 
   flat-cache@4.0.1:
     dependencies:
@@ -8301,6 +8494,8 @@ snapshots:
 
   jose@6.2.3: {}
 
+  joycon@3.1.1: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -8448,6 +8643,12 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
   loader-runner@4.3.2: {}
 
   locate-path@6.0.0:
@@ -8527,11 +8728,24 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   module-details-from-path@1.0.4: {}
 
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
 
   nanoid@3.3.12: {}
 
@@ -8715,9 +8929,25 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pirates@4.0.7: {}
+
   pkce-challenge@5.0.1: {}
 
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
   possible-typed-array-names@1.1.0: {}
+
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.7.0
+      postcss: 8.5.15
+      tsx: 4.22.4
 
   postcss-selector-parser@6.0.10:
     dependencies:
@@ -8819,6 +9049,8 @@ snapshots:
 
   react@19.2.7: {}
 
+  readdirp@4.1.2: {}
+
   recharts@3.8.1(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.16)(react@19.2.7)(redux@5.0.1))(react@19.2.7)
@@ -8877,6 +9109,8 @@ snapshots:
   reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -9108,6 +9342,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  source-map@0.7.6: {}
+
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
@@ -9217,6 +9453,16 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.7
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -9256,6 +9502,14 @@ snapshots:
       glob: 10.5.0
       minimatch: 10.2.5
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -9283,11 +9537,15 @@ snapshots:
 
   tr46@0.0.3: {}
 
+  tree-kill@1.2.2: {}
+
   ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
+
+  ts-interface-checker@0.1.13: {}
 
   ts-morph@28.0.0:
     dependencies:
@@ -9302,6 +9560,34 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@6.0.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)
+      resolve-from: 5.0.0
+      rollup: 4.61.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.15
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tsx@4.22.4:
     dependencies:
@@ -9368,6 +9654,8 @@ snapshots:
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
+
+  ufo@1.6.4: {}
 
   unbox-primitive@1.1.0:
     dependencies:


### PR DESCRIPTION
Originally PR #246 — auto-closed when R-Q5 base was deleted. Same code, rebased onto main.

`getClickhouse` read as a friendly accessor and pushed nobody toward the org-scoped helpers. Renamed across 32 files to `unscopedClickhouse` so every reader has to ask "scoped to what?"

/cron/keep-warm now uses `pingClickhouse()` instead of a synthetic SELECT 1. Settled-status check fixed to `results[1].value === true` because pingClickhouse swallows its own errors.

ESLint `no-restricted-imports` blocks both `unscopedClickhouse` and the legacy `getClickhouse` name. `src/lib/**` + `src/__tests__/**` override.

771/771 tests pass. Artificial violation → expected error.