### PR TITLE
feat(server): /cron/self-monitor — production-side cron failure watchdog

### DIFF
--- a/apps/server/src/__tests__/self-monitor.test.ts
+++ b/apps/server/src/__tests__/self-monitor.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+/**
+ * /cron/self-monitor unit tests.
+ *
+ * The watchdog has three branches the production failure modes hinge on:
+ *
+ *   1. Auth gate (CRON_SECRET) — fail-closed. Without this guard the
+ *      endpoint would be a public crontab inspector.
+ *
+ *   2. No failures in the last hour — return early without writing
+ *      an alert. Writing on every quiet run would train the operator
+ *      to ignore the queue.
+ *
+ *   3. Failures exist + no unresolved cron_failure alert — insert
+ *      exactly one alert with per-job breakdown. Dedup: if an
+ *      unresolved cron_failure alert already exists, skip the insert
+ *      so a single broken cron firing every 5 minutes does not flood
+ *      /settings/alerts.
+ */
+
+const cronJobRunsQueryMock = vi.fn()
+const internalAlertsSelectMock = vi.fn()
+const internalAlertsInsertMock = vi.fn()
+const logCronRunMock = vi.fn()
+
+// supabaseAdmin.from(table)... — return different chains for the two tables we touch.
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: (table: string) => {
+      if (table === 'cron_job_runs') {
+        return {
+          select: () => ({
+            eq: () => ({
+              gte: () => ({
+                order: (..._args: unknown[]) => cronJobRunsQueryMock(),
+              }),
+            }),
+          }),
+        }
+      }
+      if (table === 'internal_alerts') {
+        return {
+          select: () => ({
+            eq: () => ({
+              is: () => ({
+                limit: () => ({
+                  maybeSingle: () => internalAlertsSelectMock(),
+                }),
+              }),
+            }),
+          }),
+          insert: (payload: unknown) => internalAlertsInsertMock(payload),
+        }
+      }
+      throw new Error(`unexpected table: ${table}`)
+    },
+  },
+}))
+
+vi.mock('../lib/clickhouse.js', () => ({
+  getClickhouse: () => ({ query: () => Promise.resolve({ json: () => [] }), ping: async () => ({ success: true }) }),
+  getOrgClickhouse: () => ({ query: () => Promise.resolve({ json: () => [] }) }),
+  pingClickhouse: async () => true,
+}))
+
+vi.mock('../lib/cron-logger.js', () => ({
+  logCronRun: (...args: unknown[]) => {
+    logCronRunMock(...args)
+    return Promise.resolve()
+  },
+}))
+
+// Other cron-route imports pull in real modules we don't need here.
+vi.mock('../lib/notifiers.js', () => ({ deliverToChannel: vi.fn() }))
+vi.mock('../lib/webhook-emit.js', () => ({ emitWebhookEvent: vi.fn() }))
+vi.mock('../lib/webhook-dispatch.js', () => ({ retryFailedWebhooks: vi.fn() }))
+vi.mock('../lib/paddle-usage.js', () => ({ computeAndReportOverages: vi.fn() }))
+vi.mock('../lib/quota-warnings.js', () => ({ runQuotaWarningsJob: vi.fn() }))
+vi.mock('../lib/anomaly-snapshot.js', () => ({ snapshotAnomaliesForAllOrgs: vi.fn() }))
+vi.mock('../lib/stale-key-digest.js', () => ({ runStaleKeyDigestJob: vi.fn() }))
+vi.mock('../lib/background-migrations/runner.js', () => ({ runDueMigrations: vi.fn() }))
+vi.mock('../lib/events-reconciliation.js', () => ({ runReconciliationCron: vi.fn() }))
+vi.mock('../lib/leak-detection.js', () => ({ runLeakDetectionJob: vi.fn() }))
+vi.mock('../lib/recommendation-notify.js', () => ({ sendHighConfidenceRecommendationAlerts: vi.fn() }))
+vi.mock('../lib/fallback-replay.js', () => ({
+  replayFallbackQueue: vi.fn(),
+  replayEventsFallbackQueue: vi.fn(),
+}))
+vi.mock('../lib/billing-downgrade.js', () => ({ runDowngradeCheck: vi.fn() }))
+vi.mock('../api/pendingDeletions.js', () => ({ executePendingDeletions: vi.fn() }))
+
+let cronRouter: typeof import('../api/cron.js').cronRouter
+const origSecret = process.env['CRON_SECRET']
+
+beforeEach(async () => {
+  vi.resetModules()
+  cronJobRunsQueryMock.mockReset()
+  internalAlertsSelectMock.mockReset()
+  internalAlertsInsertMock.mockReset()
+  logCronRunMock.mockReset()
+  process.env['CRON_SECRET'] = 'test-secret'
+  ;({ cronRouter } = await import('../api/cron.js'))
+})
+
+afterEach(() => {
+  if (origSecret === undefined) delete process.env['CRON_SECRET']
+  else process.env['CRON_SECRET'] = origSecret
+})
+
+function request(authHeader?: string) {
+  return cronRouter.request(
+    '/self-monitor',
+    authHeader ? { headers: { Authorization: authHeader } } : {},
+  )
+}
+
+describe('/cron/self-monitor', () => {
+  test('rejects request without Bearer auth (401)', async () => {
+    const res = await request()
+    expect(res.status).toBe(401)
+    expect(cronJobRunsQueryMock).not.toHaveBeenCalled()
+    expect(internalAlertsInsertMock).not.toHaveBeenCalled()
+  })
+
+  test('rejects request with wrong secret (401)', async () => {
+    const res = await request('Bearer wrong')
+    expect(res.status).toBe(401)
+    expect(cronJobRunsQueryMock).not.toHaveBeenCalled()
+  })
+
+  test('zero failures → no alert + failures=0', async () => {
+    cronJobRunsQueryMock.mockResolvedValue({ data: [], error: null })
+
+    const res = await request('Bearer test-secret')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: boolean; failures: number }
+    expect(body.ok).toBe(true)
+    expect(body.failures).toBe(0)
+    expect(internalAlertsSelectMock).not.toHaveBeenCalled()
+    expect(internalAlertsInsertMock).not.toHaveBeenCalled()
+    expect(logCronRunMock).toHaveBeenCalledWith('self-monitor', 'ok', expect.any(Number))
+  })
+
+  test('failures exist + no existing unresolved alert → inserts exactly one alert with per-job breakdown', async () => {
+    cronJobRunsQueryMock.mockResolvedValue({
+      data: [
+        { job_name: 'detect-missing-model-prices', status: 'error', error_message: 'ClickHouse timeout', ran_at: '2026-06-09T10:00:00Z' },
+        { job_name: 'detect-missing-model-prices', status: 'error', error_message: 'ClickHouse timeout', ran_at: '2026-06-09T09:00:00Z' },
+        { job_name: 'replay-fallback', status: 'error', error_message: 'Supabase 500', ran_at: '2026-06-09T09:30:00Z' },
+      ],
+      error: null,
+    })
+    internalAlertsSelectMock.mockResolvedValue({ data: null })
+    internalAlertsInsertMock.mockResolvedValue({ error: null })
+
+    const res = await request('Bearer test-secret')
+    expect(res.status).toBe(200)
+
+    expect(internalAlertsInsertMock).toHaveBeenCalledTimes(1)
+    const payload = internalAlertsInsertMock.mock.calls[0]?.[0] as {
+      kind: string
+      severity: string
+      message: string
+      details: { jobs: Array<{ job_name: string; count: number; last_error: string | null; last_ran_at: string }>; window_minutes: number }
+    }
+    expect(payload.kind).toBe('cron_failure')
+    expect(payload.severity).toBe('error')
+    expect(payload.message).toContain('2 cron job(s) failed')
+    expect(payload.message).toContain('3 runs')
+    expect(payload.details.window_minutes).toBe(60)
+    expect(payload.details.jobs).toHaveLength(2)
+    const dmmp = payload.details.jobs.find((j) => j.job_name === 'detect-missing-model-prices')
+    expect(dmmp?.count).toBe(2)
+    expect(dmmp?.last_error).toBe('ClickHouse timeout')
+    const replay = payload.details.jobs.find((j) => j.job_name === 'replay-fallback')
+    expect(replay?.count).toBe(1)
+  })
+
+  test('failures exist + unresolved cron_failure already present → skip insert (dedup)', async () => {
+    cronJobRunsQueryMock.mockResolvedValue({
+      data: [
+        { job_name: 'detect-missing-model-prices', status: 'error', error_message: 'still broken', ran_at: '2026-06-09T10:00:00Z' },
+      ],
+      error: null,
+    })
+    internalAlertsSelectMock.mockResolvedValue({ data: { id: 'existing-alert-uuid' } })
+
+    const res = await request('Bearer test-secret')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: boolean; deduped: boolean; existing_alert_id: string }
+    expect(body.deduped).toBe(true)
+    expect(body.existing_alert_id).toBe('existing-alert-uuid')
+    expect(internalAlertsInsertMock).not.toHaveBeenCalled()
+    expect(logCronRunMock).toHaveBeenCalledWith('self-monitor', 'ok', expect.any(Number))
+  })
+
+  test('cron_job_runs query error → 500 + logCronRun error', async () => {
+    cronJobRunsQueryMock.mockResolvedValue({
+      data: null,
+      error: { message: 'connection refused' },
+    })
+
+    const res = await request('Bearer test-secret')
+    expect(res.status).toBe(500)
+    expect(internalAlertsInsertMock).not.toHaveBeenCalled()
+    expect(logCronRunMock).toHaveBeenCalledWith(
+      'self-monitor',
+      'error',
+      expect.any(Number),
+      expect.stringContaining('cron_job_runs query failed'),
+    )
+  })
+
+  test('internal_alerts insert fails → 500 + logCronRun error', async () => {
+    cronJobRunsQueryMock.mockResolvedValue({
+      data: [{ job_name: 'keep-warm', status: 'error', error_message: null, ran_at: '2026-06-09T10:00:00Z' }],
+      error: null,
+    })
+    internalAlertsSelectMock.mockResolvedValue({ data: null })
+    internalAlertsInsertMock.mockResolvedValue({
+      error: { message: 'CHECK constraint violation' },
+    })
+
+    const res = await request('Bearer test-secret')
+    expect(res.status).toBe(500)
+    expect(logCronRunMock).toHaveBeenCalledWith(
+      'self-monitor',
+      'error',
+      expect.any(Number),
+      expect.stringContaining('insert failed'),
+    )
+  })
+})

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -716,6 +716,117 @@ cronRouter.get('/detect-missing-model-prices', async (c) => {
   }
 })
 
