### PR TITLE
feat(server): Sprint 7 R-15 + R-20 PR 1 — error standard infra

### DIFF
--- a/apps/server/src/__tests__/on-error-handler.test.ts
+++ b/apps/server/src/__tests__/on-error-handler.test.ts
@@ -1,0 +1,114 @@
+import { Hono } from 'hono'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
+import { describe, expect, it, vi } from 'vitest'
+import { ApiError, isApiError } from '../lib/errors.js'
+import { requestId, type RequestIdContext } from '../middleware/requestId.js'
+
+// Sentry side-effects must be mocked so a thrown unknown error does not
+// attempt a real network capture during the test run.
+vi.mock('@sentry/node', () => ({
+  captureException: vi.fn(),
+}))
+
+/**
+ * Mirror of the onError + requestId wiring in app.ts. Recreating it here
+ * (rather than importing app.ts) keeps the test surface small and
+ * decoupled from the dozens of router-level mocks app.ts would pull in.
+ * If the wiring in app.ts changes shape, this test should change too.
+ */
+async function buildApp(): Promise<Hono<RequestIdContext>> {
+  const { captureException } = await import('@sentry/node')
+  const app = new Hono<RequestIdContext>()
+  app.use('*', requestId)
+
+  app.get('/throw-api-error', () => {
+    throw new ApiError('PUBLIC_KEY_WRITE_FORBIDDEN')
+  })
+  app.get('/throw-api-error-with-details', () => {
+    throw ApiError.from('VALIDATION_FAILED', { field: 'ttl' })
+  })
+  app.get('/throw-unknown', () => {
+    throw new Error('database connection refused')
+  })
+
+  app.onError((err, c) => {
+    const id = c.get('requestId') ?? null
+    if (isApiError(err)) {
+      return c.json(
+        {
+          error: {
+            code: err.code,
+            message: err.message,
+            ...(err.details ? { details: err.details } : {}),
+            requestId: id,
+          },
+        },
+        err.status as ContentfulStatusCode,
+      )
+    }
+    captureException(err, { tags: { request_id: id ?? 'unknown' } })
+    return c.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'Unexpected error', requestId: id } },
+      500,
+    )
+  })
+
+  return app
+}
+
+describe('global onError + requestId integration', () => {
+  it('serialises ApiError to the standard envelope and echoes the requestId', async () => {
+    const app = await buildApp()
+    const res = await app.request('/throw-api-error')
+    expect(res.status).toBe(403)
+    const body = (await res.json()) as {
+      error: { code: string; message: string; requestId: string }
+    }
+    expect(body.error.code).toBe('PUBLIC_KEY_WRITE_FORBIDDEN')
+    expect(body.error.message).toMatch(/Public scope keys cannot/i)
+    expect(body.error.requestId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    )
+    // Same id surfaces in the response header so clients can correlate
+    // without parsing the JSON body.
+    expect(res.headers.get('X-Request-ID')).toBe(body.error.requestId)
+  })
+
+  it('includes details on the envelope when ApiError.from was used', async () => {
+    const app = await buildApp()
+    const res = await app.request('/throw-api-error-with-details')
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as {
+      error: { code: string; details?: Record<string, unknown> }
+    }
+    expect(body.error.code).toBe('VALIDATION_FAILED')
+    expect(body.error.details).toEqual({ field: 'ttl' })
+  })
+
+  it('maps an unknown thrown error to a 500 INTERNAL_ERROR and captures to Sentry', async () => {
+    const { captureException } = await import('@sentry/node')
+    const app = await buildApp()
+    const res = await app.request('/throw-unknown')
+    expect(res.status).toBe(500)
+    const body = (await res.json()) as { error: { code: string; requestId: string } }
+    expect(body.error.code).toBe('INTERNAL_ERROR')
+    expect(body.error.requestId).toBeTruthy()
+    // The original error reached Sentry tagged with the same request id.
+    expect(captureException).toHaveBeenCalledTimes(1)
+    const [thrown, opts] = (captureException as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0] as [Error, { tags: { request_id: string } }]
+    expect(thrown.message).toBe('database connection refused')
+    expect(opts.tags.request_id).toBe(body.error.requestId)
+  })
+
+  it('preserves a client-supplied X-Request-ID through the error path', async () => {
+    const app = await buildApp()
+    const incoming = '018f5dcb-1234-7890-9abc-def012345678'
+    const res = await app.request('/throw-api-error', {
+      headers: { 'X-Request-ID': incoming },
+    })
+    const body = (await res.json()) as { error: { requestId: string } }
+    expect(body.error.requestId).toBe(incoming)
+    expect(res.headers.get('X-Request-ID')).toBe(incoming)
+  })
+})

