### PR TITLE
feat(web): R-26 + R-33 Sprint 5 — share viewer IOPreview + permalink + OG meta

### DIFF
--- a/apps/web/app/share/[token]/page.tsx
+++ b/apps/web/app/share/[token]/page.tsx
@@ -13,6 +13,50 @@ interface SharePayload {
   payload: unknown
 }
 
+/**
+ * Canonical site URL — used for the share permalink + OG image base.
+ * WEB_URL is the same env var the server-side notification code uses
+ * (see CLAUDE.md "도메인 & CORS 정책"). NEXT_PUBLIC_WEB_URL is the
+ * fallback for branch deploys where only the public version is set.
+ */
+function siteUrl(): string {
+  return (
+    process.env.WEB_URL ??
+    process.env.NEXT_PUBLIC_WEB_URL ??
+    'https://www.spanlens.io'
+  )
+}
+
+/**
+ * Pull a human-readable preview snippet from the share payload so the
+ * OG `description` actually represents the content. The share API
+ * already returns redacted payloads when the share is non-indexable,
+ * so this snippet is safe to publish (PII-scrubbed at the source).
+ *
+ * Cap at 140 chars so the result fits Twitter card constraints and
+ * social previews don't truncate mid-sentence.
+ */
+function previewDescription(share: SharePayload): string {
+  const fallback = 'A shared LLM trace observed by Spanlens.'
+  const payload = share.payload
+  if (!payload || typeof payload !== 'object') return fallback
+
+  if (share.scope === 'trace') {
+    const t = payload as { name?: string | null; status?: string | null }
+    if (t.name) return `${t.name}${t.status ? ` (${t.status})` : ''}`.slice(0, 140)
+  }
+  if (share.scope === 'request') {
+    const r = payload as { provider?: string; model?: string; status_code?: number }
+    if (r.provider && r.model) {
+      return `${r.provider} · ${r.model}${r.status_code ? ` · ${r.status_code}` : ''}`.slice(
+        0,
+        140,
+      )
+    }
+  }
+  return fallback
+}
+
 // SSR fetch: the share viewer renders read-only data, so we render the entire
 // page on the server. No client-side query / no auth. Falls back to notFound()
 // on any non-2xx so 404 / 410 / 500 all funnel through Next.js's not-found
