### PR TITLE
feat(infra): R-23 Sprint 3 — dev docker-compose stack + mock OpenAI server

### DIFF
--- a/apps/server/scripts/mock-openai-server.ts
+++ b/apps/server/scripts/mock-openai-server.ts
@@ -1,0 +1,207 @@
+/**
+ * Mock OpenAI-compatible HTTP server (R-3 / Sprint 3-4).
+ *
+ * Stands in for OpenAI's chat/completions endpoint in E2E and load tests.
+ * Set `OPENAI_API_BASE=http://mock-openai:4000/v1` on the server process
+ * (docker-compose.dev.yml does this for the mock-openai service) and the
+ * proxy will route to this instead of api.openai.com, so test runs do
+ * not burn real budget.
+ *
+ * Shape covered
+ *   - POST /v1/chat/completions
+ *       body.stream === true  → text/event-stream with delta tokens
+ *       body.stream !== true  → single JSON {choices:[...], usage:{...}}
+ *   - GET  /health             → 200 "ok" for the docker healthcheck
+ *
+ * What we deliberately do NOT model
+ *   - Authentication. The proxy strips its own Spanlens key before
+ *     forwarding and adds an `Authorization: Bearer <provider key>` of
+ *     its own. We accept any token (including none).
+ *   - Tool calls, vision inputs, function calls. The smoke test only
+ *     exercises the text path; widening this surface is R-3 follow-up.
+ *   - Rate limit / error injection. Future R-3 work could add a query
+ *     param like `?error=429` to deterministically trigger upstream
+ *     failures for retry-path tests.
+ *
+ * Why a hand-written Node server instead of mockoon
+ *   - Streaming. mockoon supports it but stub responses are static — we
+ *     want the choice token count to follow the requested `max_tokens`
+ *     so cost math stays plausible end-to-end.
+ *   - One file, zero new dependencies — `tsx` already runs in dev.
+ */
+
+import { createServer } from 'node:http'
+
+const PORT = Number(process.env['MOCK_OPENAI_PORT'] ?? 4000)
+
+/** Static reply token. Multiple emitted in streaming mode. */
+const REPLY_TOKEN = 'mock '
+
+interface ChatRequest {
+  model?: string
+  stream?: boolean
+  messages?: Array<{ role: string; content: string }>
+  max_tokens?: number
+}
+
+/**
+ * Build the non-streaming response body. Token counts mirror the
+ * approximate length of the (single static) assistant message so cost
+ * calculations on the proxy side land in the same ballpark as real
+ * traffic — important for the dashboards the smoke test asserts on.
+ */
+function buildSingleResponse(body: ChatRequest): unknown {
+  const model = body.model ?? 'gpt-4o-mini'
+  const promptTokens = (body.messages ?? []).reduce(
+    (acc, m) => acc + Math.ceil((m.content?.length ?? 0) / 4),
+    0,
+  ) || 10
+  const completionContent = 'mock'
+  const completionTokens = Math.max(1, Math.ceil(completionContent.length / 4))
+
+  return {
+    id: `chatcmpl-mock-${Date.now()}`,
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content: completionContent },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: promptTokens + completionTokens,
+    },
+  }
+}
+
+/**
+ * SSE chunk for the streaming path. OpenAI emits one delta per token
+ * plus a terminal `[DONE]`. The proxy's parser (parsers/openai.ts)
+ * extracts usage from the *last* chunk before `[DONE]`, so we set
+ * `usage` on the final delta and omit it from intermediate ones.
+ */
+function buildStreamChunks(body: ChatRequest): string[] {
+  const model = body.model ?? 'gpt-4o-mini'
+  const tokenCount = Math.min(body.max_tokens ?? 8, 8)
+  const promptTokens = (body.messages ?? []).reduce(
+    (acc, m) => acc + Math.ceil((m.content?.length ?? 0) / 4),
+    0,
+  ) || 10
+  const created = Math.floor(Date.now() / 1000)
+  const id = `chatcmpl-mock-${Date.now()}`
+
+  const chunks: string[] = []
+
+  // Opening delta with role.
+  chunks.push(
+    `data: ${JSON.stringify({
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model,
+      choices: [{ index: 0, delta: { role: 'assistant' }, finish_reason: null }],
+    })}\n\n`,
+  )
+
+  // Token deltas.
+  for (let i = 0; i < tokenCount; i += 1) {
+    chunks.push(
+      `data: ${JSON.stringify({
+        id,
+        object: 'chat.completion.chunk',
+        created,
+        model,
+        choices: [{ index: 0, delta: { content: REPLY_TOKEN }, finish_reason: null }],
+      })}\n\n`,
+    )
+  }
+
+  // Final delta — finish_reason + usage. OpenAI puts usage on the
+  // chunk *before* [DONE]; the proxy parser depends on this layout.
+  chunks.push(
+    `data: ${JSON.stringify({
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model,
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      usage: {
+        prompt_tokens: promptTokens,
+        completion_tokens: tokenCount,
+        total_tokens: promptTokens + tokenCount,
+      },
+    })}\n\n`,
+  )
+
+  chunks.push('data: [DONE]\n\n')
+  return chunks
+}
+
+/** Body collector with a guard so a runaway payload can't exhaust memory. */
+async function readBody(req: import('node:http').IncomingMessage): Promise<string> {
+  const MAX_BYTES = 1024 * 1024 // 1MB cap is more than enough for chat completions
+  let received = 0
+  const chunks: Buffer[] = []
+  for await (const chunk of req) {
+    const buf = chunk as Buffer
+    received += buf.byteLength
+    if (received > MAX_BYTES) {
+      throw new Error(`mock-openai: request body exceeded ${MAX_BYTES} bytes`)
+    }
+    chunks.push(buf)
+  }
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+const server = createServer(async (req, res) => {
+  // Health probe for the docker compose healthcheck.
+  if (req.method === 'GET' && req.url === '/health') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
+    res.end('ok')
+    return
+  }
+
+  // Anything not /v1/chat/completions just 404s — we don't ship the
+  // surface area we don't need until a test asks for it.
+  if (req.method !== 'POST' || req.url !== '/v1/chat/completions') {
+    res.writeHead(404, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ error: { message: 'Not implemented in mock-openai', type: 'not_found' } }))
+    return
+  }
+
+  let parsed: ChatRequest
+  try {
+    const raw = await readBody(req)
+    parsed = JSON.parse(raw) as ChatRequest
+  } catch (err) {
+    res.writeHead(400, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ error: { message: err instanceof Error ? err.message : 'bad request', type: 'invalid_request_error' } }))
+    return
+  }
+
+  if (parsed.stream) {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    })
+    for (const chunk of buildStreamChunks(parsed)) {
+      res.write(chunk)
+    }
+    res.end()
+    return
+  }
+
+  res.writeHead(200, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify(buildSingleResponse(parsed)))
+})
+
+server.listen(PORT, () => {
+  // eslint-disable-next-line no-console -- this is a script entry point, not application code
+  console.log(`[mock-openai] listening on http://localhost:${PORT}`)
+})

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,12 +1,32 @@
-# 로컬 개발용 Docker Compose
-# 공식 셀프호스팅 배포는 Phase 2E에서 별도 구성
+# 로컬 개발용 Docker Compose — R-23 통합 dev stack (Sprint 3-4).
 #
