### PR TITLE
cleanup(server): drop the _debug block from /health/deep — diagnosis done

### DIFF
--- a/apps/server/src/api/health.ts
+++ b/apps/server/src/api/health.ts
@@ -189,26 +189,6 @@ healthRouter.get('/health/deep', async (c) => {
       // OR the Supabase query failed — both are actionable.
       crons: { max_runtime_ms: cronMaxRuntime },
       webhooks: { backlog_count: webhookBacklog },
-      // R-22 follow-up diagnosis: production /health.version stays null
-      // even after the "Enable access to System Environment Variables"
-      // toggle is on. The four flags below tell us which class of system
-      // env actually reaches process.env at runtime:
-      //   - vercel_env=null + all has_*=false → no system env is exposed
-      //     (toggle didn't take, or the project never had it set)
-      //   - vercel_env='production', has_url=true, has_commit_*=false →
-      //     base envs are exposed but git-metadata is filtered out
-      //     (a separate "Expose Git Information" toggle exists in some
-      //     Vercel project shapes)
-      //   - all true → SHA is reaching us; the /health filter is wrong
-      // This block is intentionally short-lived — once we know which
-      // class we're in, the fix lands and this block is removed in the
-      // same PR that fixes the root cause.
-      _debug: {
-        vercel_env: process.env['VERCEL_ENV'] ?? null,
-        has_commit_sha: Boolean(process.env['VERCEL_GIT_COMMIT_SHA']),
-        has_commit_ref: Boolean(process.env['VERCEL_GIT_COMMIT_REF']),
-        has_url: Boolean(process.env['VERCEL_URL']),
-      },
     },
     overallOk ? 200 : 503,
   )


### PR DESCRIPTION
## What

PR #264 added a short-lived `_debug` block to figure out why production `/health` was returning `version:null` even with "Enable access to System Environment Variables" on.

The answer turned out to be timing, not a missing toggle:

1. PR #261 R-22 shipped with the toggle still OFF → `process.env.VERCEL_GIT_COMMIT_SHA = ""`
2. `/health` surfaced `""` → PR #262 truthy guard turned that into `null`
3. User flipped the toggle ON after PR #263 deployed
4. Empty commit `a43fe12` redeployed under the new toggle state; after that deploy stabilised, `/health.version` started returning the real SHA
5. Mid-debug curl at 08:55 UTC caught the previous build still serving from Vercel's edge — `Age:0` alone doesn't guarantee the new build propagated to every region

A second curl a few minutes later showed the SHA cleanly: `version: "a43fe123f50f46475b75f73e6b67b85ee163eef4"`. The system-env toggle path was working correctly all along.

## Cleanup

Pulling the diagnostic block per the original commit message: "once we know which class we're in, the fix lands and this block is removed in the same PR that fixes the root cause." No semantic change to `/health/deep` besides removing the diagnostic field.

## Verification

- typecheck + lint + 12 health tests pass
- After merge: `curl -s https://server.spanlens.io/health/deep | jq ._debug` returns `null` (field absent)
- `curl -s https://server.spanlens.io/health | jq .version` still returns the real SHA