### PR TITLE
fix: Vercel installCommand → pnpm (npm rejects workspace:* even with --omit=dev)

### DIFF
--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "framework": null,
   "outputDirectory": null,
-  "installCommand": "npm install --omit=dev",
+  "installCommand": "corepack enable && pnpm install --frozen-lockfile",
   "regions": ["icn1"],
   "functions": {
     "api/index.ts": {


### PR DESCRIPTION
## What

PR #252's `npm install --omit=dev` did not work. Run #27114179208 (post-merge deploy on commit 305c765) hit the same `EUNSUPPORTEDPROTOCOL` error.

## Why my last fix was wrong

I assumed `--omit=dev` would skip the workspace:* dependency entirely. It does not. npm rejects the package.json at parse time — before it ever distinguishes prod from dev — so the dev flag is irrelevant.

## Real fix

`apps/server/vercel.json` `installCommand` → `corepack enable && pnpm install --frozen-lockfile`. pnpm understands workspace links natively (that protocol exists for pnpm). Vercel's Node 22+ runtime has corepack built in, no extra setup needed.

## State

R-Q5 + R-Q6 commits are on main but production is still serving R-Q4 because both deploy attempts (#210 with `npm install`, then #27114179208 with `npm install --omit=dev`) failed at install time. This should let the next deploy go through.

## Verification

This PR's Vercel preview will exercise the new installCommand against the actual workspace, with the actual workspace:* dependency. If the preview deploy passes, the production deploy from main will pass too.