-# 사용법:
-#   docker compose up -d
-#   docker compose down
+# 사용법
+#   docker compose -f docker-compose.dev.yml up -d
+#   docker compose -f docker-compose.dev.yml down -v   # -v로 volume까지 정리
 #
-# 참고: Supabase는 `supabase start`(CLI)를 권장.
-# 이 파일은 CI 환경 또는 Docker만 사용하는 경우를 위한 대안.
+# 무엇을 포함하나 / 무엇을 포함 안 하나
+#
+#   포함:
+#     - server     (apps/server, Hono, tsx-watch)
+#     - db         (Postgres 17 — production과 메이저 버전 매칭, gotcha #16)
+#     - clickhouse (ClickHouse 24.10-alpine — requests 로그 전용)
+#     - mock-openai (R-3 E2E용 mock LLM, scripts/mock-openai-server.ts)
+#
+#   포함 안 함 (의도적):
+#     - GoTrue + Kong + Supabase Studio — 로컬은 `supabase start` CLI가
+#       표준 (CLAUDE.md "supabase start" 권장). dev compose에서 이 셋을
+#       관리하면 supabase CLI와 두 가지 진실의 출처가 됨. CI에서도
+#       `supabase start`를 sidecar로 띄우는 게 supabase 팀이 유지하는
+#       세팅 그대로라 깨질 일 적음.
+#     - web (apps/web)            — `pnpm --filter web dev`로 직접 실행.
+#       Next.js dev server는 hot reload + RSC 변경 감지가 컨테이너 외부
+#       실행이 훨씬 빠름.
+#
+# 환경 변수 (.env 또는 export)
+#   필수: SUPABASE_URL / SUPABASE_ANON_KEY / SUPABASE_SERVICE_ROLE_KEY /
+#         ENCRYPTION_KEY
+#   ClickHouse(컨테이너): 아래 service 안에서 자동 설정 (외부 .env 불필요)
+#   Mock OpenAI: 자동 (port 4000)
 
 version: '3.9'
 
