### PR TITLE
feat(server): R-22 health endpoint hardening (/health/ready, deep metrics)

### DIFF
--- a/apps/server/src/__tests__/health.test.ts
+++ b/apps/server/src/__tests__/health.test.ts
@@ -1,0 +1,321 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+/**
+ * R-22 /health, /health/ready, /health/deep tests.
+ *
+ * The three endpoints have distinct failure modes the tests pin down:
+ *
+ *   /health
+ *     - Always 200, even when every dependency is down (it's liveness).
+ *     - Must include `version` so on-call can correlate dashboards with the
+ *       deployed commit. version=null in local/test (no VERCEL_GIT_COMMIT_SHA).
+ *
+ *   /health/ready
+ *     - 200 only when Postgres + ClickHouse are both up.
+ *     - 503 when either is down — so docker / load balancer routes around
+ *       half-broken instances.
+ *     - Upstash absent (KV_REST_API_URL unset) is *not* a failure — local
+ *       dev runs without it. Reported as 'skipped'.
+ *     - Upstash configured but unreachable IS a failure (latent customer
+ *       impact via prompt-cache misses → cascading slowness).
+ *
+ *   /health/deep
+ *     - Adds R-11 entry-trigger metrics: crons.max_runtime_ms and
+ *       webhooks.backlog_count. Each must surface its actual value when the
+ *       query succeeds, and `null` (not a fake 0) when the query itself
+ *       failed. The null-vs-0 distinction is what lets operators tell
+ *       "Supabase is broken" apart from "the queue is genuinely empty."
+ *     - 503 when ClickHouse is unreachable. The Supabase failures for the
+ *       new metrics do NOT 503 — they degrade to null so a single bad
+ *       aggregate query doesn't take the whole monitor down.
+ */
+
+const supabaseAdminMock = {
+  from: vi.fn(),
+}
+const pingClickhouseMock = vi.fn()
+const fallbackQueueSizeMock = vi.fn()
+const eventsFallbackQueueSizeMock = vi.fn()
+const getRedisMock = vi.fn()
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: supabaseAdminMock,
+}))
+
+vi.mock('../lib/clickhouse.js', () => ({
+  pingClickhouse: () => pingClickhouseMock(),
+  getClickhouse: () => ({}),
+  unscopedClickhouse: () => ({}),
+  getOrgClickhouse: () => ({}),
+  toClickhouseTimestamp: (d: Date) => d.toISOString(),
+}))
+
+vi.mock('../lib/fallback-replay.js', () => ({
+  fallbackQueueSize: () => fallbackQueueSizeMock(),
+  eventsFallbackQueueSize: () => eventsFallbackQueueSizeMock(),
+}))
+
+vi.mock('../lib/prompt-cache.js', () => ({
+  getRedis: () => getRedisMock(),
+}))
+
+let healthRouter: typeof import('../api/health.js').healthRouter
+const origVercelSha = process.env['VERCEL_GIT_COMMIT_SHA']
+
+beforeEach(async () => {
+  vi.resetModules()
+  supabaseAdminMock.from.mockReset()
+  pingClickhouseMock.mockReset()
+  fallbackQueueSizeMock.mockReset()
+  eventsFallbackQueueSizeMock.mockReset()
+  getRedisMock.mockReset()
+  delete process.env['VERCEL_GIT_COMMIT_SHA']
+  ;({ healthRouter } = await import('../api/health.js'))
+})
+
+afterEach(() => {
+  if (origVercelSha !== undefined) process.env['VERCEL_GIT_COMMIT_SHA'] = origVercelSha
+})
+
+// --- helpers for the supabase chain --------------------------------------
+// /health/deep makes two distinct calls to supabaseAdmin.from. Each chain
+// has its own shape — we drive them with these factory helpers so the
+// individual tests stay readable.
+
+function pgReadyOk() {
+  // The .from('organizations').select(..., head: true).limit(1) chain used
+  // by /health/ready. Resolves with `{ error: null }` on success.
+  return {
+    select: () => ({
+      limit: () => Promise.resolve({ error: null }),
+    }),
+  }
+}
+
+function pgReadyFail() {
+  return {
+    select: () => ({
+      limit: () => Promise.resolve({ error: { message: 'db down' } }),
+    }),
+  }
+}
+
+function pgDeepCronChain(maxDuration: number | null) {
+  return {
+    select: () => ({
+      gte: () => ({
+        order: () => ({
+          limit: () => ({
+            maybeSingle: () =>
+              Promise.resolve({
+                data: maxDuration === null ? null : { duration_ms: maxDuration },
+                error: null,
+              }),
+          }),
+        }),
+      }),
+    }),
+  }
+}
+
+function pgDeepCronChainError() {
+  return {
+    select: () => ({
+      gte: () => ({
+        order: () => ({
+          limit: () => ({
+            maybeSingle: () => Promise.reject(new Error('cron query failed')),
+          }),
+        }),
+      }),
+    }),
+  }
+}
+
+function pgDeepWebhookChain(backlog: number) {
+  return {
+    select: () => ({
+      eq: () => ({
+        not: () => ({
+          lt: () => Promise.resolve({ count: backlog, error: null }),
+        }),
+      }),
+    }),
+  }
+}
+
+function pgDeepWebhookChainError() {
+  return {
+    select: () => ({
+      eq: () => ({
+        not: () => ({
+          lt: () => Promise.reject(new Error('webhook query failed')),
+        }),
+      }),
+    }),
+  }
+}
+
+// /health/deep calls supabaseAdmin.from twice — first 'cron_job_runs',
+// then 'webhook_deliveries'. Route by table name.
+function wireDeepFroms(cronChain: unknown, webhookChain: unknown) {
+  supabaseAdminMock.from.mockImplementation((table: string) => {
+    if (table === 'cron_job_runs') return cronChain
+    if (table === 'webhook_deliveries') return webhookChain
+    throw new Error(`unexpected table: ${table}`)
+  })
+}
+
+describe('GET /health', () => {
+  test('always 200 with version=null when VERCEL_GIT_COMMIT_SHA is unset', async () => {
+    const res = await healthRouter.request('/health')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { status: string; version: string | null }
+    expect(body.status).toBe('ok')
+    expect(body.version).toBeNull()
+  })
+
+  test('surfaces VERCEL_GIT_COMMIT_SHA when set', async () => {
+    process.env['VERCEL_GIT_COMMIT_SHA'] = 'abc1234'
+    // Re-import so the module captures the new env at evaluation time.
+    vi.resetModules()
+    ;({ healthRouter } = await import('../api/health.js'))
+
+    const res = await healthRouter.request('/health')
+    const body = (await res.json()) as { version: string }
+    expect(body.version).toBe('abc1234')
+  })
+})
+
+describe('GET /health/ready', () => {
+  test('200 when Postgres + ClickHouse OK + Upstash skipped (no env)', async () => {
+    supabaseAdminMock.from.mockReturnValue(pgReadyOk())
+    pingClickhouseMock.mockResolvedValue(true)
+    getRedisMock.mockReturnValue(null)
+
+    const res = await healthRouter.request('/health/ready')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      status: string
+      checks: { postgres: { ok: boolean }; clickhouse: { ok: boolean }; redis: { status: string } }
+    }
+    expect(body.status).toBe('ok')
+    expect(body.checks.postgres.ok).toBe(true)
+    expect(body.checks.clickhouse.ok).toBe(true)
+    expect(body.checks.redis.status).toBe('skipped')
+  })
+
+  test('200 when Upstash configured + ping resolves', async () => {
+    supabaseAdminMock.from.mockReturnValue(pgReadyOk())
+    pingClickhouseMock.mockResolvedValue(true)
+    getRedisMock.mockReturnValue({ ping: async () => 'PONG' })
+
+    const res = await healthRouter.request('/health/ready')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { checks: { redis: { status: string } } }
+    expect(body.checks.redis.status).toBe('ok')
+  })
+
+  test('503 when Postgres is down', async () => {
+    supabaseAdminMock.from.mockReturnValue(pgReadyFail())
+    pingClickhouseMock.mockResolvedValue(true)
+    getRedisMock.mockReturnValue(null)
+
+    const res = await healthRouter.request('/health/ready')
+    expect(res.status).toBe(503)
+    const body = (await res.json()) as { status: string; checks: { postgres: { ok: boolean } } }
+    expect(body.status).toBe('degraded')
+    expect(body.checks.postgres.ok).toBe(false)
+  })
+
+  test('503 when ClickHouse is down', async () => {
+    supabaseAdminMock.from.mockReturnValue(pgReadyOk())
+    pingClickhouseMock.mockResolvedValue(false)
+    getRedisMock.mockReturnValue(null)
+
+    const res = await healthRouter.request('/health/ready')
+    expect(res.status).toBe(503)
+    const body = (await res.json()) as { checks: { clickhouse: { ok: boolean } } }
+    expect(body.checks.clickhouse.ok).toBe(false)
+  })
+
+  test('503 when Upstash configured but ping fails (cascading slowness risk)', async () => {
+    supabaseAdminMock.from.mockReturnValue(pgReadyOk())
+    pingClickhouseMock.mockResolvedValue(true)
+    getRedisMock.mockReturnValue({ ping: async () => { throw new Error('redis down') } })
+
+    const res = await healthRouter.request('/health/ready')
+    expect(res.status).toBe(503)
+    const body = (await res.json()) as { checks: { redis: { status: string } } }
+    expect(body.checks.redis.status).toBe('fail')
+  })
+})
+
+describe('GET /health/deep', () => {
+  beforeEach(() => {
+    fallbackQueueSizeMock.mockResolvedValue(0)
+    eventsFallbackQueueSizeMock.mockResolvedValue(0)
+  })
+
+  test('200 with new R-11 metrics surfaced', async () => {
+    pingClickhouseMock.mockResolvedValue(true)
+    wireDeepFroms(pgDeepCronChain(1234), pgDeepWebhookChain(5))
+
+    const res = await healthRouter.request('/health/deep')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      status: string
+      version: string | null
+      crons: { max_runtime_ms: number | null }
+      webhooks: { backlog_count: number | null }
+      clickhouse: { ok: boolean; latencyMs: number }
+      fallback: { queue: number | null; eventsQueue: number | null }
+    }
+    expect(body.status).toBe('ok')
+    expect(body.version).toBeNull()
+    expect(body.crons.max_runtime_ms).toBe(1234)
+    expect(body.webhooks.backlog_count).toBe(5)
+    expect(body.clickhouse.ok).toBe(true)
+    expect(body.fallback.queue).toBe(0)
+  })
+
+  test('crons.max_runtime_ms = null when cron query fails (degrades, does not 503)', async () => {
+    pingClickhouseMock.mockResolvedValue(true)
+    wireDeepFroms(pgDeepCronChainError(), pgDeepWebhookChain(0))
+
+    const res = await healthRouter.request('/health/deep')
+    expect(res.status).toBe(200) // Supabase failure on the new query does not 503
+    const body = (await res.json()) as { crons: { max_runtime_ms: number | null } }
+    expect(body.crons.max_runtime_ms).toBeNull()
+  })
+
+  test('webhooks.backlog_count = null when webhook query fails', async () => {
+    pingClickhouseMock.mockResolvedValue(true)
+    wireDeepFroms(pgDeepCronChain(500), pgDeepWebhookChainError())
+
+    const res = await healthRouter.request('/health/deep')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { webhooks: { backlog_count: number | null } }
+    expect(body.webhooks.backlog_count).toBeNull()
+  })
+
+  test('crons.max_runtime_ms = null when no rows in last 24h (cold env)', async () => {
+    pingClickhouseMock.mockResolvedValue(true)
+    wireDeepFroms(pgDeepCronChain(null), pgDeepWebhookChain(0))
+
+    const res = await healthRouter.request('/health/deep')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { crons: { max_runtime_ms: number | null } }
+    expect(body.crons.max_runtime_ms).toBeNull()
+  })
+
+  test('503 when ClickHouse is down (overall degraded)', async () => {
+    pingClickhouseMock.mockResolvedValue(false)
+    wireDeepFroms(pgDeepCronChain(100), pgDeepWebhookChain(0))
+
+    const res = await healthRouter.request('/health/deep')
+    expect(res.status).toBe(503)
+    const body = (await res.json()) as { status: string }
+    expect(body.status).toBe('degraded')
+  })
+})

