### PR TITLE
feat(web): add Shared links to sidebar under Admin section

### DIFF
--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -273,6 +273,12 @@ const NAV_GROUPS: { label: string | null; items: NavItem[] }[] = [
     label: 'Admin',
     items: [
       { href: '/projects',  label: 'Projects & Keys' },
+      // Public share tokens live in the same Admin section as API keys —
+      // both are externally-issued credentials with the same operator
+      // workflow (list / inspect / revoke). Sitting them next to each
+      // other keeps the leak-audit flow ("rotate the key, revoke the
+      // share") one cursor move apart.
+      { href: '/shares',    label: 'Shared links' },
       { href: '/settings',  label: 'Settings' },
       { href: '/docs',      label: 'Docs' },
     ],


### PR DESCRIPTION
## Summary

Sprint 6 shipped `/shares` (PR #272) but left it URL-only — operators had to type the URL. This adds a navigation row under the **Admin** section, right after Projects & Keys.

## Placement rationale

Both rows manage externally-issued credentials with the same workflow (list / inspect / revoke). Sitting them next to each other keeps the leak-audit flow one cursor move apart.

## Changes
- `apps/web/components/layout/sidebar.tsx` — one row added under Admin, comment explains placement

## Test plan
- [x] `pnpm --filter web typecheck` — green
- [x] `pnpm --filter web lint` — green
- [ ] CI green
- [ ] After merge: Chrome MCP — confirm "Shared links" appears under Admin in production sidebar, clicking navigates to `/shares`