@@ -23,11 +43,24 @@ services:
       SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY}
       SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      # R-23: server가 in-network ClickHouse를 가리키게. spanlens DB와
+      # default user/password는 아래 clickhouse service 환경변수와 일치.
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_USER: spanlens
+      CLICKHOUSE_PASSWORD: spanlens_dev_password
+      CLICKHOUSE_DB: spanlens
+      # E2E 모드에서 mock OpenAI를 LLM upstream으로 사용. proxy가 실제
+      # OpenAI API에 도달하지 않게 하려면 OPENAI_API_BASE를 mock-openai
+      # service URL로 override. 평상시 dev에선 unset 두면 진짜 OpenAI.
+      OPENAI_API_BASE: ${OPENAI_API_BASE:-}
     volumes:
       - ./apps/server/src:/app/src
     restart: unless-stopped
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
     # R-22: readiness probe — same endpoint Vercel preview / production
     # docker invocations use. /health/ready pings Postgres + ClickHouse +
     # Upstash (Upstash 'skipped' is OK), so a half-broken container shows
@@ -47,7 +80,12 @@ services:
       start_period: 30s
 
   db:
-    image: postgres:15-alpine
+    # R-23: production은 Postgres 17 (gotcha #16). dev도 17로 맞춰서
+    # major-version skew로 인한 SQL/feature 차이 없게. supabase/postgres
+    # 이미지는 extension까지 포함이라 supabase CLI 환경과 동일하지만
+    # 별도 dependency가 무거우므로 plain alpine으로 시작 — extension
+    # 필요해지면 image만 supabase/postgres:17.x로 swap.
+    image: postgres:17-alpine
     ports:
       - '54322:5432'
     environment:
@@ -62,5 +100,61 @@ services:
       timeout: 5s
       retries: 5
 