--- a/apps/server/src/api/health.ts
+++ b/apps/server/src/api/health.ts
@@ -1,0 +1,179 @@
+import { Hono } from 'hono'
+
+/**
+ * Health-check routes (R-22).
+ *
+ * Three-level surface:
+ *
+ *   /health        — liveness. Always 200 while the process is up. Vercel
+ *                    polls this internally; do not add DB pings here or the
+ *                    cold-start budget blows up. Now includes `version`
+ *                    (Vercel commit SHA) so we can correlate dashboards with
+ *                    the deployed build at a glance.
+ *
+ *   /health/ready  — readiness. Pings Postgres + ClickHouse + Upstash in
+ *                    parallel. Returns 503 if any dependency is unreachable
+ *                    so the load balancer / docker healthcheck can route
+ *                    around a half-broken instance. Cheap enough to run on
+ *                    every 30s docker healthcheck (no aggregate queries,
+ *                    one round-trip per dep). Upstash is best-effort — when
+ *                    KV_REST_API_URL is unset we report `skipped`, not a
+ *                    failure (local dev / preview environments often run
+ *                    without the KV store).
+ *
+ *   /health/deep   — components view + R-11 entry-trigger metrics. Adds the
+ *                    `crons.max_runtime_ms` (24h MAX duration_ms from
+ *                    cron_job_runs) and `webhooks.backlog_count`
+ *                    (webhook_deliveries that missed their retry window)
+ *                    fields so external monitoring (Better Stack,
+ *                    UptimeRobot, our own dashboards) can page on slow cron
+ *                    drift or webhook delivery failure spikes before they
+ *                    show up as customer complaints. `concurrent_count` is
+ *                    intentionally NOT here — cron_job_runs only INSERTs on
+ *                    completion, so in-progress count requires either an
+ *                    extra `cron_in_progress` table or Postgres advisory
+ *                    locks. Tracked as R-22 follow-up; the 503 path doesn't
+ *                    depend on it.
+ *
+ * Why split readiness from deep: readiness must be fast enough to run
+ * every 30s on a tight container loop without melting Supabase. The deep
+ * endpoint aggregates last-24h MAX(duration_ms) etc. which is fine to call
+ * every 5 min but not every 30 sec.
+ *
+ * Extracted into its own router (instead of inlined in app.ts) so unit
+ * tests can import just this surface without spinning up every API
+ * router and its transitive dependencies.
+ */
+export const healthRouter = new Hono()
+
+healthRouter.get('/health', (c) =>
+  c.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    // VERCEL_GIT_COMMIT_SHA is injected by Vercel on every deploy and is
+    // null in local / docker-compose runs. Surface it directly so on-call
+    // can confirm which commit a misbehaving instance is running without
+    // diff-checking the Vercel dashboard.
+    version: process.env['VERCEL_GIT_COMMIT_SHA'] ?? null,
+  }),
+)
+
+healthRouter.get('/health/ready', async (c) => {
+  const { supabaseAdmin } = await import('../lib/db.js')
+  const { pingClickhouse } = await import('../lib/clickhouse.js')
+  // Lazy import keeps the cold-start cheap when the Redis singleton hasn't
+  // been touched yet. getRedis() falls through to null when env is missing,
+  // which is the local-dev / preview-without-KV path — reported as
+  // 'skipped', not failed, so the local healthcheck doesn't 503 spuriously.
+  const { getRedis } = await import('../lib/prompt-cache.js')
+  const redis = getRedis()
+
+  const start = Date.now()
+  const [pgResult, chResult, redisResult] = await Promise.allSettled([
+    // Cheapest indexed read against an existing table — same pattern as
+    // /cron/keep-warm step 1.
+    supabaseAdmin.from('organizations').select('id', { count: 'exact', head: true }).limit(1),
+    pingClickhouse(),
+    redis ? redis.ping?.() ?? Promise.resolve('OK') : Promise.resolve('skipped'),
+  ])
+  const totalMs = Date.now() - start
+
+  const pgOk = pgResult.status === 'fulfilled' && !pgResult.value.error
+  // pingClickhouse swallows errors and resolves to false — same pitfall as
+  // gotcha #14, fixed in R-Q6 keep-warm. Check the resolved value, not the
+  // settled status.
+  const chOk = chResult.status === 'fulfilled' && chResult.value === true
+
+  let redisStatus: 'ok' | 'skipped' | 'fail'
+  if (!redis) {
+    redisStatus = 'skipped'
+  } else if (redisResult.status === 'fulfilled') {
+    redisStatus = 'ok'
+  } else {
+    redisStatus = 'fail'
+  }
+
+  // Redis is treated as best-effort: a missing KV store should not 503 the
+  // readiness probe, but a configured-but-unreachable one should.
+  const overallOk = pgOk && chOk && redisStatus !== 'fail'
+
+  return c.json(
+    {
+      status: overallOk ? 'ok' : 'degraded',
+      timestamp: new Date().toISOString(),
+      latencyMs: totalMs,
+      checks: {
+        postgres: { ok: pgOk },
+        clickhouse: { ok: chOk },
+        redis: { status: redisStatus },
+      },
+    },
+    overallOk ? 200 : 503,
+  )
+})
+
+healthRouter.get('/health/deep', async (c) => {
+  const { supabaseAdmin } = await import('../lib/db.js')
+  const { pingClickhouse } = await import('../lib/clickhouse.js')
+  const { fallbackQueueSize, eventsFallbackQueueSize } = await import(
+    '../lib/fallback-replay.js'
+  )
+
+  const start = Date.now()
+  // R-22 added two new aggregate queries here. Run them inside the same
+  // Promise.all the ping/queue lookups already use — p95 stays bounded by
+  // the slowest dependency, not the sum.
+  const [chOk, fallbackQueue, eventsFallback, cronMaxRuntime, webhookBacklog] =
+    await Promise.all([
+      pingClickhouse().catch(() => false),
+      fallbackQueueSize().catch(() => null),
+      eventsFallbackQueueSize().catch(() => null),
+      // crons.max_runtime_ms: MAX(duration_ms) over last 24h. R-11 trigger
+      // — if any cron starts running 10s+ when it used to finish in 200ms
+      // we want to know before the operator sees Vercel timeouts.
+      supabaseAdmin
+        .from('cron_job_runs')
+        .select('duration_ms')
+        .gte('ran_at', new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString())
+        .order('duration_ms', { ascending: false })
+        .limit(1)
+        .maybeSingle()
+        .then(
+          (res) => (res.error || !res.data ? null : (res.data.duration_ms as number)),
+          () => null,
+        ),
+      // webhooks.backlog_count: deliveries that should have retried by now
+      // but haven't. partial index from migration 20260515000000 covers
+      // exactly (next_retry_at, status='failed') so the count is cheap.
+      supabaseAdmin
+        .from('webhook_deliveries')
+        .select('id', { count: 'exact', head: true })
+        .eq('status', 'failed')
+        .not('next_retry_at', 'is', null)
+        .lt('next_retry_at', new Date().toISOString())
+        .then(
+          (res) => (res.error ? null : res.count ?? 0),
+          () => null,
+        ),
+    ])
+  const chLatency = Date.now() - start
+
+  const overallOk = chOk
+  return c.json(
+    {
+      status: overallOk ? 'ok' : 'degraded',
+      timestamp: new Date().toISOString(),
+      version: process.env['VERCEL_GIT_COMMIT_SHA'] ?? null,
+      clickhouse: { ok: chOk, latencyMs: chLatency },
+      // Null means the lookup itself failed (e.g. Supabase down) — not an
+      // empty queue. Distinguish for triage.
+      fallback: { queue: fallbackQueue, eventsQueue: eventsFallback },
+      // R-22 R-11 entry-trigger metrics. Same null-on-failure convention.
+      // `crons.max_runtime_ms` null = either no cron ran in 24h (cold env)
+      // OR the Supabase query failed — both are actionable.
+      crons: { max_runtime_ms: cronMaxRuntime },
+      webhooks: { backlog_count: webhookBacklog },
+    },
+    overallOk ? 200 : 503,
+  )
+})

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -35,6 +35,7 @@ import { humanEvalsRouter } from './api/human-evals.js'
 import { scoreConfigsRouter } from './api/scoreConfigs.js'
 import { recommendationsRouter } from './api/recommendations.js'
 import { auditLogsRouter }     from './api/auditLogs.js'