--- a/apps/server/src/api/admin/alerts.ts
+++ b/apps/server/src/api/admin/alerts.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../../middleware/authJwt.js'
 import { requireSystemAdmin } from '../../middleware/requireSystemAdmin.js'
 import { supabaseAdmin } from '../../lib/db.js'
+import { ApiError } from '../../lib/errors.js'
 
 /**
  * Admin-only internal_alerts management.
@@ -36,7 +37,10 @@ adminAlertsRouter.get('/', async (c) => {
 
   const { data, error } = await query
   if (error) {
-    return c.json({ error: 'Failed to fetch alerts' }, 500)
+    // Sprint 7 R-15: standard error envelope. Carries the supabase error
+    // message in `details` so an operator triaging the alert can see why
+    // the fetch failed without grepping Vercel logs for the same time.
+    throw ApiError.from('INTERNAL_ERROR', { supabaseMessage: error.message })
   }
 
   return c.json({ success: true, data: data ?? [] })
@@ -57,8 +61,15 @@ adminAlertsRouter.post('/:id/resolve', async (c) => {
     .select('id, resolved_at')
     .maybeSingle()
 
-  if (error) return c.json({ error: `Resolve failed: ${error.message}` }, 500)
-  if (!data) return c.json({ error: 'Alert not found or already resolved' }, 404)
+  if (error) {
+    throw ApiError.from('INTERNAL_ERROR', { supabaseMessage: error.message })
+  }
+  if (!data) {
+    // 404 with a specific code so the dashboard can distinguish "wrong
+    // id" from "already resolved" if it ever wants to surface a friendlier
+    // toast for the idempotent case.
+    throw new ApiError('NOT_FOUND', 'Alert not found or already resolved')
+  }
 
   return c.json({ success: true, data })
 })

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,6 +1,11 @@
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { logger } from 'hono/logger'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
+import { captureException } from '@sentry/node'
+
+import { requestId } from './middleware/requestId.js'
+import { ApiError, isApiError } from './lib/errors.js'
 
 import { openaiProxy }     from './proxy/openai.js'
 import { anthropicProxy }  from './proxy/anthropic.js'
@@ -82,6 +87,9 @@ app.use('*', cors({
   credentials: true,
   maxAge: 86400,
 }))
+// Sprint 7 R-15: requestId before logger so the access log line carries
+// the same id that the response header and the onError payload echo.
+app.use('*', requestId)
 app.use('*', logger())
 
 // Health check routes extracted to api/health.ts for unit-test isolation.
@@ -224,5 +232,56 @@ app.route('/api/v1/admin/model-prices', adminModelPricesRouter)
 app.route('/api/v1/admin/model-recommendations', adminModelRecommendationsRouter)
 app.route('/api/v1/admin/background-migrations', adminBackgroundMigrationsRouter)
 app.route('/api/v1/admin/alerts', adminAlertsRouter)
+
+// Sprint 7 R-15 + R-20: global error handler. Every router can now
+// `throw new ApiError('CODE', 'message?')` and rely on this handler to
+// serialise to the standard `{ error: { code, message, details?, requestId } }`
+// shape. Unknown errors fall through to a 500 with Sentry capture so the
+// client never sees a stack trace.
+app.onError((err, c) => {
+  // requestId middleware runs before any route handler, so this should
+  // always be present in production. Treat absent as null so a unit
+  // test that exercises onError without mounting requestId still works.
+  const requestId =
+    ((c as unknown as { get: (k: string) => string | undefined }).get('requestId')) ?? null
+
+  if (isApiError(err)) {
+    return c.json(
+      {
+        error: {
+          code: err.code,
+          message: err.message,
+          ...(err.details ? { details: err.details } : {}),
+          requestId,
+        },
+      },
+      err.status as ContentfulStatusCode,
+    )
+  }
+
+  // Unknown error. Capture to Sentry (no-op when SENTRY_DSN is unset) and
+  // return an opaque 500 so we never leak stack traces or internal state.
+  captureException(err, { tags: { request_id: requestId ?? 'unknown' } })
+  return c.json(
+    {
+      error: {
+        code: 'INTERNAL_ERROR',
+        message: 'Unexpected error',
+        requestId,
+      },
+    },
+    500,
+  )
+})
+
+// Sprint 7 R-20: expose the Hono app's type so downstream packages can
+// derive a typed client. apps/web/lib/api-client.ts does
+// `hc<AppType>(...)` for full end-to-end type safety on every fetch.
+// Type-only export (no runtime cost; tsc strips it from the build).
+export type AppType = typeof app
+// Reference ApiError so the import is not tree-shaken away even if no
+// route is yet using it; remove this line in Sprint 8 once at least one
+// handler in app.ts itself throws ApiError.
+export type _AppErrorMarker = ApiError
 
 export default app

--- a/apps/server/src/lib/errors.test.ts
+++ b/apps/server/src/lib/errors.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { ApiError, ERROR_CODES, isApiError } from './errors.js'
+
+describe('ApiError', () => {
+  it('reads status and default message from the catalog when constructed by code only', () => {
+    const err = new ApiError('PUBLIC_KEY_WRITE_FORBIDDEN')
+    expect(err.code).toBe('PUBLIC_KEY_WRITE_FORBIDDEN')
+    expect(err.status).toBe(403)
+    expect(err.message).toBe(ERROR_CODES.PUBLIC_KEY_WRITE_FORBIDDEN.message)
+    expect(err.details).toBeUndefined()
+    expect(err.name).toBe('ApiError')
+  })
+
+  it('honours a custom message override while keeping the catalog status', () => {
+    const err = new ApiError('VALIDATION_FAILED', 'field "ttl" must be one of 7d, 30d, never')
+    expect(err.status).toBe(400)
+    expect(err.message).toBe('field "ttl" must be one of 7d, 30d, never')
+  })
+
+  it('attaches details via from() without overriding the message', () => {
+    const err = ApiError.from('DECRYPT_FAILED', { provider: 'openai', apiKeyId: 'abc' })
+    expect(err.status).toBe(503)
+    expect(err.message).toBe(ERROR_CODES.DECRYPT_FAILED.message)
+    expect(err.details).toEqual({ provider: 'openai', apiKeyId: 'abc' })
+  })
+
+  it('is recognised by isApiError type guard', () => {
+    const err = new ApiError('NOT_FOUND')
+    expect(isApiError(err)).toBe(true)
+  })
+
+  it('rejects vanilla Error in isApiError', () => {
+    expect(isApiError(new Error('plain'))).toBe(false)
+    expect(isApiError({ name: 'ApiError', code: 'fake' })).toBe(false)
+    expect(isApiError(null)).toBe(false)
+    expect(isApiError(undefined)).toBe(false)
+  })
+
+  it('inherits from Error so existing instanceof Error checks still match', () => {
+    const err = new ApiError('CONFLICT')
+    expect(err instanceof Error).toBe(true)
+  })
+
+  it('ERROR_CODES catalog has stable shape for every entry', () => {
+    for (const [code, entry] of Object.entries(ERROR_CODES)) {
+      expect(typeof code).toBe('string')
+      expect(code.length).toBeGreaterThan(0)
+      expect(typeof entry.status).toBe('number')
+      expect(entry.status).toBeGreaterThanOrEqual(400)
+      expect(entry.status).toBeLessThan(600)
+      expect(typeof entry.message).toBe('string')
+      expect(entry.message.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/apps/server/src/lib/errors.ts
+++ b/apps/server/src/lib/errors.ts
@@ -1,0 +1,107 @@
+/**
+ * Standard API error type for the Hono server (Sprint 7 R-15 + R-20).
+ *
+ * The 47 router files in `apps/server/src/api/` each invent their own
+ * `c.json({ error: '...' }, 4xx)` shape. The SDK and the dashboard both
+ * have to special-case which field carries the human message, what the
+ * machine-readable code is, and whether a `details` object is present.
+ * `ApiError` collapses that into one shape so the `onError` handler in
+ * `app.ts` can serialise every thrown error the same way, and the SDK
+ * can branch on a single stable `error.code` field.
+ *
+ * Throwing model:
+ *
+ *   throw new ApiError('PUBLIC_KEY_WRITE_FORBIDDEN', 'Public key cannot proxy')
+ *   throw ApiError.from('DECRYPT_FAILED', { provider: 'openai' })
+ *
+ * Both reach the global `onError` and serialise to:
+ *
+ *   { error: { code, message, details?, requestId } }
+ *
+ * Code catalog: every code lives in `ERROR_CODES` below. Adding a new
+ * code is a one-line PR; the type `ErrorCode` re-derives automatically
+ * so a typo at the throw site is a compile error rather than a silent
+ * 500.
+ */
+
+export const ERROR_CODES = {
+  // Auth and access control. These are the most operator-visible errors
+  // since they surface on every misconfigured customer integration.
+  PUBLIC_KEY_WRITE_FORBIDDEN: {
+    status: 403,
+    message: 'Public scope keys cannot use proxy, ingest, or OTLP endpoints',
+  },
+  UNAUTHORIZED: { status: 401, message: 'Unauthorized' },
+  FORBIDDEN: { status: 403, message: 'Forbidden' },
+
+  // Tenant / scoping.
+  ORGANIZATION_NOT_FOUND: { status: 404, message: 'Organization not found' },
+  PROJECT_NOT_FOUND: { status: 404, message: 'Project not found' },
+
+  // Validation. Generic catch-all; details should always carry the field
+  // names that failed.
+  VALIDATION_FAILED: { status: 400, message: 'Request validation failed' },
+  INVALID_JSON_BODY: { status: 400, message: 'Invalid JSON body' },
+
+  // Resource lifecycle.
+  NOT_FOUND: { status: 404, message: 'Resource not found' },
+  CONFLICT: { status: 409, message: 'Resource conflict' },
+
+  // Upstream / infrastructure failures.
+  DECRYPT_FAILED: {
+    status: 503,
+    message: 'Provider key decryption failed; check ENCRYPTION_KEY configuration',
+  },
+  INTERNAL_ERROR: { status: 500, message: 'Internal server error' },
+} as const
+
+export type ErrorCode = keyof typeof ERROR_CODES
+
+/**
+ * `ApiError` carries a code from the `ERROR_CODES` catalog plus an
+ * optional details object. Status code and default human message come
+ * from the catalog so the throw site stays a one-liner.
+ *
+ * The custom message overload is for the common case where the catalog
+ * default needs a contextualised suffix (e.g. add the field name to a
+ * `VALIDATION_FAILED`). Pass `undefined` to fall back to the catalog.
+ */
+export class ApiError extends Error {
+  public readonly code: ErrorCode
+  public readonly status: number
+  public readonly details: Record<string, unknown> | undefined
+
+  constructor(
+    code: ErrorCode,
+    customMessage?: string | undefined,
+    details?: Record<string, unknown>,
+  ) {
+    const entry = ERROR_CODES[code]
+    super(customMessage ?? entry.message)
+    this.name = 'ApiError'
+    this.code = code
+    this.status = entry.status
+    this.details = details
+  }
+
+  /**
+   * Convenience constructor for the common case where you only want to
+   * attach details without overriding the message: `ApiError.from('X', { ... })`.
+   */
+  static from(code: ErrorCode, details: Record<string, unknown>): ApiError {
+    return new ApiError(code, undefined, details)
+  }
+}
+
+/**
+ * Type guard: useful in middleware or tests where the caught value is
+ * `unknown` but we want to narrow without `instanceof` (which can fail
+ * across module boundaries when the same class is loaded twice).
+ */
+export function isApiError(value: unknown): value is ApiError {
+  return (
+    value instanceof Error &&
+    (value as ApiError).name === 'ApiError' &&
+    typeof (value as ApiError).code === 'string'
+  )
+}

