### PR TITLE
feat(db): R-14 Sprint 6 — register orphan-span-link background migration

### DIFF
--- a/supabase/migrations/20260609150000_register_orphan_span_link.sql
+++ b/supabase/migrations/20260609150000_register_orphan_span_link.sql
@@ -1,0 +1,32 @@
+-- Migration: register_orphan_span_link
+--
+-- R-14 (Sprint 6) — production registration of the orphan-span-link
+-- background migration. PR #270 shipped the registry entry + chunked
+-- runner; this migration kicks off the actual job by INSERTing the
+-- row that the 5-minute cron polls for.
+--
+-- Idempotency
+--   ON CONFLICT (name) DO NOTHING — re-running this migration on a DB
+--   that already has the row is a no-op. The job's status field is
+--   left alone so an operator who pauses the job ('paused') doesn't
+--   get it re-set to 'pending' by a redeploy.
+--
+-- Behaviour on a fresh DB (dev / CI)
+--   The job runs immediately on the next cron tick. orphan-span-link
+--   is safe to run against a brand-new spans table — the orphan
+--   SELECT returns zero rows and runChunk returns done:true, so it
+--   completes in one tick with no side effects. Dev devs do not need
+--   to do anything; the row is harmless.
+--
+-- After production deploy
+--   /cron/run-background-migrations picks the row up within 5 minutes.
+--   /cron/detect-orphan-spans (hourly at xx:17) provides the watchdog
+--   alert if the job stalls and orphans accumulate above 100.
+--
+-- See:
+--   apps/server/src/lib/background-migrations/registry/migrations/orphan-span-link.ts
+--   apps/server/src/api/cron.ts (/cron/detect-orphan-spans)
+
+INSERT INTO background_migrations (name, status)
+VALUES ('orphan-span-link', 'pending')
+ON CONFLICT (name) DO NOTHING;


### PR DESCRIPTION
## Summary

Production registration of the `orphan-span-link` background migration shipped in PR #270. INSERT row → 5-min cron picks it up → R-14 verification clock starts.

After this PR is merged + the new migration applied to production, the operator has 1 week to verify:
- OTLP request p95 latency 30%↓ (Sentry transactions)
- `/cron/detect-orphan-spans` reports 0 orphans older than 1h (silent watchdog)

## Changes
- `supabase/migrations/20260609150000_register_orphan_span_link.sql` (new)
  - INSERT background_migrations row, `ON CONFLICT (name) DO NOTHING` (idempotent)
  - Comment explains dev/CI safety (first chunk = no-op when no orphans)

## Test plan
- [x] Migration is idempotent (ON CONFLICT clause)
- [x] background_migrations.name is the PK (verified — `20260608030000_background_migrations.sql:31`)
- [ ] CI green (deploy-server.yml runs `supabase db push --linked --include-all` before Vercel deploy)
- [ ] After merge: confirm row exists in production (`SELECT name, status FROM background_migrations WHERE name = 'orphan-span-link'`)
- [ ] Within 10 minutes: `/cron/run-background-migrations` log shows the job picked up and completed (zero orphans on fresh deploy)
- [ ] **Sprint 6 ops follow-up (7 days)**: validate p95 30%↓ + orphan count = 0