### PR TITLE
docs: Sprint 1-6 catch-up across evals, shares, proxy, and changelog

### DIFF
--- a/apps/web/app/docs/_components/sidebar.tsx
+++ b/apps/web/app/docs/_components/sidebar.tsx
@@ -81,6 +81,7 @@ const NAV: NavGroup[] = [
     title: 'Workspace',
     items: [
       { title: 'Projects & API keys', href: '/docs/features/projects' },
+      { title: 'Shared links', href: '/docs/features/shares' },
       { title: 'Keys & encryption', href: '/docs/features/settings' },
       { title: 'Members & invitations', href: '/docs/features/members-invitations' },
       { title: 'Audit logs', href: '/docs/features/audit-logs' },

--- a/apps/web/app/docs/features/evals/page.tsx
+++ b/apps/web/app/docs/features/evals/page.tsx
@@ -34,7 +34,7 @@ export default function EvalsDocs() {
         Visit <a href="/evals">/evals</a> on a fresh workspace and the empty state shows ten
         built-in evaluator templates grouped into three categories. Click <em>Use template</em>{' '}
         to pre-fill the New evaluator dialog with a curated criterion and a recommended judge
-        model — you only need to pick which prompt the evaluator targets.
+        model. You only need to pick which prompt the evaluator targets.
       </p>
       <table>
         <thead>
@@ -80,7 +80,14 @@ export default function EvalsDocs() {
       <ul>
         <li><code>prompt_name</code>, which prompt this evaluator targets</li>
         <li><code>name</code>, e.g. &quot;Helpfulness check&quot;</li>
-        <li><code>type</code>, <code>llm_judge</code> (the only type in this release)</li>
+        <li>
+          <code>type</code>, one of <code>llm_judge</code>, <code>regex</code>, or{' '}
+          <code>json_schema</code>. The <code>regex</code> type checks the response body
+          against a configured pattern and scores 1 on match (or 0 if you flag
+          {' '}<code>must_not_match</code>). The <code>json_schema</code> type validates the
+          response body against a JSON Schema document via Ajv and scores 1 on valid.
+          Both code evaluators are free of LLM cost since no judge model is called.
+        </li>
         <li>
           <code>config</code>:
           <ul>
@@ -316,8 +323,11 @@ curl https://server.spanlens.io/api/v1/eval-runs/<run-id> \\
       <h2>Limitations</h2>
       <ul>
         <li>
-          <strong>Only <code>llm_judge</code> evaluator type.</strong> Heuristic evaluators
-          (regex, JSON schema, length) are planned for a later release.
+          <strong>Three evaluator types ship today.</strong> <code>llm_judge</code> uses a
+          model to score, <code>regex</code> checks the response against a pattern with
+          configurable match expectation, and <code>json_schema</code> validates the
+          response body against a JSON Schema document. Length and embedding similarity
+          evaluators are planned for a later release.
         </li>
         <li>
           <strong>One evaluator run at a time.</strong> Concurrent runs on the same evaluator

--- a/apps/web/app/docs/features/shares/page.tsx
+++ b/apps/web/app/docs/features/shares/page.tsx
@@ -1,0 +1,196 @@
+import { CodeBlock } from '../../_components/code-block'
+
+export const metadata = {
+  title: 'Shared links · Spanlens Docs',
+  description:
+    'Publish a public read-only render of any trace or request via /share/<token>. Manage every link from the workspace Shared links page with redaction presets, view counts, and one-click revoke.',
+}
+
+export default function SharesDocs() {
+  return (
+    <div>
+      <h1>Shared links</h1>
+      <p className="lead">
+        Anyone you give a Spanlens share link to can read the trace or request without
+        signing up. The token in the URL is the only credential, and you stay in control:
+        each link respects the redaction settings you picked, expires when you said it
+        would, and can be revoked the moment it leaks.
+      </p>
+
+      <h2>When to use a share link</h2>
+      <ul>
+        <li>
+          <strong>Bug reports.</strong> Paste the link in an issue so a teammate or vendor
+          can see the exact LLM call without an account.
+        </li>
+        <li>
+          <strong>Marketing and content.</strong> Embed a redacted trace in a blog post
+          showing how your agent handled a tough prompt.
+        </li>
+        <li>
+          <strong>Customer success.</strong> Send a customer the trace from their support
+          ticket so they can see what their request actually returned.
+        </li>
+      </ul>
+
+      <h2>Create a share</h2>
+      <p>
+        Open any trace at <code>/traces/&lt;id&gt;</code> or any request at{' '}
+        <code>/requests/&lt;id&gt;</code> and click the <strong>Share</strong> icon in the
+        top right. The dialog asks for two decisions.
+      </p>
+
+      <h3>Expiry</h3>
+      <p>
+        <strong>7 days</strong>, <strong>30 days</strong> (default), or <strong>Never</strong>.
+        A link past its expiry returns 404 instead of 410 so a token cannot be enumerated
+        by probing expired URLs.
+      </p>
+
+      <h3>Redaction preset</h3>
+      <p>Pick one of three intents instead of toggling each field by hand.</p>
+      <ul>
+        <li>
+          <strong>Marketing / external.</strong> PII patterns plus cost plus token counts
+          all hidden. The viewer still sees the conversation, latency, and HTTP status, and
+          that is usually what you want for a public post.
+        </li>
+        <li>
+          <strong>Internal team.</strong> Everything visible. Best for a Slack channel where
+          every reader is already inside your trust boundary and the debugging value of
+          token counts outweighs the leak risk.
+        </li>
+        <li>
+          <strong>Custom.</strong> Flip the individual toggles. The preset chip switches to
+          Custom the moment you change anything, so the dialog never lies about what is
+          selected.
+        </li>
+      </ul>
+      <p>
+        The defaults are fail safe. New shares start with PII masking and cost hiding on.
+        Token counts stay visible by default since they carry most of the debugging signal,
+        and search engine indexing stays off.
+      </p>
+
+      <h3>What gets masked</h3>
+      <ul>
+        <li>
+          <strong>PII.</strong> Provider keys (<code>sk-…</code>, <code>sk-ant-…</code>,{' '}
+          <code>AIza…</code>) and Spanlens keys (<code>sl_live_…</code>) inside request and
+          response bodies. Pattern based, so it catches the typical accidental paste.
+        </li>
+        <li>
+          <strong>Cost.</strong> The cost column reads <code>$&middot;&middot;&middot;</code>
+          in the viewer.
+        </li>
+        <li>
+          <strong>Token counts.</strong> Prompt, completion, and total counts read{' '}
+          <code>&middot;&middot;&middot;</code> in the viewer.
+        </li>
+      </ul>
+
+      <h2>What the viewer looks like</h2>
+      <p>
+        The shared page renders a clean read-only view with input and output side by side
+        on desktop (stacked on mobile), latency and token stats at the top, and a Spanlens
+        attribution footer that links to the signup page. Every visit bumps the share view
+        count by one.
+      </p>
+      <p>
+        The page also emits Open Graph and Twitter card metadata, so a link posted to
+        Slack, X, or LinkedIn shows the trace name plus the provider and model in the
+        preview. Search engines stay blocked unless you explicitly flip the{' '}
+        <code>indexable</code> toggle when creating the share.
+      </p>
+
+      <h2>Manage your shares</h2>
+      <p>
+        The workspace <a href="/shares"><strong>Shared links</strong></a> page lists every
+        active share in your organization, not just the ones you created. Any organization
+        member can revoke any share, so a leaked link from a teammate does not require
+        admin intervention.
+      </p>
+      <p>Each row shows:</p>
+      <ul>
+        <li>
+          <strong>Target.</strong> Trace name when the share is a trace, otherwise{' '}
+          <code>Request &lt;short-id&gt;</code>. Click to open the public viewer in a new
+          tab.
+        </li>
+        <li>
+          <strong>Redaction chips.</strong> Three chips for PII, Cost, and Tokens, plus an
+          extra warning chip when <code>indexable</code> is on. A glance tells you which
+          shares are still leaking workload intel.
+        </li>
+        <li>
+          <strong>Views.</strong> Cumulative view count since the link was published.
+        </li>
+        <li>
+          <strong>Created and Expires.</strong> Expiry under seven days surfaces in a
+          warning color so renewals do not slip.
+        </li>
+        <li>
+          <strong>Revoke.</strong> Soft delete with a confirm prompt. The public URL starts
+          returning 404 immediately and cannot be undone.
+        </li>
+      </ul>
+
+      <h3>Sort and filter</h3>
+      <p>
+        Filter by <strong>Workspace</strong> (default, every member) or <strong>My
+        shares</strong> (only what you published). Sort by <strong>Newest</strong> (default),
+        <strong>Most viewed</strong>, or <strong>Expiring soonest</strong>.
+      </p>
+
+      <h2>API</h2>
+      <p>
+        The dashboard uses these endpoints; you can call them from a script too if you need
+        to bulk audit or revoke. All three require a Spanlens dashboard JWT, which you can
+        grab from your browser session.
+      </p>
+      <CodeBlock language="bash">{`# List every active share in the workspace, sorted by view count
+curl 'https://server.spanlens.io/api/v1/shares?scope=org&sort=views' \\
+  -H "Authorization: Bearer $SPANLENS_JWT"
+
+# Create a share with the Marketing redaction preset
+curl -X POST https://server.spanlens.io/api/v1/shares \\
+  -H "Authorization: Bearer $SPANLENS_JWT" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "scope": "trace",
+    "targetId": "<trace-uuid>",
+    "ttl": "30d",
+    "redactPii": true,
+    "redactCost": true,
+    "redactTokens": true
+  }'
+
+# Revoke a share immediately (soft delete, view_count preserved)
+curl -X DELETE https://server.spanlens.io/api/v1/shares/<token> \\
+  -H "Authorization: Bearer $SPANLENS_JWT"`}</CodeBlock>
+
+      <h2>Security model</h2>
+      <p>
+        The token in the URL is the only credential. There is no per-viewer ACL. Tokens are
+        128 bits of entropy generated server side, well above any brute force threshold for
+        a rate limited public endpoint. Treat a share link the same way you treat a
+        signed S3 URL: anyone who gets the URL gets read access until you revoke or the
+        link expires.
+      </p>
+      <p>
+        Server-side enforcement runs through the service role client and reads the
+        underlying Postgres or ClickHouse row directly. The retention bypass keeps a
+        long-lived share resolvable past your plan&apos;s normal retention window, up to the
+        365 day ceiling on the analytics table.
+      </p>
+
+      <hr />
+      <p className="text-sm text-muted-foreground">
+        Related: <a href="/docs/features/traces">Traces</a> (where you create most shares),{' '}
+        <a href="/docs/features/security">Security</a> (PII masking patterns),{' '}
+        <a href="/docs/features/projects">Projects &amp; API keys</a> (the other
+        externally-issued credential type).
+      </p>
+    </div>
+  )
+}

--- a/apps/web/app/docs/proxy/page.tsx
+++ b/apps/web/app/docs/proxy/page.tsx
@@ -281,6 +281,39 @@ res, _ := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
         See <a href="/docs/features/cost-tracking">cost tracking</a> for the full formula.
       </p>
 
+      <h2>Rate limits and response headers</h2>
+      <p>
+        Every <code>/proxy/*</code> response, including the rare <code>429</code>, carries
+        four standard rate limit headers so your client can back off without guessing.
+      </p>
+      <ul>
+        <li>
+          <code>X-RateLimit-Limit</code>, requests allowed in the current window. Default
+          is 120 per minute per Spanlens key; team and enterprise plans get higher caps.
+        </li>
+        <li>
+          <code>X-RateLimit-Remaining</code>, requests left in the current window. Drops to
+          0 right before the next 429.
+        </li>
+        <li>
+          <code>X-RateLimit-Reset</code>, unix epoch second at which the window rolls over.
+          Use this directly in a sleep until the next minute boundary; do not parse the
+          server clock from <code>Date</code> since clock skew costs you retries.
+        </li>
+        <li>
+          <code>X-RateLimit-Window</code>, the window length in seconds. Currently always{' '}
+          <code>60s</code>, exposed as a header so we can change it without breaking
+          clients that read it.
+        </li>
+      </ul>
+      <p>
+        On a <code>429</code> the response also includes <code>Retry-After: 60</code>,
+        matching the window length so a naive retry-after-sleep client still works
+        correctly. The same headers ship from <code>/api/v1/*</code> dashboard endpoints
+        with a higher per-token cap, so an SDK that mirrors the proxy logic against your
+        own API works without special casing.
+      </p>
+
       <h2>Self-hosting</h2>
       <p>
         If you&apos;re running Spanlens on your own infra, replace the base URL:

--- a/apps/web/lib/changelog/entries.ts
+++ b/apps/web/lib/changelog/entries.ts
@@ -39,6 +39,61 @@ export type ChangelogTag =
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-06-08',
+    slug: 'shares-workspace-dashboard',
+    title: 'Workspace dashboard and redaction presets for shared links',
+    tags: ['feature'],
+    body: [
+      'A new [Shared links](/shares) page under the Admin section of the dashboard lists every active public share in your workspace, not just the ones you created. Sort by newest, most viewed, or expiring soonest. Each row carries redaction chips so you can spot a leak at a glance, a view counter, and a one click revoke. Any organization member can revoke any share, so a leaked token from a teammate does not need an admin to clean up.',
+      'The share creation modal on trace and request pages now offers three redaction presets instead of asking you to flip every toggle individually. Pick "Marketing / external" to hide PII, cost, and token counts in one click. Pick "Internal team" to show everything for a Slack channel inside your trust boundary. Pick "Custom" to keep manual control. Flipping any toggle silently switches the preset chip to Custom so the dialog never lies about what is selected.',
+      'See [Shared links](/docs/features/shares) for the full guide including the API endpoints for scripting bulk audit or revoke.',
+    ].join('\n\n'),
+  },
+  {
+    date: '2026-06-08',
+    slug: 'share-viewer-iopreview-og',
+    title: 'Cleaner public share viewer with input and output side by side',
+    tags: ['improvement'],
+    body: [
+      'The public `/share/<token>` page now renders input and output as two columns on desktop and stacks them on mobile. Each pane scrolls independently so a 200 KB response body no longer pushes the request out of view. The legacy stacked layout inside an expander was awkward to compare; the split panel matches how most readers actually scan an LLM call.',
+      'The share header also gets a Copy link button with a confirming "Copied" state, and the page now emits Open Graph and Twitter card metadata. A link pasted in Slack, X, or LinkedIn now produces a useful preview card showing the trace name or the provider and model rather than a blank URL.',
+      'Search engine indexing stays off by default. The viewer still respects every redaction flag you picked when you published the share.',
+    ].join('\n\n'),
+  },
+  {
+    date: '2026-06-08',
+    slug: 'otlp-faster-batches',
+    title: 'OTLP ingest is 50 to 200 ms faster per batch',
+    tags: ['improvement'],
+    body: [
+      'The OTLP receiver at `/v1/traces` used to call a synchronous Postgres function after every span insert to resolve parent linkage. On hot traces with hundreds of spans per batch that added 50 to 200 ms to the receiver p95. We moved the linkage step to a background migration that scans a new partial index in 500 row chunks, so the receiver now finishes as soon as the bulk insert returns.',
+      'OpenTelemetry SDK users should see the latency drop immediately with no client changes. A new hourly watchdog at `/cron/detect-orphan-spans` alerts if too many spans accumulate without a resolved parent, so a stuck background job surfaces fast.',
+      'Child spans whose parent arrives in a later batch render with a temporary null parent until the background job runs, typically within minutes. The UI has always tolerated null parents (parallel agent spans use them legitimately) so the eventual consistency window is visually invisible.',
+    ].join('\n\n'),
+  },
+  {
+    date: '2026-06-08',
+    slug: 'proxy-rate-limit-headers',
+    title: 'Standard rate limit headers on every proxy response',
+    tags: ['improvement'],
+    body: [
+      'Every response from `/proxy/*` and `/api/v1/*` now carries four rate limit headers so your client can back off without guessing. `X-RateLimit-Limit` is the requests allowed per window, `X-RateLimit-Remaining` is the requests left right now, `X-RateLimit-Reset` is the unix epoch second at which the window rolls over, and `X-RateLimit-Window` is the window length (currently 60s).',
+      'On a 429 the response also includes `Retry-After: 60` so a naive retry after sleep loop still works. Use `X-RateLimit-Reset` if you want to sleep until the next minute boundary precisely instead.',
+      'See the [proxy reference](/docs/proxy) for the full header list and the per plan limits.',
+    ].join('\n\n'),
+  },
+  {
+    date: '2026-06-08',
+    slug: 'evaluators-regex-json-schema',
+    title: 'Code evaluators: regex and JSON Schema (no LLM cost)',
+    tags: ['feature'],
+    body: [
+      'Two new evaluator types ship alongside the existing LLM as judge evaluator. The `regex` type checks the response body against a configured pattern and scores 1 on match (or 0 when you flag `must_not_match` to invert the check). The `json_schema` type validates the response body against a JSON Schema document via Ajv and scores 1 when the body conforms.',
+      'Neither type calls a judge model so neither type spends LLM credits. Use them for the cheap, fast checks where an LLM would be overkill. Catch when the response stops being valid JSON. Catch when a forbidden phrase slips through. Run them on every dataset row without worrying about cost.',
+      'Create them from the [Evals](/evals) page using the new evaluator dialog. Pick the type from the dropdown and the rest of the form swaps to the matching configuration. See the [Evals guide](/docs/features/evals) for the full reference.',
+    ].join('\n\n'),
+  },
+  {
     date: '2026-06-06',
     slug: 'events-unified-read-switch-live',
     title: 'Unified events table now powers every dashboard read',


### PR DESCRIPTION
## Summary

Sprint 1-6 landed five user-facing changes whose docs lagged behind. This catches up in one PR.

| File | Sprint | Change |
|---|---|---|
| `docs/features/evals` | 1 (R-7 Phase 1) | Fix line 320 still saying regex/JSON schema "planned". Update Limitations and Type bullet to describe all 3 evaluator types live today |
| `docs/features/shares` (new) | 5 + 6 (R-26+R-33) | New 170 line guide covering public viewer, redaction presets, workspace dashboard, API endpoints |
| `docs/_components/sidebar` | 5 + 6 | Add Shared links nav entry under Workspace group |
| `docs/proxy` | 2 (R-4+R-5) | New "Rate limits and response headers" section documenting X-RateLimit-* 4 headers + Retry-After |
| `lib/changelog/entries` | 1, 2, 5, 6 | 5 new entries dated 2026-06-08 (code evaluators / rate limit headers / OTLP faster / share viewer / shares dashboard) |

## Style guard
- Every new line is em-dash free per project convention for externally-exposed content
- One pre-existing em-dash in evals docs line 37 also cleaned up since the file was being edited
- Verified via `grep -n "—"` on every modified file

## Test plan
- [x] `pnpm --filter web typecheck` green
- [x] `pnpm --filter web lint` green
- [ ] CI green
- [ ] After merge: Chrome MCP visit `/docs/features/shares`, `/docs/features/evals`, `/docs/proxy`, `/changelog` to verify rendering and that the sidebar link appears