### PR TITLE
feat(sprint-8 batch 1): migrate 6 user-facing read API files to ApiError envelope

### DIFF
--- a/apps/server/scripts/migrate-errors.ts
+++ b/apps/server/scripts/migrate-errors.ts
@@ -224,19 +224,58 @@ function transformFile(filePath: string): FileResult {
   })
 
   // Insert ApiError import if any throw was emitted and not already
-  // imported. This is a textual check — simple but reliable since the
-  // import line shape is standard across the codebase.
+  // imported. Multi-line imports are common in this codebase
+  //   import {
+  //     foo,
+  //     bar,
+  //   } from './x.js'
+  // so a single-line `^import .+$` regex matches the FIRST line of a
+  // multi-line block and inserting after it lands inside the brace —
+  // a syntax error. Instead, find the end of the contiguous import
+  // block at the top of the file: the first non-import, non-blank,
+  // non-comment line marks where source code begins; insert just
+  // before it (or at the end of the last line before it). For files
+  // that have only single-line imports the behaviour is identical to
+  // the old logic.
   if (result.transformed > 0 && !content.match(/from\s+['"][^'"]*lib\/errors(\.js)?['"]/)) {
     const importPath = relativeErrorsImport(filePath)
-    // Insert after the last existing import line. If no imports exist
-    // (unlikely for this codebase) prepend at top.
-    const importMatches = [...content.matchAll(/^import .+$/gm)]
-    if (importMatches.length === 0) {
+    const lines = content.split('\n')
+
+    // Walk top-down keeping track of whether we're inside a multi-line
+    // import. Stop at the first line that is OUTSIDE any import and is
+    // not blank/comment.
+    let braceDepth = 0
+    let insertAfterLine = -1
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      const trimmed = line.trim()
+      if (braceDepth > 0) {
+        braceDepth += (line.match(/\{/g) ?? []).length
+        braceDepth -= (line.match(/\}/g) ?? []).length
+        insertAfterLine = i
+        continue
+      }
+      if (trimmed.startsWith('import ')) {
+        braceDepth += (line.match(/\{/g) ?? []).length
+        braceDepth -= (line.match(/\}/g) ?? []).length
+        insertAfterLine = i
+        continue
+      }
+      if (trimmed === '' || trimmed.startsWith('//') || trimmed.startsWith('/*') || trimmed.startsWith('*')) {
+        // Blank or comment line between imports. Keep going to capture
+        // imports that follow a comment.
+        continue
+      }
+      // First real code line. Stop.
+      break
+    }
+
+    if (insertAfterLine < 0) {
+      // No imports at all (unlikely). Prepend.
       content = `import { ApiError } from '${importPath}'\n${content}`
     } else {
-      const last = importMatches[importMatches.length - 1]
-      const insertAt = (last.index ?? 0) + last[0].length
-      content = `${content.slice(0, insertAt)}\nimport { ApiError } from '${importPath}'${content.slice(insertAt)}`
+      lines.splice(insertAfterLine + 1, 0, `import { ApiError } from '${importPath}'`)
+      content = lines.join('\n')
     }
   }
 

--- a/apps/server/src/api/me.ts
+++ b/apps/server/src/api/me.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
 import { supabaseAdmin } from '../lib/db.js'
