### PR TITLE
feat(server,web): R-7 Phase 1 — deterministic evaluator types (regex, json_schema)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -24,6 +24,7 @@
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.38.0",
     "@vercel/functions": "^3.6.2",
+    "ajv": "^8.20.0",
     "dotenv": "^17.4.2",
     "hono": "^4.12.23"
   },

--- a/apps/server/src/__tests__/eval-runner-code-evaluators.test.ts
+++ b/apps/server/src/__tests__/eval-runner-code-evaluators.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'vitest'
+import { runJsonSchema, runRegex } from '../lib/eval-runner.js'
+
+/**
+ * R-7 Phase 1: pure functions for the two deterministic evaluator types.
+ * No DB / network — these tests pin the per-sample scoring contract:
+ *
+ *   - score is exactly 0 or 1 (not 0.5, not "true")
+ *   - value_boolean mirrors the score
+ *   - reasoning carries actionable detail (pattern / Ajv message / parse
+ *     error), never just "failed" — the operator needs to know whether
+ *     the prompt regressed or the schema is wrong
+ */
+
+describe('runRegex', () => {
+  test('match: simple literal pattern', () => {
+    const r = runRegex({ pattern: 'hello' }, 'hello world')
+    expect(r.score).toBe(1)
+    expect(r.value_boolean).toBe(true)
+    expect(r.reasoning).toContain('regex matched')
+    expect(r.reasoning).toContain('hello')
+  })
+
+  test('no match: pattern absent from output', () => {
+    const r = runRegex({ pattern: 'xyz' }, 'hello world')
+    expect(r.score).toBe(0)
+    expect(r.value_boolean).toBe(false)
+    expect(r.reasoning).toContain('no match')
+    expect(r.reasoning).toContain('xyz')
+  })
+
+  test('invalid pattern throws SyntaxError (caller writes failing sample)', () => {
+    // Unbalanced parens — the runEvalRun wrapper catches this and
+    // surfaces it as a failing sample with the syntax error in
+    // reasoning. The pure function itself must throw so the wrapper
+    // can distinguish "the pattern is broken" from "no match."
+    expect(() => runRegex({ pattern: '[unclosed' }, 'irrelevant')).toThrow()
+  })
+
+  test('flags: case-insensitive match', () => {
+    const r = runRegex({ pattern: 'HELLO', flags: 'i' }, 'hello world')
+    expect(r.score).toBe(1)
+    expect(r.value_boolean).toBe(true)
+  })
+
+  test('flags: multiline anchor', () => {
+    // Without /m the `^line2` anchor would need to be at the very start.
+    const r = runRegex({ pattern: '^line2', flags: 'm' }, 'line1\nline2\nline3')
+    expect(r.score).toBe(1)
+  })
+})
+
+describe('runJsonSchema', () => {
+  test('valid: matches a simple object schema', () => {
+    const r = runJsonSchema(
+      { schema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] } },
+      JSON.stringify({ name: 'Alice' }),
+    )
+    expect(r.score).toBe(1)
+    expect(r.value_boolean).toBe(true)
+    expect(r.reasoning).toBe('valid')
+  })
+
+  test('invalid: missing required property', () => {
+    const r = runJsonSchema(
+      { schema: { type: 'object', required: ['name'] } },
+      JSON.stringify({ age: 30 }),
+    )
+    expect(r.score).toBe(0)
+    expect(r.value_boolean).toBe(false)
+    // Ajv's default error text mentions the missing property.
+    expect(r.reasoning).toContain('name')
+  })
+
+  test('invalid: wrong type', () => {
+    const r = runJsonSchema(
+      { schema: { type: 'object', properties: { count: { type: 'number' } }, required: ['count'] } },
+      JSON.stringify({ count: 'not-a-number' }),
+    )
+    expect(r.score).toBe(0)
+    // Ajv error mentions the type mismatch.
+    expect(r.reasoning).toMatch(/number|type/)
+  })
+
+  test('parse error: response is not JSON', () => {
+    const r = runJsonSchema(
+      { schema: { type: 'object' } },
+      'this is not json',
+    )
+    expect(r.score).toBe(0)
+    expect(r.value_boolean).toBe(false)
+    expect(r.reasoning).toContain('not JSON')
+  })
+
+  test('nested oneOf: one branch matches', () => {
+    const r = runJsonSchema(
+      {
+        schema: {
+          oneOf: [
+            { type: 'object', properties: { kind: { const: 'a' } }, required: ['kind'] },
+            { type: 'object', properties: { kind: { const: 'b' } }, required: ['kind'] },
+          ],
+        },
+      },
+      JSON.stringify({ kind: 'b' }),
+    )
+    expect(r.score).toBe(1)
+    expect(r.value_boolean).toBe(true)
+  })
+})

