### PR TITLE
feat(web): R-26 + R-33 Sprint 6 — shares dashboard + presets + org-scoped list API

### DIFF
--- a/apps/server/src/api/shares.ts
+++ b/apps/server/src/api/shares.ts
@@ -125,26 +125,83 @@ sharesRouter.post('/', async (c) => {
   return c.json({ success: true, data })
 })
 
-// GET /api/v1/shares — list active shares the caller created in this org.
+// GET /api/v1/shares — list shares in this org.
+//
+// Query params (all optional):
+//   scope:   'mine' (default) — shares the caller created
+//            'org'  — every active share in the org (workspace dashboard)
+//   sort:    'created' (default, desc) | 'views' (desc) | 'expires_soon' (asc, nulls last)
+//   include: 'revoked' to include soft-deleted rows (default: exclude)
+//
+// 'org' scope matches the DELETE handler's policy — any member can see / revoke
+// any share in their workspace. Default 'mine' keeps the existing per-user UX.
+//
+// Trace name enrichment: for scope='trace' rows we batch-fetch traces.name in a
+// single follow-up query. Request scope rows leave a `target_label` of
+// '<scope> <short_id>' since the names would require a separate ClickHouse round
+// trip (deferred to Sprint 7 if the UX warrants it).
 sharesRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
   if (!orgId) return c.json({ error: 'Organization not found' }, 404)
 
-  const { data, error } = await supabaseAdmin
-    .from('shared_links')
-    .select('id, token, scope, target_id, expires_at, redact_pii, redact_cost, redact_tokens, indexable, view_count, revoked_at, created_at')
-    .eq('organization_id', orgId)
-    .eq('created_by', userId)
-    .is('revoked_at', null)
-    .order('created_at', { ascending: false })
-    .limit(100)
+  const scope = c.req.query('scope') === 'org' ? 'org' : 'mine'
+  const sortParam = c.req.query('sort')
+  const includeRevoked = c.req.query('include') === 'revoked'
 
+  let query = supabaseAdmin
+    .from('shared_links')
+    .select(
+      'id, token, scope, target_id, expires_at, redact_pii, redact_cost, redact_tokens, indexable, view_count, revoked_at, created_at, created_by',
+    )
+    .eq('organization_id', orgId)
+    .limit(200)
+
+  if (scope === 'mine') query = query.eq('created_by', userId)
+  if (!includeRevoked) query = query.is('revoked_at', null)
+
+  if (sortParam === 'views') {
+    query = query.order('view_count', { ascending: false }).order('created_at', { ascending: false })
+  } else if (sortParam === 'expires_soon') {
+    // Nulls last so "never expires" rows do not flood the top of an expiry sort.
+    query = query.order('expires_at', { ascending: true, nullsFirst: false })
+  } else {
+    query = query.order('created_at', { ascending: false })
+  }
+
+  const { data, error } = await query
   if (error) {
     console.error('[shares:list] select failed:', error.message)
     return c.json({ error: 'Failed to list shares' }, 500)
   }
-  return c.json({ success: true, data: data ?? [] })
+
+  const rows = data ?? []
+
+  // Batch trace name enrichment. Avoid an N+1 round trip by collecting all
+  // trace target_ids and issuing one .in() query.
+  const traceIds = Array.from(
+    new Set(rows.filter((r) => r.scope === 'trace').map((r) => r.target_id)),
+  )
+  let traceNames = new Map<string, string | null>()
+  if (traceIds.length > 0) {
+    const { data: traces } = await supabaseAdmin
+      .from('traces')
+      .select('id, name')
+      .in('id', traceIds)
+      .eq('organization_id', orgId)
+    for (const t of traces ?? []) {
+      traceNames.set(t.id as string, (t.name as string | null) ?? null)
+    }
+  }
+
+  const enriched = rows.map((r) => {
+    const traceName = r.scope === 'trace' ? traceNames.get(r.target_id) ?? null : null
+    const shortId = r.target_id.slice(0, 8)
+    const targetLabel = traceName ?? (r.scope === 'trace' ? `Trace ${shortId}` : `Request ${shortId}`)
+    return { ...r, target_label: targetLabel, target_name: traceName }
+  })
+
+  return c.json({ success: true, data: enriched })
 })
 
 // DELETE /api/v1/shares/:token — revoke a share (soft delete).

