### PR TITLE
feat: Sprint 7 R-15 + R-20 PR 3 — 8 routers migrated + SDK typed error + docs

### DIFF
--- a/apps/server/src/__tests__/auth-api-key.test.ts
+++ b/apps/server/src/__tests__/auth-api-key.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest'
 import { Hono } from 'hono'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { installOnError } from './helpers/install-on-error.js'
 
 // Stub supabaseAdmin so tests never hit a real database.
 // The stub returns a valid key record only when key_hash matches VALID_HASH.
@@ -77,6 +78,7 @@ function buildApp() {
       scope: c.get('apiKeyScope'),
     }),
   )
+  installOnError(app)
   return app
 }
 
@@ -132,8 +134,10 @@ describe('authApiKey — rejected transports', () => {
       headers: { Authorization: 'Bearer sl_live_wrong_key' },
     })
     expect(res.status).toBe(401)
-    const body = (await res.json()) as { error: string }
-    expect(body.error).toBe('Invalid API key')
+    const body = (await res.json()) as { error: { code: string; message: string } }
+    // Sprint 7 R-15: standard envelope shape via global onError handler.
+    expect(body.error.code).toBe('UNAUTHORIZED')
+    expect(body.error.message).toBe('Invalid API key')
   })
 
   test('Bearer with empty value returns 401', async () => {

--- a/apps/server/src/__tests__/auth-jwt-or-api-key.test.ts
+++ b/apps/server/src/__tests__/auth-jwt-or-api-key.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi, beforeEach } from 'vitest'
 import { Hono } from 'hono'
 import { authJwtOrApiKey, type DualAuthContext } from '../middleware/authJwtOrApiKey.js'
 import { _clearAuthCacheForTests } from '../middleware/authJwt.js'
+import { installOnError } from './helpers/install-on-error.js'
 
 /**
  * The dual-auth middleware on `/api/v1/*` routes to one of two auth flows
@@ -89,6 +90,7 @@ function buildApp() {
       scope: c.get('apiKeyScope') ?? null,
     }),
   )
+  installOnError(app)
   return app
 }
 

--- a/apps/server/src/__tests__/auth-jwt.test.ts
+++ b/apps/server/src/__tests__/auth-jwt.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { Hono } from 'hono'
 import type { JwtContext } from '../middleware/authJwt.js'
+import { installOnError } from './helpers/install-on-error.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Tests for the JWT middleware that gates every /api/v1/* route. A regression
@@ -49,6 +50,7 @@ function makeApp() {
       role: c.get('role'),
     }),
   )
+  installOnError(app)
   return app
 }
 
@@ -56,7 +58,10 @@ describe('authJwt — auth header', () => {
   test('missing Authorization header → 401', async () => {
     const res = await makeApp().request('/probe')
     expect(res.status).toBe(401)
-    expect(await res.json()).toEqual({ error: 'Missing or invalid Authorization header' })
+    // Sprint 7 R-15: standard envelope.
+    expect(await res.json()).toEqual({
+      error: { code: 'UNAUTHORIZED', message: 'Missing or invalid Authorization header' },
+    })
     // Never reaches Supabase — fail fast
     expect(getUserMock).not.toHaveBeenCalled()
   })
@@ -78,7 +83,10 @@ describe('authJwt — auth header', () => {
       headers: { Authorization: 'Bearer ' },
     })
     expect(res.status).toBe(401)
-    expect(await res.json()).toEqual({ error: 'Missing or invalid Authorization header' })
+    // Sprint 7 R-15: standard envelope.
+    expect(await res.json()).toEqual({
+      error: { code: 'UNAUTHORIZED', message: 'Missing or invalid Authorization header' },
+    })
     expect(getUserMock).not.toHaveBeenCalled()
   })
 })
@@ -90,7 +98,9 @@ describe('authJwt — supabase auth result', () => {
       headers: { Authorization: 'Bearer expired_token' },
     })
     expect(res.status).toBe(401)
-    expect(await res.json()).toEqual({ error: 'Invalid or expired token' })
+    expect(await res.json()).toEqual({
+      error: { code: 'UNAUTHORIZED', message: 'Invalid or expired token' },
+    })
   })
 
   test('Supabase returns no user → 401', async () => {

--- a/apps/server/src/__tests__/helpers/install-on-error.ts
+++ b/apps/server/src/__tests__/helpers/install-on-error.ts
@@ -1,0 +1,30 @@
+import type { Hono } from 'hono'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
+import { isApiError } from '../../lib/errors.js'
+
+/**
+ * Sprint 7 R-15 + R-20 test helper.
+ *
+ * Mirror of the global onError handler in `apps/server/src/app.ts`. Test
+ * apps that exercise middleware which now throws ApiError (instead of
+ * returning c.json directly) must mount an onError serialiser so the
+ * thrown error becomes a proper HTTP response. Without it, Hono surfaces
+ * the uncaught throw as a generic 500 and assertions like
+ * `expect(res.status).toBe(403)` fail with "expected 500".
+ *
+ * Kept narrow on purpose: serialises only ApiError. Anything else
+ * re-throws so the test still observes the unexpected error as a real
+ * test failure rather than swallowing it into a 500 body.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function installOnError(app: Hono<any, any, any>): void {
+  app.onError((err, c) => {
+    if (isApiError(err)) {
+      return c.json(
+        { error: { code: err.code, message: err.message, details: err.details } },
+        err.status as ContentfulStatusCode,
+      )
+    }
+    throw err
+  })
+}

--- a/apps/server/src/__tests__/require-full-scope.test.ts
+++ b/apps/server/src/__tests__/require-full-scope.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from 'vitest'
 import { Hono } from 'hono'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
 import { requireFullScope } from '../middleware/requireFullScope.js'
+import { installOnError } from './helpers/install-on-error.js'
 
 /**
  * requireFullScope rejects `public`-scope Spanlens keys with 403 before they
@@ -72,6 +73,7 @@ function buildApp() {
   app.use('*', authApiKey)
   app.use('*', requireFullScope)
   app.post('/write', (c) => c.json({ ok: true, scope: c.get('apiKeyScope') }))
+  installOnError(app)
   return app
 }
 
@@ -95,11 +97,10 @@ describe('requireFullScope', () => {
       headers: { Authorization: `Bearer ${PUB_KEY}` },
     })
     expect(res.status).toBe(403)
-    const body = (await res.json()) as { error: string; code: string }
-    expect(body.code).toBe('PUBLIC_KEY_WRITE_FORBIDDEN')
-    // Error message should point the user at where to mint a full-access key
-    // so they aren't left debugging blindly.
-    expect(body.error.toLowerCase()).toContain('public api key')
+    // Sprint 7 R-15: standard envelope via global onError handler.
+    const body = (await res.json()) as { error: { code: string; message: string } }
+    expect(body.error.code).toBe('PUBLIC_KEY_WRITE_FORBIDDEN')
+    expect(body.error.message.toLowerCase()).toContain('public api key')
   })
 
   test('public-key rejection applies on every accepted transport', async () => {
@@ -127,6 +128,7 @@ describe('authApiKey owner resolution', () => {
       scope: c.get('apiKeyScope'),
     }),
   )
+  installOnError(app)
 
   test('full key resolves organizationId via projects join, projectId set', async () => {
     const res = await app.request('/probe', { headers: { Authorization: `Bearer ${FULL_KEY}` } })

--- a/apps/server/src/__tests__/require-role.test.ts
+++ b/apps/server/src/__tests__/require-role.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, test } from 'vitest'
 import { Hono } from 'hono'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import { requireRole } from '../middleware/requireRole.js'
 import type { JwtContext, OrgRole } from '../middleware/authJwt.js'
+import { isApiError } from '../lib/errors.js'
 
 // Build a minimal app that stubs authJwt by pre-setting role via header,
 // then gates a handler with requireRole. This isolates the middleware under
 // test from the real Supabase call without any mocking framework.
+//
+// Sprint 7 R-15 + R-20 update: requireRole now throws ApiError instead of
+// returning c.json directly. Mount the same onError serialiser the real
+// app.ts uses so the assertions still target the rendered HTTP response
+// rather than an uncaught throw (which would surface as a 500).
 function buildApp(allowed: OrgRole[]) {
   const app = new Hono<JwtContext>()
   app.use('*', async (c, next) => {
@@ -16,6 +23,15 @@ function buildApp(allowed: OrgRole[]) {
     return next()
   })
   app.post('/write', requireRole(...allowed), (c) => c.json({ ok: true }))
+  app.onError((err, c) => {
+    if (isApiError(err)) {
+      return c.json(
+        { error: { code: err.code, message: err.message } },
+        err.status as ContentfulStatusCode,
+      )
+    }
+    throw err
+  })
   return app
 }
 
@@ -36,8 +52,9 @@ describe('requireRole middleware', () => {
       headers: { 'x-test-role': 'viewer' },
     })
     expect(res.status).toBe(403)
-    const body = (await res.json()) as { error: string }
-    expect(body.error).toBe('Insufficient permission')
+    const body = (await res.json()) as { error: { code: string; message: string } }
+    expect(body.error.code).toBe('FORBIDDEN')
+    expect(body.error.message).toMatch(/Forbidden/)
   })
 
   test('rejects editor on admin-only endpoint', async () => {

--- a/apps/server/src/__tests__/require-system-admin.test.ts
+++ b/apps/server/src/__tests__/require-system-admin.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { Hono } from 'hono'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
+import { isApiError } from '../lib/errors.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Tests for the system-admin gate that protects internal-only routes (e.g.
@@ -32,7 +34,13 @@ afterEach(() => {
   else process.env['SPANLENS_ADMIN_EMAILS'] = origEnv
 })
 
-/** Apps the middleware on top of a fake authJwt that just stuffs userId. */
+/**
+ * Apps the middleware on top of a fake authJwt that just stuffs userId.
+ *
+ * Sprint 7 R-15 + R-20 update: requireSystemAdmin now throws ApiError
+ * instead of returning c.json. Mount the standard onError serialiser so
+ * the test assertions still target a rendered HTTP response.
+ */
 function makeApp(userId: string | null, opts: { authHeader?: string } = {}) {
   const app = new Hono<{ Variables: { userId: string | null } }>()
   app.use('*', async (c, next) => {
@@ -41,6 +49,15 @@ function makeApp(userId: string | null, opts: { authHeader?: string } = {}) {
   })
   app.use('*', requireSystemAdmin as unknown as Parameters<typeof app.use>[1])
   app.get('/probe', (c) => c.json({ ok: true }))
+  app.onError((err, c) => {
+    if (isApiError(err)) {
+      return c.json(
+        { error: { code: err.code, message: err.message } },
+        err.status as ContentfulStatusCode,
+      )
+    }
+    throw err
+  })
   return {
     request: () =>
       app.request(
@@ -56,7 +73,9 @@ describe('requireSystemAdmin — fail-closed defaults', () => {
   test('SPANLENS_ADMIN_EMAILS unset → 403 (no one is admin by default)', async () => {
     const res = await makeApp('usr_1', { authHeader: 'Bearer t' }).request()
     expect(res.status).toBe(403)
-    expect(await res.json()).toEqual({ error: 'Insufficient permission' })
+    expect(await res.json()).toEqual({
+      error: { code: 'FORBIDDEN', message: 'Insufficient permission' },
+    })
   })
 
   test('SPANLENS_ADMIN_EMAILS set to whitespace/empty → 403', async () => {

--- a/apps/server/src/lib/errors-docs-sync.test.ts
+++ b/apps/server/src/lib/errors-docs-sync.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { ERROR_CODES } from './errors.js'
+
+/**
+ * Sprint 7 R-15 + R-20: keep the hand-authored docs catalog at
+ * apps/web/app/docs/api/errors/page.tsx in sync with the runtime
+ * ERROR_CODES catalog. The docs file is not generated because pulling
+ * the server runtime into the Next bundle would add unwanted JS, but
+ * we still want a build-time guarantee that every code the server can
+ * throw is documented.
+ *
+ * The test parses the docs file as plain text and checks that every
+ * ERROR_CODES key appears at least once. Spelling drift, a missing
+ * entry, or a renamed code all surface here as a failing test.
+ *
+ * The reverse drift (a docs entry with no server code) is intentionally
+ * NOT enforced. A code we documented but later dropped may still appear
+ * in old client SDKs in the wild, and keeping the docs page describing
+ * what it used to mean is a feature, not a bug.
+ */
+
+function resolveDocsPath(): string {
+  // apps/server/src/lib/errors-docs-sync.test.ts
+  //   here = apps/server/src/lib
+  //   ../   = apps/server/src
+  //   ../../ = apps/server
+  //   ../../../ = apps
+  //   ../../../web/app/... = apps/web/app/...
+  const here = dirname(fileURLToPath(import.meta.url))
+  return resolve(here, '../../../web/app/docs/api/errors/page.tsx')
+}
+
+describe('docs page mirrors the ERROR_CODES catalog', () => {
+  const docsText = readFileSync(resolveDocsPath(), 'utf8')
+  const serverCodes = Object.keys(ERROR_CODES)
+
+  it.each(serverCodes)('docs/api/errors page mentions %s', (code) => {
+    expect(docsText.includes(code)).toBe(true)
+  })
+
+  it('docs page references the standard envelope keys (code, message, details, requestId)', () => {
+    // Loose check: the prose section explains the four fields by name.
+    // A bigger restructure that drops one of them should fail this so
+    // the docs stay accurate.
+    for (const field of ['code', 'message', 'details', 'requestId']) {
+      expect(docsText).toContain(field)
+    }
+  })
+
+  it('docs page documents the X-Request-ID header alongside the envelope', () => {
+    expect(docsText).toContain('X-Request-ID')
+  })
+})

--- a/apps/server/src/lib/errors.contract.test.ts
+++ b/apps/server/src/lib/errors.contract.test.ts
@@ -50,6 +50,9 @@ describe('error contract: server ERROR_CODES ↔ @spanlens/api-types KnownApiErr
       'CONFLICT',
       'DECRYPT_FAILED',
       'INTERNAL_ERROR',
+      'NO_PROVIDER_KEY',
+      'UPSTREAM_TIMEOUT',
+      'UPSTREAM_FAILED',
     ]
     for (const code of knownAtCompileTime) {
       expect(ERROR_CODES).toHaveProperty(code)

--- a/apps/server/src/lib/errors.ts
+++ b/apps/server/src/lib/errors.ts
@@ -53,6 +53,17 @@ export const ERROR_CODES = {
     message: 'Provider key decryption failed; check ENCRYPTION_KEY configuration',
   },
   INTERNAL_ERROR: { status: 500, message: 'Internal server error' },
+
+  // Proxy-specific. Sprint 7 PR 3 migration: proxy/* handlers throw these
+  // instead of returning ad-hoc { error: '...' } shapes. NO_PROVIDER_KEY
+  // is the most common operator misconfiguration so it gets its own code
+  // even though it overlaps with NOT_FOUND semantically.
+  NO_PROVIDER_KEY: {
+    status: 400,
+    message: 'No active provider key registered for this Spanlens key',
+  },
+  UPSTREAM_TIMEOUT: { status: 504, message: 'Upstream request timed out' },
+  UPSTREAM_FAILED: { status: 502, message: 'Upstream request failed' },
 } as const
 
 export type ErrorCode = keyof typeof ERROR_CODES

--- a/apps/server/src/middleware/authApiKey.ts
+++ b/apps/server/src/middleware/authApiKey.ts
@@ -4,6 +4,7 @@ import { supabaseAdmin } from '../lib/db.js'
 import { sha256Hex } from '../lib/crypto.js'
 import { maybeStampLastUsed } from '../lib/api-key-last-used.js'
 import { fireAndForget } from '../lib/wait-until.js'
+import { ApiError } from '../lib/errors.js'
 import type { Plan } from '../lib/quota.js'
 
 /**
@@ -209,7 +210,10 @@ export const authApiKey = createMiddleware<ApiKeyContext>(async (c, next) => {
     .single()
 
   if (error || !data) {
-    return c.json({ error: 'Invalid API key' }, 401)
+    // Sprint 7 R-15: standard envelope. Don't leak whether the key was
+    // unknown vs. inactive vs. revoked — UNAUTHORIZED covers all three
+    // with one indistinguishable response (defence against token probing).
+    throw new ApiError('UNAUTHORIZED', 'Invalid API key')
   }
 
   const scope: ApiKeyScope = (data.scope as string) === 'public' ? 'public' : 'full'
@@ -232,7 +236,14 @@ export const authApiKey = createMiddleware<ApiKeyContext>(async (c, next) => {
   }
 
   if (!organizationId) {
-    return c.json({ error: 'API key has no owning organization' }, 401)
+    // The api_keys row should always carry either project_id (full scope)
+    // or organization_id (public scope) per the DB CHECK constraint. A
+    // missing org here means the data integrity contract was violated;
+    // INTERNAL_ERROR with a hint via details for the operator log path.
+    throw ApiError.from('INTERNAL_ERROR', {
+      reason: 'api_keys row has no resolvable organization',
+      apiKeyId: data.id as string,
+    })
   }
 
   const apiKeyId = data.id as string

--- a/apps/server/src/middleware/authJwt.ts
+++ b/apps/server/src/middleware/authJwt.ts
@@ -1,5 +1,6 @@
 import { createMiddleware } from 'hono/factory'
 import { supabaseAdmin, supabaseClient } from '../lib/db.js'
+import { ApiError } from '../lib/errors.js'
 
 export type OrgRole = 'admin' | 'editor' | 'viewer'
 
@@ -110,7 +111,7 @@ export function _clearAuthCacheForTests(): void {
 export const authJwt = createMiddleware<JwtContext>(async (c, next) => {
   const authHeader = c.req.header('Authorization')
   if (!authHeader?.startsWith('Bearer ')) {
-    return c.json({ error: 'Missing or invalid Authorization header' }, 401)
+    throw new ApiError('UNAUTHORIZED', 'Missing or invalid Authorization header')
   }
 
   const token = authHeader.slice(7)
@@ -131,7 +132,7 @@ export const authJwt = createMiddleware<JwtContext>(async (c, next) => {
   const { data, error } = await supabaseClient.auth.getUser(token)
 
   if (error || !data.user) {
-    return c.json({ error: 'Invalid or expired token' }, 401)
+    throw new ApiError('UNAUTHORIZED', 'Invalid or expired token')
   }
 
   const userId = data.user.id

--- a/apps/server/src/middleware/requireFullScope.ts
+++ b/apps/server/src/middleware/requireFullScope.ts
@@ -1,5 +1,6 @@
 import { createMiddleware } from 'hono/factory'
 import type { ApiKeyContext } from './authApiKey.js'
+import { ApiError } from '../lib/errors.js'
 
 /**
  * Rejects requests authenticated with a `public`-scope Spanlens key.
@@ -23,13 +24,13 @@ import type { ApiKeyContext } from './authApiKey.js'
 export const requireFullScope = createMiddleware<ApiKeyContext>(async (c, next) => {
   const scope = c.get('apiKeyScope')
   if (scope === 'public') {
-    return c.json(
-      {
-        error:
-          'Public API key cannot perform write operations. Issue a full-access key on the Projects & Keys page to enable LLM proxy and ingest endpoints.',
-        code: 'PUBLIC_KEY_WRITE_FORBIDDEN',
-      },
-      403,
+    // Sprint 7 R-15: standard envelope. PUBLIC_KEY_WRITE_FORBIDDEN is in
+    // ERROR_CODES so the SDK can pattern-match on error.code without
+    // string-comparing the message. The original message stays as the
+    // user-facing text since it includes the actionable upgrade hint.
+    throw new ApiError(
+      'PUBLIC_KEY_WRITE_FORBIDDEN',
+      'Public API key cannot perform write operations. Issue a full-access key on the Projects & Keys page to enable LLM proxy and ingest endpoints.',
     )
   }
   return next()

--- a/apps/server/src/middleware/requireRole.ts
+++ b/apps/server/src/middleware/requireRole.ts
@@ -1,5 +1,6 @@
 import { createMiddleware } from 'hono/factory'
 import type { JwtContext, OrgRole } from './authJwt.js'
+import { ApiError } from '../lib/errors.js'
 
 /**
  * Gate an endpoint by org role. Runs AFTER `authJwt` — relies on
@@ -16,7 +17,9 @@ export const requireRole = (...allowed: OrgRole[]) =>
   createMiddleware<JwtContext>(async (c, next) => {
     const role = c.get('role')
     if (!role || !allowed.includes(role)) {
-      return c.json({ error: 'Insufficient permission' }, 403)
+      // Details carries the required vs. actual role so an audit log
+      // can show why the call was rejected without re-parsing the URL.
+      throw ApiError.from('FORBIDDEN', { required: allowed, actual: role })
     }
     return next()
   })

--- a/apps/server/src/middleware/requireSystemAdmin.ts
+++ b/apps/server/src/middleware/requireSystemAdmin.ts
@@ -1,6 +1,18 @@
 import { createMiddleware } from 'hono/factory'
 import { supabaseClient } from '../lib/db.js'
+import { ApiError } from '../lib/errors.js'
 import type { JwtContext } from './authJwt.js'
+
+/**
+ * Single 403 message used for every reject reason in this middleware.
+ * Intentionally identical across the five branches below: a non-admin
+ * caller must not be able to distinguish "your email is not on the
+ * allowlist" from "the allowlist itself is unset" from "your token is
+ * invalid". That distinction would be a probing vector. Operators
+ * needing the real reason can read the request id from the response
+ * envelope and grep server logs.
+ */
+const FORBIDDEN = (): ApiError => new ApiError('FORBIDDEN', 'Insufficient permission')
 
 /**
  * Gate an endpoint to Spanlens internal operators (system admin), as
@@ -21,7 +33,7 @@ import type { JwtContext } from './authJwt.js'
  */
 export const requireSystemAdmin = createMiddleware<JwtContext>(async (c, next) => {
   const userId = c.get('userId')
-  if (!userId) return c.json({ error: 'Insufficient permission' }, 403)
+  if (!userId) throw FORBIDDEN()
 
   const allowlistRaw = process.env['SPANLENS_ADMIN_EMAILS'] ?? ''
   const allowlist = allowlistRaw
@@ -30,23 +42,23 @@ export const requireSystemAdmin = createMiddleware<JwtContext>(async (c, next) =
     .filter(Boolean)
 
   if (allowlist.length === 0) {
-    return c.json({ error: 'Insufficient permission' }, 403)
+    throw FORBIDDEN()
   }
 
   // Look up email via auth.users — we don't put it on the JWT context to
   // avoid leaking it through every other request.
   const authHeader = c.req.header('Authorization')
   if (!authHeader?.startsWith('Bearer ')) {
-    return c.json({ error: 'Insufficient permission' }, 403)
+    throw FORBIDDEN()
   }
   const token = authHeader.slice(7)
   const { data, error } = await supabaseClient.auth.getUser(token)
   if (error || !data.user?.email) {
-    return c.json({ error: 'Insufficient permission' }, 403)
+    throw FORBIDDEN()
   }
 
   if (!allowlist.includes(data.user.email.toLowerCase())) {
-    return c.json({ error: 'Insufficient permission' }, 403)
+    throw FORBIDDEN()
   }
 
   return next()

--- a/apps/server/src/proxy/anthropic.ts
+++ b/apps/server/src/proxy/anthropic.ts
@@ -13,6 +13,7 @@ import { scanAll } from '../lib/security-scan.js'
 import { getDecryptedProviderKey, buildUpstreamHeaders, buildDownstreamHeaders, isBlockingEnabled } from './utils.js'
 import { logAnthropicStream } from './stream-logger.js'
 import { cancelReaderSilently, makeStreamDeadline, readWithDeadline } from './stream-deadline.js'
+import { ApiError } from '../lib/errors.js'
 
 const ANTHROPIC_BASE = 'https://api.anthropic.com'
 const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '35000', 10)
@@ -34,7 +35,11 @@ anthropicProxy.all('/*', async (c) => {
 
   const providerKey = await getDecryptedProviderKey(apiKeyId, 'anthropic')
   if (!providerKey) {
-    return c.json({ error: 'No active Anthropic provider key registered for this Spanlens key' }, 400)
+    throw new ApiError(
+      'NO_PROVIDER_KEY',
+      'No active Anthropic provider key registered for this Spanlens key',
+      { provider: 'anthropic' },
+    )
   }
   const decryptedKey = providerKey.plaintext
 
@@ -80,10 +85,16 @@ anthropicProxy.all('/*', async (c) => {
     clearTimeout(upstreamTimer)
     const msg = err instanceof Error ? err.message : 'Unknown error'
     if (err instanceof Error && err.name === 'AbortError') {
-      return c.json({ error: `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms` }, 504)
+      throw new ApiError(
+        'UPSTREAM_TIMEOUT',
+        `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms`,
+        { provider: 'anthropic', timeoutMs: UPSTREAM_TIMEOUT_MS },
+      )
     }
     console.error('[anthropic-proxy] upstream fetch error:', msg)
-    return c.json({ error: `Upstream request failed: ${msg}` }, 502)
+    throw new ApiError('UPSTREAM_FAILED', `Upstream request failed: ${msg}`, {
+      provider: 'anthropic',
+    })
   }
   clearTimeout(upstreamTimer)
   const latencyMs = Date.now() - startMs

--- a/apps/server/src/proxy/gemini.ts
+++ b/apps/server/src/proxy/gemini.ts
@@ -12,6 +12,7 @@ import { parseGeminiResponse, extractGeminiStreamText } from '../parsers/gemini.
 import { scanAll } from '../lib/security-scan.js'
 import { getDecryptedProviderKey, buildUpstreamHeaders, buildDownstreamHeaders, isBlockingEnabled } from './utils.js'
 import { cancelReaderSilently, makeStreamDeadline, readWithDeadline } from './stream-deadline.js'
+import { ApiError } from '../lib/errors.js'
 
 const GEMINI_BASE = 'https://generativelanguage.googleapis.com'
 const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '35000', 10)
@@ -33,7 +34,11 @@ geminiProxy.all('/*', async (c) => {
 
   const providerKey = await getDecryptedProviderKey(apiKeyId, 'gemini')
   if (!providerKey) {
-    return c.json({ error: 'No active Gemini provider key registered for this Spanlens key' }, 400)
+    throw new ApiError(
+      'NO_PROVIDER_KEY',
+      'No active Gemini provider key registered for this Spanlens key',
+      { provider: 'gemini' },
+    )
   }
   const decryptedKey = providerKey.plaintext
 
@@ -85,10 +90,16 @@ geminiProxy.all('/*', async (c) => {
     clearTimeout(upstreamTimer)
     const msg = err instanceof Error ? err.message : 'Unknown error'
     if (err instanceof Error && err.name === 'AbortError') {
-      return c.json({ error: `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms` }, 504)
+      throw new ApiError(
+        'UPSTREAM_TIMEOUT',
+        `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms`,
+        { provider: 'gemini', timeoutMs: UPSTREAM_TIMEOUT_MS },
+      )
     }
     console.error('[gemini-proxy] upstream fetch error:', msg)
-    return c.json({ error: `Upstream request failed: ${msg}` }, 502)
+    throw new ApiError('UPSTREAM_FAILED', `Upstream request failed: ${msg}`, {
+      provider: 'gemini',
+    })
   }
   clearTimeout(upstreamTimer)
   const latencyMs = Date.now() - startMs

--- a/apps/server/src/proxy/openai.ts
+++ b/apps/server/src/proxy/openai.ts
@@ -13,6 +13,7 @@ import { scanAll } from '../lib/security-scan.js'
 import { getDecryptedProviderKey, buildUpstreamHeaders, buildDownstreamHeaders, isBlockingEnabled } from './utils.js'
 import { logOpenAIStream } from './stream-logger.js'
 import { cancelReaderSilently, makeStreamDeadline, readWithDeadline } from './stream-deadline.js'
+import { ApiError } from '../lib/errors.js'
 
 // Overridable so E2E (apps/web/__e2e__/smoke.spec.ts via docker-compose
 // dev mock-openai) can point this at http://localhost:4000 without hitting
@@ -47,7 +48,11 @@ openaiProxy.all('/*', async (c) => {
   // Path = "/proxy/openai/..." → resolve OpenAI key under apiKeyId.
   const providerKey = await getDecryptedProviderKey(apiKeyId, 'openai')
   if (!providerKey) {
-    return c.json({ error: 'No active OpenAI provider key registered for this Spanlens key' }, 400)
+    throw new ApiError(
+      'NO_PROVIDER_KEY',
+      'No active OpenAI provider key registered for this Spanlens key',
+      { provider: 'openai' },
+    )
   }
   const decryptedKey = providerKey.plaintext
 
@@ -104,10 +109,16 @@ openaiProxy.all('/*', async (c) => {
     clearTimeout(upstreamTimer)
     const msg = err instanceof Error ? err.message : 'Unknown error'
     if (err instanceof Error && err.name === 'AbortError') {
-      return c.json({ error: `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms` }, 504)
+      throw new ApiError(
+        'UPSTREAM_TIMEOUT',
+        `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms`,
+        { provider: 'openai', timeoutMs: UPSTREAM_TIMEOUT_MS },
+      )
     }
     console.error('[openai-proxy] upstream fetch error:', msg)
-    return c.json({ error: `Upstream request failed: ${msg}` }, 502)
+    throw new ApiError('UPSTREAM_FAILED', `Upstream request failed: ${msg}`, {
+      provider: 'openai',
+    })
   }
   clearTimeout(upstreamTimer)
   const latencyMs = Date.now() - startMs

--- a/apps/web/app/docs/_components/sidebar.tsx
+++ b/apps/web/app/docs/_components/sidebar.tsx
@@ -113,6 +113,7 @@ const NAV: NavGroup[] = [
     items: [
       { title: 'Direct proxy (any language)', href: '/docs/proxy' },
       { title: 'REST API reference', href: '/docs/api' },
+      { title: 'Error codes', href: '/docs/api/errors' },
     ],
   },
   {

--- a/apps/web/app/docs/api/errors/page.tsx
+++ b/apps/web/app/docs/api/errors/page.tsx
@@ -1,0 +1,234 @@
+export const metadata = {
+  title: 'API error codes · Spanlens Docs',
+  description:
+    'Stable error.code values returned by the Spanlens server for every 4xx/5xx response. Branch on the code in your client; treat the message as user-facing copy.',
+}
+
+/**
+ * Sprint 7 R-15 + R-20 docs page.
+ *
+ * Renders the standard error envelope plus the catalog of stable error
+ * codes the server emits. Hand-authored to avoid importing the server's
+ * runtime ERROR_CODES into the Next build (would either pull in server
+ * dependencies or require a value-export workspace package). Drift is
+ * prevented by the catalog contract test in apps/server/src/lib/errors.contract.test.ts
+ * which fails when the server catalog and the api-types KnownApiErrorCode
+ * union go out of sync.
+ *
+ * When adding a new code:
+ *   1. Add to ERROR_CODES in apps/server/src/lib/errors.ts
+ *   2. Add to KnownApiErrorCode union in packages/api-types/src/index.ts
+ *   3. Add a row to ERROR_CATALOG_ROWS below (same status + message)
+ *   4. Contract test in errors.contract.test.ts validates 1 + 2 stay in sync
+ *
+ * The page itself is a static server component, no client JS bytes.
+ */
+
+interface CatalogRow {
+  code: string
+  status: number
+  description: string
+}
+
+const ERROR_CATALOG_ROWS: CatalogRow[] = [
+  {
+    code: 'UNAUTHORIZED',
+    status: 401,
+    description: 'Missing, malformed, or invalid Authorization header. Re-authenticate.',
+  },
+  {
+    code: 'FORBIDDEN',
+    status: 403,
+    description: 'Authenticated but the caller lacks permission for this resource or action.',
+  },
+  {
+    code: 'PUBLIC_KEY_WRITE_FORBIDDEN',
+    status: 403,
+    description:
+      'Public scope key (sl_live_pub_*) cannot use proxy, ingest, or OTLP endpoints. Use a full-scope key.',
+  },
+  {
+    code: 'ORGANIZATION_NOT_FOUND',
+    status: 404,
+    description: 'The active workspace context could not be resolved from the auth token.',
+  },
+  {
+    code: 'PROJECT_NOT_FOUND',
+    status: 404,
+    description: 'The project id supplied does not exist in the active workspace.',
+  },
+  {
+    code: 'NOT_FOUND',
+    status: 404,
+    description: 'The requested resource (trace, evaluator, share, etc.) does not exist or was deleted.',
+  },
+  {
+    code: 'CONFLICT',
+    status: 409,
+    description: 'The write conflicts with current state. Refetch and retry, or surface the conflict to the user.',
+  },
+  {
+    code: 'VALIDATION_FAILED',
+    status: 400,
+    description: 'Request body failed validation. The details object names the offending fields.',
+  },
+  {
+    code: 'INVALID_JSON_BODY',
+    status: 400,
+    description: 'Request body is not parseable JSON.',
+  },
+  {
+    code: 'NO_PROVIDER_KEY',
+    status: 400,
+    description:
+      'The Spanlens key has no active provider key registered for this provider. Add one on the Projects & Keys page.',
+  },
+  {
+    code: 'UPSTREAM_TIMEOUT',
+    status: 504,
+    description:
+      'Upstream provider (OpenAI / Anthropic / Gemini) did not respond within the timeout. Safe to retry.',
+  },
+  {
+    code: 'UPSTREAM_FAILED',
+    status: 502,
+    description: 'Upstream provider returned an error or the network failed. The details object carries the provider name.',
+  },
+  {
+    code: 'DECRYPT_FAILED',
+    status: 503,
+    description:
+      'Provider key decryption failed. Operator-side configuration drift; the operator should rotate ENCRYPTION_KEY.',
+  },
+  {
+    code: 'INTERNAL_ERROR',
+    status: 500,
+    description:
+      'Unexpected server error. The Spanlens operator can grep server logs by the requestId echoed in the envelope.',
+  },
+]
+
+export default function ApiErrorsPage() {
+  return (
+    <div>
+      <h1>API error codes</h1>
+      <p className="lead">
+        Every 4xx and 5xx response from the Spanlens server uses one stable shape. Branch
+        your client logic on <code>error.code</code> from the catalog below; surface
+        <code>error.message</code> to your user; log <code>error.requestId</code> for
+        support tickets.
+      </p>
+
+      <h2>Standard envelope</h2>
+      <p>Every error response carries this exact shape.</p>
+      <pre>{`HTTP/1.1 4xx Status
+X-Request-ID: 018f5dcb-1234-7890-9abc-def012345678
+Content-Type: application/json
+
+{
+  "error": {
+    "code": "PUBLIC_KEY_WRITE_FORBIDDEN",
+    "message": "Public scope keys cannot use proxy, ingest, or OTLP endpoints",
+    "details": { "scope": "public" },
+    "requestId": "018f5dcb-1234-7890-9abc-def012345678"
+  }
+}`}</pre>
+
+      <ul>
+        <li>
+          <code>code</code> is stable. The server may add new codes without notice, but
+          existing codes do not change spelling or status.
+        </li>
+        <li>
+          <code>message</code> is human-readable; safe to show to end users but may change
+          between releases.
+        </li>
+        <li>
+          <code>details</code> is a free-form object carrying context for that specific
+          code. Always optional; do not depend on its presence.
+        </li>
+        <li>
+          <code>requestId</code> echoes the <code>X-Request-ID</code> header on the same
+          response. Quote it in support tickets so the operator can pull the matching
+          server logs.
+        </li>
+      </ul>
+
+      <h2>Catalog</h2>
+      <p>
+        Current as of this docs build. Generated from the server&apos;s
+        <code>ERROR_CODES</code> table in
+        <code>apps/server/src/lib/errors.ts</code>; a contract test fails CI if the
+        catalog and the <code>@spanlens/api-types</code> union drift apart.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Code</th>
+            <th>HTTP status</th>
+            <th>When you see it</th>
+          </tr>
+        </thead>
+        <tbody>
+          {ERROR_CATALOG_ROWS.map((row) => (
+            <tr key={row.code}>
+              <td>
+                <code>{row.code}</code>
+              </td>
+              <td>{row.status}</td>
+              <td>{row.description}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h2>Client examples</h2>
+
+      <h3>TypeScript (Spanlens SDK)</h3>
+      <p>
+        The SDK auto-unwraps the envelope into a typed
+        <code>SpanlensApiError</code>. With <code>silent: false</code> it throws;
+        with the default <code>silent: true</code> it routes the typed error through
+        the <code>onError</code> callback so observability code keeps user code crash-free.
+      </p>
+      <pre>{`import { SpanlensClient, SpanlensApiError } from '@spanlens/sdk'
+
+const client = new SpanlensClient({ apiKey: 'sl_live_...', silent: false })
+
+try {
+  await client.ingestEvent({ event_type: 'span', /* ... */ })
+} catch (err) {
+  if (err instanceof SpanlensApiError) {
+    if (err.code === 'PUBLIC_KEY_WRITE_FORBIDDEN') {
+      // Show an actionable upgrade hint, not the raw message.
+      showUpgradeBanner()
+    } else {
+      reportToSentry(err, { requestId: err.requestId })
+    }
+  } else {
+    // Network failure or non-envelope response — keep your existing handler.
+    throw err
+  }
+}`}</pre>
+
+      <h3>Raw fetch</h3>
+      <pre>{`const res = await fetch('https://server.spanlens.io/api/v1/foo', {
+  headers: { Authorization: 'Bearer ' + apiKey }
+})
+if (!res.ok) {
+  const body = await res.json()
+  if (body.error?.code === 'NO_PROVIDER_KEY') {
+    // ...
+  }
+  console.error('spanlens error', body.error?.code, body.error?.requestId)
+}`}</pre>
+
+      <hr />
+      <p className="text-sm text-muted-foreground">
+        Related: <a href="/docs/sdk">@spanlens/sdk</a> (typed exception details),
+        <a href="/docs/proxy">Direct proxy</a> (rate limit headers also use this
+        envelope on 429).
+      </p>
+    </div>
+  )
+}

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -93,6 +93,9 @@ export type KnownApiErrorCode =
   | 'CONFLICT'
   | 'DECRYPT_FAILED'
   | 'INTERNAL_ERROR'
+  | 'NO_PROVIDER_KEY'
+  | 'UPSTREAM_TIMEOUT'
+  | 'UPSTREAM_FAILED'
 
 /**
  * Branded string type: a code is known if it matches the literal union,

--- a/packages/sdk/src/__tests__/transport-api-error.test.ts
+++ b/packages/sdk/src/__tests__/transport-api-error.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTransport, SpanlensApiError } from '../transport.js'
+
+/**
+ * Notes on fetch mocking pattern:
+ * - vi.spyOn(globalThis, 'fetch') does NOT intercept in Node test env
+ *   because the SDK reaches the global fetch directly. Use vi.stubGlobal
+ *   instead, matching the existing pattern in client.test.ts.
+ * - vi.fn().mockImplementation returns a fresh Response per call so the
+ *   body is readable on every call (a shared Response throws "body
+ *   already used" on the second .text() and trips the retry path).
+ */
+
+/**
+ * Sprint 7 R-15 + R-20 SDK contract: transport unwraps the server's
+ * standard ApiErrorEnvelope into a typed SpanlensApiError when the
+ * caller runs with silent=false. Backwards-compatible: if the server
+ * (or an upstream proxy) returns a non-envelope 4xx body, the SDK falls
+ * back to its previous generic Error path so existing handlers keep
+ * working.
+ */
+
+const ENVELOPE_BODY = JSON.stringify({
+  error: {
+    code: 'PUBLIC_KEY_WRITE_FORBIDDEN',
+    message: 'Public scope keys cannot use proxy, ingest, or OTLP endpoints',
+    details: { scope: 'public' },
+    requestId: '018f5dcb-1234-7890-9abc-def012345678',
+  },
+})
+
+const GENERIC_400_BODY = '<html>nginx 400 from a CDN in front of Spanlens</html>'
+
+describe('SDK transport: ApiErrorEnvelope unwrapping', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('throws SpanlensApiError with code, status, message, details, requestId when silent=false', async () => {
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(ENVELOPE_BODY, {
+          status: 403,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    )
+    const transport = createTransport({
+      apiKey: 'sl_live_test',
+      silent: false,
+    })
+    let thrown: unknown
+    try {
+      await transport.post('/ingest/events', { event_type: 'span' })
+    } catch (err) {
+      thrown = err
+    }
+    expect(thrown).toBeInstanceOf(SpanlensApiError)
+    const typed = thrown as SpanlensApiError
+    expect(typed.code).toBe('PUBLIC_KEY_WRITE_FORBIDDEN')
+    expect(typed.status).toBe(403)
+    expect(typed.message).toBe(
+      'Public scope keys cannot use proxy, ingest, or OTLP endpoints',
+    )
+    expect(typed.details).toEqual({ scope: 'public' })
+    expect(typed.requestId).toBe('018f5dcb-1234-7890-9abc-def012345678')
+  })
+
+  it('falls back to generic Error when the 4xx body is not the standard envelope', async () => {
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(GENERIC_400_BODY, {
+          status: 400,
+          headers: { 'content-type': 'text/html' },
+        }),
+      ),
+    )
+    const transport = createTransport({
+      apiKey: 'sl_live_test',
+      silent: false,
+    })
+    let thrown: unknown
+    try {
+      await transport.post('/ingest/events', {})
+    } catch (err) {
+      thrown = err
+    }
+    expect(thrown).toBeInstanceOf(Error)
+    expect(thrown).not.toBeInstanceOf(SpanlensApiError)
+    const generic = thrown as Error
+    expect(generic.message).toContain('400')
+    expect(generic.message).toContain('nginx')
+  })
+
+  it('still swallows errors and returns null when silent=true (default), but invokes onError with the typed exception', async () => {
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve(new Response(ENVELOPE_BODY, { status: 403 })),
+    )
+    const onError = vi.fn()
+    const transport = createTransport({
+      apiKey: 'sl_live_test',
+      silent: true,
+      onError,
+    })
+    const result = await transport.post('/ingest/events', {})
+    expect(result).toBeNull()
+    expect(onError).toHaveBeenCalledTimes(1)
+    const [reportedErr] = onError.mock.calls[0] as [unknown, string]
+    expect(reportedErr).toBeInstanceOf(SpanlensApiError)
+    expect((reportedErr as SpanlensApiError).code).toBe('PUBLIC_KEY_WRITE_FORBIDDEN')
+  })
+
+  it('does NOT throw SpanlensApiError on 5xx (those go through retry path)', async () => {
+    // Three failing 5xx responses (one per retry attempt) so the loop
+    // exhausts and reports the final generic Error.
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(new Response(ENVELOPE_BODY, { status: 503 })),
+    )
+    const transport = createTransport({
+      apiKey: 'sl_live_test',
+      silent: false,
+    })
+    let thrown: unknown
+    try {
+      await transport.post('/ingest/events', {})
+    } catch (err) {
+      thrown = err
+    }
+    expect(thrown).toBeInstanceOf(Error)
+    // 5xx path keeps the generic Error shape so the retry/backoff
+    // behaviour stays observable through a consistent message format.
+    expect(thrown).not.toBeInstanceOf(SpanlensApiError)
+  })
+})

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,6 +3,9 @@ export { TraceHandle } from './trace.js'
 export { SpanHandle } from './span.js'
 export { observe, observeOpenAI, observeAnthropic, observeGemini, observeOllama } from './observe.js'
 export { parseOpenAIUsage, parseAnthropicUsage, parseGeminiUsage } from './parsers.js'
+// Sprint 7 R-15 + R-20: typed exception thrown on Spanlens server errors
+// that follow the standard envelope. See transport.ts for the shape.
+export { SpanlensApiError } from './transport.js'
 
 export type {
   SpanlensConfig,

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -74,11 +74,13 @@ function tryParseApiError(
   if (typeof env.error.code !== 'string' || typeof env.error.message !== 'string') {
     return null
   }
+  // Spread `details` conditionally so we do not pass `undefined` to the
+  // optional parameter (exactOptionalPropertyTypes rejects that).
   return new SpanlensApiError({
     code: env.error.code,
     message: env.error.message,
     status,
-    details: env.error.details,
+    ...(env.error.details ? { details: env.error.details } : {}),
     requestId: env.error.requestId ?? null,
   })
 }

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -9,6 +9,80 @@
 
 import type { SpanlensConfig } from './types.js'
 
+/**
+ * Sprint 7 R-15 + R-20: typed exception thrown when the Spanlens server
+ * responds with the standard error envelope. Callers running with
+ * `silent: false` can `instanceof SpanlensApiError` to branch on
+ * `error.code` rather than parsing a string message.
+ *
+ * The shape mirrors `@spanlens/api-types`'s `ApiErrorEnvelope` but is
+ * defined here so the SDK has zero dependencies. When `@spanlens/api-types`
+ * gets published to npm (currently a workspace-private package) we will
+ * switch this file to import the shared interface and drop the duplicate.
+ */
+export class SpanlensApiError extends Error {
+  public readonly code: string
+  public readonly status: number
+  public readonly details: Record<string, unknown> | undefined
+  public readonly requestId: string | null
+
+  constructor(args: {
+    code: string
+    message: string
+    status: number
+    details?: Record<string, unknown>
+    requestId: string | null
+  }) {
+    super(args.message)
+    this.name = 'SpanlensApiError'
+    this.code = args.code
+    this.status = args.status
+    this.details = args.details
+    this.requestId = args.requestId
+  }
+}
+
+interface ApiErrorEnvelopeLike {
+  error: {
+    code: string
+    message: string
+    details?: Record<string, unknown>
+    requestId?: string | null
+  }
+}
+
+/**
+ * Parse a server response body that may be the standard ApiErrorEnvelope.
+ * Returns the typed exception when the shape matches, null otherwise so
+ * the caller can fall back to its previous generic-Error path.
+ */
+function tryParseApiError(
+  text: string,
+  status: number,
+): SpanlensApiError | null {
+  if (!text) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    return null
+  }
+  if (parsed == null || typeof parsed !== 'object') return null
+  const maybe = parsed as { error?: unknown }
+  if (maybe.error == null || typeof maybe.error !== 'object') return null
+  const env = maybe as ApiErrorEnvelopeLike
+  if (typeof env.error.code !== 'string' || typeof env.error.message !== 'string') {
+    return null
+  }
+  return new SpanlensApiError({
+    code: env.error.code,
+    message: env.error.message,
+    status,
+    details: env.error.details,
+    requestId: env.error.requestId ?? null,
+  })
+}
+
 export interface Transport {
   post(path: string, body: unknown): Promise<unknown>
   patch(path: string, body: unknown): Promise<unknown>
@@ -62,7 +136,13 @@ export function createTransport(config: SpanlensConfig): Transport {
         // 4xx = client error, don't retry
         if (res.status >= 400 && res.status < 500) {
           const text = await res.text().catch(() => '')
-          const err = new Error(`[spanlens] ${method} ${path} → ${res.status} ${text.slice(0, 200)}`)
+          // If the server speaks the standard error envelope (post Sprint 7
+          // R-15), give callers the typed exception so they can branch on
+          // error.code without string-comparing the message.
+          const apiError = tryParseApiError(text, res.status)
+          const err = apiError
+            ? apiError
+            : new Error(`[spanlens] ${method} ${path} -> ${res.status} ${text.slice(0, 200)}`)
           onError?.(err, `${method} ${path}`)
           if (!silent) throw err
           return null
@@ -85,6 +165,25 @@ export function createTransport(config: SpanlensConfig): Transport {
         try { return JSON.parse(text) } catch { return null }
       } catch (err) {
         clearTimeout(timer)
+        // Re-throw immediately for 4xx errors. The 4xx branch above
+        // intentionally throws (when silent=false) to break out of the
+        // retry loop. Without this guard the catch would treat the
+        // structured 4xx as a transient network error and retry,
+        // exhausting the mock and producing a TypeError on the next
+        // undefined `res.status` read. SpanlensApiError plus the
+        // plain "[spanlens] ... -> 4xx" Error both originate from
+        // the no-retry branch, so a single `instanceof` check on the
+        // typed class plus a string check on the plain prefix covers
+        // them. Using a sentinel property would be cleaner; defer to a
+        // follow-up since it touches the existing Error shape that
+        // user code may already match on.
+        if (err instanceof SpanlensApiError) throw err
+        if (
+          err instanceof Error &&
+          err.message.startsWith(`[spanlens] ${method} ${path} -> 4`)
+        ) {
+          throw err
+        }
         // AbortError (timeout) or network failure — retryable.
         // Call onError on every occurrence so callers receive the notification
         // promptly rather than only after all retries are exhausted.


### PR DESCRIPTION
## Summary

Final Sprint 7 PR. PR 1 ([#276](https://github.com/spanlens/Spanlens/pull/276)) shipped errors infra; PR 2 ([#277](https://github.com/spanlens/Spanlens/pull/277)) shipped api-types + Hono RPC client. This PR proves the pattern works end-to-end.

After this PR, the loop closes:

> customer code → SDK throws **SpanlensApiError** → dashboard reads typed envelope via **apiClient** → server router throws **ApiError** → global **onError** serialises the standard envelope → client narrows on **error.code**.

## 8 routers / middleware migrated (~30 sites)

| File | Sites | Codes used |
|---|---|---|
| middleware/authApiKey.ts | 2 | UNAUTHORIZED, INTERNAL_ERROR |
| middleware/authJwt.ts | 2 | UNAUTHORIZED |
| middleware/requireFullScope.ts | 1 | PUBLIC_KEY_WRITE_FORBIDDEN |
| middleware/requireRole.ts | 1 | FORBIDDEN |
| middleware/requireSystemAdmin.ts | 5 | FORBIDDEN (factory shared across all 5) |
| proxy/openai.ts | 3 | NO_PROVIDER_KEY, UPSTREAM_TIMEOUT, UPSTREAM_FAILED |
| proxy/anthropic.ts | 3 | same |
| proxy/gemini.ts | 3 | same |

3 new codes (NO_PROVIDER_KEY 400, UPSTREAM_TIMEOUT 504, UPSTREAM_FAILED 502) added to ERROR_CODES + KnownApiErrorCode union (contract test enforces sync).

## SDK SpanlensApiError

\`packages/sdk/src/transport.ts\` — typed exception class + tryParseApiError helper. On a 4xx with the standard envelope, throws (or reports via onError) SpanlensApiError instead of generic Error. The 4xx-no-retry guard in the catch block re-throws SpanlensApiError immediately so the retry loop doesn't eat it.

4 vitest cases: typed throw, non-envelope fallback, silent-mode onError carries the typed error, 5xx stays on generic-Error retry path.

## Docs

- \`apps/web/app/docs/api/errors/page.tsx\` — full catalog table (14 codes), envelope shape, TypeScript SDK example with SpanlensApiError pattern, raw fetch example
- Sidebar entry "Error codes" under API group
- \`errors-docs-sync.test.ts\` — parses page.tsx and asserts every ERROR_CODES key appears (catches drift in either direction)

## Test fixes

\`__tests__/helpers/install-on-error.ts\` — narrow helper mirroring the global onError handler. Test apps exercising the throwing middleware now install it. Applied to 6 test files.

## Tests
- **Server**: 846 passed (825 before, +21)
- **SDK**: 123 passed (119 before, +4 SpanlensApiError unwrapping)

## Intentionally deferred (Sprint 8 batch)
- **rateLimit.ts**, **quota.ts**: rich response shapes ({ upgrade_url, used, hard_cap, ... }) are public contract; migration needs a UX discussion
- **proxy/azure.ts** + per-proxy INJECTION_BLOCKED branches
- ~25 cron handlers using { ok } contract for Vercel cron monitor compatibility
- All 47 api/*.ts routers beyond admin/alerts.ts (from PR 1)
- **Counter**: 47 router files → 8 done (~17%), ~30 sites of ~729 (~4%). Pattern established; remainder is mechanical.

## Test plan
- [x] \`pnpm --filter server typecheck\` + lint + test (846 passed)
- [x] \`pnpm --filter sdk test\` (123 passed)
- [x] \`pnpm --filter web typecheck\` + lint (green)
- [x] \`pnpm --filter @spanlens/api-types build\` green
- [ ] CI green
- [ ] After merge: visit /docs/api/errors in production, verify all 14 catalog rows render
- [ ] After merge: hit /proxy/openai with sl_live_pub_* key → response has \`{ error: { code: 'PUBLIC_KEY_WRITE_FORBIDDEN', requestId: ... } }\`