### PR TITLE
ops: Tier 1+2 follow-up — CLAUDE.md fix + aggregate-usage migration + cron safety net round 3

### DIFF
--- a/.github/workflows/cron-server.yml
+++ b/.github/workflows/cron-server.yml
@@ -50,10 +50,18 @@ name: Cron — server sub-daily
 on:
   schedule:
     # Cadence has to match what the handler expects. Listed here in the
-    # same order as the `if:` checks below for grepability.
+    # same order as the `if:` checks below for grepability. Each entry
+    # fires only the matching job (the `if:` predicates downstream
+    # compare github.event.schedule to the cron string).
     - cron: '*/5 * * * *'      # every 5 min — replay-fallback, run-background-migrations, keep-warm
     - cron: '0 */6 * * *'      # every 6h on the hour — execute-pending-deletions
-    - cron: '31 * * * *'       # hourly at :31 — self-monitor
+    - cron: '31 * * * *'       # hourly :31 — self-monitor
+    - cron: '17 * * * *'       # hourly :17 — detect-orphan-spans
+    - cron: '0 * * * *'        # hourly :00 — detect-missing-model-prices
+    - cron: '0 2 * * *'        # daily 02:00 — events-reconciliation
+    - cron: '0 9 * * *'        # daily 09:00 — recommend-savings-alerts
+    - cron: '0 10 * * *'       # daily 10:00 — check-past-due-downgrades
+    - cron: '0 9 * * 1'        # weekly Monday 09:00 — stale-key-reminders
   workflow_dispatch:
 
 concurrency:
@@ -133,6 +141,114 @@ jobs:
           STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
             -H "Authorization: Bearer $CRON_SECRET" \
             "$BASE_URL/cron/self-monitor")
+          echo "Status: $STATUS"
+          cat /tmp/body
+          if [ "$STATUS" -ge 400 ]; then exit 1; fi
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+
+  hourly-17:
+    name: Hourly at :17 (detect-orphan-spans)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '17 * * * *' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: POST /cron/detect-orphan-spans
+        run: |
+          BASE_URL='https://spanlens-server.vercel.app'
+          STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            "$BASE_URL/cron/detect-orphan-spans")
+          echo "Status: $STATUS"
+          cat /tmp/body
+          if [ "$STATUS" -ge 400 ]; then exit 1; fi
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+
+  hourly-00:
+    name: Hourly at :00 (detect-missing-model-prices)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '0 * * * *' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: POST /cron/detect-missing-model-prices
+        run: |
+          BASE_URL='https://spanlens-server.vercel.app'
+          STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            "$BASE_URL/cron/detect-missing-model-prices")
+          echo "Status: $STATUS"
+          cat /tmp/body
+          if [ "$STATUS" -ge 400 ]; then exit 1; fi
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+
+  daily-02:
+    name: Daily 02:00 UTC (events-reconciliation)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '0 2 * * *' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: POST /cron/events-reconciliation
+        run: |
+          BASE_URL='https://spanlens-server.vercel.app'
+          STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            "$BASE_URL/cron/events-reconciliation")
+          echo "Status: $STATUS"
+          cat /tmp/body
+          if [ "$STATUS" -ge 400 ]; then exit 1; fi
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+
+  daily-09:
+    name: Daily 09:00 UTC (recommend-savings-alerts)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '0 9 * * *' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: POST /cron/recommend-savings-alerts
+        run: |
+          BASE_URL='https://spanlens-server.vercel.app'
+          STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            "$BASE_URL/cron/recommend-savings-alerts")
+          echo "Status: $STATUS"
+          cat /tmp/body
+          if [ "$STATUS" -ge 400 ]; then exit 1; fi
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+
+  daily-10:
+    name: Daily 10:00 UTC (check-past-due-downgrades)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '0 10 * * *' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: POST /cron/check-past-due-downgrades
+        run: |
+          BASE_URL='https://spanlens-server.vercel.app'
+          STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            "$BASE_URL/cron/check-past-due-downgrades")
+          echo "Status: $STATUS"
+          cat /tmp/body
+          if [ "$STATUS" -ge 400 ]; then exit 1; fi
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+
+  weekly-mon-09:
+    name: Weekly Monday 09:00 UTC (stale-key-reminders)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '0 9 * * 1' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: POST /cron/stale-key-reminders
+        run: |
+          BASE_URL='https://spanlens-server.vercel.app'
+          STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            "$BASE_URL/cron/stale-key-reminders")
           echo "Status: $STATUS"
           cat /tmp/body
           if [ "$STATUS" -ge 400 ]; then exit 1; fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,15 +54,15 @@ DB 쓰기(로깅) → supabaseAdmin (service_role, RLS bypass)
 DB 읽기(조회) → supabaseClient (anon key, RLS 적용)
 미들웨어 혼용 금지. dual-auth가 필요한 read API는 `authJwtOrApiKey` 한 곳만 사용.
 