--- a/apps/server/src/middleware/requestId.test.ts
+++ b/apps/server/src/middleware/requestId.test.ts
@@ -1,0 +1,49 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { requestId, type RequestIdContext } from './requestId.js'
+
+function makeApp(): Hono<RequestIdContext> {
+  const app = new Hono<RequestIdContext>()
+  app.use('*', requestId)
+  app.get('/', (c) => c.json({ id: c.get('requestId') }))
+  return app
+}
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+describe('requestId middleware', () => {
+  it('generates a UUIDv4 when no X-Request-ID header is present', async () => {
+    const app = makeApp()
+    const res = await app.request('/')
+    const body = (await res.json()) as { id: string }
+    expect(body.id).toMatch(UUID_REGEX)
+    expect(res.headers.get('X-Request-ID')).toBe(body.id)
+  })
+
+  it('echoes a valid client-supplied X-Request-ID without rewriting it', async () => {
+    const app = makeApp()
+    // A real upstream gateway value (UUIDv7) — should be preserved verbatim.
+    const incoming = '018f5dcb-1234-7890-9abc-def012345678'
+    const res = await app.request('/', { headers: { 'X-Request-ID': incoming } })
+    const body = (await res.json()) as { id: string }
+    expect(body.id).toBe(incoming)
+    expect(res.headers.get('X-Request-ID')).toBe(incoming)
+  })
+
+  it('rejects a malformed client-supplied id and generates a fresh one', async () => {
+    const app = makeApp()
+    // Garbage that could break log correlation if we trusted it.
+    const res = await app.request('/', { headers: { 'X-Request-ID': '../../etc/passwd' } })
+    const body = (await res.json()) as { id: string }
+    expect(body.id).not.toBe('../../etc/passwd')
+    expect(body.id).toMatch(UUID_REGEX)
+  })
+
+  it('issues distinct ids across two consecutive requests', async () => {
+    const app = makeApp()
+    const a = (await (await app.request('/')).json()) as { id: string }
+    const b = (await (await app.request('/')).json()) as { id: string }
+    expect(a.id).not.toBe(b.id)
+  })
+})