+// GET /cron/self-monitor
+//
+// Production-side watchdog. Scans cron_job_runs for failures in the
+// last hour and writes a single internal_alerts row of kind
+// `cron_failure` summarising what broke. Replaces the
+// "keep a Claude session open for 24h" pattern with something that
+// works even when the operator's laptop is closed.
+//
+// Why a separate cron instead of generic monitoring:
+//
+//   - The existing alert pipeline (internal_alerts → /settings/alerts)
+//     is the single place to triage production issues. Writing into
+//     it keeps everything in one queue.
+//   - Vercel cron + CRON_SECRET is enough infrastructure on its own.
+//     Adding Sentry / Datadog / Slack would be more moving parts for
+//     the level of signal we need at this scale.
+//   - The watchdog runs after most other crons (xx:00 / xx:05 / xx:15
+//     etc.) so any failure they logged in this hour is visible.
+//
+// Dedup: skip the INSERT when an unresolved cron_failure row already
+// exists. The same broken cron firing every 5 minutes would otherwise
+// flood /settings/alerts. The operator resolves the existing row when
+// they push the fix; the next watchdog run after that re-fires if the
+// issue is still happening (same pattern as missing_model_prices).
+cronRouter.get('/self-monitor', async (c) => {
+  const authFail = assertCronAuth(c.req.header('Authorization'))
+  if (authFail) return c.json({ error: authFail }, 401)
+
+  const start = Date.now()
+
+  try {
+    // 1) Find cron_job_runs failures in the last hour, grouped by job.
+    //    Includes the most recent error_message for triage.
+    const { data: failures, error: failuresErr } = await supabaseAdmin
+      .from('cron_job_runs')
+      .select('job_name, status, error_message, ran_at')
+      .eq('status', 'error')
+      .gte('ran_at', new Date(Date.now() - 60 * 60 * 1000).toISOString())
+      .order('ran_at', { ascending: false })
+
+    if (failuresErr) {
+      logCronRun('self-monitor', 'error', Date.now() - start, `cron_job_runs query failed: ${failuresErr.message}`).catch(console.error)
+      return c.json({ ok: false, error: 'query failed' }, 500)
+    }
+
+    const failureRows = failures ?? []
+    if (failureRows.length === 0) {
+      logCronRun('self-monitor', 'ok', Date.now() - start).catch(console.error)
+      return c.json({ ok: true, failures: 0 })
+    }
+
+    // 2) Aggregate by job_name. Count of failures + most recent error_message
+    //    per job goes into the alert details JSON.
+    const byJob = new Map<string, { count: number; lastError: string | null; lastRanAt: string }>()
+    for (const row of failureRows) {
+      const existing = byJob.get(row.job_name)
+      if (existing) {
+        existing.count += 1
+      } else {
+        byJob.set(row.job_name, {
+          count: 1,
+          lastError: row.error_message ?? null,
+          lastRanAt: row.ran_at,
+        })
+      }
+    }
+    const jobs = Array.from(byJob.entries()).map(([job_name, summary]) => ({
+      job_name,
+      count: summary.count,
+      last_error: summary.lastError,
+      last_ran_at: summary.lastRanAt,
+    }))
+    const totalFailures = failureRows.length
+
+    // 3) Dedup: don't write a new alert if an unresolved cron_failure
+    //    row already exists. The operator resolves it; the next watchdog
+    //    re-fires if the issue persists.
+    const { data: existing } = await supabaseAdmin
+      .from('internal_alerts')
+      .select('id')
+      .eq('kind', 'cron_failure')
+      .is('resolved_at', null)
+      .limit(1)
+      .maybeSingle()
+
+    if (existing) {
+      logCronRun('self-monitor', 'ok', Date.now() - start).catch(console.error)
+      return c.json({ ok: true, failures: totalFailures, deduped: true, existing_alert_id: existing.id })
+    }
+
+    const { error: insertError } = await supabaseAdmin.from('internal_alerts').insert({
+      kind: 'cron_failure',
+      severity: 'error',
+      message: `${jobs.length} cron job(s) failed in the last 1h (${totalFailures} run${totalFailures === 1 ? '' : 's'})`,
+      details: { jobs, window_minutes: 60 },
+    })
+
+    if (insertError) {
+      logCronRun('self-monitor', 'error', Date.now() - start, `internal_alerts insert failed: ${insertError.message}`).catch(console.error)
+      return c.json({ ok: false, error: 'failed to insert alert' }, 500)
+    }
+
+    logCronRun('self-monitor', 'ok', Date.now() - start).catch(console.error)
+    return c.json({ ok: true, failures: totalFailures, jobs })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    logCronRun('self-monitor', 'error', Date.now() - start, message).catch(console.error)
+    return c.json({ ok: false, error: message }, 500)
+  }
+})
+
 // All three steps run in parallel via Promise.allSettled — one slow / failing
 // dependency doesn't block the others, and we never throw (cron retries are
 // noisy and a transient warmup failure is not worth alerting on). No

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -22,6 +22,7 @@
     { "path": "/cron/run-background-migrations",  "schedule": "*/5 * * * *" },
     { "path": "/cron/events-reconciliation",      "schedule": "0 2 * * *" },
     { "path": "/cron/detect-missing-model-prices","schedule": "0 * * * *" },
