### PR TITLE
fix(web): /demo/dashboard React #418 hydration mismatch

### DIFF
--- a/apps/web/app/demo/dashboard/page.tsx
+++ b/apps/web/app/demo/dashboard/page.tsx
@@ -1,5 +1,24 @@
 'use client'
-import { useMemo, useState } from 'react'
+import { useMemo, useState, useSyncExternalStore } from 'react'
+
+// Module-level cache so useSyncExternalStore's getSnapshot returns the
+// same number on every call. Without the cache, each call returned a
+// fresh Date.now() and React's identity comparison treated every render
+// as "store changed" → forceStoreRerender → render → forceStoreRerender,
+// until "Maximum update depth exceeded" fired. The cache is fine for the
+// demo dashboard: the page only needs `now` once at mount to compute
+// "fired X mins ago" relative timestamps.
+let cachedClientNow = 0
+function getClientNow(): number {
+  if (cachedClientNow === 0) cachedClientNow = Date.now()
+  return cachedClientNow
+}
+function getServerNow(): number {
+  return 0
+}
+function subscribeNow(): () => void {
+  return () => {}
+}
 import Link from 'next/link'
 import { Topbar } from '@/components/layout/topbar'
 import { KpiCard } from '@/components/dashboard/kpi-card'
@@ -144,8 +163,16 @@ export default function DemoDashboardPage() {
     'border-border',
   ]
 
-  // Capture "now" once at mount — demo timestamps are static relative to load.
-  const [now] = useState(() => Date.now())
+  // SSR + first client paint return 0 so React hydrates from identical
+  // HTML. The client snapshot returns a *cached* timestamp (captured on
+  // first call) so subsequent invocations return the same reference and
+  // React stops re-rendering. Returning a fresh `Date.now()` on every
+  // call sent useSyncExternalStore into an infinite update loop that
+  // bubbled up through recharts as "Maximum update depth exceeded".
+  //
+  // Same shape as the R-Q3 docs/_components/table-of-contents.tsx fix.
+  // CLAUDE.md gotcha #22 pattern.
+  const now = useSyncExternalStore(subscribeNow, getClientNow, getServerNow)
 
   const firedMinsAgo = firingAlert.last_triggered_at
     ? Math.max(1, Math.round((now - new Date(firingAlert.last_triggered_at).getTime()) / 60_000))