+import { ApiError } from '../lib/errors.js'
 
 /**
  * Endpoints that introspect the *Spanlens API key* presented in the
@@ -76,7 +77,7 @@ meRouter.get('/', async (c) => {
       .eq('is_active', true),
   ])
 
-  if (!project) return c.json({ error: 'Project not found' }, 404)
+  if (!project) throw new ApiError('NOT_FOUND', 'Project not found')
 
   const providers = Array.from(
     new Set((providerKeys ?? []).map((row) => row.provider as string)),

--- a/apps/server/src/api/organizations.ts
+++ b/apps/server/src/api/organizations.ts
@@ -5,6 +5,7 @@ import { supabaseAdmin } from '../lib/db.js'
 import { randomHex, sha256Hex } from '../lib/crypto.js'
 import { OWNED_WORKSPACE_LIMITS, effectiveOwnedPlan, type Plan } from '../lib/quota.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
+import { ApiError } from '../lib/errors.js'
 
 export const organizationsRouter = new Hono<JwtContext>()
 
@@ -36,7 +37,7 @@ organizationsRouter.get('/', async (c) => {
     .eq('user_id', userId)
     .order('created_at', { ascending: true })
 
-  if (error) return c.json({ error: 'Failed to fetch workspaces' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to fetch workspaces')
 
   // Shape the join output so the client sees a flat list with role attached.
   interface Row {
@@ -61,7 +62,7 @@ organizationsRouter.get('/', async (c) => {
 // on owner_id — that broke invited members who aren't owners.
 organizationsRouter.get('/me', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const { data, error } = await supabaseAdmin
     .from('organizations')
@@ -70,7 +71,7 @@ organizationsRouter.get('/me', async (c) => {
     .single()
 
   if (error || !data) {
-    return c.json({ error: 'Organization not found' }, 404)
+    throw new ApiError('NOT_FOUND', 'Organization not found')
   }
 
   return c.json({ success: true, data })
@@ -87,7 +88,7 @@ organizationsRouter.get('/me', async (c) => {
 //   leak_detection_enabled   : boolean
 organizationsRouter.patch('/me/security', requireAdmin, async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: {
     stale_key_alerts_enabled?: unknown
@@ -97,7 +98,7 @@ organizationsRouter.patch('/me/security', requireAdmin, async (c) => {
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   const patch: {
@@ -108,7 +109,7 @@ organizationsRouter.patch('/me/security', requireAdmin, async (c) => {
 
   if (body.stale_key_alerts_enabled !== undefined) {
     if (typeof body.stale_key_alerts_enabled !== 'boolean') {
-      return c.json({ error: 'stale_key_alerts_enabled must be a boolean' }, 400)
+      throw new ApiError('VALIDATION_FAILED', 'stale_key_alerts_enabled must be a boolean')
     }
     patch.stale_key_alerts_enabled = body.stale_key_alerts_enabled
   }
@@ -116,20 +117,20 @@ organizationsRouter.patch('/me/security', requireAdmin, async (c) => {
   if (body.stale_key_threshold_days !== undefined) {
     const n = Number(body.stale_key_threshold_days)
     if (!Number.isInteger(n) || n < 30 || n > 365) {
-      return c.json({ error: 'stale_key_threshold_days must be an integer between 30 and 365' }, 400)
+      throw new ApiError('VALIDATION_FAILED', 'stale_key_threshold_days must be an integer between 30 and 365')
     }
     patch.stale_key_threshold_days = n
   }
 
   if (body.leak_detection_enabled !== undefined) {
     if (typeof body.leak_detection_enabled !== 'boolean') {
-      return c.json({ error: 'leak_detection_enabled must be a boolean' }, 400)
+      throw new ApiError('VALIDATION_FAILED', 'leak_detection_enabled must be a boolean')
     }
     patch.leak_detection_enabled = body.leak_detection_enabled
   }
 
   if (Object.keys(patch).length === 0) {
-    return c.json({ error: 'no fields to update' }, 400)
+    throw new ApiError('BAD_REQUEST', 'no fields to update')
   }
 
   const { data, error } = await supabaseAdmin
@@ -140,7 +141,7 @@ organizationsRouter.patch('/me/security', requireAdmin, async (c) => {
     .single()
 
   if (error || !data) {
-    return c.json({ error: 'Update failed' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Update failed')
   }
 
   void recordAuditEvent(c, {
@@ -162,14 +163,14 @@ organizationsRouter.patch('/me/overage', requireAdmin, async (c) => {
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   const patch: { allow_overage?: boolean; overage_cap_multiplier?: number } = {}
 
   if (body.allow_overage !== undefined) {
     if (typeof body.allow_overage !== 'boolean') {
-      return c.json({ error: 'allow_overage must be a boolean' }, 400)
+      throw new ApiError('VALIDATION_FAILED', 'allow_overage must be a boolean')
     }
     patch.allow_overage = body.allow_overage
   }
@@ -177,13 +178,13 @@ organizationsRouter.patch('/me/overage', requireAdmin, async (c) => {
   if (body.overage_cap_multiplier !== undefined) {
     const n = Number(body.overage_cap_multiplier)
     if (!Number.isInteger(n) || n < 1 || n > 100) {
-      return c.json({ error: 'overage_cap_multiplier must be an integer between 1 and 100' }, 400)
+      throw new ApiError('VALIDATION_FAILED', 'overage_cap_multiplier must be an integer between 1 and 100')
     }
     patch.overage_cap_multiplier = n
   }
 
   if (Object.keys(patch).length === 0) {
-    return c.json({ error: 'no fields to update' }, 400)
+    throw new ApiError('BAD_REQUEST', 'no fields to update')
   }
 
   const { data, error } = await supabaseAdmin
@@ -194,7 +195,7 @@ organizationsRouter.patch('/me/overage', requireAdmin, async (c) => {
     .single()
 
   if (error || !data) {
-    return c.json({ error: 'Organization not found or update failed' }, 404)
+    throw new ApiError('NOT_FOUND', 'Organization not found or update failed')
   }
 
   void recordAuditEvent(c, {
@@ -217,17 +218,17 @@ organizationsRouter.patch('/me/overage', requireAdmin, async (c) => {
 // Body: { hide_powered_by_badge: boolean }
 organizationsRouter.patch('/me/branding', requireAdmin, async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: { hide_powered_by_badge?: unknown }
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   if (typeof body.hide_powered_by_badge !== 'boolean') {
-    return c.json({ error: 'hide_powered_by_badge must be a boolean' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'hide_powered_by_badge must be a boolean')
   }
 
   // Plan gate. Read the current plan and require team+ to flip the switch ON.
@@ -257,7 +258,7 @@ organizationsRouter.patch('/me/branding', requireAdmin, async (c) => {
     .select('id, plan, hide_powered_by_badge')
     .single()
 
-  if (error || !data) return c.json({ error: 'Update failed' }, 500)
+  if (error || !data) throw new ApiError('INTERNAL_ERROR', 'Update failed')
 
   void recordAuditEvent(c, {
     action: 'workspace.branding_update',
@@ -321,7 +322,7 @@ organizationsRouter.post('/bootstrap', async (c) => {
     .insert({ name: workspaceName, owner_id: userId })
     .select('id, name, plan, created_at, updated_at')
     .single()
-  if (orgErr || !org) return c.json({ error: 'Failed to create organization' }, 500)
+  if (orgErr || !org) throw new ApiError('INTERNAL_ERROR', 'Failed to create organization')
 
   // Rollback helper — on any later failure, undo the org + anything downstream.
   const rollback = async () => {
@@ -334,7 +335,7 @@ organizationsRouter.post('/bootstrap', async (c) => {
     .insert({ organization_id: org.id, user_id: userId, role: 'admin' })
   if (memberErr) {
     await rollback()
-    return c.json({ error: 'Failed to create org membership' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to create org membership')
   }
 
   // 3. default project — idempotent: reuse one if it already exists with
@@ -358,7 +359,7 @@ organizationsRouter.post('/bootstrap', async (c) => {
       .single()
     if (projErr || !created) {
       await rollback()
-      return c.json({ error: 'Failed to create default project' }, 500)
+      throw new ApiError('INTERNAL_ERROR', 'Failed to create default project')
     }
     project = created
   }
@@ -378,7 +379,7 @@ organizationsRouter.post('/bootstrap', async (c) => {
   })
   if (keyErr) {
     await rollback()
-    return c.json({ error: 'Failed to create API key' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to create API key')
   }
 
   return c.json({
@@ -409,11 +410,11 @@ organizationsRouter.post('/', async (c) => {
   try {
     body = await c.req.json() as { name?: unknown }
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   if (typeof body.name !== 'string' || body.name.trim().length === 0) {
-    return c.json({ error: 'name is required' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'name is required')
   }
 
   // Owned-workspace cap. Counts every org the user is `owner_id` of (regardless
@@ -425,7 +426,7 @@ organizationsRouter.post('/', async (c) => {
     .from('organizations')
     .select('plan')
     .eq('owner_id', userId)
-  if (ownedErr) return c.json({ error: 'Failed to check workspace count' }, 500)
+  if (ownedErr) throw new ApiError('INTERNAL_ERROR', 'Failed to check workspace count')
   const ownedPlans = (ownedRows ?? []).map((r) => r.plan as Plan)
   const effective = effectiveOwnedPlan(ownedPlans)
   const cap = OWNED_WORKSPACE_LIMITS[effective]
@@ -454,7 +455,7 @@ organizationsRouter.post('/', async (c) => {
     .select('id, name, plan, created_at, updated_at')
     .single()
 
-  if (error || !org) return c.json({ error: 'Failed to create workspace' }, 500)
+  if (error || !org) throw new ApiError('INTERNAL_ERROR', 'Failed to create workspace')
 
   const rollback = async () => {
     await supabaseAdmin.from('organizations').delete().eq('id', org.id)
@@ -465,7 +466,7 @@ organizationsRouter.post('/', async (c) => {
     .insert({ organization_id: org.id, user_id: userId, role: 'admin' })
   if (memberError) {
     await rollback()
-    return c.json({ error: 'Failed to create workspace membership' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to create workspace membership')
   }
 
   // Default project so the new workspace opens to something usable rather
@@ -475,7 +476,7 @@ organizationsRouter.post('/', async (c) => {
     .insert({ organization_id: org.id, name: 'Default Project' })
   if (projErr) {
     await rollback()
-    return c.json({ error: 'Failed to create default project' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to create default project')
   }
 
   return c.json({ success: true, data: org }, 201)
@@ -490,11 +491,11 @@ organizationsRouter.patch('/:id', requireAdmin, async (c) => {
   try {
     body = await c.req.json() as { name?: unknown }
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   if (typeof body.name !== 'string' || body.name.trim().length === 0) {
-    return c.json({ error: 'name is required' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'name is required')
   }
 
   const { data, error } = await supabaseAdmin
@@ -506,7 +507,7 @@ organizationsRouter.patch('/:id', requireAdmin, async (c) => {
     .single()
 
   if (error || !data) {
-    return c.json({ error: 'Organization not found or access denied' }, 404)
+    throw new ApiError('NOT_FOUND', 'Organization not found or access denied')
   }
 
   void recordAuditEvent(c, {

--- a/apps/server/src/api/projects.ts
+++ b/apps/server/src/api/projects.ts
@@ -4,6 +4,7 @@ import { requireRole } from '../middleware/requireRole.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { checkProjectQuota } from '../lib/quota.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
+import { ApiError } from '../lib/errors.js'
 
 export const projectsRouter = new Hono<JwtContext>()
 
@@ -15,7 +16,7 @@ const requireAdmin = requireRole('admin')
 // GET /api/v1/projects — list all projects for the user's org
 projectsRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const { data, error } = await supabaseAdmin
     .from('projects')
@@ -23,7 +24,7 @@ projectsRouter.get('/', async (c) => {
     .eq('organization_id', orgId)
     .order('created_at', { ascending: false })
 
-  if (error) return c.json({ error: 'Failed to fetch projects' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to fetch projects')
 
   return c.json({ success: true, data: data ?? [] })
 })
@@ -32,7 +33,7 @@ projectsRouter.get('/', async (c) => {
 projectsRouter.get('/:id', async (c) => {
   const projectId = c.req.param('id')
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const { data, error } = await supabaseAdmin
     .from('projects')
@@ -41,7 +42,7 @@ projectsRouter.get('/:id', async (c) => {
     .eq('organization_id', orgId)
     .single()
 
-  if (error || !data) return c.json({ error: 'Project not found' }, 404)
+  if (error || !data) throw new ApiError('NOT_FOUND', 'Project not found')
 
   return c.json({ success: true, data })
 })
@@ -49,17 +50,17 @@ projectsRouter.get('/:id', async (c) => {
 // POST /api/v1/projects
 projectsRouter.post('/', requireEdit, async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: { name?: unknown; description?: unknown }
   try {
     body = await c.req.json() as { name?: unknown; description?: unknown }
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   if (typeof body.name !== 'string' || body.name.trim().length === 0) {
-    return c.json({ error: 'name is required' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'name is required')
   }
 
   // Enforce per-plan project limit (Free 1 / Starter 5 / Team 20 / Enterprise ∞)
@@ -85,7 +86,7 @@ projectsRouter.post('/', requireEdit, async (c) => {
     .select('id, name, description, created_at, updated_at')
     .single()
 
-  if (error || !data) return c.json({ error: 'Failed to create project' }, 500)
+  if (error || !data) throw new ApiError('INTERNAL_ERROR', 'Failed to create project')
 
   void recordAuditEvent(c, {
     action: 'project.create',
@@ -101,13 +102,13 @@ projectsRouter.post('/', requireEdit, async (c) => {
 projectsRouter.patch('/:id', requireEdit, async (c) => {
   const projectId = c.req.param('id')
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: { name?: unknown; description?: unknown }
   try {
     body = await c.req.json() as { name?: unknown; description?: unknown }
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   const updates: Record<string, unknown> = {}
@@ -118,7 +119,7 @@ projectsRouter.patch('/:id', requireEdit, async (c) => {
     updates['description'] = body.description.trim()
   }
   if (Object.keys(updates).length === 0) {
-    return c.json({ error: 'No valid fields to update' }, 400)
+    throw new ApiError('BAD_REQUEST', 'No valid fields to update')
   }
 
   const { data, error } = await supabaseAdmin
@@ -129,7 +130,7 @@ projectsRouter.patch('/:id', requireEdit, async (c) => {
     .select('id, name, description, created_at, updated_at')
     .single()
 
-  if (error || !data) return c.json({ error: 'Project not found or access denied' }, 404)
+  if (error || !data) throw new ApiError('NOT_FOUND', 'Project not found or access denied')
 
   void recordAuditEvent(c, {
     action: 'project.update',
@@ -145,7 +146,7 @@ projectsRouter.patch('/:id', requireEdit, async (c) => {
 projectsRouter.delete('/:id', requireAdmin, async (c) => {
   const projectId = c.req.param('id')
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const { error } = await supabaseAdmin
     .from('projects')
@@ -153,7 +154,7 @@ projectsRouter.delete('/:id', requireAdmin, async (c) => {
     .eq('id', projectId)
     .eq('organization_id', orgId)
 
-  if (error) return c.json({ error: 'Failed to delete project' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to delete project')
 
   void recordAuditEvent(c, {
     action: 'project.delete',

--- a/apps/server/src/api/requests.ts
+++ b/apps/server/src/api/requests.ts
@@ -20,6 +20,7 @@ import {
 } from '../lib/events-query.js'
 import { useEventsForRequests } from '../lib/feature-flags.js'
 import { fromClickhouseTimestamp } from '../lib/clickhouse.js'
+import { ApiError } from '../lib/errors.js'
 
 export const requestsRouter = new Hono<JwtContext>()
 
@@ -61,7 +62,7 @@ interface RequestRow {
 // Query params: projectId, provider, model, status, from, to, page, limit
 requestsRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const projectId       = c.req.query('projectId')
   const provider        = c.req.query('provider')
@@ -210,7 +211,7 @@ requestsRouter.get('/', async (c) => {
     })
   } catch (err) {
     console.error('[requests:list] ClickHouse query failed:', err instanceof Error ? err.message : err)
-    return c.json({ error: 'Failed to fetch requests' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to fetch requests')
   }
 })
 
@@ -249,7 +250,7 @@ function parseJsonColumn(value: string | null | undefined, fallback: unknown): u
 requestsRouter.get('/:id', async (c) => {
   const requestId = c.req.param('id')
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   try {
     const scope = await requestsScope(orgId)
@@ -261,7 +262,7 @@ requestsRouter.get('/:id', async (c) => {
       limit: 1,
     })
     const data = rows[0]
-    if (!data) return c.json({ error: 'Request not found' }, 404)
+    if (!data) throw new ApiError('NOT_FOUND', 'Request not found')
 
     const keyMap = await fetchProviderKeyNames(orgId, [data.provider_key_id])
     const flat = {
@@ -279,7 +280,7 @@ requestsRouter.get('/:id', async (c) => {
     return c.json({ success: true, data: flat })
   } catch (err) {
     console.error('[requests:detail] ClickHouse query failed:', err instanceof Error ? err.message : err)
-    return c.json({ error: 'Request not found' }, 404)
+    throw new ApiError('NOT_FOUND', 'Request not found')
   }
 })
 
@@ -299,7 +300,7 @@ requestsRouter.get('/:id', async (c) => {
 requestsRouter.post('/:id/replay', requireRole('admin', 'editor'), async (c) => {
   const requestId = c.req.param('id')
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: { model?: unknown } = {}
   try {
@@ -323,7 +324,7 @@ requestsRouter.post('/:id/replay', requireRole('admin', 'editor'), async (c) => 
     limit: 1,
   })
   const data = rows[0]
-  if (!data) return c.json({ error: 'Request not found' }, 404)
+  if (!data) throw new ApiError('NOT_FOUND', 'Request not found')
 
   const original = (parseJsonColumn(data.request_body, {}) ?? {}) as Record<string, unknown>
   const replayBody = overrideModel
@@ -382,7 +383,7 @@ requestsRouter.post('/:id/replay', requireRole('admin', 'editor'), async (c) => 
 requestsRouter.post('/:id/replay/run', requireRole('admin', 'editor'), async (c) => {
   const requestId = c.req.param('id')
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: { model?: unknown } = {}
   try { body = (await c.req.json()) as { model?: unknown } } catch { body = {} }
@@ -406,7 +407,7 @@ requestsRouter.post('/:id/replay/run', requireRole('admin', 'editor'), async (c)
     limit: 1,
   })
   const data = rows[0]
-  if (!data) return c.json({ error: 'Request not found' }, 404)
+  if (!data) throw new ApiError('NOT_FOUND', 'Request not found')
 
   const original = (parseJsonColumn(data.request_body, {}) ?? {}) as Record<string, unknown>
   if ('_truncated' in original) {
@@ -428,7 +429,7 @@ requestsRouter.post('/:id/replay/run', requireRole('admin', 'editor'), async (c)
     providerKey = await getDecryptedProviderKey(data.api_key_id, data.provider)
   }
 
-  if (!providerKey) return c.json({ error: 'Provider key not found or inactive' }, 400)
+  if (!providerKey) throw new ApiError('BAD_REQUEST', 'Provider key not found or inactive')
 
   // ── Build replay body (force non-streaming) ───────────────────────────────
   // We force non-streaming because the dashboard expects a single JSON

--- a/apps/server/src/api/stats.ts
+++ b/apps/server/src/api/stats.ts
@@ -11,6 +11,7 @@ import {
   type OverviewRow,
   type TimeseriesRow,
 } from '../lib/stats-queries.js'
+import { ApiError } from '../lib/errors.js'
 
 /**
  * Stats endpoints — SQL-aggregated server-side.
@@ -56,7 +57,7 @@ function rowToOverview(row: OverviewRow) {
 // GET /api/v1/stats/overview?compare=true
 statsRouter.get('/overview', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const projectId = c.req.query('projectId')
   const from = c.req.query('from')
@@ -103,7 +104,7 @@ statsRouter.get('/overview', async (c) => {
     return c.json({ success: true, data: rowToOverview(overview) })
   } catch (err) {
     console.error('[stats:overview] ClickHouse query failed:', err instanceof Error ? err.message : err)
-    return c.json({ error: 'Failed to fetch stats' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to fetch stats')
   }
 })
 
@@ -116,7 +117,7 @@ function selectGranularity(fromIso: string | null): 'hour' | 'day' {
 // GET /api/v1/stats/models?hours=24 — per-model breakdown, sorted by cost desc
 statsRouter.get('/models', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const hours = parseClampedFloat(c.req.query('hours'), 24, 0.001, 24 * 30)
   const projectId = c.req.query('projectId')
@@ -136,14 +137,14 @@ statsRouter.get('/models', async (c) => {
     return c.json({ success: true, data: models, meta: { hours, count: models.length } })
   } catch (err) {
     console.error('[stats:models] ClickHouse query failed:', err instanceof Error ? err.message : err)
-    return c.json({ error: 'Failed to fetch model stats' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to fetch model stats')
   }
 })
 
 // GET /api/v1/stats/timeseries
 statsRouter.get('/timeseries', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const projectId = c.req.query('projectId')
   const from = c.req.query('from')
@@ -172,7 +173,7 @@ statsRouter.get('/timeseries', async (c) => {
     return c.json({ success: true, data: series, meta: { granularity } })
   } catch (err) {
     console.error('[stats:timeseries] ClickHouse query failed:', err instanceof Error ? err.message : err)
-    return c.json({ error: 'Failed to fetch timeseries' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to fetch timeseries')
   }
 })
 
@@ -181,7 +182,7 @@ statsRouter.get('/timeseries', async (c) => {
 // page chart's hover tooltip to explain spikes.
 statsRouter.get('/timeseries-breakdown', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const projectId = c.req.query('projectId')
   const from = c.req.query('from')
@@ -204,7 +205,7 @@ statsRouter.get('/timeseries-breakdown', async (c) => {
     return c.json({ success: true, data, meta: { granularity } })
   } catch (err) {
     console.error('[stats:timeseries-breakdown] ClickHouse query failed:', err instanceof Error ? err.message : err)
-    return c.json({ error: 'Failed to fetch timeseries breakdown' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to fetch timeseries breakdown')
   }
 })
 
@@ -227,7 +228,7 @@ function olsRegression(ys: number[]): { slope: number; intercept: number } {
 // GET /api/v1/stats/spend-forecast — monthly spend forecast via linear regression
 statsRouter.get('/spend-forecast', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const projectId = c.req.query('projectId')
 
@@ -248,7 +249,7 @@ statsRouter.get('/spend-forecast', async (c) => {
     })
   } catch (err) {
     console.error('[stats:spend-forecast] ClickHouse query failed:', err instanceof Error ? err.message : err)
-    return c.json({ error: 'Failed to fetch spend forecast' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to fetch spend forecast')
   }
 
   const costByDate = new Map<string, number>()
@@ -328,7 +329,7 @@ statsRouter.get('/spend-forecast', async (c) => {
  */
 statsRouter.get('/latency', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const hours = parseClampedFloat(c.req.query('hours'), 24, 0.001, 24 * 30)
 
@@ -361,6 +362,6 @@ statsRouter.get('/latency', async (c) => {
     })
   } catch (err) {
     console.error('[stats:latency] ClickHouse query failed:', err instanceof Error ? err.message : err)
-    return c.json({ error: 'Failed to fetch latency data' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to fetch latency data')
   }
 })