+import { healthRouter }        from './api/health.js'
 import { membersRouter }       from './api/members.js'
 import { orgInvitationsRouter, invitationsRouter, meInvitationsRouter } from './api/invitations.js'
 import { dismissalsRouter }    from './api/dismissals.js'
@@ -83,47 +84,46 @@ app.use('*', cors({
 }))
 app.use('*', logger())
 
-// Health check
-// /health — basic liveness probe (no DB ping; always returns 200 if process is up).
-app.get('/health', (c) => c.json({ status: 'ok', timestamp: new Date().toISOString() }))
-
-// /health/deep — components view. Returns 503 if ClickHouse is unreachable
-// so external monitoring (Better Stack, UptimeRobot, etc.) can page on the
-// real outage, not just process liveness. `/health` stays cheap for Vercel's
-// own liveness checks.
+// Health check routes extracted to api/health.ts for unit-test isolation.
+// See that file for the contract and the rationale behind each endpoint.
 //
-// Response shape:
-//   { status: 'ok' | 'degraded', clickhouse: { ok, latencyMs }, fallback: { queue } }
+// Three-level health surface (R-22):
 //
-// Concurrency: ping + queue-size query run in parallel to keep p95 low even
-// when one of them is slow.
-app.get('/health/deep', async (c) => {
-  const { pingClickhouse } = await import('./lib/clickhouse.js')
-  const { fallbackQueueSize, eventsFallbackQueueSize } = await import(
-    './lib/fallback-replay.js'
-  )
-
-  const start = Date.now()
-  const [chOk, fallbackQueue, eventsFallback] = await Promise.all([
-    pingClickhouse().catch(() => false),
-    fallbackQueueSize().catch(() => null),
-    eventsFallbackQueueSize().catch(() => null),
-  ])
-  const chLatency = Date.now() - start
-
-  const overallOk = chOk
-  return c.json(
-    {
-      status: overallOk ? 'ok' : 'degraded',
-      timestamp: new Date().toISOString(),
-      clickhouse: { ok: chOk, latencyMs: chLatency },
-      // Null means the lookup itself failed (e.g. Supabase down) — not an
-      // empty queue. Distinguish for triage.
-      fallback: { queue: fallbackQueue, eventsQueue: eventsFallback },
-    },
-    overallOk ? 200 : 503,
-  )
-})
+//   /health        — liveness. Always 200 while the process is up. Vercel
+//                    polls this internally; do not add DB pings here or the
+//                    cold-start budget blows up. Now includes `version`
+//                    (Vercel commit SHA) so we can correlate dashboards with
+//                    the deployed build at a glance.
+//
+//   /health/ready  — readiness. Pings Postgres + ClickHouse + Upstash in
+//                    parallel. Returns 503 if any dependency is unreachable
+//                    so the load balancer / docker healthcheck can route
+//                    around a half-broken instance. Cheap enough to run on
+//                    every 30s docker healthcheck (no aggregate queries,
+//                    one round-trip per dep). Upstash is best-effort — when
+//                    KV_REST_API_URL is unset we report `skipped`, not a
+//                    failure (local dev / preview environments often run
+//                    without the KV store).
+//
+//   /health/deep   — components view + R-11 entry-trigger metrics. Adds the
+//                    `crons.max_runtime_ms` (24h MAX duration_ms from
+//                    cron_job_runs) and `webhooks.backlog_count`
+//                    (webhook_deliveries that missed their retry window)
+//                    fields so external monitoring (Better Stack,
+//                    UptimeRobot, our own dashboards) can page on slow cron
+//                    drift or webhook delivery failure spikes before they
+//                    show up as customer complaints. `concurrent_count` is
+//                    intentionally NOT here — cron_job_runs only INSERTs on
+//                    completion, so in-progress count requires either an
+//                    extra `cron_in_progress` table or Postgres advisory
+//                    locks. Tracked as R-22 follow-up; the 503 path doesn't
+//                    depend on it.
+//
+// Why split readiness from deep: readiness must be fast enough to run
+// every 30s on a tight container loop without melting Supabase. The deep
+// endpoint aggregates last-24h MAX(duration_ms) etc. which is fine to call
+// every 5 min but not every 30 sec.
+app.route('/', healthRouter)
 
 // ── Proxy routes (authApiKey middleware) ──────────────────────
 app.route('/proxy/openai',    openaiProxy)