@@ -417,7 +444,7 @@ export default function DemoDashboardPage() {
               >
                 <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 sm:grid sm:items-baseline" style={{ gridTemplateColumns: '56px 80px 1fr', gap: 14 }}>
                   <span className="font-mono text-[10.5px] text-text-faint shrink-0">
-                    {new Date(e.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false })}
+                    {new Date(e.created_at).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })}
                   </span>
                   <span className={cn(
                     'font-mono text-[9px] uppercase tracking-[0.04em] px-[5px] py-[1px] rounded-[3px] border self-center shrink-0',

--- a/apps/web/lib/demo-data.ts
+++ b/apps/web/lib/demo-data.ts
@@ -25,7 +25,12 @@ import type { Dataset, DatasetItem, DatasetWithItems } from '@/lib/queries/use-d
 import type { Experiment, ExperimentResult } from '@/lib/queries/use-experiments'
 import type { AnnotationQueueItem, CorrelationPair } from '@/lib/queries/use-human-evals'
 
-const N = Date.now()
+// Round to the hour so SSR (server bundle module-load time) and CSR
+// (client bundle module-load time) agree even when they evaluate in
+// different processes. Hydration mismatch only re-emerges if the two
+// land on opposite sides of an hour boundary, which is a 1-in-3600
+// race we accept for demo data. CLAUDE.md gotcha #22.
+const N = Math.floor(Date.now() / 3_600_000) * 3_600_000
 const min = (m: number) => new Date(N - m * 60_000).toISOString()
 const hrs = (h: number) => min(h * 60)
 const day = (d: number) => hrs(d * 24)
@@ -566,8 +571,13 @@ export const DEMO_STATS_OVERVIEW: StatsOverview = {
 function generateTimeseries(): TimeseriesPoint[] {
   const points: TimeseriesPoint[] = []
   for (let i = 23; i >= 0; i--) {
-    const base = Math.round(95 + Math.sin(i * 0.4) * 20 + Math.random() * 10)
-    const cost = parseFloat((base * 0.034 + Math.random() * 0.5).toFixed(3))
+    // Deterministic "noise" so KpiCard sparkline SVG paths match between
+    // SSR and CSR. Using Math.random() here produced different values on
+    // the two module-load evaluations and React #418'd the dashboard.
+    const noise1 = Math.sin(i * 13.7) * 5 + 5 // 0..10 pseudo-noise
+    const noise2 = Math.sin(i * 7.3) * 0.25 + 0.25 // 0..0.5 pseudo-noise
+    const base = Math.round(95 + Math.sin(i * 0.4) * 20 + noise1)
+    const cost = parseFloat((base * 0.034 + noise2).toFixed(3))
     points.push({
       date: new Date(N - i * 3_600_000).toISOString(),
       requests: base,
@@ -590,7 +600,11 @@ export const DEMO_SPEND_FORECAST: SpendForecast = {
   weeklyDeltaPct: 12.4,
   dailyTrendUsd: 2.18,
   timeseries: Array.from({ length: 31 }, (_, i) => ({
-    date: new Date(N - (new Date().getDate() - 1 - i) * 86_400_000).toISOString().slice(0, 10),
+    // Use a fixed dayOfMonth (matches DEMO_SPEND_FORECAST.dayOfMonth above)
+    // instead of `new Date().getDate()` — the latter would be evaluated on
+    // SSR vs CSR with different "now" values, producing off-by-one dates
+    // around the user's midnight (gotcha #22 again).
+    date: new Date(N - (4 - 1 - i) * 86_400_000).toISOString().slice(0, 10),
     actual: i < 4 ? parseFloat((60 + i * 2.1 + Math.sin(i) * 4).toFixed(2)) : null,
     projected: i >= 3 ? parseFloat((61 + i * 2.2 + Math.sin(i) * 3).toFixed(2)) : null,
   })),


### PR DESCRIPTION
## What

`/demo/dashboard` was logging React #418 ("Hydration failed") on every page load. Three independent non-deterministic sources, all in CLAUDE.md gotcha #22's pattern family:

| Where | Pattern | Symptom |
|---|---|---|
| `app/demo/dashboard/page.tsx` | `useState(() => Date.now())` | SSR captured server time, first client render captured browser time |
| `lib/demo-data.ts:28` | `const N = Date.now()` evaluated at module load | Server bundle and client bundle ran the module in separate processes |
| `lib/demo-data.ts:569-570` | `Math.random()` inside `generateTimeseries()` | KpiCard `<path d="...">` attributes char-by-char different between server and client HTML — the most visible symptom |

## Fixes

1. **Dashboard page**: `useSyncExternalStore` with a module-level cache. Tried `useState(0) + useEffect(setNow)` first — rejected by React 19's `react-hooks/set-state-in-effect` lint rule (which is *exactly* the rule that exists to push you toward useSyncExternalStore here). Tried `getSnapshot: () => Date.now()` second — fresh number every call triggered an infinite update loop that surfaced through recharts as "Maximum update depth exceeded". The cached-snapshot shape is the third attempt and matches the R-Q3 `docs/_components/table-of-contents.tsx` fix from PR #240.

2. **demo-data N**: `Math.floor(Date.now() / 3_600_000) * 3_600_000`. Server and client agree within the same hour. Remaining 1-in-3600 race accepted for demo data.

3. **Math.random in generateTimeseries**: replaced with `Math.sin(i * 13.7) * 5 + 5` and `Math.sin(i * 7.3) * 0.25 + 0.25` — same shape of "noise" the sparkline needed, deterministic per index `i`. Also replaced `new Date().getDate()` with the hardcoded `4` already used by `DEMO_SPEND_FORECAST.dayOfMonth` two lines up.

## Discovery

Surfaced during Sprint 0 production smoke test of R-Q1~R-Q6. Bug predates this Sprint — every visitor to `/demo/dashboard` was seeing it. CLAUDE.md gotcha #22 lists all three patterns; this PR retroactively applies them.

## Verification

- ✅ `pnpm --filter web typecheck + lint` clean
- ✅ Chrome MCP on local dev: dashboard renders with `fired 29m ago` and console shows zero hydration warnings (down from three: #418, infinite-loop, recharts ChartDataContextProvider error)
- ⏳ Vercel preview from this PR will exercise prod-like SSR