--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -37,26 +37,56 @@ evalsRouter.post('/evaluators', async (c) => {
 
   if (!promptName) return c.json({ error: 'promptName is required' }, 400)
   if (!name) return c.json({ error: 'name is required' }, 400)
-  if (type !== 'llm_judge') return c.json({ error: 'Unsupported evaluator type' }, 400)
+  if (type !== 'llm_judge' && type !== 'regex' && type !== 'json_schema') {
+    return c.json({ error: 'type must be one of: llm_judge, regex, json_schema' }, 400)
+  }
 
   if (!body.config || typeof body.config !== 'object' || Array.isArray(body.config)) {
     return c.json({ error: 'config object is required' }, 400)
   }
   const config = body.config as Record<string, unknown>
 
-  const criterion = typeof config.criterion === 'string' ? config.criterion.trim() : ''
-  const judgeProvider = typeof config.judge_provider === 'string' ? config.judge_provider : ''
-  const judgeModel = typeof config.judge_model === 'string' ? config.judge_model.trim() : ''
-  const scaleMin = typeof config.scale_min === 'number' ? config.scale_min : 0
-  const scaleMax = typeof config.scale_max === 'number' ? config.scale_max : 1
+  // R-7 Phase 1 — per-type config validation. Each type carries its own
+  // shape, and we store it verbatim so the runner can dispatch off the
+  // `type` column without consulting a schema registry.
+  let validatedConfig: Record<string, unknown>
 
-  if (!criterion) return c.json({ error: 'config.criterion is required' }, 400)
-  if (judgeProvider !== 'openai' && judgeProvider !== 'anthropic' && judgeProvider !== 'gemini') {
-    return c.json({ error: 'config.judge_provider must be "openai", "anthropic", or "gemini"' }, 400)
-  }
-  if (!judgeModel) return c.json({ error: 'config.judge_model is required' }, 400)
-  if (!(scaleMax > scaleMin)) {
-    return c.json({ error: 'config.scale_max must be greater than scale_min' }, 400)
+  if (type === 'llm_judge') {
+    const criterion = typeof config.criterion === 'string' ? config.criterion.trim() : ''
+    const judgeProvider = typeof config.judge_provider === 'string' ? config.judge_provider : ''
+    const judgeModel = typeof config.judge_model === 'string' ? config.judge_model.trim() : ''
+    const scaleMin = typeof config.scale_min === 'number' ? config.scale_min : 0
+    const scaleMax = typeof config.scale_max === 'number' ? config.scale_max : 1
+
+    if (!criterion) return c.json({ error: 'config.criterion is required' }, 400)
+    if (judgeProvider !== 'openai' && judgeProvider !== 'anthropic' && judgeProvider !== 'gemini') {
+      return c.json({ error: 'config.judge_provider must be "openai", "anthropic", or "gemini"' }, 400)
+    }
+    if (!judgeModel) return c.json({ error: 'config.judge_model is required' }, 400)
+    if (!(scaleMax > scaleMin)) {
+      return c.json({ error: 'config.scale_max must be greater than scale_min' }, 400)
+    }
+    validatedConfig = { criterion, judge_provider: judgeProvider, judge_model: judgeModel, scale_min: scaleMin, scale_max: scaleMax }
+  } else if (type === 'regex') {
+    const pattern = typeof config.pattern === 'string' ? config.pattern : ''
+    const flags = typeof config.flags === 'string' ? config.flags : ''
+    if (!pattern) return c.json({ error: 'config.pattern is required' }, 400)
+    // Compile-test the pattern at create time so a typo can't lurk
+    // until first eval run — same fail-fast pattern as score_configs
+    // does for category validation.
+    try {
+      new RegExp(pattern, flags)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: `invalid regex pattern: ${message}` }, 400)
+    }
+    validatedConfig = { pattern, flags }
+  } else {
+    // type === 'json_schema'
+    if (!config.schema || typeof config.schema !== 'object' || Array.isArray(config.schema)) {
+      return c.json({ error: 'config.schema must be a JSON Schema object' }, 400)
+    }
+    validatedConfig = { schema: config.schema }
   }
 
   // Verify prompt exists for this org
@@ -67,10 +97,15 @@ evalsRouter.post('/evaluators', async (c) => {
     .eq('name', promptName)
   if (!promptCount) return c.json({ error: 'Prompt not found' }, 404)
 
-  // Optional score config — verified to belong to the same org so a
-  // caller can't bind an evaluator to someone else's config row.
+  // Optional score config — only meaningful for LLM-as-judge runs.
+  // Verified to belong to the same org so a caller can't bind an
+  // evaluator to someone else's config row.
   let scoreConfigId: string | null = null
-  if (typeof body.scoreConfigId === 'string' && body.scoreConfigId.trim().length > 0) {
+  if (
+    type === 'llm_judge' &&
+    typeof body.scoreConfigId === 'string' &&
+    body.scoreConfigId.trim().length > 0
+  ) {
     const candidate = body.scoreConfigId.trim()
     const { data: sc } = await supabaseAdmin
       .from('score_configs')
@@ -90,7 +125,7 @@ evalsRouter.post('/evaluators', async (c) => {
       prompt_name: promptName,
       name,
       type,
-      config: { criterion, judge_provider: judgeProvider, judge_model: judgeModel, scale_min: scaleMin, scale_max: scaleMax },
+      config: validatedConfig,
       created_by: userId ?? null,
       score_config_id: scoreConfigId,
     })

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -1,15 +1,28 @@
 /**
- * LLM-as-judge evaluation runner.
+ * Evaluation runner.
  *
- * Executes an eval_run by:
- *   1. Fetching the evaluator + prompt_version
- *   2. Sampling N requests from production for that prompt_version
- *   3. Calling the judge LLM (using the user's provider key) on each sample
- *   4. Persisting per-sample scores + aggregate
+ * Two execution paths share an entry point (runEvalRun) and a sample
+ * fetch, but diverge on how the score is produced:
  *
- * Concurrency: processes samples in a small concurrency window (default 5)
- * to avoid burning rate limits while keeping latency reasonable.
+ *   evaluator.type === 'llm_judge'  (default)
+ *     1. Fetch evaluator + prompt_version
+ *     2. Sample N requests from production OR generate from a dataset
+ *     3. Call the judge LLM (using the user's provider key) on each
+ *     4. Parse judge reply (typed or NUMERIC) into a JudgeOutcome
+ *
+ *   evaluator.type === 'regex' | 'json_schema'  (R-7 Phase 1)
+ *     1. Fetch evaluator (config only — no provider key needed)
+ *     2. Sample N production responses for the prompt_version
+ *     3. For each response, run runRegex / runJsonSchema synchronously
+ *     4. score = 1 (pass) | 0 (fail), value_boolean mirrors the pass bit
+ *
+ * Concurrency: the LLM-as-judge path processes samples in a small
+ * concurrency window (default 5) to avoid burning rate limits while
+ * keeping latency reasonable. The deterministic path is sync-per-row
+ * so concurrency is not needed.
  */
+
+import Ajv, { type ErrorObject } from 'ajv'
 
 import { supabaseAdmin } from './db.js'
 import { requestsScope, selectRequests } from './requests-query.js'
@@ -612,6 +625,211 @@ interface SampleOutcome extends JudgeOutcome {
   datasetItemId: string | null
 }
 
+// ─── R-7 Phase 1: deterministic evaluator types ──────────────────────────
+//
+// Both runRegex and runJsonSchema are pure, sync, free of provider keys
+// and side effects. The eval_run flow wraps them with sample fetch +
+// eval_results INSERT + aggregate so the API surface stays the same as
+// the llm_judge path.
+
+export interface RegexConfig {
+  pattern: string
+  flags?: string
+}
+
+export interface JsonSchemaConfig {
+  // Ajv accepts plain JSON Schema objects. Keep this `unknown` at the
+  // boundary so we can hand the validation error back to the operator
+  // instead of throwing if they author a bad schema.
+  schema: unknown
+}
+
+/**
+ * Deterministic 0/1 outcome shared by both code evaluator types. Matches
+ * the JudgeOutcome shape on the columns the eval_results table actually
+ * stores, so the existing INSERT path doesn't need a new branch.
+ */
+export interface SimpleEvalResult {
+  score: 0 | 1
+  value_boolean: boolean
+  reasoning: string
+}
+
+/**
+ * runRegex — pass iff the pattern matches the response text.
+ *
+ * Throws when the pattern itself is invalid (bad regex syntax, unknown
+ * flag). The runEvalRun wrapper catches the throw and writes a 0 row
+ * with the error message in reasoning, so a typo in a customer's
+ * evaluator config produces failing samples rather than silently
+ * skipping the whole run.
+ */
+export function runRegex(config: RegexConfig, output: string): SimpleEvalResult {
+  // No defensive normalisation of flags. Ajv's "user-authored config"
+  // policy applies here too — surface the SyntaxError verbatim if they
+  // pass an unsupported flag like 'q'.
+  const re = new RegExp(config.pattern, config.flags ?? '')
+  const matched = re.test(output)
+  return {
+    score: matched ? 1 : 0,
+    value_boolean: matched,
+    reasoning: matched ? `regex matched: /${config.pattern}/${config.flags ?? ''}` : `no match for /${config.pattern}/${config.flags ?? ''}`,
+  }
+}
+
+/**
+ * runJsonSchema — pass iff the response parses as JSON and validates
+ * against the schema.
+ *
+ * Two failure modes share a single returned shape: parse error (invalid
+ * JSON) and validation error (well-formed JSON that doesn't match the
+ * schema). Operators reading /evals/runs/:id need to tell those apart,
+ * so the reasoning field carries the actual Ajv error text or the
+ * SyntaxError message — never a generic 'failed'.
+ */
+export function runJsonSchema(
+  config: JsonSchemaConfig,
+  output: string,
+): SimpleEvalResult {
+  // Lazy Ajv instance — `new Ajv()` allocates its own validator cache.
+  // Per-call instantiation keeps the test surface tiny (no shared state
+  // between samples) and is cheap enough for the deterministic path.
+  const ajv = new Ajv({ allErrors: false })
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(output)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return {
+      score: 0,
+      value_boolean: false,
+      reasoning: `not JSON: ${message}`,
+    }
+  }
+
+  let validate: ReturnType<typeof ajv.compile>
+  try {
+    // Ajv requires the schema to be a plain object. A non-object schema
+    // is a config error, not a sample failure — surface it as a failing
+    // sample so the operator sees it on the first run.
+    validate = ajv.compile(config.schema as Parameters<typeof ajv.compile>[0])
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return {
+      score: 0,
+      value_boolean: false,
+      reasoning: `schema compile error: ${message}`,
+    }
+  }
+
+  const valid = validate(parsed)
+  if (valid) {
+    return { score: 1, value_boolean: true, reasoning: 'valid' }
+  }
+
+  const errs = (validate.errors ?? []) as ErrorObject[]
+  const reasoning = errs.length > 0 ? ajv.errorsText(errs) : 'invalid (no error details)'
+  return { score: 0, value_boolean: false, reasoning }
+}
+
+/**
+ * Run a deterministic eval against the production sample set. Mirrors
+ * the sample-fetch step of runEvalRun (LLM-as-judge production path)
+ * but skips provider-key resolution, the judge prompt, and concurrency
+ * windowing. Used by runEvalRun when evaluator.type is regex or
+ * json_schema.
+ */
+async function runSimpleEvalRun(
+  evalRunId: string,
+  organizationId: string,
+  promptVersionId: string,
+  sampleSize: number,
+  sampleFrom: string | null | undefined,
+  sampleTo: string | null | undefined,
+  evaluatorType: 'regex' | 'json_schema',
+  config: RegexConfig | JsonSchemaConfig,
+): Promise<void> {
+  const sampleFilters: string[] = [
+    'prompt_version_id = {promptVersionId:UUID}',
+    "response_body != ''",
+  ]
+  const sampleParams: Record<string, unknown> = { promptVersionId }
+  if (sampleFrom) {
+    sampleFilters.push('created_at >= parseDateTime64BestEffort({sampleFrom:String})')
+    sampleParams['sampleFrom'] = sampleFrom
+  }
+  if (sampleTo) {
+    sampleFilters.push('created_at <= parseDateTime64BestEffort({sampleTo:String})')
+    sampleParams['sampleTo'] = sampleTo
+  }
+
+  interface SampleQueryRow {
+    id: string
+    response_body: string
+  }
+  const scope = await requestsScope(organizationId)
+  const samples = await selectRequests<SampleQueryRow>({
+    scope,
+    select: 'id, response_body',
+    filters: sampleFilters.join(' AND '),
+    orderBy: 'created_at DESC',
+    limit: sampleSize,
+    params: sampleParams,
+  })
+
+  // Score each sample synchronously — no I/O after the initial fetch.
+  const scored = samples
+    .map((s) => {
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(s.response_body)
+      } catch {
+        parsed = s.response_body
+      }
+      const responseText = extractResponseText(parsed) ?? ''
+      if (!responseText) return null
+
+      const result: SimpleEvalResult =
+        evaluatorType === 'regex'
+          ? runRegex(config as RegexConfig, responseText)
+          : runJsonSchema(config as JsonSchemaConfig, responseText)
+
+      return {
+        eval_run_id: evalRunId,
+        request_id: s.id,
+        dataset_item_id: null,
+        score: result.score,
+        reasoning: result.reasoning,
+        value_number: null,
+        value_string: null,
+        value_boolean: result.value_boolean,
+        cost_usd: 0,
+        tokens: 0,
+      }
+    })
+    .filter((r): r is NonNullable<typeof r> => r !== null)
+
+  if (scored.length > 0) {
+    const { error: insErr } = await supabaseAdmin.from('eval_results').insert(scored)
+    if (insErr) throw new Error(`eval_results insert failed: ${insErr.message}`)
+  }
+
+  const totalScore = scored.reduce((acc, r) => acc + r.score, 0)
+  const aggregateScore = scored.length > 0 ? totalScore / scored.length : 0
+  await supabaseAdmin
+    .from('eval_runs')
+    .update({
+      status: 'completed',
+      sample_count: scored.length,
+      aggregate_score: aggregateScore,
+      total_cost_usd: 0,
+      total_tokens: 0,
+      completed_at: new Date().toISOString(),
+    })
+    .eq('id', evalRunId)
+}
+
 /**
  * Main entry point. Executes the eval_run end-to-end and updates DB rows.
  * Designed to be invoked via `fireAndForget(c, runEvalRun(...))` so the HTTP
@@ -655,15 +873,42 @@ export async function runEvalRun(input: RunInput): Promise<void> {
     // Load evaluator config. `score_config_id` is nullable — when NULL we
     // keep the legacy NUMERIC-only behaviour exactly so existing
     // evaluators don't change semantics overnight.
+    //
+    // R-7 Phase 1: also select `type` so we can route deterministic
+    // evaluators (regex / json_schema) before the LLM-as-judge prelude.
     const { data: evaluator, error: evErr } = await supabaseAdmin
       .from('evaluators')
-      .select('id, config, score_config_id')
+      .select('id, type, config, score_config_id')
       .eq('id', evaluatorId)
       .eq('organization_id', organizationId)
       .maybeSingle()
 
     if (evErr || !evaluator) {
       throw new Error('Evaluator not found')
+    }
+
+    // R-7 Phase 1: deterministic types short-circuit before the
+    // LLM-as-judge config validation + provider-key resolution. Dataset
+    // source is not yet supported for these types — Phase 2 will lift
+    // the runProvider/runModel pieces of the dataset path so they can
+    // share it.
+    if (evaluator.type === 'regex' || evaluator.type === 'json_schema') {
+      if (source === 'dataset') {
+        throw new Error(`evaluator type '${evaluator.type}' currently only supports source='production' (dataset coming in R-7 Phase 2)`)
+      }
+      await runSimpleEvalRun(
+        evalRunId,
+        organizationId,
+        promptVersionId,
+        sampleSize,
+        sampleFrom,
+        sampleTo,
+        evaluator.type,
+        evaluator.config as unknown as RegexConfig | JsonSchemaConfig,
+      )
+      // Internal trace closes via the outer finally — note `samples` count
+      // and aggregate the simple path produced via internalTrace.end below.
+      return
     }
 
     const config = evaluator.config as unknown as JudgeConfig

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -196,28 +196,86 @@ function NewEvaluatorDialog({
   const scoreConfigsList = useMemo(() => scoreConfigsQuery.data ?? [], [scoreConfigsQuery.data])
   const [error, setError] = useState('')
 
+  // R-7 Phase 1: evaluator type. llm_judge keeps the existing form,
+  // regex / json_schema swap criterion + provider/model out for a
+  // pattern field or a JSON Schema textarea. Templates always create
+  // llm_judge evaluators today, so the selector defaults to that even
+  // when initialTemplate is set.
+  const [evaluatorType, setEvaluatorType] = useState<'llm_judge' | 'regex' | 'json_schema'>(
+    'llm_judge',
+  )
+  const [regexPattern, setRegexPattern] = useState('')
+  const [regexFlags, setRegexFlags] = useState('')
+  const [jsonSchemaText, setJsonSchemaText] = useState('{\n  "type": "object"\n}')
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setError('')
-    if (!promptName || !name.trim() || !criterion.trim()) {
-      setError('All fields required')
+    if (!promptName || !name.trim()) {
+      setError('Prompt and name are required')
       return
     }
     try {
-      await createMutation.mutateAsync({
-        promptName,
-        name: name.trim(),
-        config: {
-          criterion: criterion.trim(),
-          judge_provider: judgeProvider,
-          judge_model: judgeModel,
-          scale_min: scaleMin,
-          scale_max: scaleMax,
-        },
-        ...(scoreConfigId ? { scoreConfigId } : {}),
-      })
+      if (evaluatorType === 'llm_judge') {
+        if (!criterion.trim()) {
+          setError('Criterion is required for LLM-as-judge evaluators')
+          return
+        }
+        await createMutation.mutateAsync({
+          promptName,
+          name: name.trim(),
+          config: {
+            criterion: criterion.trim(),
+            judge_provider: judgeProvider,
+            judge_model: judgeModel,
+            scale_min: scaleMin,
+            scale_max: scaleMax,
+          },
+          ...(scoreConfigId ? { scoreConfigId } : {}),
+        })
+      } else if (evaluatorType === 'regex') {
+        if (!regexPattern) {
+          setError('Pattern is required')
+          return
+        }
+        // Compile-check on the client too — the operator sees the
+        // SyntaxError without a server round-trip.
+        try {
+          new RegExp(regexPattern, regexFlags)
+        } catch (err) {
+          setError(err instanceof Error ? err.message : 'Invalid regex')
+          return
+        }
+        await createMutation.mutateAsync({
+          promptName,
+          name: name.trim(),
+          type: 'regex',
+          config: { pattern: regexPattern, flags: regexFlags },
+        })
+      } else {
+        let parsedSchema: unknown
+        try {
+          parsedSchema = JSON.parse(jsonSchemaText)
+        } catch (err) {
+          setError(`Schema is not valid JSON: ${err instanceof Error ? err.message : String(err)}`)
+          return
+        }
+        if (!parsedSchema || typeof parsedSchema !== 'object' || Array.isArray(parsedSchema)) {
+          setError('Schema must be a JSON object')
+          return
+        }
+        await createMutation.mutateAsync({
+          promptName,
+          name: name.trim(),
+          type: 'json_schema',
+          config: { schema: parsedSchema },
+        })
+      }
       onClose()
       setName(''); setCriterion(''); setPromptName('')
+      setRegexPattern(''); setRegexFlags('')
+      setJsonSchemaText('{\n  "type": "object"\n}')
+      setEvaluatorType('llm_judge')
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create')
     }
@@ -258,60 +316,140 @@ function NewEvaluatorDialog({
             />
           </div>
 
+          {/* R-7 Phase 1: type selector. Switches the rest of the form
+              between LLM-as-judge (criterion + provider + model) and the
+              two deterministic types (regex pattern, JSON Schema). */}
           <div>
             <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
-              Criterion (what to score)
+              Type
             </label>
-            <textarea
-              value={criterion}
-              onChange={(e) => setCriterion(e.target.value)}
-              rows={3}
-              placeholder="e.g. Is the response friendly, polite, and clearly addresses the customer's question?"
-              required
-              className="w-full px-2 py-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong resize-none"
-            />
+            <Select
+              value={evaluatorType}
+              onValueChange={(v) => setEvaluatorType(v as 'llm_judge' | 'regex' | 'json_schema')}
+            >
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="llm_judge">LLM as judge</SelectItem>
+                <SelectItem value="regex">Regex (pattern match)</SelectItem>
+                <SelectItem value="json_schema">JSON Schema (structure check)</SelectItem>
+              </SelectContent>
+            </Select>
             <p className="font-mono text-[10.5px] text-text-faint mt-1">
-              Judge model scores 0–1 against this criterion.
+              {evaluatorType === 'llm_judge'
+                ? 'Judge model scores 0..1 against a free-form criterion.'
+                : evaluatorType === 'regex'
+                  ? 'Deterministic 0/1 — passes when the pattern matches the response.'
+                  : 'Deterministic 0/1 — passes when the response parses as JSON and matches the schema.'}
             </p>
           </div>
 
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
-                Judge provider
-              </label>
-              <Select value={judgeProvider || undefined} onValueChange={(v) => {
-                  const p = v as 'openai' | 'anthropic' | 'gemini'
-                  setJudgeProvider(p)
-                  setJudgeModel(judgeModels[p][0] ?? '')
-                }}>
-                <SelectTrigger><SelectValue placeholder="Select provider…" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="openai">OpenAI</SelectItem>
-                  <SelectItem value="anthropic">Anthropic</SelectItem>
-                  <SelectItem value="gemini">Gemini</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div>
-              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
-                Judge model
-              </label>
-              <Select {...(judgeModel ? { value: judgeModel } : {})} onValueChange={setJudgeModel}>
-                <SelectTrigger><SelectValue placeholder="Select model…" /></SelectTrigger>
-                <SelectContent>
-                  {judgeModels[judgeProvider].map((m) => (
-                    <SelectItem key={m} value={m}>{m}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
+          {evaluatorType === 'llm_judge' && (
+            <>
+              <div>
+                <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                  Criterion (what to score)
+                </label>
+                <textarea
+                  value={criterion}
+                  onChange={(e) => setCriterion(e.target.value)}
+                  rows={3}
+                  placeholder="e.g. Is the response friendly, polite, and clearly addresses the customer's question?"
+                  required
+                  className="w-full px-2 py-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong resize-none"
+                />
+                <p className="font-mono text-[10.5px] text-text-faint mt-1">
+                  Judge model scores 0–1 against this criterion.
+                </p>
+              </div>
 
-          {/* Optional typed score config. When omitted the evaluator
-              falls back to the legacy NUMERIC 0..1 scoring path so
-              existing dashboards keep working unchanged. */}
-          {scoreConfigsList.length > 0 && (
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                    Judge provider
+                  </label>
+                  <Select value={judgeProvider || undefined} onValueChange={(v) => {
+                      const p = v as 'openai' | 'anthropic' | 'gemini'
+                      setJudgeProvider(p)
+                      setJudgeModel(judgeModels[p][0] ?? '')
+                    }}>
+                    <SelectTrigger><SelectValue placeholder="Select provider…" /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="openai">OpenAI</SelectItem>
+                      <SelectItem value="anthropic">Anthropic</SelectItem>
+                      <SelectItem value="gemini">Gemini</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div>
+                  <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                    Judge model
+                  </label>
+                  <Select {...(judgeModel ? { value: judgeModel } : {})} onValueChange={setJudgeModel}>
+                    <SelectTrigger><SelectValue placeholder="Select model…" /></SelectTrigger>
+                    <SelectContent>
+                      {judgeModels[judgeProvider].map((m) => (
+                        <SelectItem key={m} value={m}>{m}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </>
+          )}
+
+          {evaluatorType === 'regex' && (
+            <div className="grid grid-cols-[1fr_120px] gap-3">
+              <div>
+                <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                  Pattern
+                </label>
+                <input
+                  type="text"
+                  value={regexPattern}
+                  onChange={(e) => setRegexPattern(e.target.value)}
+                  placeholder="e.g. ^\\{.*\\}$"
+                  required
+                  className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong"
+                />
+              </div>
+              <div>
+                <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                  Flags
+                </label>
+                <input
+                  type="text"
+                  value={regexFlags}
+                  onChange={(e) => setRegexFlags(e.target.value)}
+                  placeholder="e.g. im"
+                  className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong"
+                />
+              </div>
+            </div>
+          )}
+
+          {evaluatorType === 'json_schema' && (
+            <div>
+              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                JSON Schema
+              </label>
+              <textarea
+                value={jsonSchemaText}
+                onChange={(e) => setJsonSchemaText(e.target.value)}
+                rows={8}
+                spellCheck={false}
+                required
+                className="w-full px-2 py-2 rounded-[5px] border border-border bg-bg font-mono text-[11.5px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong resize-y"
+              />
+              <p className="font-mono text-[10.5px] text-text-faint mt-1">
+                Standard JSON Schema (draft-07). Default accepts any object.
+              </p>
+            </div>
+          )}
+
+          {/* Optional typed score config (LLM-as-judge only). When omitted
+              the evaluator falls back to the legacy NUMERIC 0..1 scoring
+              path so existing dashboards keep working unchanged. */}
+          {evaluatorType === 'llm_judge' && scoreConfigsList.length > 0 && (
             <div>
               <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
                 Score config (optional)

--- a/apps/web/lib/queries/use-evals.ts
+++ b/apps/web/lib/queries/use-evals.ts
@@ -81,14 +81,44 @@ export function useEvaluators(promptName?: string) {
   })
 }
 
-export interface CreateEvaluatorInput {
-  promptName: string
-  name: string
-  config: JudgeConfig
-  /** 4B.1c — optional pointer at a typed score config. NULL preserves
-   *  the legacy NUMERIC 0..1 behaviour. */
-  scoreConfigId?: string | null
+/**
+ * R-7 Phase 1: code evaluator config shapes.
+ *
+ * Both are deterministic per-sample checks. The server stores them as
+ * the evaluator row's `config` jsonb verbatim, and the runner
+ * dispatches on `evaluator.type` (not on which keys are present).
+ */
+export interface RegexConfig {
+  pattern: string
+  flags?: string
 }
+
+export interface JsonSchemaConfig {
+  schema: unknown
+}
+
+export type CreateEvaluatorInput =
+  | {
+      promptName: string
+      name: string
+      type?: 'llm_judge'
+      config: JudgeConfig
+      /** 4B.1c — optional pointer at a typed score config. NULL preserves
+       *  the legacy NUMERIC 0..1 behaviour. */
+      scoreConfigId?: string | null
+    }
+  | {
+      promptName: string
+      name: string
+      type: 'regex'
+      config: RegexConfig
+    }
+  | {
+      promptName: string
+      name: string
+      type: 'json_schema'
+      config: JsonSchemaConfig
+    }
 
 export function useCreateEvaluator() {
   const qc = useQueryClient()
@@ -97,10 +127,12 @@ export function useCreateEvaluator() {
       const body: Record<string, unknown> = {
         promptName: input.promptName,
         name: input.name,
-        type: 'llm_judge',
+        type: input.type ?? 'llm_judge',
         config: input.config,
       }
-      if (input.scoreConfigId) body.scoreConfigId = input.scoreConfigId
+      if (input.type === undefined || input.type === 'llm_judge') {
+        if (input.scoreConfigId) body.scoreConfigId = input.scoreConfigId
+      }
       const res = await apiPost<ApiEnvelope<Evaluator>>('/api/v1/evaluators', body)
       return res.data
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@vercel/functions':
         specifier: ^3.6.2
         version: 3.6.2
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2

--- a/supabase/migrations/20260609130000_evaluators_type_check_extend.sql
+++ b/supabase/migrations/20260609130000_evaluators_type_check_extend.sql
@@ -1,0 +1,33 @@
+-- Migration: extend evaluators.type CHECK with 'regex' and 'json_schema'
+--
+-- R-7 Phase 1 adds two deterministic evaluator types alongside the
+-- existing llm_judge: regex (pattern match against the response text)
+-- and json_schema (Ajv validation). Both produce a 0/1 score so they
+-- can share the eval_results column shape without schema changes.
+--
+-- The original CHECK from 20260513000000_evals.sql:17 was inline:
+--     CHECK (type IN ('llm_judge'))
+-- PostgreSQL auto-named the constraint. The exact name depends on PG
+-- version (usually `evaluators_type_check` but we don't want to bet on
+-- it), so look it up through pg_constraint instead of hard-coding the
+-- DROP target. Same pattern as 20260609120000 for internal_alerts.kind.
+
+DO $$
+DECLARE c_name text;
+BEGIN
+  SELECT conname INTO c_name
+  FROM pg_constraint
+  WHERE conrelid = 'public.evaluators'::regclass
+    AND contype = 'c'
+    AND pg_get_constraintdef(oid) LIKE '%type%llm_judge%';
+
+  IF c_name IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE evaluators DROP CONSTRAINT %I', c_name);
+  END IF;
+END $$;
+
+ALTER TABLE evaluators ADD CONSTRAINT evaluators_type_check
+  CHECK (type IN ('llm_judge', 'regex', 'json_schema'));
+
+COMMENT ON COLUMN evaluators.type IS
+  'Evaluator family. ''llm_judge'' uses an LLM-as-judge prompt; ''regex'' and ''json_schema'' (R-7 Phase 1, 2026-06-09) are deterministic over the response text. config JSON shape is type-dependent: see apps/server/src/lib/eval-runner.ts for the per-type contract.';


### PR DESCRIPTION
## What

LLM-as-judge has been the only evaluator type since 4B. Adding two deterministic types unlocks two classes of evals that didn't make sense to spend judge-LLM tokens on:

| Type | Score | Use case |
|---|---|---|
| `regex` | 1 if pattern matches | "Does the response contain an email / phone / SKU?" |
| `json_schema` | 1 if parses + matches schema | "Does the JSON output have the keys downstream consumers expect?" |

Both score 0/1 per sample so they share the `eval_results` column shape with `llm_judge` — no new tables, no new aggregate UI.

## Changes

- **Migration** `20260609130000_evaluators_type_check_extend.sql`: extend `evaluators.type` CHECK from {`llm_judge`} to {`llm_judge`, `regex`, `json_schema`}. DO block + `pg_constraint` lookup (same pattern as PR #260's internal_alerts.kind extension)
- **`lib/eval-runner.ts`**: `runRegex` / `runJsonSchema` pure sync functions + `runSimpleEvalRun` wrapper that reuses the production sample-fetch path but skips provider key resolution and judge prompt. `runEvalRun` entry routes deterministic types before the LLM-as-judge config validation
- **`api/evals.ts` POST /api/v1/evaluators**: accept new types, per-type config validation, regex compile-test at create time so a typo fails fast, scoreConfigId only meaningful for llm_judge
- **`+ ajv`** ^8.20.0 (server)
- **10 new unit tests** (runRegex 5 + runJsonSchema 5). 800 tests pass (790 → +10 from R-22)
- **`evals-client.tsx` NewEvaluatorDialog**: Type selector at top; selecting Regex swaps in pattern + flags fields, JSON Schema swaps in a textarea with `{ "type": "object" }` starter. Client-side compile check on regex + JSON.parse on schema so operator sees errors without a server round-trip. Score-config dropdown only in llm_judge mode

## Verification

- `pnpm typecheck` (full monorepo): 5 workspaces pass
- `pnpm --filter server lint + test`: 800/800 pass
- `pnpm --filter web typecheck + lint`: clean
- Applied migration via `supabase db push --local --include-all`, verified `\d evaluators` lists all three CHECK values
- Server smoke test plan after merge: POST /api/v1/evaluators with type=regex from /evals/new → verify new row, then trigger run → eval_results rows have value_boolean true/false based on pattern match

## Out of scope (R-7 Phase 2 follow-up)

- `source='dataset'` for regex / json_schema — needs the prompt-generation step from LLM-as-judge dataset path
- `evaluator_templates` seeds for the new types. Current table is shaped for LLM-as-judge only (`criterion` + `recommended_judge_provider` + `recommended_judge_model` are NOT NULL). Adding type-aware templates requires either a nullable refactor or a parallel `code_evaluator_templates` table — both bigger than this PR. The new types are still discoverable through the dialog's Type selector