### PR TITLE
fix(server): R-22 health version uses truthy check, not nullish coalescing

### DIFF
--- a/apps/server/src/api/health.ts
+++ b/apps/server/src/api/health.ts
@@ -54,7 +54,15 @@ healthRouter.get('/health', (c) =>
     // null in local / docker-compose runs. Surface it directly so on-call
     // can confirm which commit a misbehaving instance is running without
     // diff-checking the Vercel dashboard.
-    version: process.env['VERCEL_GIT_COMMIT_SHA'] ?? null,
+    // Use || (truthy) not ?? (nullish) — Vercel populates the env var as
+    // an empty string when "Automatically expose System Environment
+    // Variables" is OFF or the project hasn't opted into git-metadata
+    // injection. Production /health was returning version:"" instead of
+    // null after R-22 landed (PR #261) for exactly this reason. Treating
+    // "" as null means dashboards display "unknown" rather than an empty
+    // chip, which is what an operator actually wants when the SHA
+    // genuinely isn't available.
+    version: process.env['VERCEL_GIT_COMMIT_SHA'] || null,
   }),
 )
 
@@ -163,7 +171,15 @@ healthRouter.get('/health/deep', async (c) => {
     {
       status: overallOk ? 'ok' : 'degraded',
       timestamp: new Date().toISOString(),
-      version: process.env['VERCEL_GIT_COMMIT_SHA'] ?? null,
+      // Use || (truthy) not ?? (nullish) — Vercel populates the env var as
+    // an empty string when "Automatically expose System Environment
+    // Variables" is OFF or the project hasn't opted into git-metadata
+    // injection. Production /health was returning version:"" instead of
+    // null after R-22 landed (PR #261) for exactly this reason. Treating
+    // "" as null means dashboards display "unknown" rather than an empty
+    // chip, which is what an operator actually wants when the SHA
+    // genuinely isn't available.
+    version: process.env['VERCEL_GIT_COMMIT_SHA'] || null,
       clickhouse: { ok: chOk, latencyMs: chLatency },
       // Null means the lookup itself failed (e.g. Supabase down) — not an
       // empty queue. Distinguish for triage.


### PR DESCRIPTION
## What

Production `/health` was returning `version:""` instead of `version:null` after R-22 (PR #261) landed.

`process.env['VERCEL_GIT_COMMIT_SHA']` resolves to an empty string in this project (probably because "Automatically expose System Environment Variables" toggle is off or git-metadata injection isn't wired). `?? null` (nullish coalescing) treats `""` as a valid value and passes it through.

## Fix

`?? null` → `|| null` (truthy check). Operationally identical: an empty string is "we don't know which commit this is running," same as undefined.

## Verification

- Local: `pnpm --filter server test health` 12/12 still pass — the existing version=null assertion already exercises the unset-env path (process.env returns undefined, both `??` and `||` produce null there)
- Production verify: after merge, `curl -s https://server.spanlens.io/health | jq .version` should return `null` (was `""`)

## Follow-up (separate from this PR)

The actual SHA isn't reaching the runtime — Vercel deployment metadata has it (`gitCommitSha: 503f441...`) but `process.env` doesn't. Either:
  - Vercel Project Settings → Environment Variables → enable "Automatically expose System Environment Variables"
  - Or declare `VERCEL_GIT_COMMIT_SHA` explicitly in `vercel.json` env mapping

Out of scope here; this PR just stops the cosmetic empty-string from leaking into the response.