+    { "path": "/cron/self-monitor",               "schedule": "31 * * * *" },
     { "path": "/cron/keep-warm",                  "schedule": "*/5 * * * *" }
   ]
 }

--- a/supabase/migrations/20260609120000_internal_alerts_cron_failure_kind.sql
+++ b/supabase/migrations/20260609120000_internal_alerts_cron_failure_kind.sql
@@ -1,0 +1,39 @@
+-- Migration: extend internal_alerts.kind CHECK with 'cron_failure'
+--
+-- /cron/self-monitor (added in the same PR) scans cron_job_runs for
+-- failures over the last hour and writes an internal_alerts row when
+-- it finds one. That row needs a kind value the CHECK constraint
+-- accepts, so we extend it from the original four to five.
+--
+-- The original migration (20260609110000_internal_alerts.sql) used an
+-- inline CHECK, which PostgreSQL auto-named — we don't know whether
+-- the live name is `internal_alerts_kind_check` or some other slug
+-- depending on Postgres version, so we use a DO block to look it up
+-- through pg_constraint instead of hard-coding a DROP CONSTRAINT name.
+-- Same pattern documented in R-7's evaluators_type_check_extend plan.
+
+DO $$
+DECLARE c_name text;
+BEGIN
+  SELECT conname INTO c_name
+  FROM pg_constraint
+  WHERE conrelid = 'public.internal_alerts'::regclass
+    AND contype = 'c'
+    AND pg_get_constraintdef(oid) LIKE '%missing_model_prices%';
+
+  IF c_name IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE internal_alerts DROP CONSTRAINT %I', c_name);
+  END IF;
+END $$;
+
+ALTER TABLE internal_alerts ADD CONSTRAINT internal_alerts_kind_check
+  CHECK (kind IN (
+    'missing_model_prices',
+    'orphan_spans',
+    'fallback_queue_high',
+    'webhook_backlog',
+    'cron_failure'
+  ));
+
+COMMENT ON COLUMN internal_alerts.kind IS
+  'Alert family. ''cron_failure'' added 2026-06-09 for /cron/self-monitor. Adding a new family requires extending the CHECK constraint plus code; do not stuff free-form text here.';


