### PR TITLE
feat: Sprint 7 R-15 + R-20 PR 2 — api-types package + Hono RPC client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,14 @@ jobs:
       - name: Build @spanlens/eslint-plugin
         run: pnpm --filter @spanlens/eslint-plugin build
 
+      # `apps/server` and `apps/web` import from `@spanlens/api-types`
+      # whose `package.json` exports point at `dist/index.d.ts`. `pnpm
+      # install` does not build dependents, so without this step the
+      # typecheck job fails with `Cannot find module '@spanlens/api-types'`.
+      # See Sprint 7 PR 2 (#277) where this was added.
+      - name: Build @spanlens/api-types
+        run: pnpm --filter @spanlens/api-types build
+
       - name: Typecheck (all packages)
         run: pnpm --recursive typecheck
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -29,6 +29,7 @@
     "hono": "^4.12.23"
   },
   "devDependencies": {
+    "@spanlens/api-types": "workspace:*",
     "@types/node": "^25.8.0",
     "@typescript-eslint/eslint-plugin": "^8.60.1",
     "@typescript-eslint/parser": "^8.60.1",

--- a/apps/server/src/lib/errors.contract.test.ts
+++ b/apps/server/src/lib/errors.contract.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  ApiErrorEnvelope,
+  KnownApiErrorCode,
+} from '@spanlens/api-types'
+import { isApiErrorEnvelope } from '@spanlens/api-types'
+import { ApiError, ERROR_CODES } from './errors.js'
+
+/**
+ * Sprint 7 R-15 + R-20 contract: the server's `ERROR_CODES` catalog and
+ * the `@spanlens/api-types` `KnownApiErrorCode` union are the same set
+ * at the type and runtime level. A new server code added without
+ * mirroring it in the package will fail compilation here, which is
+ * exactly the prompt we want: a developer adding a code in the server
+ * sees the package needs the same string before the PR merges.
+ *
+ * Why two places: api-types ships to npm consumers (SDK, future
+ * third-party clients) and cannot depend on apps/server. ERROR_CODES is
+ * the runtime source of truth inside the server. They MUST stay in sync;
+ * the test forces it.
+ */
+describe('error contract: server ERROR_CODES ↔ @spanlens/api-types KnownApiErrorCode', () => {
+  it('every server code is a KnownApiErrorCode at the type level', () => {
+    // Type-only assertion: if a code is added to ERROR_CODES without
+    // updating KnownApiErrorCode, `code satisfies KnownApiErrorCode`
+    // becomes a compile error and this test file fails `pnpm typecheck`
+    // before vitest even runs.
+    for (const code of Object.keys(ERROR_CODES)) {
+      const narrowed = code as KnownApiErrorCode
+      // Round-trip the narrowing back to string so runtime equality also
+      // catches a case-sensitivity drift (e.g. someone exporting
+      // 'Public_Key_Write_Forbidden').
+      expect(narrowed).toBe(code)
+    }
+  })
+
+  it('every KnownApiErrorCode literal exists in ERROR_CODES at runtime', () => {
+    // The union is closed (no `string & {}` brand here) so spelling
+    // every literal explicitly is fine and matches the count via the
+    // exhaustive switch below.
+    const knownAtCompileTime: KnownApiErrorCode[] = [
+      'PUBLIC_KEY_WRITE_FORBIDDEN',
+      'UNAUTHORIZED',
+      'FORBIDDEN',
+      'ORGANIZATION_NOT_FOUND',
+      'PROJECT_NOT_FOUND',
+      'VALIDATION_FAILED',
+      'INVALID_JSON_BODY',
+      'NOT_FOUND',
+      'CONFLICT',
+      'DECRYPT_FAILED',
+      'INTERNAL_ERROR',
+    ]
+    for (const code of knownAtCompileTime) {
+      expect(ERROR_CODES).toHaveProperty(code)
+    }
+    // Catches the opposite drift: server adds a code but the union is
+    // out of date. Without this check the type-level test still passes
+    // (everything in the smaller set is "known") and we silently ship
+    // an undocumented code to clients.
+    expect(Object.keys(ERROR_CODES).sort()).toEqual([...knownAtCompileTime].sort())
+  })
+
+  it('ApiError serialises to a shape that satisfies ApiErrorEnvelope at runtime', () => {
+    const err = ApiError.from('VALIDATION_FAILED', { field: 'ttl' })
+    const envelope: ApiErrorEnvelope = {
+      error: {
+        code: err.code,
+        message: err.message,
+        ...(err.details ? { details: err.details } : {}),
+        requestId: 'test-request-id',
+      },
+    }
+    expect(isApiErrorEnvelope(envelope)).toBe(true)
+    expect(envelope.error.code).toBe('VALIDATION_FAILED')
+    expect(envelope.error.details).toEqual({ field: 'ttl' })
+  })
+
+  it('isApiErrorEnvelope rejects shapes missing required fields', () => {
+    expect(isApiErrorEnvelope({})).toBe(false)
+    expect(isApiErrorEnvelope({ error: 'string' })).toBe(false)
+    expect(isApiErrorEnvelope({ error: { code: 'X' } })).toBe(false)
+    expect(isApiErrorEnvelope({ error: { message: 'X' } })).toBe(false)
+    expect(isApiErrorEnvelope(null)).toBe(false)
+    expect(isApiErrorEnvelope(undefined)).toBe(false)
+  })
+
+  it('isApiErrorEnvelope accepts an unknown future code without breaking', () => {
+    // Forward compatibility: a client running an older api-types should
+    // still parse an error from a newer server whose code is not in the
+    // union yet. The envelope shape is what gates parsing, not the code
+    // membership.
+    const futureEnvelope = {
+      error: {
+        code: 'BRAND_NEW_FUTURE_CODE',
+        message: 'something new',
+        requestId: 'id',
+      },
+    }
+    expect(isApiErrorEnvelope(futureEnvelope)).toBe(true)
+  })
+})

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -1,0 +1,109 @@
+/**
+ * Hono RPC client for apps/server, bound to the live AppType.
+ *
+ * This file IS the only place in apps/web that is allowed to import from
+ * `apps/server` (type-only). The dependency direction
+ * `packages/* → apps/*` is forbidden by CLAUDE.md, but `apps/web → apps/server`
+ * is allowed as long as the import is type-only so no server runtime code
+ * leaks into the Next bundle. `import type` plus `verbatimModuleSyntax` in
+ * tsconfig.base.json guarantees that.
+ *
+ * Why bind here instead of inside `@spanlens/api-types`: the AppType is
+ * generated from the running router tree in `apps/server/src/app.ts`. A
+ * package that re-exported AppType would have to depend on `server`,
+ * which violates the packages-to-apps direction. Putting the binding in
+ * `apps/web` keeps the dependency arrow pointing the right way and still
+ * gives every fetch end-to-end type safety.
+ *
+ * Usage:
+ *
+ *   import { apiClient, throwIfApiError } from '@/lib/api-client'
+ *
+ *   const res = await apiClient.api.v1.shares.$get({ query: { scope: 'org' } })
+ *   await throwIfApiError(res)
+ *   const body = await res.json()
+ *   // body is { success: true, data: ShareRow[] }
+ *
+ * Migration plan (this file is intentionally additive in PR 2):
+ *   1. Land alongside existing `apiGet`/`apiPost` helpers in `lib/api.ts`.
+ *   2. PR 3+ migrates one TanStack hook at a time from the old helpers
+ *      to apiClient. Both keep working in parallel during the rollout.
+ *   3. Eventually `lib/api.ts` becomes a thin compat layer or goes away.
+ */
+
+import { hc } from 'hono/client'
+// Type-only import: stripped at compile time, no server runtime in the bundle.
+import type { AppType } from 'server/src/app'
+
+import { isApiErrorEnvelope, type ApiErrorEnvelope } from '@spanlens/api-types'
+
+/**
+ * Resolves the API origin for the typed client. Mirrors `lib/api.ts`'s
+ * fallback chain so a Vercel preview deployment, a local dev, and a
+ * production build all pick the same backend the rest of the dashboard
+ * uses.
+ */
+function resolveBaseUrl(): string {
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    // SSR'd page rendered in the browser: prefer the explicit env so the
+    // client does not accidentally talk to its own Next server.
+    return process.env.NEXT_PUBLIC_API_URL ?? window.location.origin
+  }
+  return process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001'
+}
+
+export const apiClient = hc<AppType>(resolveBaseUrl())
+
+/**
+ * Domain-specific error class thrown when a Hono RPC call returns a
+ * non-2xx whose body matches the `ApiErrorEnvelope` shape. Carries the
+ * structured fields so consumers can branch on `error.code`.
+ *
+ * Why not just bubble the raw envelope: every TanStack hook then needs
+ * its own narrowing logic and `instanceof Error` checks fall through to
+ * a generic 500 toast. A typed Error subclass is the one shape React
+ * Query, Sentry, and the existing toast utility all already understand.
+ */
+export class SpanlensApiError extends Error {
+  public readonly code: string
+  public readonly status: number
+  public readonly details: Record<string, unknown> | undefined
+  public readonly requestId: string | null
+
+  constructor(envelope: ApiErrorEnvelope, status: number) {
+    super(envelope.error.message)
+    this.name = 'SpanlensApiError'
+    this.code = envelope.error.code
+    this.status = status
+    this.details = envelope.error.details
+    this.requestId = envelope.error.requestId
+  }
+}
+
+/**
+ * Helper that inspects a Hono RPC `Response` and throws a typed
+ * `SpanlensApiError` when the body matches the standard error envelope.
+ * Returns the response unchanged on success so it composes cleanly:
+ *
+ *   const body = await throwIfApiError(await apiClient.api.v1.foo.$get())
+ *
+ * Non-envelope errors (HTML 502 from a CDN, network failure) reach the
+ * caller as the original `fetch` failure so they can be handled with the
+ * existing retry logic in TanStack Query.
+ */
+export async function throwIfApiError(res: Response): Promise<Response> {
+  if (res.ok) return res
+  // Clone so the caller can still read the body if they catch and want
+  // the raw bytes.
+  const cloned = res.clone()
+  let parsed: unknown
+  try {
+    parsed = await cloned.json()
+  } catch {
+    return res
+  }
+  if (isApiErrorEnvelope(parsed)) {
+    throw new SpanlensApiError(parsed, res.status)
+  }
+  return res
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/react-toast": "^1.2.1",
     "@radix-ui/react-tooltip": "^1.1.3",
     "@sentry/nextjs": "^10.56.0",
+    "@spanlens/api-types": "workspace:*",
     "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.107.0",
     "@tanstack/react-query": "^5.101.0",
@@ -50,7 +51,9 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.7",
+    "hono": "^4.12.23",
     "postcss": "^8",
+    "server": "workspace:*",
     "tailwindcss": "^4.3.0",
     "typescript": "^6"
   }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,6 +1,7 @@
 {
   "framework": "nextjs",
   "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "pnpm --filter web build",
+  "buildCommand": "pnpm --filter @spanlens/api-types build && pnpm --filter web build",
   "regions": ["icn1"]
 }
