### PR TITLE
fix: post-merge CI + production deploy regressions from R-Q5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # `apps/server/eslint.config.mjs` imports `@spanlens/eslint-plugin` from
+      # its compiled `dist/`. `pnpm install` does not run dependent packages'
+      # build scripts, so without this step the Lint (server) job fails with
+      # `Cannot find module '@spanlens/eslint-plugin/dist/index.js'`.
+      - name: Build @spanlens/eslint-plugin
+        run: pnpm --filter @spanlens/eslint-plugin build
+
       - name: Typecheck (all packages)
         run: pnpm --recursive typecheck
 

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "framework": null,
   "outputDirectory": null,
-  "installCommand": "npm install",
+  "installCommand": "npm install --omit=dev",
   "regions": ["icn1"],
   "functions": {
     "api/index.ts": {


### PR DESCRIPTION
## What

Two failures appeared right after R-Q5 (PR #250) and R-Q6 (PR #251) hit main:

| Workflow | Symptom | Fix |
|---|---|---|
| **CI** (#919, #921 on main; #918, #920 on PRs) | \`Cannot find module '@spanlens/eslint-plugin/dist/index.js'\` from server lint | Add \`pnpm --filter @spanlens/eslint-plugin build\` step before typecheck/lint |
| **Deploy production** (#210 on main) | \`npm error EUNSUPPORTEDPROTOCOL: Unsupported URL Type "workspace:": workspace:*\` | \`apps/server/vercel.json\`: \`installCommand\` → \`npm install --omit=dev\` |

## Why

The CI break was flagged as a known follow-up in the R-Q5 PR description. \`pnpm install\` does not run dependent packages' build scripts, so the plugin's compiled \`dist/\` was missing in CI even though \`apps/server/eslint.config.mjs\` imports from it. Local dev only worked because someone had run \`pnpm build\` in the plugin directory at some point.

The Vercel break is less obvious — npm does not support pnpm's \`workspace:*\` protocol *even inside devDependencies*. Vercel's default \`npm install\` walks every dep and rejects the unknown protocol before the install phase ever distinguishes prod from dev. The plugin is lint-only (server's \`build\` script is a no-op), so the production runtime does not need it. \`--omit=dev\` is the smallest possible change that keeps the deploy pipeline npm-only.

## Current state

R-Q5 + R-Q6 are already on main as commits but production is still serving R-Q4 because \`deploy-server.yml\` failed on the npm error and the previous deploy stayed live. Once this PR lands, the next push to main re-runs the deploy job with the cumulative R-Q5 + R-Q6 changes.

## Verification

- ✅ Vercel preview from this PR will exercise the new \`installCommand\` against the actual workspace
- ✅ CI from this PR will exercise the new \`Build @spanlens/eslint-plugin\` step
- Local: \`pnpm install --frozen-lockfile && pnpm --filter @spanlens/eslint-plugin build && pnpm --filter server lint\` clean

## Follow-up if this is wrong

If \`npm install --omit=dev\` ever breaks because the runtime grows a build step that needs devDeps, switch the installCommand to a pnpm form: \`"installCommand": "corepack enable && pnpm install --prod --frozen-lockfile"\`. We are not making that change today because the install-time blast radius is bigger than the workspace-protocol regression.