### PR TITLE
feat(server): R-14 Sprint 5 — OTLP parent resolution async

### DIFF
--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -827,6 +827,82 @@ cronRouter.get('/self-monitor', async (c) => {
   }
 })
 
+// GET /cron/detect-orphan-spans
+// R-14 (Sprint 5/6) watchdog. The `orphan-span-link` background migration
+// is supposed to resolve external_parent_span_id → parent_span_id for OTLP
+// spans whose parent arrived in a later batch. If that job is stuck (lock
+// stolen by a crashed worker, registry mismatch, or just genuinely too
+// many orphans for the chunk budget) we want a single internal_alerts row
+// rather than silent data drift.
+//
+// Threshold logic: count orphans older than 1h (anything younger may still
+// be in flight from a recently-arrived sibling batch). Alert when the
+// count exceeds 100 — picked low enough that a real backlog surfaces fast,
+// high enough that one slow OTLP batch doesn't page the operator.
+// Dedup against unresolved alerts of the same kind so the operator gets
+// one chip, not one per cron tick.
+cronRouter.get('/detect-orphan-spans', async (c) => {
+  const authFail = assertCronAuth(c.req.header('Authorization'))
+  if (authFail) return c.json({ error: authFail }, 401)
+
+  const start = Date.now()
+  const THRESHOLD = 100
+  const olderThan = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+
+  try {
+    const { count, error: countError } = await supabaseAdmin
+      .from('spans')
+      .select('id', { count: 'exact', head: true })
+      .is('parent_span_id', null)
+      .not('external_parent_span_id', 'is', null)
+      .lt('created_at', olderThan)
+
+    if (countError) {
+      logCronRun('detect-orphan-spans', 'error', Date.now() - start, countError.message).catch(console.error)
+      return c.json({ ok: false, error: countError.message }, 500)
+    }
+
+    const orphanCount = count ?? 0
+
+    if (orphanCount <= THRESHOLD) {
+      logCronRun('detect-orphan-spans', 'ok', Date.now() - start).catch(console.error)
+      return c.json({ ok: true, count: orphanCount, threshold: THRESHOLD, alerted: false })
+    }
+
+    const { data: existing } = await supabaseAdmin
+      .from('internal_alerts')
+      .select('id')
+      .eq('kind', 'orphan_spans')
+      .is('resolved_at', null)
+      .limit(1)
+      .maybeSingle()
+
+    if (existing) {
+      logCronRun('detect-orphan-spans', 'ok', Date.now() - start).catch(console.error)
+      return c.json({ ok: true, count: orphanCount, threshold: THRESHOLD, alerted: false, deduped: true, existing_alert_id: existing.id })
+    }
+
+    const { error: insertError } = await supabaseAdmin.from('internal_alerts').insert({
+      kind: 'orphan_spans',
+      severity: 'warn',
+      message: `${orphanCount} orphan spans > 1h old (threshold ${THRESHOLD})`,
+      details: { count: orphanCount, threshold: THRESHOLD, older_than: olderThan },
+    })
+
+    if (insertError) {
+      logCronRun('detect-orphan-spans', 'error', Date.now() - start, `internal_alerts insert failed: ${insertError.message}`).catch(console.error)
+      return c.json({ ok: false, error: 'failed to insert alert' }, 500)
+    }
+
+    logCronRun('detect-orphan-spans', 'ok', Date.now() - start).catch(console.error)
+    return c.json({ ok: true, count: orphanCount, threshold: THRESHOLD, alerted: true })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    logCronRun('detect-orphan-spans', 'error', Date.now() - start, message).catch(console.error)
+    return c.json({ ok: false, error: message }, 500)
+  }
+})
+
 // All three steps run in parallel via Promise.allSettled — one slow / failing
 // dependency doesn't block the others, and we never throw (cron retries are
 // noisy and a transient warmup failure is not worth alerting on). No

--- a/apps/server/src/api/otlp.ts
+++ b/apps/server/src/api/otlp.ts
@@ -138,18 +138,18 @@ otlpRouter.post('/v1/traces', authApiKey, requireFullScope, async (c) => {
         }
       }
 