+

--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@spanlens/api-types",
+  "version": "0.1.0",
+  "description": "Shared error envelope and type helpers for clients that talk to apps/server.",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0"
+  }
+}

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -1,0 +1,103 @@
+/**
+ * @spanlens/api-types — error envelope contract shared between server
+ * and every typed client (apps/web, packages/sdk).
+ *
+ * Why a separate package: the dashboard, the SDK, and any third-party
+ * consumer (Hono RPC, a generated OpenAPI client) all need to agree on
+ * the shape of an error response. Defining that shape in
+ * `apps/server/src/lib/errors.ts` works for the server, but the CLAUDE.md
+ * dependency rule forbids `packages/` from importing `apps/`. The
+ * envelope therefore lives here as the source of truth; the server's
+ * `ApiError` class implements it (test verifies they stay in sync).
+ *
+ * Intentionally NOT exported here:
+ *   - The Hono `AppType`. That type is generated from the live router
+ *     tree in `apps/server/src/app.ts` and would force a server-to-
+ *     package import. Consumers wanting Hono RPC do
+ *     `import type { AppType } from 'server/src/app'` directly from
+ *     within `apps/web`, where the dependency direction is allowed.
+ *   - The `ApiError` class. Class identity does not survive a network
+ *     boundary; clients should branch on `error.code` string instead.
+ */
+
+/**
+ * Stable shape every API error response uses. Echoed back as:
+ *
+ *   HTTP/1.1 4xx Status
+ *   X-Request-ID: <uuid>
+ *   {
+ *     "error": {
+ *       "code": "PUBLIC_KEY_WRITE_FORBIDDEN",
+ *       "message": "Public scope keys cannot use proxy, ingest, or OTLP endpoints",
+ *       "details": { ... } | undefined,
+ *       "requestId": "<uuid>"
+ *     }
+ *   }
+ *
+ * Clients should branch on `code` (stable identifier), surface `message`
+ * to the user, log `requestId` for support tickets, and treat `details`
+ * as a free-form bag of debugging context.
+ */
+export interface ApiErrorEnvelope {
+  error: {
+    /** Stable identifier from the server's ERROR_CODES catalog. */
+    code: string
+    /** Human-readable message; safe to display to end users. */
+    message: string
+    /** Free-form debugging context. Only present when the server attached one. */
+    details?: Record<string, unknown>
+    /**
+     * UUID stamped by the requestId middleware. Always present in production
+     * responses; nullable so test harnesses without the middleware mounted
+     * can still serialise.
+     */
+    requestId: string | null
+  }
+}
+
+/**
+ * Type guard for the envelope. Useful in fetch wrappers that have to
+ * narrow `unknown` into a typed error before throwing a domain-specific
+ * exception. Does not validate the `code` against any enum because the
+ * client and server may ship at different versions; an unknown code is a
+ * valid envelope, just one the client cannot interpret structurally.
+ */
+export function isApiErrorEnvelope(value: unknown): value is ApiErrorEnvelope {
+  if (value == null || typeof value !== 'object') return false
+  const maybe = value as { error?: unknown }
+  if (maybe.error == null || typeof maybe.error !== 'object') return false
+  const err = maybe.error as { code?: unknown; message?: unknown }
+  return typeof err.code === 'string' && typeof err.message === 'string'
+}
+
+/**
+ * Initial code catalog mirror. The server's `ERROR_CODES` in
+ * `apps/server/src/lib/errors.ts` is the source of truth at runtime; the
+ * union below exists only so SDK / dashboard code can write
+ * `if (error.code === 'PUBLIC_KEY_WRITE_FORBIDDEN')` without a string
+ * literal that the compiler cannot help with.
+ *
+ * Stay loose intentionally: new server codes ship without coordination,
+ * and a `KnownApiErrorCode | (string & {})` union lets clients keep
+ * narrowing on the known set while still accepting any string at runtime.
+ */
+export type KnownApiErrorCode =
+  | 'PUBLIC_KEY_WRITE_FORBIDDEN'
+  | 'UNAUTHORIZED'
+  | 'FORBIDDEN'
+  | 'ORGANIZATION_NOT_FOUND'
+  | 'PROJECT_NOT_FOUND'
+  | 'VALIDATION_FAILED'
+  | 'INVALID_JSON_BODY'
+  | 'NOT_FOUND'
+  | 'CONFLICT'
+  | 'DECRYPT_FAILED'
+  | 'INTERNAL_ERROR'
+
+/**
+ * Branded string type: a code is known if it matches the literal union,
+ * otherwise it stays a plain string at the type level. Lets switch
+ * statements stay exhaustive for known cases while still accepting
+ * forward-compatible unknown codes from a newer server.
+ */
+export type ApiErrorCode = KnownApiErrorCode | (string & { _brand?: 'forward-compatible' })