@@ -48,10 +92,38 @@ export async function generateMetadata({
     ? { index: true, follow: true }
     : { index: false, follow: false }
   const scope = share?.scope === 'request' ? 'Request' : 'Trace'
+  const title = share ? `Shared ${scope} · Spanlens` : 'Share · Spanlens'
+  const description = share ? previewDescription(share) : 'A shared LLM trace observed by Spanlens.'
+  const url = `${siteUrl()}/share/${encodeURIComponent(token)}`
+
+  // R-26 Sprint 5: emit OG + Twitter card metadata so the share link
+  // produces a useful preview when posted to Slack, X, LinkedIn, etc.
+  // We intentionally do NOT set `openGraph.images` yet — there is no
+  // canonical share preview asset in /public, and pointing at a path
+  // that 404s makes Slack/X show a broken-image card (worse than no
+  // image, which falls back to the site favicon). Sprint 6 owns either
+  // a static `/og-share.png` upload or a dynamic `/api/og-image` route
+  // that renders a per-trace summary card via vercel/og. The current
+  // metadata still drives a clean text card with title + description.
   return {
-    title: share ? `Shared ${scope} · Spanlens` : 'Share · Spanlens',
-    description: 'A shared LLM trace observed by Spanlens.',
+    title,
+    description,
     robots,
+    alternates: {
+      canonical: url,
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: 'Spanlens',
+      type: 'article',
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
   }
 }
 
@@ -73,5 +145,12 @@ export default async function ShareTokenPage({
   const share = await fetchShare(token)
   if (!share) notFound()
 
-  return <ShareView share={share} />
+  // Build the permalink server-side so the CopyPermalink button doesn't
+  // touch `window.location` at first render — share-view.tsx is a Client
+  // Component but the very first hydration pass runs both SSR and CSR,
+  // and `window` is undefined in SSR. Passing the URL down explicitly
+  // keeps the two passes identical (no React hydration mismatch).
+  const permalink = `${siteUrl()}/share/${encodeURIComponent(token)}`
+
+  return <ShareView share={{ ...share, permalink }} />
 }

--- a/apps/web/app/share/[token]/share-view.tsx
+++ b/apps/web/app/share/[token]/share-view.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import Link from 'next/link'
+import { IOPreview } from '@/components/share/io-preview'
+import { CopyPermalink } from '@/components/share/copy-permalink'
 
 interface ShareViewProps {
   share: {
@@ -12,6 +14,10 @@ interface ShareViewProps {
     /** PLG Loop ② — true only when the share's org is on team+ and opted out. */
     hidePoweredBy?: boolean
     payload: unknown
+    /** R-26 Sprint 5: canonical share URL passed from the SSR page so
+     *  the CopyPermalink button doesn't read window.location at first
+     *  render (would crash SSR). */
+    permalink?: string
   }
 }
 
@@ -100,8 +106,11 @@ function ShareHeader({ share }: ShareViewProps) {
             Shared {share.scope}
           </span>
         </div>
-        <div className="font-mono text-[11px] text-text-muted">
-          {share.viewCount} {share.viewCount === 1 ? 'view' : 'views'} · expires {expiresLabel}
+        <div className="flex items-center gap-3">
+          <div className="font-mono text-[11px] text-text-muted">
+            {share.viewCount} {share.viewCount === 1 ? 'view' : 'views'} · expires {expiresLabel}
+          </div>
+          {share.permalink ? <CopyPermalink url={share.permalink} /> : null}
         </div>
       </div>
     </header>
@@ -212,17 +221,14 @@ function SpanRow({ span, isCritical }: { span: SharedSpan; isCritical: boolean }
           {span.total_tokens != null && <span>{span.total_tokens} tok</span>}
         </div>
       </summary>
-      <div className="px-4 pb-4 border-t border-border space-y-3">
+      <div className="px-4 pb-4 border-t border-border space-y-3 pt-3">
         {span.error_message && (
           <div className="font-mono text-[11.5px] text-status-error whitespace-pre-wrap">
             {span.error_message}
           </div>
         )}
-        {span.input != null && (
-          <JsonBlock label="Input" value={span.input} />
-        )}
-        {span.output != null && (
-          <JsonBlock label="Output" value={span.output} />
+        {(span.input != null || span.output != null) && (
+          <IOPreview input={span.input} output={span.output} />
         )}
       </div>
     </details>
@@ -274,11 +280,13 @@ function RequestView({ payload }: { payload: SharedRequestPayload }) {
         </div>
       )}
 
-      {payload.request_body != null && (
-        <JsonBlock label="Request" value={payload.request_body} />
-      )}
-      {payload.response_body != null && (
-        <JsonBlock label="Response" value={payload.response_body} />
+      {(payload.request_body != null || payload.response_body != null) && (
+        <IOPreview
+          input={payload.request_body}
+          output={payload.response_body}
+          inputLabel="Request"
+          outputLabel="Response"
+        />
       )}
     </div>
   )
@@ -295,17 +303,6 @@ function Stat({ label, value }: { label: string; value: string }) {
   )
 }
 
-function JsonBlock({ label, value }: { label: string; value: unknown }) {
-  const text =
-    typeof value === 'string' ? value : JSON.stringify(value, null, 2)
-  return (
-    <div>
-      <div className="text-[10px] uppercase tracking-wider text-text-muted mb-2">
-        {label}
-      </div>
-      <pre className="bg-bg-elevated border border-border rounded-md p-3 font-mono text-[11.5px] overflow-x-auto whitespace-pre-wrap break-words">
-        {text}
-      </pre>
-    </div>
-  )
-}
+// JsonBlock was replaced by IOPreview (R-26 Sprint 5) — input/output now
+// render side-by-side on desktop. The legacy single-pane component had no
+// remaining call sites; removed to keep this file focused.

--- a/apps/web/components/share/copy-permalink.tsx
+++ b/apps/web/components/share/copy-permalink.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useState } from 'react'
+
+/**
+ * CopyPermalink — small button in the share viewer header that copies
+ * the current URL to the clipboard. Shows a transient "Copied" state
+ * so the user knows the click landed without us shipping a toast lib.
+ *
+ * Why we don't read `window.location.href` lazily: the share page is
+ * fully SSR (no auth on the public token), so `window` would crash
+ * the first render. The page passes the canonical URL down explicitly
+ * (computed from the token + WEB_URL env) so SSR and CSR agree.
+ *
+ * Fallback path: if `navigator.clipboard.writeText` rejects (older
+ * Safari over http, blocked permissions), we surface a tiny "Press
+ * Ctrl+C" hint that lets the user select the URL from a visible input.
+ * Pure progressive enhancement — the button never throws.
+ */
+export function CopyPermalink({ url }: { url: string }) {
+  const [state, setState] = useState<'idle' | 'copied' | 'fallback'>('idle')
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(url)
+      setState('copied')
+      setTimeout(() => setState('idle'), 1800)
+    } catch {
+      setState('fallback')
+      setTimeout(() => setState('idle'), 4000)
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="px-2 py-1 rounded text-[11px] font-mono border border-border hover:bg-bg-elevated transition-colors"
+        aria-label="Copy permalink to this shared view"
+      >
+        {state === 'copied' ? 'Copied' : 'Copy link'}
+      </button>
+      {state === 'fallback' ? (
+        <input
+          readOnly
+          value={url}
+          onFocus={(e) => e.currentTarget.select()}
+          className="text-[10.5px] font-mono px-1 py-0.5 border border-border rounded bg-bg-elevated max-w-[200px]"
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/components/share/io-preview.tsx
+++ b/apps/web/components/share/io-preview.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+/**
+ * IOPreview — input / output split panel for the public share viewer.
+ *
+ * R-26 + R-33 (Sprint 5) goal: make the `/share/:token` page render LLM
+ * I/O the way a non-Spanlens reader expects to scan it — input on the
+ * left, output on the right, side-by-side on desktop. The previous
+ * `<JsonBlock>` rendering stacked them vertically inside a `<details>`,
+ * which made comparison awkward on a marketing-grade share link.
+ *
+ * Layout:
+ *   - Desktop (md+): `grid-cols-2` so input and output sit at equal
+ *     widths and scroll independently.
+ *   - Mobile (<md): single column, output below input. Tailwind's
+ *     `md:grid-cols-2 grid-cols-1` defers to the smaller breakpoint
+ *     by default — no JS to thrash on resize.
+ *
+ * JSON pretty rendering: we keep the simple `<pre>` rendering instead
+ * of pulling in `react-json-view` (113 KB unpacked, requires `'use
+ * client'` deep in the tree and ships React 18 peer dep that conflicts
+ * with our React 19 install). The whitespace-pre-wrap + monospace gets
+ * 95% of the visual benefit with no bundle cost. Depth-5+ nested
+ * payloads render fine — JSON.stringify(value, null, 2) indents every
+ * level uniformly and the container scrolls horizontally if needed.
+ *
+ * Empty values: when one side is null/undefined, we still render the
+ * panel with a "—" placeholder so the grid keeps a stable 2-column
+ * shape (otherwise the remaining panel snaps to full width and the
+ * layout shifts when the user toggles span details).
+ */
+
+interface IOPreviewProps {
+  input: unknown
+  output: unknown
+  /** Optional small label above each pane — defaults to "Input"/"Output". */
+  inputLabel?: string
+  outputLabel?: string
+}
+
+function formatValue(value: unknown): string {
+  if (value == null) return '—'
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    // Circular ref or non-serialisable — fall back to a reasonable string.
+    return String(value)
+  }
+}
+
+export function IOPreview({
+  input,
+  output,
+  inputLabel = 'Input',
+  outputLabel = 'Output',
+}: IOPreviewProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+      <IOPane label={inputLabel} value={input} />
+      <IOPane label={outputLabel} value={output} />
+    </div>
+  )
+}
+
+function IOPane({ label, value }: { label: string; value: unknown }) {
+  const text = formatValue(value)
+  const isEmpty = value == null
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-wider text-text-muted mb-2">
+        {label}
+      </div>
+      <pre
+        className={
+          'bg-bg-elevated border border-border rounded-md p-3 font-mono text-[11.5px] overflow-x-auto whitespace-pre-wrap break-words max-h-[480px] overflow-y-auto ' +
+          (isEmpty ? 'text-text-muted italic' : '')
+        }
+      >
+        {text}
+      </pre>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

PLG Loop ① conversion strengthening. Scope is the **public `/share/:token` page only** — internal `/traces` and `/requests` viewers are untouched.

After this PR, a shared link rendered in Slack/X/LinkedIn has:
- Side-by-side Input | Output panels on desktop, stacked on mobile
- "Copy link" button next to the view count
- OG + Twitter card metadata with a description pulled from the redacted payload (trace name / provider+model)

Sprint 5 R-26 + R-33 Steps 1-2 complete. Sprint 6 owns Steps 3-5 (workspace `/shares` dashboard, `GET /api/v1/shares` list endpoint, redaction preset modal in share creation UX).

## Changes
- `apps/web/components/share/io-preview.tsx` (new) — split panel, `md:grid-cols-2` + mobile stacked, `max-h-[480px]` per pane
- `apps/web/components/share/copy-permalink.tsx` (new) — `clipboard.writeText` with copied state + Ctrl+C fallback
- `apps/web/app/share/[token]/share-view.tsx` — wire IOPreview into `SpanRow` + `RequestView`, drop legacy `JsonBlock`
- `apps/web/app/share/[token]/page.tsx` — `generateMetadata` openGraph + twitter, canonical URL alternate, `permalink` prop computed server-side

## Test plan
- [x] `pnpm --filter web typecheck` — green
- [x] `pnpm --filter web lint` — green
- [x] Scope guard — `git diff apps/web/app/(dashboard)/traces/ apps/web/components/traces/` = 0 lines
- [x] No copy/paste from Langfuse `web/src/components/trace/` (own implementation)
- [ ] CI green
- [ ] After merge: spot-check `/share/<existing-token>` on preview Vercel — IOPreview renders side-by-side on desktop, stacked on mobile (Chrome DevTools narrow viewport)
- [ ] `curl -A "Slackbot 1.0 (+https://api.slack.com/robots)" https://www.spanlens.io/share/<token>` includes `og:title` + `og:description`