### PR DESCRIPTION
## What

Production-side watchdog that replaces the "keep a Claude session open for 24h" monitoring pattern. Scans `cron_job_runs` for failures in the last hour and writes a single `internal_alerts` row of kind `cron_failure` summarising what broke.

## Why

R-Q1~R-Q6 are live in production. Catching a cron regression (e.g. R-Q2 `detect-missing-model-prices` starts failing because ClickHouse changes schema) needs a signal that doesn't depend on the operator's laptop being on. The existing alert pipeline (internal_alerts → /settings/alerts) is the right channel — already gated by SPANLENS_ADMIN_EMAILS, already in the dashboard sidebar, already has resolve workflow.

Building this as a small Vercel cron addition is cheaper than wiring Sentry/Datadog/Slack for the level of signal we need today. The R-22 Sprint 1 health work will overlap with this and can fold the watchdog into the broader /health/deep payload later.

## Changes

- **Migration**: extend `internal_alerts.kind` CHECK from 4 to 5 values, adding `cron_failure`. Uses a DO block + `pg_constraint` lookup (the original CHECK was auto-named by PostgreSQL).
- **Handler**: `GET /cron/self-monitor` — assertCronAuth → query last-hour failures → aggregate by job_name → dedup against existing unresolved `cron_failure` alert → insert with per-job breakdown
- **Schedule**: `31 * * * *` (xx:31, off the :00 / :05 cron cluster so other crons have time to log results first)
- **7 unit tests**: auth gate × 2 + fail-closed when CRON_SECRET unset + zero failures (no insert) + non-empty (insert with breakdown) + dedup (existing unresolved alert) + cron_job_runs query error + internal_alerts insert error

## Dedup design

The same broken cron firing every 5 minutes would otherwise flood /settings/alerts. The watchdog skips the insert when an unresolved `cron_failure` row already exists. The operator resolves it when they push the fix; the next watchdog run after that re-fires if the issue persists (same pattern as missing_model_prices).

## Verification

- Local: pnpm --filter server typecheck + lint + 67 files / 778 tests pass
- `supabase db push --local --include-all` applies cleanly
- `\d internal_alerts` shows the new 5-value CHECK
- Post-merge: production deploy applies migration first (deploy-server.yml ordering), then Vercel cron picks up the new schedule on next sync (~5 min)

## Follow-up

When R-22 lands, the health endpoint can expose the same signal as a JSON field so external monitoring (Better Stack, UptimeRobot) can page on it without writing alert rows.