--- a/packages/api-types/tsconfig.json
+++ b/packages/api-types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
         specifier: ^4.12.23
         version: 4.12.23
     devDependencies:
+      '@spanlens/api-types':
+        specifier: workspace:*
+        version: link:../../packages/api-types
       '@types/node':
         specifier: ^25.8.0
         version: 25.8.0
@@ -123,6 +126,9 @@ importers:
       '@sentry/nextjs':
         specifier: ^10.56.0
         version: 10.56.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.106.2(postcss@8.5.15))
+      '@spanlens/api-types':
+        specifier: workspace:*
+        version: link:../../packages/api-types
       '@supabase/ssr':
         specifier: ^0.10.3
         version: 0.10.3(@supabase/supabase-js@2.107.0)
@@ -199,15 +205,27 @@ importers:
       eslint-config-next:
         specifier: 16.2.7
         version: 16.2.7(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      hono:
+        specifier: ^4.12.23
+        version: 4.12.23
       postcss:
         specifier: ^8
         version: 8.5.15
+      server:
+        specifier: workspace:*
+        version: link:../server
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
       typescript:
         specifier: ^6
         version: 6.0.3
+
+  packages/api-types:
+    devDependencies:
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
 
   packages/cli:
     dependencies:
@@ -7793,8 +7811,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.7
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -7816,7 +7834,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7827,22 +7845,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7853,7 +7871,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary

Second of three Sprint 7 PRs. PR 1 ([#276](https://github.com/spanlens/Spanlens/pull/276)) shipped server-side errors infra. This PR establishes the cross-package contract so apps/web and (eventually) the SDK consume that contract with full type safety.

After this PR:
- \`@spanlens/api-types\` (workspace package) defines \`ApiErrorEnvelope\` shape that the server already emits
- apps/web has a typed Hono RPC client at \`apps/web/lib/api-client.ts\` ready to replace the existing \`apiGet\`/\`apiPost\` helpers one hook at a time
- A contract test forces the server's \`ERROR_CODES\` catalog and the package's \`KnownApiErrorCode\` union to stay in sync

## Why two homes for the error shape

- Server \`ERROR_CODES\` is runtime source of truth; can't ship to npm
- \`@spanlens/api-types\` is the type-only npm-shippable mirror
- CLAUDE.md forbids \`packages/* → apps/*\`, so the package can't reach into the server
- Contract test makes drift in either direction a failing test

## Why AppType binds in apps/web (not the package)

- \`AppType = typeof app\` is derived from the live router tree
- Re-exporting AppType from a package would force \`packages → apps\` dependency
- \`apps/web → apps/server\` is allowed when type-only; \`import type\` strips all server runtime
- Result: zero server bytes in the Next bundle, full end-to-end types

## Changes
- \`packages/api-types/\` (new, \`@spanlens/api-types@0.1.0\`) — ApiErrorEnvelope, isApiErrorEnvelope, KnownApiErrorCode union, ApiErrorCode forward-compatible variant
- \`apps/web/lib/api-client.ts\` (new) — \`apiClient = hc<AppType>(...)\`, \`SpanlensApiError\` class, \`throwIfApiError\` helper, resolveBaseUrl mirrors existing fallback chain
- \`apps/server/src/lib/errors.contract.test.ts\` (new, 5 tests) — bidirectional drift check + envelope shape + forward compatibility
- package.json wiring: server adds api-types as devDep, web adds api-types runtime + server/hono as type-only devDeps

## Tests (+5 contract = 830 total)
- Every server code is KnownApiErrorCode at type level
- Every union literal exists in ERROR_CODES at runtime (catches reverse drift)
- ApiError serialises to envelope shape that isApiErrorEnvelope accepts
- Envelope guard rejects malformed shapes (null, missing fields, wrong types)
- Forward compat: envelope guard accepts unknown future codes

## Test plan
- [x] \`pnpm install\` resolves new workspace deps
- [x] \`pnpm --filter @spanlens/api-types build\` green
- [x] \`pnpm --filter server typecheck\` + \`lint\` + \`test\` (830 passed)
- [x] \`pnpm --filter web typecheck\` + \`lint\` green
- [ ] CI green
- [ ] After merge: \`apiClient.api.v1.shares.\$get({ query: { scope: 'org' } })\` autocompletes in apps/web

## Intentionally deferred to PR 3
- No router migrations beyond the one in PR 1
- No TanStack hook rewrites to use \`apiClient\` (additive in this PR, parallel rollout in PR 3+)
- SDK \`SpanlensApiError\` (different from web's class with the same name; SDK target ships later)
- docs/api/errors auto-generated page