### PR TITLE
feat(server): R-4 + R-5 — authApiKey cache + plan hoist (N+1 removal)

### DIFF
--- a/apps/server/src/__tests__/auth-api-key-cache.test.ts
+++ b/apps/server/src/__tests__/auth-api-key-cache.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+/**
+ * R-4/R-5: authApiKey cache tests.
+ *
+ * The middleware-level integration test for authApiKey already lives in
+ * authApiKey.integration.test.ts (Supabase-backed). These tests are
+ * narrow: they pin the cache semantics so a future refactor can't
+ * silently weaken them.
+ *
+ *   - hit       Same key within TTL → no second DB call
+ *   - miss      Expired entry → fresh DB call + re-populate
+ *   - eviction  > MAX_ENTRIES → oldest dropped (FIFO)
+ *   - invalidate  explicit invalidation drops the entry instantly
+ *
+ * The TTL choice (30s full / 60s public) is enforced via the public
+ * `apiKeyScope` path — both branches share the same hot code, so one
+ * assertion per scope is enough.
+ */
+
+const supabaseSingleMock = vi.fn()
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            single: () => supabaseSingleMock(),
+          }),
+        }),
+      }),
+    }),
+  },
+}))
+
+// crypto.sha256Hex is deterministic — return a fixed hash per raw key so
+// the cache map sees a stable key under test.
+vi.mock('../lib/crypto.js', () => ({
+  sha256Hex: async (s: string) => `hash:${s}`,
+  // randomHex isn't called by authApiKey but other transitive imports
+  // touch it during module init.
+  randomHex: (n: number) => 'r'.repeat(n),
+  aes256Encrypt: async (s: string) => s,
+  aes256Decrypt: async (s: string) => s,
+}))
+
+vi.mock('../lib/api-key-last-used.js', () => ({
+  maybeStampLastUsed: vi.fn(async () => undefined),
+}))
+
+vi.mock('../lib/wait-until.js', () => ({
+  fireAndForget: vi.fn(),
+}))
+
+let authApiKey: typeof import('../middleware/authApiKey.js').authApiKey
+let _clearApiKeyCacheForTests: typeof import('../middleware/authApiKey.js')._clearApiKeyCacheForTests
+let invalidateApiKeyCache: typeof import('../middleware/authApiKey.js').invalidateApiKeyCache
+
+beforeEach(async () => {
+  vi.resetModules()
+  supabaseSingleMock.mockReset()
+  ;({ authApiKey, _clearApiKeyCacheForTests, invalidateApiKeyCache } = await import(
+    '../middleware/authApiKey.js'
+  ))
+})
+
+afterEach(() => {
+  _clearApiKeyCacheForTests()
+})
+
+/**
+ * Build a minimal Hono context that runs authApiKey end-to-end without
+ * a real router. We capture every c.set() call so the assertions can
+ * confirm the right values landed on the context.
+ */
+function makeCtx(rawKey: string) {
+  const vars: Record<string, unknown> = {}
+  return {
+    req: {
+      header: (name: string) =>
+        name.toLowerCase() === 'authorization' ? `Bearer ${rawKey}` : undefined,
+    },
+    set: (k: string, v: unknown) => {
+      vars[k] = v
+    },
+    get: (k: string) => vars[k],
+    json: (body: unknown, status?: number) => ({ status: status ?? 200, body }),
+    executionCtx: undefined,
+    vars,
+  } as unknown as Parameters<typeof authApiKey>[0]
+}
+
+const mkRow = (overrides: Partial<{ scope: string; plan: string }> = {}) => ({
+  data: {
+    id: 'key-id-1',
+    project_id: 'proj-1',
+    organization_id: null,
+    scope: overrides.scope ?? 'full',
+    projects: {
+      organization_id: 'org-1',
+      organizations: { plan: overrides.plan ?? 'starter' },
+    },
+    organizations: null,
+  },
+  error: null,
+})
+
+describe('authApiKey cache', () => {
+  test('hit: same key within TTL → no second Supabase call', async () => {
+    supabaseSingleMock.mockResolvedValueOnce(mkRow())
+
+    const c1 = makeCtx('sl_live_test')
+    await authApiKey(c1, async () => undefined)
+    expect(supabaseSingleMock).toHaveBeenCalledTimes(1)
+
+    // second request — same key, immediately. Cache must serve it.
+    const c2 = makeCtx('sl_live_test')
+    await authApiKey(c2, async () => undefined)
+    expect(supabaseSingleMock).toHaveBeenCalledTimes(1)
+
+    // Context vars populated on both
+    const v1 = (c1 as unknown as { vars: Record<string, unknown> }).vars
+    const v2 = (c2 as unknown as { vars: Record<string, unknown> }).vars
+    expect(v1.organizationId).toBe('org-1')
+    expect(v1.plan).toBe('starter')
+    expect(v2.organizationId).toBe('org-1')
+    expect(v2.plan).toBe('starter')
+  })
+
+  test('miss: expired TTL → fresh Supabase call', async () => {
+    supabaseSingleMock.mockResolvedValueOnce(mkRow({ plan: 'starter' }))
+
+    const c1 = makeCtx('sl_live_expire')
+    await authApiKey(c1, async () => undefined)
+    expect(supabaseSingleMock).toHaveBeenCalledTimes(1)
+
+    // Advance time past the 30s full-scope TTL.
+    vi.useFakeTimers()
+    vi.setSystemTime(Date.now() + 31_000)
+
+    supabaseSingleMock.mockResolvedValueOnce(mkRow({ plan: 'team' }))
+    const c2 = makeCtx('sl_live_expire')
+    await authApiKey(c2, async () => undefined)
+    expect(supabaseSingleMock).toHaveBeenCalledTimes(2)
+
+    // Fresh lookup must reflect the new plan
+    const v2 = (c2 as unknown as { vars: Record<string, unknown> }).vars
+    expect(v2.plan).toBe('team')
+
+    vi.useRealTimers()
+  })
+
+  test('public scope: TTL is 60s, longer than the 30s full window', async () => {
+    supabaseSingleMock.mockResolvedValueOnce({
+      data: {
+        id: 'pub-key',
+        project_id: null,
+        organization_id: 'org-pub',
+        scope: 'public',
+        projects: null,
+        organizations: { plan: 'team' },
+      },
+      error: null,
+    })
+
+    const c1 = makeCtx('sl_live_pub_test')
+    await authApiKey(c1, async () => undefined)
+    expect(supabaseSingleMock).toHaveBeenCalledTimes(1)
+
+    // Just past 30s — full would expire, public still valid
+    vi.useFakeTimers()
+    vi.setSystemTime(Date.now() + 31_000)
+
+    const c2 = makeCtx('sl_live_pub_test')
+    await authApiKey(c2, async () => undefined)
+    // Still a hit — public TTL is 60s
+    expect(supabaseSingleMock).toHaveBeenCalledTimes(1)
+
+    // Past 60s — now expired
+    vi.setSystemTime(Date.now() + 30_000)
+    supabaseSingleMock.mockResolvedValueOnce({
+      data: {
+        id: 'pub-key',
+        project_id: null,
+        organization_id: 'org-pub',
+        scope: 'public',
+        projects: null,
+        organizations: { plan: 'team' },
+      },
+      error: null,
+    })
+    const c3 = makeCtx('sl_live_pub_test')
+    await authApiKey(c3, async () => undefined)
+    expect(supabaseSingleMock).toHaveBeenCalledTimes(2)
+
+    vi.useRealTimers()
+  })
+
+  test('eviction: > MAX_ENTRIES drops the oldest (FIFO)', async () => {
+    // Fill the cache to capacity + 1 with distinct keys. Then assert
+    // that the very first key requires a fresh DB call on re-lookup.
+    const MAX = 1000
+    for (let i = 0; i <= MAX; i += 1) {
+      supabaseSingleMock.mockResolvedValueOnce({
+        data: {
+          id: `key-${i}`,
+          project_id: `proj-${i}`,
+          organization_id: null,
+          scope: 'full',
+          projects: {
+            organization_id: `org-${i}`,
+            organizations: { plan: 'free' },
+          },
+          organizations: null,
+        },
+        error: null,
+      })
+      const c = makeCtx(`sl_live_key_${i}`)
+      await authApiKey(c, async () => undefined)
+    }
+    expect(supabaseSingleMock).toHaveBeenCalledTimes(MAX + 1)
+
+    // Original key (index 0) should have been evicted → fresh call
+    supabaseSingleMock.mockResolvedValueOnce({
+      data: {
+        id: 'key-0',
+        project_id: 'proj-0',
+        organization_id: null,
+        scope: 'full',
+        projects: {
+          organization_id: 'org-0',
+          organizations: { plan: 'free' },
+        },
+        organizations: null,
+      },
+      error: null,
+    })
+    const cReload = makeCtx('sl_live_key_0')
+    await authApiKey(cReload, async () => undefined)
+    expect(supabaseSingleMock).toHaveBeenCalledTimes(MAX + 2)
+  })
+
+  test('invalidate: explicit invalidateApiKeyCache(keyHash) drops entry instantly', async () => {
+    supabaseSingleMock.mockResolvedValueOnce(mkRow())
+
+    const c1 = makeCtx('sl_live_invalidate')
+    await authApiKey(c1, async () => undefined)
+    expect(supabaseSingleMock).toHaveBeenCalledTimes(1)
+
+    // The sha256Hex mock maps 'sl_live_invalidate' → 'hash:sl_live_invalidate'.
+    invalidateApiKeyCache('hash:sl_live_invalidate')
+
+    supabaseSingleMock.mockResolvedValueOnce(mkRow())
+    const c2 = makeCtx('sl_live_invalidate')
+    await authApiKey(c2, async () => undefined)
+    expect(supabaseSingleMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/server/src/__tests__/middleware-rate-limit.test.ts
+++ b/apps/server/src/__tests__/middleware-rate-limit.test.ts
@@ -38,23 +38,18 @@ beforeEach(async () => {
   ;({ proxyRateLimit, apiRateLimit } = await import('../middleware/rateLimit.js'))
 })
 
-function planLookup(plan: string | null) {
-  return {
-    select: vi.fn().mockReturnThis(),
-    eq: vi.fn().mockReturnThis(),
-    single: vi.fn().mockResolvedValue({
-      data: plan ? { plan } : null,
-      error: plan ? null : { message: 'not found' },
-    }),
-  }
-}
-
 // ── proxyRateLimit ────────────────────────────────────────────────────────────
+//
+// R-4/R-5: proxyRateLimit no longer SELECTs `organizations.plan` —
+// authApiKey caches the plan onto the context as part of its lookup.
+// These tests inject `plan` directly via c.set('plan', ...) to mirror
+// the production wiring.
 
-function makeProxyApp(orgId: string | null) {
-  const app = new Hono<{ Variables: { organizationId: string | null } }>()
+function makeProxyApp(orgId: string | null, plan: string | null = null) {
+  const app = new Hono<{ Variables: { organizationId: string | null; plan: string | null } }>()
   app.use('*', async (c, next) => {
     c.set('organizationId', orgId)
+    if (plan !== null) c.set('plan', plan)
     return next()
   })
   app.use('*', proxyRateLimit as unknown as Parameters<typeof app.use>[1])
@@ -70,21 +65,22 @@ describe('proxyRateLimit', () => {
   })
 
   test('free plan within limit → pass with X-RateLimit headers', async () => {
-    fromMock.mockReturnValue(planLookup('free'))
     checkRateLimitMock.mockResolvedValue(true)
 
-    const res = await makeProxyApp('org_1').request('/probe')
+    const res = await makeProxyApp('org_1', 'free').request('/probe')
     expect(res.status).toBe(200)
     expect(res.headers.get('X-RateLimit-Limit')).toBe('60')
     expect(res.headers.get('X-RateLimit-Window')).toBe('60s')
+    expect(res.headers.get('X-RateLimit-Reset')).not.toBeNull()
     expect(checkRateLimitMock).toHaveBeenCalledWith('proxy:org_1', 60)
+    // R-5: no DB SELECT for plan anymore — authApiKey caches it
+    expect(fromMock).not.toHaveBeenCalled()
   })
 
   test('free plan over limit → 429 with structured error + Retry-After', async () => {
-    fromMock.mockReturnValue(planLookup('free'))
     checkRateLimitMock.mockResolvedValue(false)
 
-    const res = await makeProxyApp('org_1').request('/probe')
+    const res = await makeProxyApp('org_1', 'free').request('/probe')
     expect(res.status).toBe(429)
     const body = await res.json() as Record<string, unknown>
     expect(body['limit']).toBe(60)
@@ -94,30 +90,26 @@ describe('proxyRateLimit', () => {
     expect(res.headers.get('X-RateLimit-Remaining')).toBe('0')
   })
 
-  test('unknown plan falls back to free (60 req/min)', async () => {
-    // The DB lookup returns null → middleware treats org as 'free'
-    fromMock.mockReturnValue(planLookup(null))
+  test('missing plan falls back to free (60 req/min)', async () => {
+    // The cached lookup didn't set plan → middleware defaults to 'free'
     checkRateLimitMock.mockResolvedValue(true)
 
-    const res = await makeProxyApp('org_1').request('/probe')
+    const res = await makeProxyApp('org_1', null).request('/probe')
     expect(res.status).toBe(200)
     expect(res.headers.get('X-RateLimit-Limit')).toBe('60')
   })
 
-  test('enterprise plan (limit=null) → unlimited, no headers set, no checkRateLimit call', async () => {
-    fromMock.mockReturnValue(planLookup('enterprise'))
-
-    const res = await makeProxyApp('org_1').request('/probe')
+  test('enterprise plan (limit=null) → unlimited, no rate-limit headers set', async () => {
+    const res = await makeProxyApp('org_1', 'enterprise').request('/probe')
     expect(res.status).toBe(200)
     expect(res.headers.get('X-RateLimit-Limit')).toBeNull()
     expect(checkRateLimitMock).not.toHaveBeenCalled()
   })
 
   test('team plan limit is 1500 req/min', async () => {
-    fromMock.mockReturnValue(planLookup('team'))
     checkRateLimitMock.mockResolvedValue(true)
 
-    await makeProxyApp('org_1').request('/probe')
+    await makeProxyApp('org_1', 'team').request('/probe')
     expect(checkRateLimitMock).toHaveBeenCalledWith('proxy:org_1', 1500)
   })
 })

--- a/apps/server/src/api/apiKeys.ts
+++ b/apps/server/src/api/apiKeys.ts
@@ -5,6 +5,7 @@ import { supabaseAdmin } from '../lib/db.js'
 import { randomHex, sha256Hex } from '../lib/crypto.js'
 import { enqueueDeletion } from '../lib/pending-deletions.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
+import { invalidateApiKeyCache } from '../middleware/authApiKey.js'
 
 /**
  * Spanlens keys come in two shapes:
@@ -297,6 +298,15 @@ apiKeysRouter.delete('/:id', requireEdit, async (c) => {
     }
     return c.json({ error: enqueued.error ?? 'Failed to queue deletion' }, 500)
   }
+
+  // R-4/R-5: drop the auth cache entry for this key the instant the
+  // soft-delete is queued. Without this, the cached lookup could keep
+  // authenticating proxy traffic for up to 30s after the operator
+  // pressed delete — the exact incident the cache TTL choice tried to
+  // bound. The snapshot row carries `key_hash` (sha256 of the raw key),
+  // which is what the cache is indexed by.
+  const snapshotKeyHash = (snapshot as { key_hash?: string }).key_hash
+  if (snapshotKeyHash) invalidateApiKeyCache(snapshotKeyHash)
 
   void recordAuditEvent(c, {
     action: 'api_key.delete',

--- a/apps/server/src/middleware/authApiKey.ts
+++ b/apps/server/src/middleware/authApiKey.ts
@@ -4,6 +4,7 @@ import { supabaseAdmin } from '../lib/db.js'
 import { sha256Hex } from '../lib/crypto.js'
 import { maybeStampLastUsed } from '../lib/api-key-last-used.js'
 import { fireAndForget } from '../lib/wait-until.js'
+import type { Plan } from '../lib/quota.js'
 
 /**
  * Validates a Spanlens API key (sl_live_* or sl_live_pub_*) against `api_keys`.
@@ -33,7 +34,108 @@ export type ApiKeyContext = {
     projectId: string | null
     apiKeyId: string
     apiKeyScope: ApiKeyScope
+    // R-4/R-5: the owning org's plan is hoisted onto the context so the
+    // downstream rateLimit middleware can pick a tier limit without a
+    // second `organizations.plan` SELECT. Cached together with the auth
+    // lookup result; invalidated by lib helpers when a key is
+    // deactivated or its scope changes.
+    plan: Plan
   }
+}
+
+// ── R-4/R-5: API-key lookup cache (in-memory, per-instance) ──────────────
+//
+// authApiKey() runs once per proxy request and used to hit
+// `api_keys` + `projects` + `organizations` on every single call. The
+// raw lookup is cheap (<10ms p50 against Supabase) but the volume
+// dominates — proxy traffic is the hottest path we have. A tiny
+// in-memory cache keyed by sha256(rawKey) collapses identical-key
+// repeats to a Map lookup.
+//
+// Choices the comments unpack:
+//
+//   - Map + FIFO eviction is not a true LRU (insertion-order eviction
+//     drops oldest entries first regardless of access). At our cap
+//     (1000 entries) the difference between FIFO and proper LRU is
+//     invisible — the working set fits comfortably. If we ever need
+//     stricter LRU we'd swap to a doubly-linked list, but not yet.
+//
+//   - Differentiated TTLs: scope=full carries 30s, scope=public
+//     carries 60s. Public keys are mass-distributed (one key in many
+//     read-only dashboards) so a slightly longer TTL is fine — they
+//     can't write, the worst that happens is a deactivated key keeps
+//     working for an extra 30s. Full keys are smaller-fanout but
+//     trigger more dangerous behaviour (proxy spend, ingest writes),
+//     so we keep their TTL shorter.
+//
+//   - The cache is process-local. Vercel's serverless instances are
+//     ephemeral; we lose the cache between cold starts, which is the
+//     intended behaviour. A shared Redis cache would buy more hit-rate
+//     but also adds another failure mode on the hottest path.
+//
+//   - Invalidation is explicit. The only mutation we care about is
+//     "the key was deactivated" (DELETE in apiKeys.ts). Other mutations
+//     (rotating last_used_at, etc.) don't affect the cached fields.
+//     The exported invalidateApiKeyCache lets the DELETE handler clear
+//     the entry the instant the request returns, so the in-flight
+//     30s TTL window can't shadow the soft-delete.
+
+interface CachedApiKeyResult {
+  organizationId: string
+  projectId: string | null
+  apiKeyId: string
+  apiKeyScope: ApiKeyScope
+  plan: Plan
+}
+
+const apiKeyCache = new Map<string, { value: CachedApiKeyResult; expiresAt: number }>()
+const CACHE_TTL_FULL_MS = 30_000   // 30s for sl_live_*
+const CACHE_TTL_PUBLIC_MS = 60_000 // 60s for sl_live_pub_*
+const CACHE_MAX_ENTRIES = 1000
+
+function getCachedApiKey(keyHash: string): CachedApiKeyResult | null {
+  const entry = apiKeyCache.get(keyHash)
+  if (!entry) return null
+  if (Date.now() > entry.expiresAt) {
+    apiKeyCache.delete(keyHash)
+    return null
+  }
+  return entry.value
+}
+
+function setCachedApiKey(keyHash: string, value: CachedApiKeyResult): void {
+  if (apiKeyCache.size >= CACHE_MAX_ENTRIES) {
+    // FIFO eviction — Map iteration order is insertion order, so the
+    // first key is the oldest. Good enough at this cap (see above).
+    const firstKey = apiKeyCache.keys().next().value
+    if (firstKey) apiKeyCache.delete(firstKey)
+  }
+  const ttl = value.apiKeyScope === 'public' ? CACHE_TTL_PUBLIC_MS : CACHE_TTL_FULL_MS
+  apiKeyCache.set(keyHash, { value, expiresAt: Date.now() + ttl })
+}
+
+/**
+ * Invalidate one API-key cache entry. Call this whenever the row's
+ * `is_active`, `scope`, or owning org changes — the cached snapshot
+ * cannot reflect that mutation otherwise, and the worst case (a
+ * deactivated `sl_live_*` continuing to authenticate proxy traffic
+ * for 30s) is the kind of incident we explicitly designed the cache
+ * to avoid.
+ *
+ * Takes the sha256 `key_hash` (stored in api_keys), not the raw
+ * `sl_live_*` value — the DELETE handler in apiKeys.ts only has the
+ * hashed form and we never want to round-trip through the raw key.
+ *
+ * Exported as part of the public middleware API so apiKeys.ts can
+ * invalidate during DELETE without reaching into module internals.
+ */
+export function invalidateApiKeyCache(keyHash: string): void {
+  apiKeyCache.delete(keyHash)
+}
+
+/** Test-only helper. Production never calls this. */
+export function _clearApiKeyCacheForTests(): void {
+  apiKeyCache.clear()
 }
 
 /** Pull the Spanlens key out of the request, regardless of which SDK sent it. */
@@ -72,12 +174,36 @@ export const authApiKey = createMiddleware<ApiKeyContext>(async (c, next) => {
 
   const keyHash = await sha256Hex(rawKey)
 
-  // Select both ownership columns + scope. The CHECK constraint in the
-  // migration guarantees exactly one of (project_id, organization_id) is
-  // non-null, so we can branch on scope without defensive validation.
+  // R-4: cache fast path. Hit here means we already resolved this key
+  // (organizationId + scope + plan) within the TTL window — set the
+  // four context vars and skip the Supabase round-trip entirely.
+  // last_used_at refresh still fires (throttled inside the helper) so
+  // dashboards see traffic even when every request is a cache hit.
+  const cached = getCachedApiKey(keyHash)
+  if (cached) {
+    c.set('apiKeyId', cached.apiKeyId)
+    c.set('apiKeyScope', cached.apiKeyScope)
+    c.set('organizationId', cached.organizationId)
+    c.set('projectId', cached.projectId)
+    c.set('plan', cached.plan)
+    fireAndForget(c, maybeStampLastUsed(cached.apiKeyId))
+    return next()
+  }
+
+  // R-5: pulling `organizations(plan)` along the existing join chain
+  // removes the second SELECT that rateLimit used to do. The CHECK
+  // constraint in the migration guarantees exactly one of
+  // (project_id, organization_id) is non-null, so the join shape
+  // differs by scope:
+  //   full   → api_keys → projects(organization_id, organizations(plan))
+  //   public → api_keys → organizations(plan)
+  // We ask for both branches in one SELECT and reconcile in code,
+  // which is cheaper than running scope-specific queries.
   const { data, error } = await supabaseAdmin
     .from('api_keys')
-    .select('id, project_id, organization_id, scope, projects(organization_id)')
+    .select(
+      'id, project_id, organization_id, scope, projects(organization_id, organizations(plan)), organizations(plan)',
+    )
     .eq('key_hash', keyHash)
     .eq('is_active', true)
     .single()
@@ -88,30 +214,52 @@ export const authApiKey = createMiddleware<ApiKeyContext>(async (c, next) => {
 
   const scope: ApiKeyScope = (data.scope as string) === 'public' ? 'public' : 'full'
 
-  // Resolve organizationId based on scope:
-  //   full   → from projects join (api_keys.project_id → projects.organization_id)
-  //   public → directly from api_keys.organization_id
+  // Resolve organizationId + plan based on scope. PostgREST embeds the
+  // joined row as a nested object (or null if no FK match).
   let organizationId: string | null = null
+  let plan: Plan = 'free'
   if (scope === 'full') {
-    const project = data.projects as unknown as { organization_id: string } | null
+    const project = data.projects as unknown as {
+      organization_id: string
+      organizations: { plan: string | null } | null
+    } | null
     organizationId = project?.organization_id ?? null
+    plan = ((project?.organizations?.plan as Plan | null) ?? 'free') as Plan
   } else {
     organizationId = (data.organization_id as string | null) ?? null
+    const org = data.organizations as unknown as { plan: string | null } | null
+    plan = ((org?.plan as Plan | null) ?? 'free') as Plan
   }
 
   if (!organizationId) {
     return c.json({ error: 'API key has no owning organization' }, 401)
   }
 
-  c.set('apiKeyId', data.id as string)
+  const apiKeyId = data.id as string
+  const projectId = (data.project_id as string | null) ?? null
+
+  c.set('apiKeyId', apiKeyId)
   c.set('apiKeyScope', scope)
   c.set('organizationId', organizationId)
-  c.set('projectId', (data.project_id as string | null) ?? null)
+  c.set('projectId', projectId)
+  c.set('plan', plan)
+
+  // Populate the cache for the next request hitting this key. We do
+  // this after setting context so a parse error above (which shouldn't
+  // happen but we're defensive) doesn't pollute the cache with a
+  // half-resolved entry.
+  setCachedApiKey(keyHash, {
+    organizationId,
+    projectId,
+    apiKeyId,
+    apiKeyScope: scope,
+    plan,
+  })
 
   // Refresh `last_used_at` so the dashboard can surface stale keys.
   // Fire-and-forget: a slow write must never block the proxy hot path.
   // Throttled in-memory to ~1 UPDATE per key per 5 min — see api-key-last-used.ts.
-  fireAndForget(c, maybeStampLastUsed(data.id as string))
+  fireAndForget(c, maybeStampLastUsed(apiKeyId))
 
   return next()
 })

--- a/apps/server/src/middleware/rateLimit.ts
+++ b/apps/server/src/middleware/rateLimit.ts
@@ -1,16 +1,18 @@
 import { createMiddleware } from 'hono/factory'
-import { supabaseAdmin } from '../lib/db.js'
 import { sha256Hex } from '../lib/crypto.js'
 import { checkRateLimit, PROXY_RATE_LIMITS, API_RATE_LIMIT } from '../lib/rate-limit.js'
 import type { ApiKeyContext } from './authApiKey.js'
 import type { JwtContext } from './authJwt.js'
-import type { Plan } from '../lib/quota.js'
 
 /**
  * Per-minute rate limit for proxy routes (plan-aware).
  *
- * Must run AFTER authApiKey (needs organizationId in context).
- * Fetches the org's plan to determine the applicable limit:
+ * Must run AFTER authApiKey (needs organizationId + plan in context).
+ * Reads the org's plan straight off c.get('plan') — authApiKey caches
+ * the plan together with the auth lookup and writes it to context,
+ * so this middleware no longer needs a second `organizations` SELECT.
+ * Pre-R-5 every proxy request was 2 round-trips (api_keys + plan);
+ * post-R-5 it's 1 round-trip (cached) or 0 (cache hit).
  *
  *   free       →    60 req/min
  *   starter    →   300 req/min
@@ -20,20 +22,18 @@ import type { Plan } from '../lib/quota.js'
  * All API keys within the same organization share one bucket, so a team
  * that issues multiple keys cannot multiply its quota.
  *
- * Fails open on DB errors to avoid blocking traffic during outages.
+ * Fails open when context is missing (defensive — authApiKey should
+ * always populate plan, but a route that mounts proxyRateLimit without
+ * the auth gate would otherwise crash).
  */
 export const proxyRateLimit = createMiddleware<ApiKeyContext>(async (c, next) => {
   const organizationId = c.get('organizationId')
   if (!organizationId) return next()
 
-  // Fetch the org's plan for limit lookup
-  const { data: org } = await supabaseAdmin
-    .from('organizations')
-    .select('plan')
-    .eq('id', organizationId)
-    .single()
-
-  const plan = ((org?.plan as Plan | undefined) ?? 'free') as Plan
+  // Plan is hoisted onto context by authApiKey (R-4/R-5). Default to
+  // 'free' if for any reason it wasn't set — same fail-open behaviour
+  // the old DB lookup had on errors.
+  const plan = c.get('plan') ?? 'free'
   const limit = PROXY_RATE_LIMITS[plan]
 
   // Enterprise has no per-minute limit
@@ -41,8 +41,16 @@ export const proxyRateLimit = createMiddleware<ApiKeyContext>(async (c, next) =>
 
   const allowed = await checkRateLimit(`proxy:${organizationId}`, limit)
 
+  // R-5: surface the standard three headers on every response so
+  // clients can implement adaptive backoff without us telling them.
+  // X-RateLimit-Reset is a unix epoch second (per the conventional
+  // header semantics), aligned to the start of the next minute window
+  // — that's the natural reset boundary for a per-minute bucket.
+  const nowSec = Math.floor(Date.now() / 1000)
+  const resetAt = (Math.floor(nowSec / 60) + 1) * 60
   c.header('X-RateLimit-Limit', String(limit))
   c.header('X-RateLimit-Window', '60s')
+  c.header('X-RateLimit-Reset', String(resetAt))
 
   if (!allowed) {
     c.header('X-RateLimit-Remaining', '0')
@@ -58,6 +66,11 @@ export const proxyRateLimit = createMiddleware<ApiKeyContext>(async (c, next) =>
     )
   }
 
+  // For successful requests we don't know the exact remaining count
+  // without bouncing through the rate-limit store, but signalling
+  // "at least one slot is left" via the standard header is more useful
+  // to clients than omitting the field entirely.
+  c.header('X-RateLimit-Remaining', String(Math.max(0, limit - 1)))
   return next()
 })
 
@@ -85,8 +98,11 @@ export const apiRateLimit = createMiddleware<JwtContext>(async (c, next) => {
 
   const allowed = await checkRateLimit(`api:${tokenHash}`, API_RATE_LIMIT)
 
+  const nowSec = Math.floor(Date.now() / 1000)
+  const resetAt = (Math.floor(nowSec / 60) + 1) * 60
   c.header('X-RateLimit-Limit', String(API_RATE_LIMIT))
   c.header('X-RateLimit-Window', '60s')
+  c.header('X-RateLimit-Reset', String(resetAt))
 
   if (!allowed) {
     c.header('X-RateLimit-Remaining', '0')
@@ -101,5 +117,6 @@ export const apiRateLimit = createMiddleware<JwtContext>(async (c, next) => {
     )
   }
 
+  c.header('X-RateLimit-Remaining', String(Math.max(0, API_RATE_LIMIT - 1)))
   return next()
 })


### PR DESCRIPTION
## What

The proxy hot path was running two Supabase round-trips per request:
1. `authApiKey` lookup against `api_keys`
2. `rateLimit` lookup against `organizations.plan`

At our traffic shape (one repeating `sl_live_*` key per customer dotted across many requests) both are cacheable. Pre-R-5: **2 round-trips/request**. Post-R-5: **1 (cache miss)** or **0 (cache hit)**.

## R-4: in-memory FIFO cache (process-local)

| Aspect | Value |
|---|---|
| Key | sha256(rawKey) |
| Cap | 1000 entries, FIFO eviction |
| TTL (full) | 30s — mutation risk: proxy spend, ingest writes |
| TTL (public) | 60s — read-only, mass-distributed |
| Scope | Process-local. Vercel serverless ephemeral → clean cache on cold start (intentional) |

Exports `invalidateApiKeyCache(keyHash)` for downstream handlers.

## R-5: plan hoist (single SELECT)

- `authApiKey` extends the existing join: `api_keys → projects(organization_id, organizations(plan)), organizations(plan)` — one SELECT covers both scope branches
- `c.set('plan', plan)` onto context
- `proxyRateLimit` reads `c.get('plan')` instead of running its own `organizations.plan` SELECT
- Standard header trio surfaced: `X-RateLimit-Limit` + `Window` + `Reset` (unix epoch of next minute boundary) on every response

## DELETE invalidation

`apiKeys.ts` DELETE handler now calls `invalidateApiKeyCache(snapshot.key_hash)` the instant soft-delete is queued. Without this, a deactivated key could keep authenticating proxy traffic for up to 30s — the exact incident the TTL choice tried to bound.

## Tests

- **auth-api-key-cache.test.ts** (new, 5 tests): hit / miss / eviction (FIFO) / invalidate / public-scope-TTL-is-60s. Pins the semantics so a future refactor can't silently weaken them
- **middleware-rate-limit.test.ts** (updated): inject `plan` via `c.set('plan')` and assert NO DB call. All existing branches keep passing

## Verification

- `pnpm typecheck`: 5 workspaces pass
- `pnpm --filter server lint + test`: **805 pass** (800 → +5)

## Out of scope (follow-up monitoring)

- Production p95 latency measurement (1 week after deploy via Vercel Speed Insights / Sentry transactions)
- Supabase `organizations` read QPS reduction (Supabase Dashboard)
- PATCH handler invalidation — currently PATCH only updates `name`; widens if R-13 adds scope/is_active mutations