### PR TITLE
debug(server): temporarily expose Vercel system-env flags in /health/deep

### DIFF
--- a/apps/server/src/api/health.ts
+++ b/apps/server/src/api/health.ts
@@ -189,6 +189,26 @@ healthRouter.get('/health/deep', async (c) => {
       // OR the Supabase query failed — both are actionable.
       crons: { max_runtime_ms: cronMaxRuntime },
       webhooks: { backlog_count: webhookBacklog },
+      // R-22 follow-up diagnosis: production /health.version stays null
+      // even after the "Enable access to System Environment Variables"
+      // toggle is on. The four flags below tell us which class of system
+      // env actually reaches process.env at runtime:
+      //   - vercel_env=null + all has_*=false → no system env is exposed
+      //     (toggle didn't take, or the project never had it set)
+      //   - vercel_env='production', has_url=true, has_commit_*=false →
+      //     base envs are exposed but git-metadata is filtered out
+      //     (a separate "Expose Git Information" toggle exists in some
+      //     Vercel project shapes)
+      //   - all true → SHA is reaching us; the /health filter is wrong
+      // This block is intentionally short-lived — once we know which
+      // class we're in, the fix lands and this block is removed in the
+      // same PR that fixes the root cause.
+      _debug: {
+        vercel_env: process.env['VERCEL_ENV'] ?? null,
+        has_commit_sha: Boolean(process.env['VERCEL_GIT_COMMIT_SHA']),
+        has_commit_ref: Boolean(process.env['VERCEL_GIT_COMMIT_REF']),
+        has_url: Boolean(process.env['VERCEL_URL']),
+      },
     },
     overallOk ? 200 : 503,
   )


### PR DESCRIPTION
## What

R-22 follow-up. Production `/health` returns `version:null` after PR #261 + #262. The "Enable access to System Environment Variables" toggle is on (user confirmed) but `VERCEL_GIT_COMMIT_SHA` doesn't reach `process.env` at runtime even after a fresh deploy (verified via empty-commit redeploy at `a43fe12`).

Add a short-lived `_debug` block to `/health/deep` so a single curl tells us which class of failure we're in.

## Diagnosis matrix

| Response | Diagnosis | Fix |
|---|---|---|
| all false / null | No system env exposed at all | Toggle didn't take — re-check Vercel project settings |
| `vercel_env='production'`, `has_url=true`, `has_commit_*=false` | Base envs exposed, git-metadata filtered out | Some Vercel project shapes have a separate "Expose Git Information" toggle |
| all true | SHA is reaching us; the /health filter is wrong | Look at the code again |

## Safety

Booleans only — actual SHA stays redacted. Safe to ship to production. If we end up needing this beyond the diagnosis window the proper home is `/admin/_diagnostics` behind `SPANLENS_ADMIN_EMAILS`, not `/health/deep`.

## Cleanup

The same PR that fixes the root cause removes `_debug`. This branch is named `debug/*` for a reason — not a permanent surface.

## Verification

- `pnpm --filter server typecheck + lint`: clean
- 12 `/health` tests pass (no assertion on `_debug` so they keep passing as the block evolves)
- After merge: `curl -s https://server.spanlens.io/health/deep | jq ._debug` returns the diagnostic block