+  clickhouse:
+    # R-23: requests 테이블 호스트. production은 ClickHouse Cloud
+    # Development tier, dev/CI는 컨테이너로 충분 (CLAUDE.md DB 작업
+    # 규칙 참조). 24.10은 production tier가 사용하는 메이저 라인.
+    image: clickhouse/clickhouse-server:24.10-alpine
+    ports:
+      - '8123:8123'  # HTTP — server가 사용
+      - '9000:9000'  # native protocol — clickhouse-client / tooling
+    environment:
+      CLICKHOUSE_DB: spanlens
+      CLICKHOUSE_USER: spanlens
+      CLICKHOUSE_PASSWORD: spanlens_dev_password
+      # dev에서 임의 SQL을 빠르게 시도할 수 있게 default user 권한 풀어둠.
+      # production 이미지엔 들어가지 않게 분리된 dev compose 파일.
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: '1'
+    volumes:
+      - clickhouse_data:/var/lib/clickhouse
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    healthcheck:
+      # ClickHouse는 HTTP 8123에 GET /ping → "Ok." 200을 반환.
+      # node -e fetch 패턴은 ClickHouse 컨테이너에 node가 없어 사용 불가
+      # — wget은 alpine ClickHouse 이미지에 포함되어 있음.
+      test: ['CMD-SHELL', 'wget -q -O - http://localhost:8123/ping | grep -q Ok']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
+  mock-openai:
+    # R-3 E2E용 OpenAI-compatible mock. server의 OPENAI_API_BASE를
+    # http://mock-openai:4000/v1로 override하면 실제 OpenAI API에 비용
+    # 없이 E2E를 돌릴 수 있다. 평상시 dev에선 OPENAI_API_BASE를 비워두면
+    # 진짜 OpenAI로 갑니다 (이 컨테이너는 그래도 띄우지만 traffic이 안 옴).
+    build:
+      context: ./apps/server
+      dockerfile: Dockerfile.dev
+    command: ['pnpm', 'exec', 'tsx', 'scripts/mock-openai-server.ts']
+    ports:
+      - '4000:4000'
+    environment:
+      MOCK_OPENAI_PORT: 4000
+    volumes:
+      - ./apps/server/scripts:/app/scripts
+    healthcheck:
+      test:
+        - 'CMD-SHELL'
+        - "node -e \"fetch('http://localhost:4000/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
 volumes:
   postgres_data:
+  clickhouse_data:


### PR DESCRIPTION
## What

R-3 / R-23 Sprint 3 Step 1+2 (1/2 in the series). Brings the local dev/CI stack to "one command" parity: a single `docker compose -f docker-compose.dev.yml up -d` brings up Postgres 17 + ClickHouse + Hono server + mock OpenAI endpoint so E2E tests run against a closed loop without real OpenAI traffic or budget.

## Services in docker-compose.dev.yml

| Service | Image | Why |
|---|---|---|
| `db` | `postgres:17-alpine` | Production parity (gotcha #16). Was 15 — major-version skew risk |
| `clickhouse` | `clickhouse/clickhouse-server:24.10-alpine` | requests log host |
| `server` | local build (Dockerfile.dev) | Hono, depends on db + clickhouse `service_healthy` |
| `mock-openai` | local build (runs `scripts/mock-openai-server.ts`) | OpenAI-compatible stub for E2E |

## Mock OpenAI surface (apps/server/scripts/mock-openai-server.ts)

- `POST /v1/chat/completions`
  - `stream=false` → single JSON `{choices, usage}` with plausible token counts
  - `stream=true` → text/event-stream with one delta per token, usage on chunk before `[DONE]` (matches what `parsers/openai.ts` expects)
- `GET /health` for docker healthcheck

Hand-written Node over mockoon because (a) streaming token counts must follow request shape so cost math stays plausible end-to-end, (b) zero new dependencies — `tsx` already runs in dev.

## Explicitly NOT in this PR

- GoTrue / Kong / Supabase Studio — local dev uses `supabase start` (CLAUDE.md standard). Bundling these creates two sources of truth and breaks on supabase CLI updates. CI sidecars `supabase start` separately
- `apps/web` — runs faster outside the container (Next.js hot reload + RSC)
- Mock OpenAI auth, tool-calls, vision, error injection — R-3 follow-up

## Verification

File-level only (actual container boot requires Docker Desktop on operator's machine):
- `pnpm --filter server typecheck + lint`: clean
- `pnpm --filter server test`: 805 pass (unchanged)

Manual smoke recipe after merge:
```bash
docker compose -f docker-compose.dev.yml up -d
sleep 30
curl -s http://localhost:8123/ping            # → "Ok."
curl -s http://localhost:4000/health           # → "ok"
curl -s -X POST http://localhost:4000/v1/chat/completions   -H 'Content-Type: application/json'   -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'
docker compose -f docker-compose.dev.yml down -v
```

## Follow-up (next PRs in this series)

- **Sprint 4 Step 1**: `apps/web/__e2e__/smoke.spec.ts` — signup → api key → proxy(mock-openai) → /requests dashboard
- **Sprint 4 Step 2**: `.github/workflows/e2e.yml` — runs the smoke spec against this docker stack in CI