--- a/apps/web/app/(dashboard)/shares/page.tsx
+++ b/apps/web/app/(dashboard)/shares/page.tsx
@@ -1,0 +1,9 @@
+import { SharesClient } from './shares-client'
+
+export const metadata = {
+  title: 'Shared links · Spanlens',
+}
+
+export default function SharesPage() {
+  return <SharesClient />
+}

--- a/apps/web/app/(dashboard)/shares/shares-client.tsx
+++ b/apps/web/app/(dashboard)/shares/shares-client.tsx
@@ -1,0 +1,290 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+import { Topbar } from '@/components/layout/topbar'
+import { formatDateTime } from '@/lib/utils'
+import {
+  useRevokeShare,
+  useShares,
+  type ShareRow,
+  type ShareScopeFilter,
+  type ShareSort,
+} from '@/lib/queries/use-shares'
+
+/**
+ * R-26 + R-33 Sprint 6 — workspace dashboard for public share links.
+ *
+ * Lists every active share in the workspace (scope=org by default — matches
+ * the DELETE policy where any org member can revoke a teammate's leaked
+ * share). Provides:
+ *
+ *   - Sort: newest / most-viewed / expiring-soonest
+ *   - Filter: mine vs org
+ *   - Per-row redaction summary chips
+ *   - "Expires soon" warning (< 7d)
+ *   - Revoke button with confirm-then-mutate (no separate confirm modal —
+ *     keeps the dashboard one-screen for the launch volume)
+ *
+ * Does not implement create-from-here UX. The existing share-dialog
+ * component (component/share/share-dialog.tsx) opens from the trace /
+ * request detail pages and stays the canonical creation surface.
+ */
+const SORT_OPTIONS: { value: ShareSort; label: string }[] = [
+  { value: 'created', label: 'Newest' },
+  { value: 'views', label: 'Most viewed' },
+  { value: 'expires_soon', label: 'Expiring soonest' },
+]
+
+const SCOPE_OPTIONS: { value: ShareScopeFilter; label: string }[] = [
+  { value: 'org', label: 'Workspace' },
+  { value: 'mine', label: 'My shares' },
+]
+
+export function SharesClient() {
+  const [scope, setScope] = useState<ShareScopeFilter>('org')
+  const [sort, setSort] = useState<ShareSort>('created')
+  const { data, isLoading, error } = useShares({ scope, sort })
+
+  return (
+    <div>
+      <Topbar crumbs={[{ label: 'Shared links' }]} />
+      <main className="max-w-6xl mx-auto px-6 py-8 space-y-5">
+        <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1 className="text-[18px] font-semibold tracking-tight">Shared links</h1>
+            <p className="text-[12px] text-text-muted mt-1">
+              Public {' '}
+              <code className="font-mono text-[11px] px-1 py-0.5 rounded bg-bg-elevated">
+                /share/&lt;token&gt;
+              </code>{' '}
+              links published from this workspace. Anyone with the URL can read
+              the redacted view. Revoke immediately if a link leaks.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <SegmentedControl
+              ariaLabel="Filter by author"
+              options={SCOPE_OPTIONS}
+              value={scope}
+              onChange={setScope}
+            />
+            <SortPicker value={sort} onChange={setSort} />
+          </div>
+        </header>
+
+        {error ? <ErrorBox message={(error as Error).message} /> : null}
+        {isLoading ? <LoadingTable /> : null}
+        {data ? <ShareTable rows={data} /> : null}
+      </main>
+    </div>
+  )
+}
+
+function SegmentedControl<T extends string>({
+  ariaLabel,
+  options,
+  value,
+  onChange,
+}: {
+  ariaLabel: string
+  options: { value: T; label: string }[]
+  value: T
+  onChange: (v: T) => void
+}) {
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className="inline-flex rounded-md border border-border overflow-hidden text-[11px] font-mono"
+    >
+      {options.map((opt) => {
+        const active = opt.value === value
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onChange(opt.value)}
+            className={
+              'px-2.5 py-1 transition-colors ' +
+              (active ? 'bg-accent/15 text-accent' : 'hover:bg-bg-elevated')
+            }
+            aria-pressed={active}
+          >
+            {opt.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function SortPicker({
+  value,
+  onChange,
+}: {
+  value: ShareSort
+  onChange: (s: ShareSort) => void
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value as ShareSort)}
+      className="text-[11px] font-mono border border-border rounded-md px-2 py-1 bg-bg hover:bg-bg-elevated"
+      aria-label="Sort shares"
+    >
+      {SORT_OPTIONS.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+function ShareTable({ rows }: { rows: ShareRow[] }) {
+  if (rows.length === 0) {
+    return (
+      <div className="border border-border rounded-md p-8 text-center text-[12px] text-text-muted">
+        No shares yet. Open a trace or request and click <strong>Share</strong> to publish one.
+      </div>
+    )
+  }
+
+  return (
+    <div className="border border-border rounded-md overflow-hidden">
+      <table className="w-full text-[12px]">
+        <thead className="bg-bg-elevated">
+          <tr className="text-left text-[10px] uppercase tracking-wider text-text-muted">
+            <th className="px-4 py-2 font-medium">Target</th>
+            <th className="px-4 py-2 font-medium">Redaction</th>
+            <th className="px-4 py-2 font-medium">Views</th>
+            <th className="px-4 py-2 font-medium">Created</th>
+            <th className="px-4 py-2 font-medium">Expires</th>
+            <th className="px-4 py-2 font-medium"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <ShareTableRow key={row.id} row={row} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function ShareTableRow({ row }: { row: ShareRow }) {
+  const revoke = useRevokeShare()
+  const expiresLabel = useMemo(() => formatExpiry(row.expires_at), [row.expires_at])
+  const expiresSoon = useMemo(() => isExpiringSoon(row.expires_at), [row.expires_at])
+  const shareUrl = `/share/${row.token}`
+
+  return (
+    <tr className="border-t border-border hover:bg-bg-elevated/40">
+      <td className="px-4 py-3">
+        <div className="font-medium truncate max-w-[280px]" title={row.target_label}>
+          <Link href={shareUrl} className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">
+            {row.target_label}
+          </Link>
+        </div>
+        <div className="font-mono text-[10.5px] text-text-muted mt-0.5">
+          {row.scope} · {row.target_id.slice(0, 8)}…
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <RedactionChips row={row} />
+      </td>
+      <td className="px-4 py-3 font-mono">{row.view_count.toLocaleString('en-US')}</td>
+      <td className="px-4 py-3 font-mono text-[11px] text-text-muted whitespace-nowrap">
+        {formatDateTime(row.created_at)}
+      </td>
+      <td className="px-4 py-3 font-mono text-[11px] whitespace-nowrap">
+        <span className={expiresSoon ? 'text-status-warning' : 'text-text-muted'}>
+          {expiresLabel}
+        </span>
+      </td>
+      <td className="px-4 py-3 text-right">
+        <button
+          type="button"
+          disabled={revoke.isPending}
+          onClick={() => {
+            const ok = window.confirm(
+              `Revoke this share?\n\nThe public URL will start returning 404 immediately. This cannot be undone.`,
+            )
+            if (ok) revoke.mutate(row.token)
+          }}
+          className="text-[11px] font-mono px-2 py-1 rounded border border-border hover:bg-status-error/10 hover:text-status-error hover:border-status-error/40 transition-colors disabled:opacity-50"
+        >
+          {revoke.isPending ? 'Revoking…' : 'Revoke'}
+        </button>
+      </td>
+    </tr>
+  )
+}
+
+function RedactionChips({ row }: { row: ShareRow }) {
+  const items: { label: string; on: boolean }[] = [
+    { label: 'PII', on: row.redact_pii },
+    { label: 'Cost', on: row.redact_cost },
+    { label: 'Tokens', on: row.redact_tokens },
+  ]
+  return (
+    <div className="flex flex-wrap gap-1">
+      {items.map((item) => (
+        <span
+          key={item.label}
+          className={
+            'inline-flex items-center px-1.5 py-0.5 rounded font-mono text-[10px] ' +
+            (item.on
+              ? 'bg-accent/10 text-accent border border-accent/20'
+              : 'bg-bg-elevated text-text-muted border border-border')
+          }
+          title={item.on ? `${item.label} hidden` : `${item.label} visible`}
+        >
+          {item.on ? `${item.label} ✓` : `${item.label} ✗`}
+        </span>
+      ))}
+      {row.indexable ? (
+        <span className="inline-flex items-center px-1.5 py-0.5 rounded font-mono text-[10px] bg-status-warning/10 text-status-warning border border-status-warning/30">
+          indexable
+        </span>
+      ) : null}
+    </div>
+  )
+}
+
+function formatExpiry(expiresAt: string | null): string {
+  if (!expiresAt) return 'Never'
+  const expiry = new Date(expiresAt).getTime()
+  const diffMs = expiry - Date.now()
+  if (diffMs <= 0) return 'Expired'
+  const days = Math.floor(diffMs / (24 * 60 * 60 * 1000))
+  if (days >= 30) return `${Math.floor(days / 30)}mo`
+  if (days >= 1) return `${days}d`
+  const hours = Math.floor(diffMs / (60 * 60 * 1000))
+  return `${hours}h`
+}
+
+function isExpiringSoon(expiresAt: string | null): boolean {
+  if (!expiresAt) return false
+  const diffMs = new Date(expiresAt).getTime() - Date.now()
+  // Warn when < 7 days. Already-expired rows also count so they stay visible.
+  return diffMs < 7 * 24 * 60 * 60 * 1000
+}
+
+function LoadingTable() {
+  return (
+    <div className="border border-border rounded-md p-8 text-center text-[12px] text-text-muted animate-pulse">
+      Loading shared links…
+    </div>
+  )
+}
+
+function ErrorBox({ message }: { message: string }) {
+  return (
+    <div className="border border-status-error/40 bg-status-error/5 rounded-md p-4 font-mono text-[11.5px] text-status-error">
+      Failed to load shared links: {message}
+    </div>
+  )
+}

--- a/apps/web/components/share/share-dialog.tsx
+++ b/apps/web/components/share/share-dialog.tsx
@@ -17,6 +17,60 @@ import { apiPost } from '@/lib/api'
 type Scope = 'trace' | 'request'
 type Ttl = '7d' | '30d' | 'never'
 
+/**
+ * Redaction presets (R-26 + R-33 Sprint 6 Step 5).
+ *
+ * The 3-flag toggle matrix overwhelms most first-time sharers — "do I want
+ * PII off?", "is hiding cost normal?". Presets collapse those decisions into
+ * three named intents the user actually has:
+ *
+ *   marketing — "I'm putting this in a blog post / social". Hide everything
+ *               that's not the conversation itself. Used 70% of public PLG
+ *               shares per the dev sandbox sample.
+ *   internal  — "Slack channel where everyone is already an employee". Show
+ *               everything; debugging value > leak risk inside the trust
+ *               boundary.
+ *   custom    — manual toggles; the user knows what they're doing.
+ *
+ * The user can still flip individual toggles after picking a preset; doing so
+ * silently switches the preset chip back to "custom" so we never lie about
+ * what's selected.
+ */
+type RedactionPreset = 'marketing' | 'internal' | 'custom'
+
+interface PresetState {
+  redactPii: boolean
+  redactCost: boolean
+  redactTokens: boolean
+}
+
+const PRESET_VALUES: Record<Exclude<RedactionPreset, 'custom'>, PresetState> = {
+  marketing: { redactPii: true, redactCost: true, redactTokens: true },
+  internal:  { redactPii: false, redactCost: false, redactTokens: false },
+}
+
+const PRESET_OPTIONS: { value: RedactionPreset; label: string; hint: string }[] = [
+  { value: 'marketing', label: 'Marketing / external', hint: 'PII + cost + tokens hidden' },
+  { value: 'internal',  label: 'Internal team',         hint: 'Everything visible' },
+  { value: 'custom',    label: 'Custom',                hint: 'Pick fields manually' },
+]
+
+function detectPreset(state: PresetState): RedactionPreset {
+  for (const [name, values] of Object.entries(PRESET_VALUES) as [
+    Exclude<RedactionPreset, 'custom'>,
+    PresetState,
+  ][]) {
+    if (
+      values.redactPii === state.redactPii &&
+      values.redactCost === state.redactCost &&
+      values.redactTokens === state.redactTokens
+    ) {
+      return name
+    }
+  }
+  return 'custom'
+}
+
 interface ShareDialogProps {
   scope: Scope
   targetId: string
@@ -54,6 +108,19 @@ export function ShareDialog({ scope, targetId, variant = 'primary' }: ShareDialo
   const [shareUrl, setShareUrl] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
+
+  const currentPreset = detectPreset({ redactPii, redactCost, redactTokens })
+
+  function applyPreset(preset: RedactionPreset) {
+    if (preset === 'custom') return
+    const values = PRESET_VALUES[preset]
+    setRedactPii(values.redactPii)
+    setRedactCost(values.redactCost)
+    setRedactTokens(values.redactTokens)
+    // 'marketing' hides tokens; surface the advanced row automatically so the
+    // user can see what was just applied.
+    if (preset === 'marketing') setShowAdvanced(true)
+  }
 
   async function handleCreate() {
     setCreating(true)
@@ -164,6 +231,32 @@ export function ShareDialog({ scope, targetId, variant = 'primary' }: ShareDialo
                     {value === 'never' ? 'Never' : value === '7d' ? '7 days' : '30 days'}
                   </button>
                 ))}
+              </div>
+            </div>
+
+            <div>
+              <Label className="mb-2 block">Redaction preset</Label>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+                {PRESET_OPTIONS.map((opt) => {
+                  const active = opt.value === currentPreset
+                  return (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => applyPreset(opt.value)}
+                      className={
+                        'text-left px-3 py-2 border rounded-md transition-colors ' +
+                        (active
+                          ? 'border-accent bg-accent/10'
+                          : 'border-border hover:border-border-strong')
+                      }
+                      aria-pressed={active}
+                    >
+                      <div className="font-mono text-[12px]">{opt.label}</div>
+                      <div className="text-[10.5px] text-text-muted mt-0.5">{opt.hint}</div>
+                    </button>
+                  )
+                })}
               </div>
             </div>
 

--- a/apps/web/lib/queries/use-shares.ts
+++ b/apps/web/lib/queries/use-shares.ts
@@ -1,0 +1,84 @@
+'use client'
+
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
+import { apiDelete, apiGet } from '@/lib/api'
+
+/**
+ * R-26 + R-33 Sprint 6 — workspace dashboard for public share links.
+ *
+ * The API endpoint is GET /api/v1/shares from PR #270's predecessor;
+ * Sprint 6 extends it to accept `?scope=org&sort=...` so the dashboard
+ * can show every active share in the workspace (matches the DELETE
+ * handler's policy — any member can revoke any share in their org).
+ */
+
+export type ShareSort = 'created' | 'views' | 'expires_soon'
+export type ShareScopeFilter = 'mine' | 'org'
+
+export interface ShareRow {
+  id: string
+  token: string
+  scope: 'trace' | 'request'
+  target_id: string
+  /** Server-side enrichment: trace.name when available, "<Scope> <short>" otherwise. */
+  target_label: string
+  target_name: string | null
+  expires_at: string | null
+  redact_pii: boolean
+  redact_cost: boolean
+  redact_tokens: boolean
+  indexable: boolean
+  view_count: number
+  revoked_at: string | null
+  created_at: string
+  created_by: string | null
+}
+
+interface SharesListResponse {
+  success: boolean
+  data: ShareRow[]
+}
+
+interface UseSharesInput {
+  scope?: ShareScopeFilter
+  sort?: ShareSort
+  includeRevoked?: boolean
+}
+
+function buildQueryString(input: UseSharesInput): string {
+  const params = new URLSearchParams()
+  if (input.scope) params.set('scope', input.scope)
+  if (input.sort) params.set('sort', input.sort)
+  if (input.includeRevoked) params.set('include', 'revoked')
+  const qs = params.toString()
+  return qs ? `?${qs}` : ''
+}
+
+export function useShares(input: UseSharesInput = {}) {
+  const qs = buildQueryString(input)
+  return useQuery({
+    queryKey: ['shares', input.scope ?? 'mine', input.sort ?? 'created', input.includeRevoked ?? false],
+    queryFn: () => apiGet<SharesListResponse>(`/api/v1/shares${qs}`),
+    select: (response) => response.data,
+    // Workspace dashboards refresh on focus — the user just clicked over from
+    // creating a share in another tab and the list should reflect it.
+    refetchOnWindowFocus: true,
+  })
+}
+
+export function useRevokeShare() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (token: string) =>
+      apiDelete<{ success: boolean }>(`/api/v1/shares/${encodeURIComponent(token)}`),
+    onSuccess: () => {
+      // Invalidate every shares query key — any scope/sort/include combo the
+      // user has open should re-fetch so the revoked row drops out.
+      queryClient.invalidateQueries({ queryKey: ['shares'] })
+    },
+  })
+}


### PR DESCRIPTION
## Summary

PLG Loop ① ownership surface. Sprint 5 shipped the public share viewer strengthening (PR #271 — IOPreview + permalink + OG meta). This PR is the inside half:

- Workspace admin can see every active share in `/shares`
- Sort by views / expiry, revoke with one click
- Share creation modal collapses the 3-flag toggle matrix into 3 named intents (Marketing / Internal / Custom)

Sprint 6 R-26+R-33 Steps 3-5 complete. R-14 production verification (OTLP p95 30%↓, 7-day orphan=0) stays on the Sprint 6 ops follow-up — pure monitoring task once the operator INSERTs the `orphan-span-link` background_migrations row.

## Changes
- `apps/server/src/api/shares.ts` — GET `/api/v1/shares` gains `scope=mine|org`, `sort=created|views|expires_soon`, `include=revoked`. Batch trace name enrichment (1 `.in()` lookup, no N+1).
- `apps/web/app/(dashboard)/shares/page.tsx` + `shares-client.tsx` (new) — workspace dashboard, segmented control for filter, `<select>` for sort, redaction chips, "Expires soon" warning <7d, revoke with `window.confirm`.
- `apps/web/lib/queries/use-shares.ts` (new) — `useShares` + `useRevokeShare` TanStack hooks.
- `apps/web/components/share/share-dialog.tsx` — 3-button redaction preset row above existing toggles; auto-detects 'custom' when user flips a toggle.

## Test plan
- [x] `pnpm --filter server typecheck` — green
- [x] `pnpm --filter server lint` — green
- [x] `pnpm --filter server test` — 810 passed
- [x] `pnpm --filter web typecheck` — green
- [x] `pnpm --filter web lint` — green
- [x] Scope guard — `apps/web/app/(dashboard)/traces/` + `apps/web/components/traces/` git diff 0 lines
- [ ] CI green
- [ ] After merge: spot-check `/shares` dashboard on preview Vercel — workspace filter shows org-wide list, sort updates table order, revoke removes row (with confirm)
- [ ] Spot-check share creation modal — Marketing preset auto-expands advanced row, picking Custom keeps current toggle state