--- a/apps/server/src/api/traces.ts
+++ b/apps/server/src/api/traces.ts
@@ -9,6 +9,7 @@ import {
   listTracesFromEvents,
   getTraceWithSpansFromEvents,
 } from '../lib/traces-events-queries.js'
+import { ApiError } from '../lib/errors.js'
 
 export const tracesRouter = new Hono<JwtContext>()
 
@@ -19,7 +20,7 @@ tracesRouter.use('*', authJwtOrApiKey)
 // page, limit
 tracesRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const projectId = c.req.query('projectId')
   const status = c.req.query('status')
@@ -97,7 +98,7 @@ tracesRouter.get('/', async (c) => {
   }
 
   const { data, error, count } = await query
-  if (error) return c.json({ error: 'Failed to fetch traces' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to fetch traces')
 
   return c.json({
     success: true,
@@ -110,12 +111,12 @@ tracesRouter.get('/', async (c) => {
 tracesRouter.get('/:id', async (c) => {
   const traceId = c.req.param('id')
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   if (useEventsForRequests) {
     try {
       const { trace, spans } = await getTraceWithSpansFromEvents(traceId, orgId)
-      if (!trace) return c.json({ error: 'Trace not found' }, 404)
+      if (!trace) throw new ApiError('NOT_FOUND', 'Trace not found')
       const criticalSpanIds = computeCriticalPath(spans)
       return c.json({
         success: true,
@@ -138,7 +139,7 @@ tracesRouter.get('/:id', async (c) => {
     .eq('organization_id', orgId)
     .single()
 
-  if (traceErr || !trace) return c.json({ error: 'Trace not found' }, 404)
+  if (traceErr || !trace) throw new ApiError('NOT_FOUND', 'Trace not found')
 
   const { data: spans, error: spansErr } = await supabaseAdmin
     .from('spans')
@@ -148,7 +149,7 @@ tracesRouter.get('/:id', async (c) => {
     .eq('trace_id', traceId)
     .order('started_at', { ascending: true })
 
-  if (spansErr) return c.json({ error: 'Failed to fetch spans' }, 500)
+  if (spansErr) throw new ApiError('INTERNAL_ERROR', 'Failed to fetch spans')
 
   const criticalSpanIds = computeCriticalPath(spans ?? [])
 


### PR DESCRIPTION
Batch 1 of Sprint 8 error envelope migration. 75 of 84 legacy sites auto-migrated. See commit body for codemod-fix details (multi-line import insertion bug).