### PR TITLE
fix(web): demo layout client-only guard — backstop for residual #418

### DIFF
--- a/apps/web/app/demo/_client-guard.tsx
+++ b/apps/web/app/demo/_client-guard.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useSyncExternalStore, type ReactNode } from 'react'
+
+/**
+ * Mount-only render guard for the demo subsystem.
+ *
+ * Why this exists: PR #255/#256/#257 fixed the obvious hydration
+ * mismatches in /demo/dashboard and the wider demo pages
+ * (useState(() => Date.now()), Math.random module init, locale-less
+ * toLocale* calls). React #418 still surfaced on
+ * /demo/dashboard + /demo/traces because of a shared chunk we couldn't
+ * fully audit in a reasonable amount of time — the minified production
+ * stack trace identifies the React internals (rX → rY → …) but not
+ * the calling component.
+ *
+ * Rather than chase the last source, we wrap every demo page in this
+ * guard. SSR + first client paint render `null`. After mount the
+ * client snapshot returns `true` and the real children render. The
+ * tree is therefore hydrated from `<>` on both passes — there is no
+ * HTML to diff, so no possible mismatch.
+ *
+ * Trade-offs
+ *   - First-paint shows nothing under <DemoLayout> for ~1 frame
+ *     (16-50ms). The full-page layout chrome (sidebar, banner) renders
+ *     immediately because <DemoLayout> stays a server component; only
+ *     `children` waits for mount. Users do not perceive the gap on
+ *     real devices.
+ *   - SEO impact: zero. /demo/* is `noindex` and not part of the
+ *     marketing funnel.
+ *   - The guard is cheap (one useSyncExternalStore call per page) and
+ *     does not opt into Next.js's static rendering, so we keep all
+ *     other Next features (Link prefetch, code splitting, error
+ *     boundaries) intact.
+ *
+ * This is intentionally scoped to /demo/* via the layout file. Live
+ * dashboard pages must NOT use this — they need SSR for first-paint
+ * speed and SEO of authenticated landing pages.
+ *
+ * CLAUDE.md gotcha #22 family.
+ */
+
+const subscribe = (): (() => void) => () => {}
+const getClientSnapshot = (): boolean => true
+const getServerSnapshot = (): boolean => false
+
+export function DemoClientGuard({ children }: { children: ReactNode }) {
+  const mounted = useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot)
+  if (!mounted) return null
+  return <>{children}</>
+}

--- a/apps/web/app/demo/layout.tsx
+++ b/apps/web/app/demo/layout.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { DemoSidebar } from '@/components/layout/demo-sidebar'
 import { SidebarProvider } from '@/lib/sidebar-context'
 import { CommandPaletteProvider } from '@/components/command-palette'
+import { DemoClientGuard } from './_client-guard'
 
 export default function DemoLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -28,7 +29,12 @@ export default function DemoLayout({ children }: { children: React.ReactNode }) 
           </Link>
         </div>
         <main className="flex-1 overflow-y-auto min-w-0">
-          <div className="px-4 py-4 md:px-8 md:py-7">{children}</div>
+          <div className="px-4 py-4 md:px-8 md:py-7">
+            {/* Renders nothing during SSR + first client paint to sidestep any
+                remaining #418 hydration mismatches in demo children. See
+                _client-guard.tsx for the rationale and trade-offs. */}
+            <DemoClientGuard>{children}</DemoClientGuard>
+          </div>
         </main>
       </div>
     </div>


### PR DESCRIPTION
## What

PR #255/#256/#257 chased every Hydration mismatch we could identify by source-code grep (useState(() => Date.now()), Math.random module init, locale-less toLocale*, recharts ResponsiveContainer SSR, duplicate React keys). Production /demo/dashboard + /demo/traces still threw React #418 on every load.

The minified production stack (`rX → rY → sd → …`) names React internals but not the calling component. The chunk that fires the error has zero /demo source strings on inspection, so the residual mismatch lives in a shared component path we did not enumerate exhaustively in the available time budget.

## Approach

Stop chasing. Wrap the demo layout's `children` in `DemoClientGuard`:
- SSR + first client paint return `null` for the inner subtree
- After mount, the real tree renders
- There is no HTML to diff between the two passes, so no mismatch is possible

Full-page chrome (sidebar, banner) stays SSR'd, so users still see the demo shell on first paint — only the inner content waits one frame.

## Trade-offs accepted

- First-paint shows nothing under the demo content area for ~16-50ms. Imperceptible on real devices; the layout chrome covers it
- SEO impact: zero (/demo/* is noindex)
- Live (authenticated) dashboard pages MUST NOT use this — they need SSR for first-paint speed and authenticated-landing SEO. The guard is scoped to `apps/web/app/demo/layout.tsx` by design

## Implementation note

`useSyncExternalStore` with stable getServer/getClient/subscribe functions (same shape as R-Q3 hydration fix and PR #256 `useHydrationSafeNow`). Naive `getSnapshot: () => Date.now()` would have triggered "Maximum update depth exceeded" via recharts mid-debug — confirmed during PR #256 work — so the stable references matter.

## Verification

Local pnpm dev /demo/dashboard reloads with console limited to a chrome-extension log line. typecheck + lint pass.

Vercel preview from this PR will exercise the actual SSR pipeline.