--- a/apps/server/src/middleware/requestId.ts
+++ b/apps/server/src/middleware/requestId.ts
@@ -1,0 +1,52 @@
+import { createMiddleware } from 'hono/factory'
+import { randomUUID } from 'node:crypto'
+
+/**
+ * Sprint 7 R-15 + R-20: per-request trace id middleware.
+ *
+ * Stamps a UUIDv4 onto every incoming request before any other route or
+ * middleware runs. Two consumers:
+ *
+ *   1. The global `onError` handler in `app.ts` echoes this id back to
+ *      the client inside the standard `{ error: { requestId } }` shape,
+ *      so a customer reporting a 500 can quote a single value that the
+ *      operator can grep in Vercel logs.
+ *   2. Sentry events tag this id via `captureException(err, { tags: ... })`,
+ *      linking a captured exception to the corresponding response.
+ *
+ * If the client already supplied an `X-Request-ID` header (e.g. from a
+ * gateway upstream of Spanlens), we honour it instead of generating a
+ * fresh one. This keeps the request id stable across a multi-hop path
+ * so log correlation works end to end.
+ *
+ * Mount order: must come AFTER `cors` (so preflight responses are not
+ * tagged) and BEFORE every router and the `onError` handler.
+ *
+ * Env contract: middleware augments Hono variables with `requestId: string`.
+ * Other middleware and handlers that read `c.get('requestId')` should type
+ * themselves with `Hono<RequestIdContext>` (or a wider Env that merges it).
+ */
+export type RequestIdContext = {
+  Variables: {
+    requestId: string
+  }
+}
+
+export const requestId = createMiddleware<RequestIdContext>(async (c, next) => {
+  const incoming = c.req.header('X-Request-ID')
+  const id = isLikelyUuid(incoming) ? incoming : randomUUID()
+  c.set('requestId', id)
+  c.header('X-Request-ID', id)
+  await next()
+})
+
+/**
+ * Accept any well-formed UUID v1-v8. We do not require strictly v4 here
+ * because upstream gateways often emit v7 (time-ordered). The length and
+ * shape check is enough; a hostile client cannot forge a request id into
+ * something that breaks log correlation downstream.
+ */
+function isLikelyUuid(value: string | undefined): value is string {
+  if (!value) return false
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+}