-### 통합 키(unified key) 모델 — 2026-05-05부터
+### 통합 키(unified key) 모델 — 2026-05-05 + 2026-05-05 nested
 - `api_keys.provider_key_id` **컬럼 없음** (마이그레이션 20260505040000_unified_keys로 제거).
 - `sl_live_*` 키는 **프로젝트 단위**로 발급되고 provider-agnostic. provider는 request URL path
   (`/proxy/openai/...` vs `/proxy/anthropic/...` vs `/proxy/gemini/...`)에서 추론.
-- `provider_keys.project_id`는 **NOT NULL** — 모든 provider AI key는 명시적으로 한 프로젝트에 속함.
-  org-level fallback row 사라짐.
-- 같은 `(project_id, provider)`에 active=true 키 1개만 허용 (UNIQUE INDEX).
+- **`provider_keys.api_key_id` NOT NULL** (마이그레이션 `20260505080000_provider_keys_under_api_keys.sql`로 `project_id` 컬럼 DROP + `api_key_id` 컬럼 추가). Provider key는 이제 한 Spanlens API key에 nested된 형태로 소유됨 — `apps/server/src/proxy/openai.ts`의 `getDecryptedProviderKey(apiKeyId, 'openai')`가 이 컬럼으로 lookup. **CLAUDE.md 이전 버전이 "provider_keys.project_id NOT NULL"이라고 잘못 적혀있었음** (PR #269의 E2E spec 13-fix 시리즈 8번째 fix에서 발견).
+- 같은 `(api_key_id, provider)`에 active=true 키 1개만 허용 (UNIQUE INDEX).
 - 새 provider key 발급/조회: `apps/server/src/api/providerKeys.ts` (`/api/v1/provider-keys`).
 - 새 Spanlens key 발급/조회: `apps/server/src/api/apiKeys.ts` (`/api/v1/api-keys`) — provider 정보 더 이상 안 받음.
+- 새 코드 또는 마이그레이션 작성 시 CLAUDE.md 이 섹션만 보지 말고 `supabase/migrations/` 최신 file (특히 20260505080000) 까지 확인 (gotcha ㉜ 참고).
 
 ### Public scope 모델 — 2026-06-04부터 (마이그레이션 20260604040000)
 - `api_keys.scope` text NOT NULL DEFAULT `'full'` CHECK in (`'full'`, `'public'`).

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -60,16 +60,111 @@ cronRouter.get('/aggregate-usage', async (c) => {
   const today = now.toISOString().slice(0, 10)
   const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
 
-  const results: { date: string; rows: number | null; error?: string }[] = []
+  // The Postgres function aggregate_usage_daily() used to do this work
+  // back when requests lived in Postgres. P5.1 (gotcha #3, 2026-05-16)
+  // moved requests to ClickHouse, but the function (and this handler)
+  // were not migrated. The function still references the now-dropped
+  // public.requests table, so every cron tick was returning "relation
+  // requests does not exist" until this fix landed. Production logs
+  // confirmed the error continuously since the migration.
+  //
+  // The cron-only path that needs aggregation now does ClickHouse SELECT
+  // for the day window + Postgres UPSERT into usage_daily. RLS bypass
+  // via service-role is OK here because aggregate-usage scans across
+  // every tenant by design (it's the source of the dashboard's daily
+  // rollup view).
+  const results: Array<{
+    date: string
+    rows: number | null
+    error?: string
+  }> = []
 
   for (const date of [yesterday, today]) {
-    const { data, error } = await supabaseAdmin.rpc('aggregate_usage_daily', {
-      target_date: date,
-    })
-    if (error) {
-      results.push({ date, rows: null, error: error.message })
-    } else {
-      results.push({ date, rows: data as number })
+    try {
+      // ClickHouse query: aggregate every successful LLM call for the
+      // target day. The where clause mirrors the original SQL function:
+      //   - status_code < 400 (skip errored calls)
+      //   - non-empty model (skip rows we could not parse usage from)
+      // Limits: none — ClickHouse aggregates in-DB so even a billion
+      // rows per day stays cheap. We do not need the per-tenant
+      // requestsScope helper because the cron is operator-internal and
+      // by definition aggregates across every tenant.
+      const sql = `
+        SELECT
+          organization_id,
+          project_id,
+          provider,
+          model,
+          count() AS request_count,
+          sum(prompt_tokens) AS prompt_tokens,
+          sum(completion_tokens) AS completion_tokens,
+          sum(total_tokens) AS total_tokens,
+          sum(cost_usd) AS cost_usd
+        FROM requests
+        WHERE created_at >= parseDateTime64BestEffort({dayStart:String})
+          AND created_at <  parseDateTime64BestEffort({dayEnd:String})
+          AND status_code < 400
+          AND model != ''
+          AND project_id != ''
+        GROUP BY organization_id, project_id, provider, model
+      `
+      const dayStart = `${date} 00:00:00.000`
+      const dayEnd = `${date} 23:59:59.999`
+      const ch = unscopedClickhouse()
+      const queryResult = await ch.query({
+        query: sql,
+        query_params: { dayStart, dayEnd },
+        format: 'JSONEachRow',
+      })
+      const rows = (await queryResult.json()) as Array<{
+        organization_id: string
+        project_id: string
+        provider: string
+        model: string
+        request_count: string | number
+        prompt_tokens: string | number
+        completion_tokens: string | number
+        total_tokens: string | number
+        cost_usd: string | number
+      }>
+
+      if (rows.length === 0) {
+        results.push({ date, rows: 0 })
+        continue
+      }
+
+      // Upsert each row into usage_daily. The UNIQUE constraint on
+      // (organization_id, project_id, date, provider, model) makes
+      // re-running a no-op for the same day — later hourly ticks just
+      // overwrite the totals with the latest counts.
+      // gotcha #19: ClickHouse JSONEachRow returns numbers as strings,
+      // so wrap each numeric in Number() before writing to Postgres.
+      const upserts = rows.map((r) => ({
+        organization_id: r.organization_id,
+        project_id: r.project_id,
+        date,
+        provider: r.provider,
+        model: r.model,
+        request_count: Number(r.request_count ?? 0),
+        prompt_tokens: Number(r.prompt_tokens ?? 0),
+        completion_tokens: Number(r.completion_tokens ?? 0),
+        total_tokens: Number(r.total_tokens ?? 0),
+        cost_usd: Number(r.cost_usd ?? 0),
+        updated_at: new Date().toISOString(),
+      }))
+      const { error: upsertError } = await supabaseAdmin
+        .from('usage_daily')
+        .upsert(upserts, {
+          onConflict: 'organization_id,project_id,date,provider,model',
+        })
+      if (upsertError) {
+        results.push({ date, rows: null, error: upsertError.message })
+      } else {
+        results.push({ date, rows: upserts.length })
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      results.push({ date, rows: null, error: msg })
     }
   }
 
@@ -77,7 +172,7 @@ cronRouter.get('/aggregate-usage', async (c) => {
   logCronRun('aggregate-usage', hasError ? 'error' : 'ok', Date.now() - start, hasError ? results.find((r) => r.error)?.error : undefined).catch(console.error)
 
   return c.json({
-    success: true,
+    success: !hasError,
     ran_at: now.toISOString(),
     results,
   })


### PR DESCRIPTION
Three loosely-coupled cleanups that close out today's session.

## Changes
- **CLAUDE.md** "통합 키" section: schema fix (project_id → api_key_id)
- **/cron/aggregate-usage**: rewrite to ClickHouse SELECT + Postgres UPSERT (gotcha #3 follow-up; handler was 100% broken since P5.1)
- **cron-server.yml**: add the 6 remaining silent Vercel crons to GH Actions safety net (now covers all 11 sub-daily endpoints)
- **06-plan v1.25**: change-log entry

See commit body for full rationale per chunk.

## Test plan
- [x] `pnpm --filter server typecheck` + lint green
- [x] `pnpm --filter server test` 846 passed
- [ ] CI green
- [ ] After merge: trigger 'Cron — server sub-daily' manually, verify all 9 jobs return 200
- [ ] After merge: next /cron/aggregate-usage tick returns 200 + usage_daily gets fresh rows (production has usage today so we should see real INSERTs)