### PR TITLE
fix(web): demo subsystem React #418 hydration mismatches — full audit

### DIFF
--- a/apps/web/app/demo/alerts/[id]/page.tsx
+++ b/apps/web/app/demo/alerts/[id]/page.tsx
@@ -6,6 +6,7 @@ import { DEMO_ALERTS, DEMO_CHANNELS, DEMO_DELIVERIES } from '@/lib/demo-data'
 import type { AlertType } from '@/lib/queries/types'
 import { Topbar } from '@/components/layout/topbar'
 import { cn, formatDateTime } from '@/lib/utils'
+import { useHydrationSafeNow } from '@/lib/hydration-safe-now'
 
 function fmtThreshold(type: AlertType, threshold: number): string {
   if (type === 'budget') return `$${threshold}`
@@ -37,7 +38,7 @@ export default function DemoAlertDetailPage({ params }: { params: Promise<{ id: 
   const { id } = use(params)
   // Stable "now" for the 24h delivery bucket. Demo data has fixed timestamps,
   // so re-evaluating on every render isn't useful.
-  const [mountNow] = useState(() => Date.now())
+  const mountNow = useHydrationSafeNow()
 
   const alert = DEMO_ALERTS.find((a) => a.id === id)
   const channels = DEMO_CHANNELS

--- a/apps/web/app/demo/alerts/page.tsx
+++ b/apps/web/app/demo/alerts/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useState } from 'react'
 import Link from 'next/link'
+import { useHydrationSafeNow } from '@/lib/hydration-safe-now'
 import { Mail, MessageSquare, Search } from 'lucide-react'
 import { DEMO_ALERTS, DEMO_CHANNELS, DEMO_DELIVERIES } from '@/lib/demo-data'
 import type { AlertRow } from '@/lib/queries/types'
@@ -99,7 +100,7 @@ function AlertRuleRow({ a, last }: { a: AlertRow; last: boolean }) {
           {a.window_minutes}m
           {a.last_triggered_at && (
             <span className="text-text-faint ml-2">
-              · last fired {new Date(a.last_triggered_at).toLocaleString()}
+              · last fired {new Date(a.last_triggered_at).toLocaleString('en-US')}
             </span>
           )}
         </div>
@@ -169,7 +170,7 @@ export default function DemoAlertsPage() {
   const isFiltered = query.trim().length > 0 || status !== 'all'
 
   // Capture "now" once at mount — demo data is static.
-  const [now] = useState(() => Date.now())
+  const now = useHydrationSafeNow()
   const fires24h = deliveries.filter(
     (d) => now - new Date(d.created_at).getTime() < 24 * 60 * 60 * 1000,
   ).length
@@ -407,7 +408,7 @@ export default function DemoAlertsPage() {
                     className="flex items-center gap-4 px-[14px] py-2 border-b border-border last:border-0 text-[11.5px]"
                   >
                     <span className="font-mono text-text-faint">
-                      {new Date(d.created_at).toLocaleString()}
+                      {new Date(d.created_at).toLocaleString('en-US')}
                     </span>
                     <span
                       className={cn(

--- a/apps/web/app/demo/dashboard/page.tsx
+++ b/apps/web/app/demo/dashboard/page.tsx
@@ -226,7 +226,7 @@ export default function DemoDashboardPage() {
           </div>
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[13px] sm:text-[14px] text-text-muted">
             <span>Last 24h:</span>
-            <b className="text-text font-medium">{o.totalRequests.toLocaleString()} requests</b>
+            <b className="text-text font-medium">{o.totalRequests.toLocaleString('en-US')} requests</b>
             <span className="text-text-faint">·</span>
             <b className="text-text font-medium">{fmtCost(o.totalCostUsd)} spent</b>
             <span className="text-text-faint">·</span>
@@ -274,7 +274,7 @@ export default function DemoDashboardPage() {
           <KpiCard
             className={kpiCellClasses[0]}
             label="Requests · 24h"
-            value={o.totalRequests.toLocaleString()}
+            value={o.totalRequests.toLocaleString('en-US')}
             delta={fmtDelta(o.requestsDelta)}
             deltaVariant={deltaVariantFor(o.requestsDelta, true)}
             sparkValues={sparkRequests}
@@ -347,7 +347,7 @@ export default function DemoDashboardPage() {
                     <span className="text-text-faint text-[10.5px] uppercase tracking-[0.04em] mr-1.5">{m.provider}</span>
                     {m.model}
                   </span>
-                  <span className="text-[12px] text-text-muted text-right">{m.requestCount.toLocaleString()}</span>
+                  <span className="text-[12px] text-text-muted text-right">{m.requestCount.toLocaleString('en-US')}</span>
                   <span className="text-[12px] text-text font-medium text-right">{fmtCost(m.totalCostUsd)}</span>
                 </div>
               ))}

--- a/apps/web/app/demo/datasets/page.tsx
+++ b/apps/web/app/demo/datasets/page.tsx
@@ -61,7 +61,7 @@ export default function DemoDatasetsPage() {
         <div className="grid grid-cols-2 min-w-[280px]">
           {[
             { label: 'Datasets', value: String(DEMO_DATASETS.length) },
-            { label: 'Total items', value: totalItems.toLocaleString() },
+            { label: 'Total items', value: totalItems.toLocaleString('en-US') },
           ].map((s, i) => (
             <div key={s.label} className={cn('px-[18px] py-[14px]', i < 1 && 'border-r border-border')}>
               <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-2">{s.label}</div>

--- a/apps/web/app/demo/evals/page.tsx
+++ b/apps/web/app/demo/evals/page.tsx
@@ -242,7 +242,7 @@ function EvaluatorRow({
               >
                 <StatusBadge status={r.status} />
                 <span className="font-mono text-[11.5px] text-text-muted">
-                  {new Date(r.started_at).toLocaleString()}
+                  {new Date(r.started_at).toLocaleString('en-US')}
                 </span>
                 <span className="font-mono text-[11.5px] text-text-faint">
                   {r.scored_count}/{r.sample_size}

--- a/apps/web/app/demo/prompts/[name]/page.tsx
+++ b/apps/web/app/demo/prompts/[name]/page.tsx
@@ -40,7 +40,7 @@ function VersionsTab({ prompt }: { prompt: (typeof DEMO_PROMPTS)[number] }) {
             current
           </span>
           <span className="font-mono text-[11px] text-text-faint ml-auto">
-            {new Date(prompt.created_at).toLocaleDateString()} · by {prompt.created_by}
+            {new Date(prompt.created_at).toLocaleDateString('en-US')} · by {prompt.created_by}
           </span>
         </div>
 
@@ -121,10 +121,10 @@ function VersionsTab({ prompt }: { prompt: (typeof DEMO_PROMPTS)[number] }) {
                 )}
                 <span className="font-mono text-[11px] text-text-faint ml-auto">
                   {v === prompt.version
-                    ? new Date(prompt.created_at).toLocaleDateString()
+                    ? new Date(prompt.created_at).toLocaleDateString('en-US')
                     : new Date(
                         new Date(prompt.created_at).getTime() - (prompt.version - v) * 86400000 * 3,
-                      ).toLocaleDateString()}
+                      ).toLocaleDateString('en-US')}
                 </span>
                 <span className="font-mono text-[11px] text-text-faint">{prompt.created_by}</span>
               </div>
@@ -181,13 +181,13 @@ function CallsTab() {
                 {r.status_code}
               </span>
             </span>
-            <span className="text-text-muted">{r.total_tokens.toLocaleString()}</span>
+            <span className="text-text-muted">{r.total_tokens.toLocaleString('en-US')}</span>
             <span className="text-text-muted">
               {r.cost_usd != null ? `$${r.cost_usd.toFixed(5)}` : '—'}
             </span>
             <span className="text-text-muted">{r.latency_ms}ms</span>
             <span className="text-text-faint text-right text-[11px]">
-              {new Date(r.created_at).toLocaleTimeString()}
+              {new Date(r.created_at).toLocaleTimeString('en-US')}
             </span>
           </div>
         ))}
@@ -203,7 +203,7 @@ function TrafficTab({ prompt }: { prompt: (typeof DEMO_PROMPTS)[number] }) {
   if (!stats) return <div className="p-[22px] text-text-muted text-[13px]">No traffic data.</div>
 
   const statItems = [
-    { label: 'Total calls',   value: stats.calls.toLocaleString() },
+    { label: 'Total calls',   value: stats.calls.toLocaleString('en-US') },
     { label: 'Total spend',   value: fmtUsd(stats.totalCostUsd) },
     { label: 'Avg cost/call', value: stats.avgCostUsd != null ? fmtUsd(stats.avgCostUsd) : '—' },
     { label: 'Avg latency',   value: stats.avgLatencyMs != null ? fmtMs(stats.avgLatencyMs) : '—' },
@@ -551,7 +551,7 @@ function PlaygroundTab({ prompt }: { prompt: (typeof DEMO_PROMPTS)[number] }) {
               <div className="grid grid-cols-4 gap-3">
                 {[
                   { label: 'Model', value: demoResult.model },
-                  { label: 'Tokens', value: demoResult.totalTokens.toLocaleString() },
+                  { label: 'Tokens', value: demoResult.totalTokens.toLocaleString('en-US') },
                   { label: 'Cost', value: `$${demoResult.costUsd.toFixed(5)}` },
                   { label: 'Latency', value: `${(demoResult.latencyMs / 1000).toFixed(2)}s` },
                 ].map((s) => (

--- a/apps/web/app/demo/prompts/page.tsx
+++ b/apps/web/app/demo/prompts/page.tsx
@@ -132,7 +132,7 @@ export default function DemoPromptsPage() {
           {[
             { label: 'Total prompts',             value: String(all.length) },
             { label: 'Total versions',            value: String(totalVersions) },
-            { label: `Total calls`,               value: totalCalls > 0 ? totalCalls.toLocaleString() : '—' },
+            { label: `Total calls`,               value: totalCalls > 0 ? totalCalls.toLocaleString('en-US') : '—' },
             { label: `Total spend`,               value: totalSpend > 0 ? fmtUsd(totalSpend) : '—' },
             { label: `A/B tests`,                 value: String(abCount) },
           ].map((s, i) => (
@@ -354,7 +354,7 @@ export default function DemoPromptsPage() {
 
                 {/* Calls */}
                 <span className={cn(p.stats && p.stats.calls > 0 ? 'text-text' : 'text-text-faint')}>
-                  {p.stats?.calls ? p.stats.calls.toLocaleString() : '—'}
+                  {p.stats?.calls ? p.stats.calls.toLocaleString('en-US') : '—'}
                 </span>
 
                 {/* Avg cost */}
@@ -384,7 +384,7 @@ export default function DemoPromptsPage() {
 
                 {/* Updated date */}
                 <span className="text-text-faint text-right text-[11px]">
-                  {new Date(p.created_at).toLocaleDateString()}
+                  {new Date(p.created_at).toLocaleDateString('en-US')}
                 </span>
               </button>
             ))}

--- a/apps/web/app/demo/requests/[id]/page.tsx
+++ b/apps/web/app/demo/requests/[id]/page.tsx
@@ -84,9 +84,9 @@ export default function DemoRequestDetailPage({ params }: { params: Promise<{ id
     { label: 'Model', value: req.model },
     { label: 'Latency', value: `${req.latency_ms} ms`, warn: req.latency_ms > 2000 },
     { label: 'Cost', value: fmtCost(req.cost_usd) },
-    { label: 'Prompt tokens', value: req.prompt_tokens.toLocaleString() },
-    { label: 'Completion tokens', value: req.completion_tokens.toLocaleString() },
-    { label: 'Total tokens', value: req.total_tokens.toLocaleString() },
+    { label: 'Prompt tokens', value: req.prompt_tokens.toLocaleString('en-US') },
+    { label: 'Completion tokens', value: req.completion_tokens.toLocaleString('en-US') },
+    { label: 'Total tokens', value: req.total_tokens.toLocaleString('en-US') },
     ...(req.trace_id
       ? [{ label: 'Trace ID', value: req.trace_id.slice(0, 16) + '…', link: `/demo/traces/${req.trace_id}` }]
       : [{ label: 'Trace ID', value: '—' }]),
@@ -112,7 +112,7 @@ export default function DemoRequestDetailPage({ params }: { params: Promise<{ id
             {req.id.startsWith('req-') ? req.id : req.id.slice(0, 8) + '…'}
           </h1>
           <p className="font-mono text-[12px] text-text-muted mt-1">
-            {new Date(req.created_at).toLocaleString()}
+            {new Date(req.created_at).toLocaleString('en-US')}
           </p>
         </div>
         <span

--- a/apps/web/app/demo/requests/page.tsx
+++ b/apps/web/app/demo/requests/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { Suspense, useCallback, useMemo, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { useHydrationSafeNow } from '@/lib/hydration-safe-now'
 import { cn } from '@/lib/utils'
 import { Topbar } from '@/components/layout/topbar'
 import { DemoExportButton } from '@/components/ui/demo-export-button'
@@ -99,7 +100,7 @@ function StatStrip() {
   const stats = [
     {
       label: 'Requests · 24h',
-      value: totalReqs.toLocaleString(),
+      value: totalReqs.toLocaleString('en-US'),
       spark: sparkReqs,
       warn: false,
       good: false,
@@ -372,12 +373,12 @@ function RequestsTable({
                 <span className={isErr ? 'text-accent' : 'text-text'}>
                   {req.latency_ms}ms
                 </span>
-                <span className="text-text-muted">{req.total_tokens.toLocaleString()}</span>
+                <span className="text-text-muted">{req.total_tokens.toLocaleString('en-US')}</span>
                 <span className="text-text">{fmtCost(req.cost_usd)}</span>
                 <span className={isErr ? 'text-bad' : 'text-good'}>{req.status_code}</span>
                 <span
                   className="text-text-faint text-right"
-                  title={new Date(req.created_at).toLocaleString()}
+                  title={new Date(req.created_at).toLocaleString('en-US')}
                 >
                   {relAge(req.created_at)}
                 </span>
@@ -413,7 +414,7 @@ function DemoRequestsContent() {
   }, [])
 
   // Capture "now" once at mount — demo data is static, no need for live time.
-  const [now] = useState(() => Date.now())
+  const now = useHydrationSafeNow()
 
   const filtered = useMemo(() => {
     let rows = [...DEMO_REQUESTS]
@@ -658,7 +659,7 @@ function DemoRequestsContent() {
         {/* Pagination (demo: single page) */}
         <div className="flex items-center justify-between px-[22px] py-3 border-t border-border shrink-0">
           <span className="font-mono text-[11px] text-text-faint">
-            Page 1 · {filtered.length.toLocaleString()} total
+            Page 1 · {filtered.length.toLocaleString('en-US')} total
           </span>
           <div className="flex gap-1.5">
             <button

--- a/apps/web/app/demo/savings/page.tsx
+++ b/apps/web/app/demo/savings/page.tsx
@@ -222,13 +222,13 @@ function DemoPercentileGrid({
         style={{ display: 'grid', gridTemplateColumns: '80px 1fr 1fr 1fr 80px', gap: 8, alignItems: 'center' }}
       >
         <span className="text-text-faint">Prompt</span>
-        <span className="text-text text-center">{data.p50PromptTokens.toLocaleString()}</span>
+        <span className="text-text text-center">{data.p50PromptTokens.toLocaleString('en-US')}</span>
         <span className={cn('text-center font-medium', promptWarn ? 'text-warn' : 'text-text')}>
-          {data.p95PromptTokens.toLocaleString()}
+          {data.p95PromptTokens.toLocaleString('en-US')}
         </span>
-        <span className="text-text-muted text-center">{data.p99PromptTokens.toLocaleString()}</span>
+        <span className="text-text-muted text-center">{data.p99PromptTokens.toLocaleString('en-US')}</span>
         <span className={cn('text-right', promptWarn ? 'text-warn' : 'text-text-faint')}>
-          ≤ {maxPromptTokens.toLocaleString()}
+          ≤ {maxPromptTokens.toLocaleString('en-US')}
           {promptWarn ? ' ⚠' : ' ✓'}
         </span>
       </div>
@@ -239,13 +239,13 @@ function DemoPercentileGrid({
         style={{ display: 'grid', gridTemplateColumns: '80px 1fr 1fr 1fr 80px', gap: 8, alignItems: 'center' }}
       >
         <span className="text-text-faint">Completion</span>
-        <span className="text-text text-center">{data.p50CompletionTokens.toLocaleString()}</span>
+        <span className="text-text text-center">{data.p50CompletionTokens.toLocaleString('en-US')}</span>
         <span className={cn('text-center font-medium', complWarn ? 'text-warn' : 'text-text')}>
-          {data.p95CompletionTokens.toLocaleString()}
+          {data.p95CompletionTokens.toLocaleString('en-US')}
         </span>
-        <span className="text-text-muted text-center">{data.p99CompletionTokens.toLocaleString()}</span>
+        <span className="text-text-muted text-center">{data.p99CompletionTokens.toLocaleString('en-US')}</span>
         <span className={cn('text-right', complWarn ? 'text-warn' : 'text-text-faint')}>
-          ≤ {maxCompletionTokens.toLocaleString()}
+          ≤ {maxCompletionTokens.toLocaleString('en-US')}
           {complWarn ? ' ⚠' : ' ✓'}
         </span>
       </div>
@@ -361,7 +361,7 @@ function RecRow({
       {/* Samples */}
       <div>
         <div className="font-mono text-[10px] text-text-faint uppercase tracking-[0.03em] mb-[3px]">SAMPLES</div>
-        <div className={cn('text-[12.5px]', isHidden ? 'text-text-muted' : 'text-text')}>{r.sampleCount.toLocaleString()}</div>
+        <div className={cn('text-[12.5px]', isHidden ? 'text-text-muted' : 'text-text')}>{r.sampleCount.toLocaleString('en-US')}</div>
         <div className="font-mono text-[10.5px] text-text-faint mt-0.5">~{Math.round(r.avgCompletionTokens)} output tk</div>
       </div>
 
@@ -737,7 +737,7 @@ export default function DemoSavingsPage() {
                   <div>
                     <div className="text-text-faint uppercase text-[10px] tracking-[0.05em] mb-1">Last {windowLabel}</div>
                     <div className="text-text font-medium">{fmtUsd(simRec.totalCostUsdLastNDays)}</div>
-                    <div className="text-text-muted text-[10.5px]">{simRec.sampleCount.toLocaleString()} requests</div>
+                    <div className="text-text-muted text-[10.5px]">{simRec.sampleCount.toLocaleString('en-US')} requests</div>
                   </div>
                   <div>
                     <div className="text-text-faint uppercase text-[10px] tracking-[0.05em] mb-1">Projected monthly save</div>

--- a/apps/web/app/demo/traces/[id]/page.tsx
+++ b/apps/web/app/demo/traces/[id]/page.tsx
@@ -71,7 +71,7 @@ function SpanDetailPanel({ span, onClose }: SpanDetailPanelProps) {
           {[
             { label: 'Duration', value: fmtDuration(span.duration_ms) },
             { label: 'Status',   value: span.status },
-            { label: 'Tokens',   value: span.total_tokens > 0 ? span.total_tokens.toLocaleString() : '—' },
+            { label: 'Tokens',   value: span.total_tokens > 0 ? span.total_tokens.toLocaleString('en-US') : '—' },
             { label: 'Cost',     value: fmtCost(span.cost_usd) },
           ].map((s) => (
             <div key={s.label} className="rounded-[5px] border border-border bg-bg-elev px-3 py-2">
@@ -88,9 +88,9 @@ function SpanDetailPanel({ span, onClose }: SpanDetailPanelProps) {
           <div>
             <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-1.5">Tokens</div>
             <div className="flex gap-3 font-mono text-[12px] text-text-muted">
-              <span>{span.prompt_tokens.toLocaleString()} prompt</span>
+              <span>{span.prompt_tokens.toLocaleString('en-US')} prompt</span>
               <span className="text-text-faint">·</span>
-              <span>{span.completion_tokens.toLocaleString()} completion</span>
+              <span>{span.completion_tokens.toLocaleString('en-US')} completion</span>
             </div>
           </div>
         )}
@@ -347,7 +347,7 @@ export default function DemoTraceDetailPage({ params }: { params: Promise<{ id: 
             },
             {
               label: 'Tokens',
-              value: traceDetail.total_tokens.toLocaleString(),
+              value: traceDetail.total_tokens.toLocaleString('en-US'),
               warn: false,
             },
             {
@@ -454,7 +454,7 @@ export default function DemoTraceDetailPage({ params }: { params: Promise<{ id: 
                 <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-2">Trace metadata</div>
                 <div className="grid grid-cols-2 md:grid-cols-3 gap-2 font-mono text-[11px] text-text-muted">
                   <span><span className="text-text-faint">ID:</span> {traceDetail.id}</span>
-                  <span><span className="text-text-faint">Started:</span> {new Date(traceDetail.started_at).toLocaleString()}</span>
+                  <span><span className="text-text-faint">Started:</span> {new Date(traceDetail.started_at).toLocaleString('en-US')}</span>
                   {Boolean(traceDetail.metadata?.environment) && (
                     <span><span className="text-text-faint">Env:</span> {String(traceDetail.metadata?.environment ?? '')}</span>
                   )}

--- a/apps/web/app/demo/traces/page.tsx
+++ b/apps/web/app/demo/traces/page.tsx
@@ -174,7 +174,7 @@ export default function DemoTracesPage() {
       <div className="overflow-x-auto shrink-0 border-b border-border">
         <div className="grid grid-cols-5 min-w-[480px]">
           {[
-            { label: 'Traces',            value: DEMO_TRACES.length.toLocaleString(), warn: false },
+            { label: 'Traces',            value: DEMO_TRACES.length.toLocaleString('en-US'), warn: false },
             { label: 'p50 duration',      value: fmtDuration(p50),                   warn: false },
             { label: 'p95 duration',      value: fmtDuration(p95),                   warn: p95 != null && p95 > 8000 },
             { label: 'Avg spans / trace', value: avgSpans != null ? avgSpans.toFixed(1) : '—', warn: false },
@@ -301,7 +301,7 @@ export default function DemoTracesPage() {
                   <span className="text-text-muted">{t.span_count}</span>
                   <span className={isErr ? 'text-bad' : 'text-text'}>{fmtDuration(t.duration_ms)}</span>
                   <span className="text-text">{fmtCost(t.total_cost_usd)}</span>
-                  <span className="text-text-muted">{t.total_tokens.toLocaleString()}</span>
+                  <span className="text-text-muted">{t.total_tokens.toLocaleString('en-US')}</span>
                   <span className="pr-4 flex items-center">
                     <TraceDurationBar
                       durationMs={t.duration_ms}
@@ -319,7 +319,7 @@ export default function DemoTracesPage() {
                       <span className="font-mono text-[9.5px] px-[5px] py-[2px] rounded-[3px] bg-bg-muted text-text-faint border border-border uppercase tracking-[0.04em]">ok</span>
                     )}
                   </span>
-                  <span className="text-text-faint text-right" title={new Date(t.started_at).toLocaleString()}>
+                  <span className="text-text-faint text-right" title={new Date(t.started_at).toLocaleString('en-US')}>
                     {fmtAge(t.started_at)}
                   </span>
                 </button>

--- a/apps/web/app/demo/users/[userId]/page.tsx
+++ b/apps/web/app/demo/users/[userId]/page.tsx
@@ -16,7 +16,7 @@ function fmtCost(n: number | null | undefined): string {
 }
 
 function fmtCount(n: number): string {
-  return n.toLocaleString()
+  return n.toLocaleString('en-US')
 }
 
 export default async function DemoUserDetailPage({ params }: { params: Promise<{ userId: string }> }) {
@@ -45,8 +45,8 @@ export default async function DemoUserDetailPage({ params }: { params: Promise<{
     { label: 'Avg latency', value: `${Math.round(avgLatency)} ms` },
     { label: 'Error count', value: fmtCount(errorCount), warn: errorCount > 0 },
     { label: 'Distinct models', value: fmtCount(distinctModels) },
-    { label: 'First seen', value: firstSeen ? new Date(firstSeen).toLocaleDateString() : '—' },
-    { label: 'Last seen', value: lastSeen ? new Date(lastSeen).toLocaleDateString() : '—' },
+    { label: 'First seen', value: firstSeen ? new Date(firstSeen).toLocaleDateString('en-US') : '—' },
+    { label: 'Last seen', value: lastSeen ? new Date(lastSeen).toLocaleDateString('en-US') : '—' },
   ]
 
   return (
@@ -109,7 +109,7 @@ export default async function DemoUserDetailPage({ params }: { params: Promise<{
                     })}
                   </span>
                   <span className="truncate">{r.model}</span>
-                  <span className="text-text-muted">{r.total_tokens.toLocaleString()}</span>
+                  <span className="text-text-muted">{r.total_tokens.toLocaleString('en-US')}</span>
                   <span>{fmtCost(r.cost_usd)}</span>
                   <span className={isErr ? 'text-bad' : 'text-good'}>{r.status_code}</span>
                 </Link>

--- a/apps/web/app/demo/users/page.tsx
+++ b/apps/web/app/demo/users/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
+import { useHydrationSafeNow } from '@/lib/hydration-safe-now'
 import { ArrowDown, ArrowUp, ArrowUpDown, Check, Copy, Search, Users as UsersIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Topbar } from '@/components/layout/topbar'
@@ -165,7 +166,7 @@ function SortBtn({
 
 export default function DemoUsersPage() {
   const all = useMemo(() => aggregate(), [])
-  const [now] = useState(() => Date.now())
+  const now = useHydrationSafeNow()
   const [query, setQuery] = useState('')
   const [sortKey, setSortKey] = useState<SortKey>('total_cost_usd')
   const [sortDir, setSortDir] = useState<SortDir>('desc')

--- a/apps/web/lib/hydration-safe-now.ts
+++ b/apps/web/lib/hydration-safe-now.ts
@@ -1,0 +1,51 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+
+/**
+ * Hydration-safe `Date.now()` for client components.
+ *
+ * Why this exists: a naive `const [now] = useState(() => Date.now())`
+ * captures **server** time during SSR and **browser** time on the first
+ * client render. The two diverge by seconds-to-hours depending on
+ * Vercel region vs. user timezone, and React fires #418 ("hydration
+ * failed") whenever the gap shows up in rendered text (e.g. "fired X
+ * mins ago" labels).
+ *
+ * This hook returns `0` during SSR + the first client paint so the
+ * tree hydrates from identical HTML, then returns a cached real
+ * timestamp on the post-hydration commit. The cache is module-level
+ * so React's identity check sees the same number on every subsequent
+ * render — without that, an unmemoized `() => Date.now()` triggers
+ * an infinite update loop ("Maximum update depth exceeded") that
+ * bubbles up through any client component that subscribes to the
+ * store (we hit this with recharts during the demo dashboard fix).
+ *
+ * Use this anywhere a demo page wants a "now" reference for relative
+ * timestamps. Live (authenticated) dashboards should keep using a
+ * useEffect + setInterval pattern so they tick — this helper
+ * intentionally never updates after first paint.
+ *
+ * History: introduced after PR #255/#256 fixed the same pattern in
+ * /demo/dashboard. /demo/users, /demo/requests, /demo/alerts,
+ * /demo/alerts/[id] still had the original useState(() => Date.now())
+ * shape and were producing the same #418 in production.
+ */
+let cachedNow = 0
+
+function getClientNow(): number {
+  if (cachedNow === 0) cachedNow = Date.now()
+  return cachedNow
+}
+
+function getServerNow(): number {
+  return 0
+}
+
+function subscribeNow(): () => void {
+  return () => {}
+}
+
+export function useHydrationSafeNow(): number {
+  return useSyncExternalStore(subscribeNow, getClientNow, getServerNow)
+}


### PR DESCRIPTION
## What

PR #255 and #256 fixed /demo/dashboard but the same #418 surfaced on /demo/traces (same chunk). Full audit of `apps/web/app/demo/**` found two recurring CLAUDE.md gotcha #22 patterns across the subsystem:

| # | Pattern | Where |
|---|---|---|
| 1 | `useState(() => Date.now())` — SSR captures server time, first client render captures browser time | users, requests, alerts, alerts/[id] (4 pages) |
| 2 | `new Date(x).toLocale*()` with no explicit locale — Vercel iad1 region runs en-US, Korean user browsers run ko-KR, format strings diverge | ~14 call sites across 10 pages |

## Changes

**New shared helper** `apps/web/lib/hydration-safe-now.ts` — useSyncExternalStore with a module-level cache. SSR + first paint return 0; post-hydration the client sees a single cached `Date.now()` reading. Same shape as R-Q3 docs/_components/table-of-contents.tsx and PR #256.

Four `useState(() => Date.now())` call sites swapped to `useHydrationSafeNow()`.

**Sed across `apps/web/app/demo/**`**:
```
s/\.toLocaleString\(\)/.toLocaleString('en-US')/g
s/\.toLocaleDateString\(\)/.toLocaleDateString('en-US')/g
s/\.toLocaleTimeString\(\)/.toLocaleTimeString('en-US')/g
```

Catches both Date and Number `.toLocale*()` calls. Number is locale-independent for current digit volumes (en-US and ko-KR both render "1,234") but pinning every call to 'en-US' future-proofs the demo against locales with subtle differences (Indian numbering, French nbsp separators).

`git grep -E '\.toLocale\w*\(\)' apps/web/app/demo/` now returns zero matches.

## Verification

Local pnpm dev + Chrome MCP:
- /demo/dashboard, /demo/traces, /demo/alerts, /demo/users all load with console clean
- typecheck + lint pass

## Not in this PR

- existing utils.ts `formatDate` / `formatDateTime` / `formatTime` helpers are the recommended path going forward; migrating existing demo call sites to use them is a separate refactor
- live (authenticated) dashboard pages also have some `useState(() => Date.now())` — they need different handling (they should tick over time) so they're out of scope here