-      // ── 5. Resolve external parent → UUID parent links ─────────────
-      // link_otlp_span_parents() updates child.parent_span_id = parent.id
-      // by matching child.external_parent_span_id = parent.external_span_id
-      // within this trace. Only updates rows where parent_span_id IS NULL
-      // so the call is idempotent.
-      const { error: linkErr } = await supabaseAdmin.rpc('link_otlp_span_parents', {
-        p_trace_id: traceUuid,
-      })
-      if (linkErr) {
-        // Non-fatal: spans are still visible; just parent linkage is missing.
-        console.error('[otlp] link_otlp_span_parents failed:', linkErr.message)
-      }
+      // ── 5. Parent linkage runs asynchronously (R-14, Sprint 5) ─────
+      // The synchronous link_otlp_span_parents() RPC used to run here
+      // turned each OTLP batch into N+1 round-trips on the spans table.
+      // It now lives in the `orphan-span-link` background migration
+      // (registry/migrations/orphan-span-link.ts) which scans rows
+      // matching the spans_orphan_external_parent_idx in chunks. The
+      // RPC itself is still in the DB for one-shot reconciliation but
+      // no request path calls it. Children whose parent arrived in a
+      // later batch are visible immediately (rendered with a null
+      // parent until the background job runs, typically within minutes).
+      // The /cron/detect-orphan-spans cron alerts if the orphan count
+      // exceeds threshold so a stuck job is noticed quickly.
     } catch (err) {
       console.error('[otlp] unexpected error processing trace group:', externalTraceId, err)
       rejectedSpans += spans.length

--- a/apps/server/src/lib/background-migrations/registry/index.ts
+++ b/apps/server/src/lib/background-migrations/registry/index.ts
@@ -27,6 +27,7 @@ import { noopHealthcheck } from './migrations/noop-healthcheck.js'
 import { backfillEventsFromRequests } from './migrations/backfill-events-from-requests.js'
 import { backfillTracesFromSupabase } from './migrations/backfill-traces-from-supabase.js'
 import { backfillSpansFromSupabase } from './migrations/backfill-spans-from-supabase.js'
+import { orphanSpanLink } from './migrations/orphan-span-link.js'
 
 const REGISTRY = new Map<string, BackgroundMigration>([
   // Always-registered no-op so the cron has something to exercise on
@@ -46,6 +47,15 @@ const REGISTRY = new Map<string, BackgroundMigration>([
   //   name='backfill-spans-from-supabase'
   [backfillTracesFromSupabase.name, backfillTracesFromSupabase],
   [backfillSpansFromSupabase.name, backfillSpansFromSupabase],
+
+  // R-14 (Sprint 5) — resolve OTLP external_parent_span_id → UUID
+  // parent_span_id outside the request path. The OTLP receiver used
+  // to call link_otlp_span_parents() RPC synchronously, which added
+  // 50-200ms to every OTLP POST at hot traces. INSERT a row into
+  // `background_migrations` with name='orphan-span-link' to start it;
+  // the chunked scan reuses the `spans_orphan_external_parent_idx`
+  // partial index so each tick is cheap.
+  [orphanSpanLink.name, orphanSpanLink],
 ])
 
 export function getRegistry(): ReadonlyMap<string, BackgroundMigration> {

--- a/apps/server/src/lib/background-migrations/registry/migrations/orphan-span-link.test.ts
+++ b/apps/server/src/lib/background-migrations/registry/migrations/orphan-span-link.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock supabaseAdmin before importing the SUT so the import-time
+// closure binds to our stub. The mock returns a stack of chainable
+// builders so each call to `supabaseAdmin.from('spans')` consumes
+// one queued response. Tests script the response sequence per case.
+type Builder = {
+  select: ReturnType<typeof vi.fn>
+  is: ReturnType<typeof vi.fn>
+  not: ReturnType<typeof vi.fn>
+  gt: ReturnType<typeof vi.fn>
+  order: ReturnType<typeof vi.fn>
+  limit: ReturnType<typeof vi.fn>
+  eq: ReturnType<typeof vi.fn>
+  maybeSingle: ReturnType<typeof vi.fn>
+  update: ReturnType<typeof vi.fn>
+  then: (resolve: (value: unknown) => void) => void
+}
+
+type Response = { data?: unknown; error?: { message: string } | null }
+
+let responseQueue: Response[] = []
+const updateCalls: { id: string; parent_span_id: string }[] = []
+
+function makeBuilder(): Builder {
+  const builder = {} as Builder
+  builder.select = vi.fn(() => builder)
+  builder.is = vi.fn(() => builder)
+  builder.not = vi.fn(() => builder)
+  builder.gt = vi.fn(() => builder)
+  builder.order = vi.fn(() => builder)
+  builder.limit = vi.fn(() => {
+    const next = responseQueue.shift() ?? { data: [], error: null }
+    return Promise.resolve(next) as unknown as Builder
+  })
+  builder.eq = vi.fn(() => builder)
+  builder.maybeSingle = vi.fn(() => {
+    const next = responseQueue.shift() ?? { data: null, error: null }
+    return Promise.resolve(next)
+  })
+  builder.update = vi.fn((payload: { parent_span_id: string }) => {
+    return {
+      eq: (_col: string, id: string) => {
+        updateCalls.push({ id, parent_span_id: payload.parent_span_id })
+        const next = responseQueue.shift() ?? { error: null }
+        return Promise.resolve(next)
+      },
+    } as unknown as Builder
+  })
+  return builder
+}
+
+vi.mock('../../../db.js', () => ({
+  supabaseAdmin: {
+    from: vi.fn(() => makeBuilder()),
+  },
+}))
+
+import { orphanSpanLink } from './orphan-span-link.js'
+
+describe('orphan-span-link background migration', () => {
+  beforeEach(() => {
+    responseQueue = []
+    updateCalls.length = 0
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns done:true when no orphan rows remain', async () => {
+    responseQueue.push({ data: [], error: null })
+    const result = await orphanSpanLink.runChunk({})
+    expect(result).toEqual({ done: true })
+  })
+
+  it('links an orphan to its parent when both share a trace', async () => {
+    // 1st .limit() — orphan SELECT
+    responseQueue.push({
+      data: [
+        {
+          id: 'child-1',
+          trace_id: 'trace-A',
+          external_parent_span_id: 'otel-parent-A',
+        },
+      ],
+      error: null,
+    })
+    // 2nd response — maybeSingle() parent lookup
+    responseQueue.push({ data: { id: 'parent-uuid-1' }, error: null })
+    // 3rd response — update().eq()
+    responseQueue.push({ error: null })
+
+    const result = await orphanSpanLink.runChunk({})
+    expect(result.done).toBe(false)
+    if (result.done === false) {
+      expect((result.state as { matched: number }).matched).toBe(1)
+      expect((result.state as { lastId: string }).lastId).toBe('child-1')
+    }
+    expect(updateCalls).toEqual([
+      { id: 'child-1', parent_span_id: 'parent-uuid-1' },
+    ])
+  })
+
+  it('leaves orphans whose parent has not arrived yet — does NOT throw', async () => {
+    responseQueue.push({
+      data: [
+        {
+          id: 'child-2',
+          trace_id: 'trace-B',
+          external_parent_span_id: 'otel-missing-B',
+        },
+      ],
+      error: null,
+    })
+    // maybeSingle() returns null — parent not ingested yet
+    responseQueue.push({ data: null, error: null })
+
+    const result = await orphanSpanLink.runChunk({})
+    expect(result.done).toBe(false)
+    if (result.done === false) {
+      expect((result.state as { matched: number }).matched).toBe(0)
+      expect((result.state as { scanned: number }).scanned).toBe(1)
+    }
+    expect(updateCalls).toEqual([])
+  })
+
+  it('advances cursor.lastId so the next chunk does not rescan the same row', async () => {
+    responseQueue.push({
+      data: [
+        { id: 'a', trace_id: 't', external_parent_span_id: 'x' },
+        { id: 'b', trace_id: 't', external_parent_span_id: 'y' },
+      ],
+      error: null,
+    })
+    responseQueue.push({ data: null, error: null }) // a's parent miss
+    responseQueue.push({ data: null, error: null }) // b's parent miss
+
+    const result = await orphanSpanLink.runChunk({ lastId: '0' })
+    expect(result.done).toBe(false)
+    if (result.done === false) {
+      expect((result.state as { lastId: string }).lastId).toBe('b')
+    }
+  })
+
+  it('throws when the orphan SELECT errors so the runner can mark failed', async () => {
+    responseQueue.push({ data: null, error: { message: 'network down' } })
+    await expect(orphanSpanLink.runChunk({})).rejects.toThrow(/network down/)
+  })
+})

--- a/apps/server/src/lib/background-migrations/registry/migrations/orphan-span-link.ts
+++ b/apps/server/src/lib/background-migrations/registry/migrations/orphan-span-link.ts
@@ -1,0 +1,121 @@
+import type { BackgroundMigration, ChunkResult, ChunkState } from '../../index.js'
+import { supabaseAdmin } from '../../../db.js'
+
+/**
+ * R-14 (Sprint 5) — resolve OTLP `external_parent_span_id` → Spanlens
+ * `parent_span_id` UUID outside the request path.
+ *
+ * Why a background migration: the OTLP receiver used to call the
+ * `link_otlp_span_parents()` RPC after every batch insert. That RPC
+ * scanned the spans table for the trace and updated children whose
+ * parent had just been inserted. At hot traces (multi-thousand spans)
+ * this added ~50-200ms to every OTLP POST and showed up in p95.
+ *
+ * The fix: insert spans without resolving the linkage, then let a
+ * chunked job scan `spans_orphan_external_parent_idx` (partial index
+ * on `external_parent_span_id IS NOT NULL AND parent_span_id IS NULL`)
+ * and patch them in batches. The eventual consistency window is
+ * typically a single 5-minute cron tick — children render with a
+ * temporary null parent until then, which the UI already tolerates
+ * (parallel agent spans have unfilled parents legitimately).
+ *
+ * Idempotency: the SELECT skips rows whose `parent_span_id` is already
+ * set, and the UPDATE only runs when we find a matching parent in the
+ * same trace. A chunk that re-runs after a crash sees the patched rows
+ * absent from the orphan scan and resumes from the next id.
+ *
+ * Cursor: keyset on `spans.id` (UUID v4). We carry the last id we
+ * processed and resume strictly above it. Two corner cases:
+ *
+ *   • Orphans created AFTER the cursor's start: picked up on the next
+ *     full pass once `lastId` rolls back to null at done=true.
+ *   • Orphans whose parent simply never arrived (dropped batch): they
+ *     stay unmatched forever, which is the desired behaviour — the
+ *     /cron/detect-orphan-spans cron alerts when too many accumulate.
+ */
+
+interface Cursor {
+  lastId: string
+  scanned: number
+  matched: number
+}
+
+const CHUNK_SIZE = 500
+const ZERO_UUID = '00000000-0000-0000-0000-000000000000'
+
+function readCursor(state: ChunkState): Cursor {
+  return {
+    lastId: typeof state['lastId'] === 'string' ? (state['lastId'] as string) : ZERO_UUID,
+    scanned: typeof state['scanned'] === 'number' ? (state['scanned'] as number) : 0,
+    matched: typeof state['matched'] === 'number' ? (state['matched'] as number) : 0,
+  }
+}
+
+interface OrphanRow {
+  id: string
+  trace_id: string
+  external_parent_span_id: string
+}
+
+export const orphanSpanLink: BackgroundMigration = {
+  name: 'orphan-span-link',
+  description:
+    'R-14 — resolve OTLP external_parent_span_id → parent_span_id UUID outside the OTLP request path. Chunks of ' +
+    CHUNK_SIZE +
+    ' orphan spans.',
+
+  async runChunk(state: ChunkState): Promise<ChunkResult> {
+    const cursor = readCursor(state)
+
+    const { data, error } = await supabaseAdmin
+      .from('spans')
+      .select('id, trace_id, external_parent_span_id')
+      .is('parent_span_id', null)
+      .not('external_parent_span_id', 'is', null)
+      .gt('id', cursor.lastId)
+      .order('id', { ascending: true })
+      .limit(CHUNK_SIZE)
+
+    if (error) {
+      throw new Error(`orphan-span-link select failed: ${error.message}`)
+    }
+
+    const rows = (data ?? []) as OrphanRow[]
+    if (rows.length === 0) return { done: true }
+
+    let matched = 0
+    for (const row of rows) {
+      // Lookup the parent within the same trace by the OTel span_id.
+      // maybeSingle() returns null silently if the parent hasn't been
+      // ingested yet — that's expected for a chunk that races a still
+      // arriving OTLP batch, the next pass will pick the orphan up.
+      const { data: parent } = await supabaseAdmin
+        .from('spans')
+        .select('id')
+        .eq('trace_id', row.trace_id)
+        .eq('external_span_id', row.external_parent_span_id)
+        .maybeSingle()
+
+      if (parent) {
+        const { error: updateError } = await supabaseAdmin
+          .from('spans')
+          .update({ parent_span_id: parent.id })
+          .eq('id', row.id)
+        if (!updateError) matched++
+      }
+    }
+
+    const lastRow = rows[rows.length - 1]!
+    const nextCursor: Cursor = {
+      lastId: lastRow.id,
+      scanned: cursor.scanned + rows.length,
+      matched: cursor.matched + matched,
+    }
+
+    return {
+      done: false,
+      state: nextCursor as unknown as ChunkState,
+      progressCurrent: nextCursor.scanned,
+    }
+  },
+}

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -23,6 +23,7 @@
     { "path": "/cron/events-reconciliation",      "schedule": "0 2 * * *" },
     { "path": "/cron/detect-missing-model-prices","schedule": "0 * * * *" },
     { "path": "/cron/self-monitor",               "schedule": "31 * * * *" },
+    { "path": "/cron/detect-orphan-spans",        "schedule": "17 * * * *" },
     { "path": "/cron/keep-warm",                  "schedule": "*/5 * * * *" }
   ]
 }

--- a/supabase/migrations/20260609140000_spans_orphan_index.sql
+++ b/supabase/migrations/20260609140000_spans_orphan_index.sql
@@ -1,0 +1,21 @@
+-- Migration: spans_orphan_index
+-- Purpose: Partial index for fast lookup of orphan spans — spans whose
+-- OTLP parent (external_parent_span_id) is set but whose Spanlens
+-- parent_span_id UUID is still NULL.
+--
+-- Need: R-14 (Sprint 5) removes the synchronous link_otlp_span_parents()
+-- RPC call from the OTLP receiver. Instead a background_migrations job
+-- `orphan-span-link` scans for these rows in chunks and a cron
+-- (`/cron/detect-orphan-spans`) alerts if too many accumulate. Both
+-- workflows scan `WHERE external_parent_span_id IS NOT NULL AND
+-- parent_span_id IS NULL`, which would otherwise be a full-table scan
+-- on the spans table.
+--
+-- Why partial: spans with parent_span_id already set are >99% of the
+-- table (parents typically arrive before children in OTLP batches that
+-- still hit the sync RPC). A partial index over only the orphan subset
+-- stays small (~MB-scale) even at trace-table sizes.
+
+CREATE INDEX IF NOT EXISTS spans_orphan_external_parent_idx
+  ON spans (external_parent_span_id)
+  WHERE external_parent_span_id IS NOT NULL AND parent_span_id IS NULL;


### PR DESCRIPTION
## Summary

Move `link_otlp_span_parents()` out of the OTLP receiver's request path into a chunked background migration. The synchronous RPC was adding 50-200ms p95 to every OTLP POST on hot traces because it scanned the spans table after each batch insert.

After this PR:
- OTLP batches insert spans and return immediately (no RPC, no extra round-trip)
- `orphan-span-link` background migration scans `spans_orphan_external_parent_idx` partial index in 500-row chunks
- `/cron/detect-orphan-spans` watchdog alerts at >100 orphans older than 1h via existing `internal_alerts` kind

Sprint 5 R-14 Steps 1-5 complete. Sprint 6 owns the OTLP p95 verification + 7-day "orphan = 0" production check.

## Changes
- `supabase/migrations/20260609140000_spans_orphan_index.sql` — partial index on `(external_parent_span_id) WHERE external_parent_span_id IS NOT NULL AND parent_span_id IS NULL`
- `apps/server/src/api/otlp.ts` — remove sync RPC call after bulk insert
- `apps/server/src/lib/background-migrations/registry/migrations/orphan-span-link.ts` + `.test.ts` — chunked migration (500 rows, keyset cursor on `spans.id`, 5 tests)
- `apps/server/src/lib/background-migrations/registry/index.ts` — register `orphan-span-link`
- `apps/server/src/api/cron.ts` + `apps/server/vercel.json` — `/cron/detect-orphan-spans` handler + xx:17 hourly schedule

## Test plan
- [x] `pnpm --filter server typecheck` — green
- [x] `pnpm --filter server lint` — green
- [x] `pnpm --filter server test` — 810 passed (+5 orphan-span-link)
- [ ] CI green
- [ ] After merge: INSERT into `background_migrations` (name='orphan-span-link', status='pending') in production
- [ ] After merge: monitor `/cron/detect-orphan-spans` for 24h — alert should stay quiet
- [ ] Sprint 6: verify OTLP p95 dropped ≥30% in Sentry transaction view