### PR DESCRIPTION
## Summary

First of three PRs for Sprint 7 (R-15 + R-20). This one ships the **infrastructure** so the next two PRs can migrate existing surface without inventing the pattern twice.

After this PR:
- Every router can throw \`ApiError('CODE', 'optional message', { details? })\` and the global \`onError\` handler serialises to the standard envelope
- Every request carries an \`X-Request-ID\` (generated UUIDv4 or echoed client value) that the error envelope echoes and Sentry tags
- \`AppType\` is exported from \`app.ts\` so PR 2 can wire \`hc<AppType>(...)\` in apps/web for end-to-end typed fetches
- One new router (admin alerts from R-Q2) already uses the new pattern as a working example

## Changes
- \`lib/errors.ts\` (new) — ApiError class + 10-entry ERROR_CODES catalog + isApiError type guard
- \`middleware/requestId.ts\` (new) — UUIDv4 stamping + client header echo, typed via createMiddleware
- \`app.ts\` — mount requestId, install onError handler with Sentry capture for unknowns, export AppType
- \`api/admin/alerts.ts\` — first router migrated to ApiError

## Tests (+15 vs base, 825 total)
- \`lib/errors.test.ts\` (7) — catalog shape, custom message override, details via from(), type guard
- \`middleware/requestId.test.ts\` (4) — generate vs echo, malformed input rejected, distinct ids
- \`__tests__/on-error-handler.test.ts\` (4) — standard envelope serialisation, details echoed, unknown error reaches Sentry tagged with request id, client X-Request-ID round-trips through error path

## Intentionally deferred
- **\`/cron/detect-orphan-spans\`** uses \`{ ok: true|false }\` contract for Vercel cron monitor compatibility. Sprint 8 will batch-migrate all ~30 cron endpoints with a helper that preserves the \`{ ok }\` shape
- **47 existing api/*.ts routers** (~729 error sites). PR 3 handles auth + proxy hot path (8 routers). PR 2 is independent (api-types package)

## Test plan
- [x] \`pnpm --filter server typecheck\` green
- [x] \`pnpm --filter server lint\` green
- [x] \`pnpm --filter server test\` 825 passed (810 before)
- [ ] CI green
- [ ] After merge: hit any 4xx endpoint in production, check response carries \`requestId\` and the same id appears in \`X-Request-ID\` header