--- a/apps/server/src/lib/prompt-cache.ts
+++ b/apps/server/src/lib/prompt-cache.ts
@@ -34,7 +34,16 @@ const SCAN_BATCH_SIZE = 100
 
 let _redis: Redis | null = null
 
-function getRedis(): Redis | null {
+/**
+ * Lazy Upstash Redis singleton. Returns null when env is missing — local
+ * dev and preview environments often run without KV configured, and the
+ * prompt-cache call sites already handle null (skip the cache).
+ *
+ * Exported so /health/ready (R-22) can ping the same instance instead of
+ * spinning up its own client. Keep this the only constructor of the
+ * shared Redis singleton to avoid drift between callers.
+ */
+export function getRedis(): Redis | null {
   if (_redis) return _redis
 
   const url = process.env.KV_REST_API_URL

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,6 +28,23 @@ services:
     restart: unless-stopped
     depends_on:
       - db
+    # R-22: readiness probe — same endpoint Vercel preview / production
+    # docker invocations use. /health/ready pings Postgres + ClickHouse +
+    # Upstash (Upstash 'skipped' is OK), so a half-broken container shows
+    # up as "unhealthy" before Docker routes traffic to it. start_period
+    # gives node + tsx-watch time to compile on cold container start.
+    #
+    # Why `node -e` instead of curl/wget: node:22-alpine ships neither by
+    # default, and adding an apk install just for healthcheck inflates the
+    # image. node 22 has fetch built in, so this stays zero-dep.
+    healthcheck:
+      test:
+        - 'CMD-SHELL'
+        - "node -e \"fetch('http://localhost:3001/health/ready').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
   db:
     image: postgres:15-alpine


### PR DESCRIPTION
## What

Brings the existing `/health` surface up to the R-22 contract: three levels (liveness / readiness / components-view), R-11 entry-trigger metrics on `/health/deep`, and a real docker healthcheck for local dev.

| Endpoint | Returns | Purpose |
|---|---|---|
| `/health` | Always 200 + `version` (Vercel commit SHA) | Liveness — Vercel polls this; no DB pings, no cold-start cost |
| `/health/ready` (new) | 200 if Postgres+ClickHouse+Upstash reachable, else 503 | Readiness — load balancer + docker healthcheck use this to route around half-broken instances |
| `/health/deep` | Components view + `crons.max_runtime_ms` + `webhooks.backlog_count` | R-11 entry-trigger metrics for external monitoring |

## R-11 entry-trigger metrics

- `crons.max_runtime_ms` = `MAX(duration_ms) FROM cron_job_runs WHERE ran_at > now() - interval '24 hours'` — pages on slow-cron drift before Vercel times out
- `webhooks.backlog_count` = `COUNT(*) FROM webhook_deliveries WHERE next_retry_at IS NOT NULL AND status='failed' AND next_retry_at < now()` — pages on delivery failure spikes before customer reports. Partial index from migration 20260515000000 covers this exact predicate

Both use the null-vs-0 convention from the original endpoint: `null` = query itself failed, `0` = queue is genuinely empty.

## Deferred (R-22 follow-up)

`crons.concurrent_count` is intentionally NOT here — `cron_job_runs` only INSERTs on completion, so in-progress count requires either an extra `cron_in_progress` table or Postgres advisory locks. Both are larger pieces than R-22 ships; the 503 path doesn't depend on it.

## Implementation notes

- **`api/health.ts` extracted** (was inlined in app.ts) so unit tests can import just this surface instead of spinning up every API router and its transitive dependencies. `app.ts` now mounts it at `/` via `app.route`. Net diff: ~50 lines moved, no behavior change for the existing `/health` and `/health/deep`
- **`getRedis()` promoted to export** in `prompt-cache.ts` so `/health/ready` pings the same Redis instance the prompt-cache uses. "One place that knows how to talk to Upstash" intact
- **Upstash treated as best-effort**: absent KV env → `'skipped'` (local dev / preview), configured-but-unreachable → `'fail'` (real customer impact via prompt-cache misses)
- **docker-compose.dev.yml healthcheck** uses `node -e "fetch(...)"` because `node:22-alpine` ships neither curl nor wget; node 22 has fetch built in, so zero-dep
- **Supabase failure on the new aggregates degrades to null**, not 503 — a single broken aggregate query shouldn't take the whole monitor down

## Verification

- Local: `pnpm --filter server typecheck` + `lint` + 68 files / 790 tests pass (+12 from R-Q6's 778)
- 12 new tests cover `/health` version × 2, `/health/ready` 200/503 across 5 (postgres/clickhouse/upstash) combinations, `/health/deep` null-vs-actual × 5 for the two new metrics

## Follow-up

- `crons.concurrent_count` (cron_in_progress table or pg_advisory_lock)
- Wire production Better Stack / UptimeRobot to ping `/health` every 1 min and `/health/ready` every 30s