### PR TITLE
fix: remove workspace:* from apps/server/package.json — Vercel install can't read it

### DIFF
--- a/apps/server/eslint.config.mjs
+++ b/apps/server/eslint.config.mjs
@@ -1,6 +1,15 @@
 import tsParser from '@typescript-eslint/parser'
 import tsPlugin from '@typescript-eslint/eslint-plugin'
-import spanlensPlugin from '@spanlens/eslint-plugin'
+// `@spanlens/eslint-plugin` deliberately not in package.json. Adding it as a
+// workspace dependency breaks Vercel deploys: vercel runs `npm install` from
+// `apps/server/`, npm rejects `workspace:*` at package.json parse time, and
+// switching to pnpm hits "Headless installation requires a pnpm-lock.yaml file"
+// because the lockfile lives at the monorepo root. Pulling the plugin in via
+// relative path keeps the server's install graph npm-compatible while still
+// resolving for `pnpm --filter server lint` locally and in CI (where the
+// plugin is built first by the dedicated `Build @spanlens/eslint-plugin`
+// step in .github/workflows/ci.yml).
+import spanlensPlugin from '../../packages/eslint-plugin/dist/index.js'
 import globals from 'globals'
 
 // R-Q6: `unscopedClickhouse` (renamed from `getClickhouse`) returns the

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,7 +28,6 @@
     "hono": "^4.12.23"
   },
   "devDependencies": {
-    "@spanlens/eslint-plugin": "workspace:*",
     "@types/node": "^25.8.0",
     "@typescript-eslint/eslint-plugin": "^8.60.1",
     "@typescript-eslint/parser": "^8.60.1",

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "framework": null,
   "outputDirectory": null,
-  "installCommand": "corepack enable && pnpm install --frozen-lockfile",
+  "installCommand": "npm install",
   "regions": ["icn1"],
   "functions": {
     "api/index.ts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,6 @@ importers:
         specifier: ^4.12.23
         version: 4.12.23
     devDependencies:
-      '@spanlens/eslint-plugin':
-        specifier: workspace:*
-        version: link:../../packages/eslint-plugin
       '@types/node':
         specifier: ^25.8.0
         version: 25.8.0


### PR DESCRIPTION
## What

Three failed deploys after R-Q5 (each fixing the previous attempt):

| Attempt | Approach | Failure |
|---|---|---|
| R-Q5 merge (original) | `npm install` | `EUNSUPPORTEDPROTOCOL: workspace:*` |
| PR #252 | `npm install --omit=dev` | Same — npm rejects `workspace:*` at parse time, before --omit=dev is consulted |
| PR #253 | `corepack enable && pnpm install --frozen-lockfile` | `Headless installation requires a pnpm-lock.yaml file` — lockfile lives at monorepo root, Vercel runs install from `apps/server/` |

The pattern: Vercel deploys `apps/server/` as if it were a standalone npm project. Every package.json field that requires workspace knowledge breaks it. Easiest exit: stop declaring the plugin as a server dependency.

## Changes

- `apps/server/package.json` — drop `"@spanlens/eslint-plugin": "workspace:*"`
- `apps/server/vercel.json` — `installCommand` back to `npm install` (default)
- `apps/server/eslint.config.mjs` — import the plugin via relative path `'../../packages/eslint-plugin/dist/index.js'` with a comment explaining why

The plugin is lint-only — server runtime doesn't need it. Local and CI lint still work because:
- `pnpm install` at the workspace root builds the dependency graph as a unit
- `.github/workflows/ci.yml` has `Build @spanlens/eslint-plugin` step before lint (from PR #252)

## Verification

- ✅ `pnpm install` clean
- ✅ `pnpm --filter @spanlens/eslint-plugin build` produces `dist/`
- ✅ `pnpm --filter server lint` clean
- ✅ Artificial `__violation__.ts` (no check) → 1 error with same friendly message as before — rule still fires
- ✅ Vercel preview from this PR will exercise the deploy pipeline with the actual server changes

## State

Production server is still serving R-Q4 code. Once this lands and the post-merge deploy completes, R-Q5 + R-Q6 finally roll out.