### PR TITLE
feat(sprint-8 batch 2): migrate 5 user-facing read-API files

### DIFF
--- a/apps/server/src/api/datasets.ts
+++ b/apps/server/src/api/datasets.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { requestsScope, selectRequests } from '../lib/requests-query.js'
+import { ApiError } from '../lib/errors.js'
 
 export const datasetsRouter = new Hono<JwtContext>()
 
@@ -13,18 +14,18 @@ datasetsRouter.use('*', authJwt)
 datasetsRouter.post('/', async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: { name?: unknown; description?: unknown }
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   const name = typeof body.name === 'string' ? body.name.trim() : ''
   const description = typeof body.description === 'string' ? body.description.trim() : null
-  if (!name) return c.json({ error: 'name is required' }, 400)
+  if (!name) throw new ApiError('VALIDATION_FAILED', 'name is required')
 
   const { data, error } = await supabaseAdmin
     .from('datasets')
@@ -39,7 +40,7 @@ datasetsRouter.post('/', async (c) => {
 
   if (error || !data) {
     if (error?.code === '23505') {
-      return c.json({ error: 'A dataset with this name already exists' }, 409)
+      throw new ApiError('CONFLICT', 'A dataset with this name already exists')
     }
     return c.json({ error: error?.message ?? 'Failed to create dataset' }, 500)
   }
@@ -49,7 +50,7 @@ datasetsRouter.post('/', async (c) => {
 // GET /api/v1/datasets — list (with item counts)
 datasetsRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const { data: datasets, error } = await supabaseAdmin
     .from('datasets')
@@ -87,7 +88,7 @@ datasetsRouter.get('/', async (c) => {
 // GET /api/v1/datasets/:id — single dataset + items
 datasetsRouter.get('/:id', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const id = c.req.param('id')
 
@@ -99,7 +100,7 @@ datasetsRouter.get('/:id', async (c) => {
     .is('archived_at', null)
     .maybeSingle()
 
-  if (dsErr || !dataset) return c.json({ error: 'Dataset not found' }, 404)
+  if (dsErr || !dataset) throw new ApiError('NOT_FOUND', 'Dataset not found')
 
   const { data: items, error: itemsErr } = await supabaseAdmin
     .from('dataset_items')
@@ -115,7 +116,7 @@ datasetsRouter.get('/:id', async (c) => {
 // DELETE /api/v1/datasets/:id — soft delete (archive)
 datasetsRouter.delete('/:id', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const id = c.req.param('id')
   const { error } = await supabaseAdmin
@@ -133,7 +134,7 @@ datasetsRouter.delete('/:id', async (c) => {
 // POST /api/v1/datasets/:id/items — add a single item
 datasetsRouter.post('/:id/items', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const datasetId = c.req.param('id')
 
@@ -145,24 +146,24 @@ datasetsRouter.post('/:id/items', async (c) => {
     .eq('organization_id', orgId)
     .is('archived_at', null)
     .maybeSingle()
-  if (!ds) return c.json({ error: 'Dataset not found' }, 404)
+  if (!ds) throw new ApiError('NOT_FOUND', 'Dataset not found')
 
   let body: { input?: unknown; expectedOutput?: unknown; sourceRequestId?: unknown }
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   if (!body.input || typeof body.input !== 'object' || Array.isArray(body.input)) {
-    return c.json({ error: 'input must be an object' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'input must be an object')
   }
   const input = body.input as Record<string, unknown>
   // Accept shapes: { variables: {...} } or { messages: [...] }
   const hasVars = input.variables && typeof input.variables === 'object'
   const hasMsgs = Array.isArray(input.messages)
   if (!hasVars && !hasMsgs) {
-    return c.json({ error: 'input must contain "variables" object or "messages" array' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'input must contain "variables" object or "messages" array')
   }
 
   const expectedOutput = typeof body.expectedOutput === 'string' ? body.expectedOutput : null
@@ -190,7 +191,7 @@ datasetsRouter.post('/:id/items', async (c) => {
 // can show "8/10 inserted, 2 skipped (missing input)".
 datasetsRouter.post('/:id/items/bulk', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const datasetId = c.req.param('id')
 
@@ -202,25 +203,25 @@ datasetsRouter.post('/:id/items/bulk', async (c) => {
     .eq('organization_id', orgId)
     .is('archived_at', null)
     .maybeSingle()
-  if (!ds) return c.json({ error: 'Dataset not found' }, 404)
+  if (!ds) throw new ApiError('NOT_FOUND', 'Dataset not found')
 
   let body: { items?: unknown }
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   if (!Array.isArray(body.items)) {
-    return c.json({ error: 'items must be an array' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'items must be an array')
   }
   if (body.items.length === 0) {
-    return c.json({ error: 'items array is empty' }, 400)
+    throw new ApiError('BAD_REQUEST', 'items array is empty')
   }
   // Cap per-request size to keep payload + memory bounded. Most uploads
   // are <1000 rows in practice.
   if (body.items.length > 5000) {
-    return c.json({ error: 'items array too large (max 5000)' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'items array too large (max 5000)')
   }
 
   // Normalize each row to the schema enforced by single-item POST:
@@ -276,7 +277,7 @@ datasetsRouter.post('/:id/items/bulk', async (c) => {
 // POST /api/v1/datasets/:id/items/import-requests — bulk import from production
 datasetsRouter.post('/:id/items/import-requests', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const datasetId = c.req.param('id')
 
@@ -287,20 +288,20 @@ datasetsRouter.post('/:id/items/import-requests', async (c) => {
     .eq('organization_id', orgId)
     .is('archived_at', null)
     .maybeSingle()
-  if (!ds) return c.json({ error: 'Dataset not found' }, 404)
+  if (!ds) throw new ApiError('NOT_FOUND', 'Dataset not found')
 
   let body: { requestIds?: unknown }
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   if (!Array.isArray(body.requestIds) || body.requestIds.length === 0) {
-    return c.json({ error: 'requestIds (array) is required' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'requestIds (array) is required')
   }
   const ids = body.requestIds.filter((x): x is string => typeof x === 'string').slice(0, 200)
-  if (ids.length === 0) return c.json({ error: 'No valid request IDs' }, 400)
+  if (ids.length === 0) throw new ApiError('BAD_REQUEST', 'No valid request IDs')
 
   // Fetch source requests from ClickHouse. body columns are JSON strings —
   // parse at the boundary so the existing extraction logic stays unchanged.
@@ -322,7 +323,7 @@ datasetsRouter.post('/:id/items/import-requests', async (c) => {
     return c.json({ error: err instanceof Error ? err.message : 'ClickHouse query failed' }, 500)
   }
   if (rawRequests.length === 0) {
-    return c.json({ error: 'No matching requests found' }, 404)
+    throw new ApiError('NOT_FOUND', 'No matching requests found')
   }
   const requests = rawRequests.map((r) => {
     const parse = (s: string): Record<string, unknown> | null => {
@@ -384,7 +385,7 @@ datasetsRouter.post('/:id/items/import-requests', async (c) => {
 // DELETE /api/v1/datasets/:id/items/:itemId
 datasetsRouter.delete('/:id/items/:itemId', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const itemId = c.req.param('itemId')
   const { error } = await supabaseAdmin

--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -3,6 +3,7 @@ import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { runEvalRun, estimateJudgeCostUsd } from '../lib/eval-runner.js'
 import { fireAndForget } from '../lib/wait-until.js'
+import { ApiError } from '../lib/errors.js'
 
 export const evalsRouter = new Hono<JwtContext>()
 
@@ -14,7 +15,7 @@ evalsRouter.use('*', authJwt)
 evalsRouter.post('/evaluators', async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: {
     promptName?: unknown
@@ -28,21 +29,21 @@ evalsRouter.post('/evaluators', async (c) => {
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   const promptName = typeof body.promptName === 'string' ? body.promptName.trim() : ''
   const name = typeof body.name === 'string' ? body.name.trim() : ''
   const type = typeof body.type === 'string' ? body.type.trim() : 'llm_judge'
 
-  if (!promptName) return c.json({ error: 'promptName is required' }, 400)
-  if (!name) return c.json({ error: 'name is required' }, 400)
+  if (!promptName) throw new ApiError('VALIDATION_FAILED', 'promptName is required')
+  if (!name) throw new ApiError('VALIDATION_FAILED', 'name is required')
   if (type !== 'llm_judge' && type !== 'regex' && type !== 'json_schema') {
-    return c.json({ error: 'type must be one of: llm_judge, regex, json_schema' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'type must be one of: llm_judge, regex, json_schema')
   }
 
   if (!body.config || typeof body.config !== 'object' || Array.isArray(body.config)) {
-    return c.json({ error: 'config object is required' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'config object is required')
   }
   const config = body.config as Record<string, unknown>
 
@@ -58,19 +59,19 @@ evalsRouter.post('/evaluators', async (c) => {
     const scaleMin = typeof config.scale_min === 'number' ? config.scale_min : 0
     const scaleMax = typeof config.scale_max === 'number' ? config.scale_max : 1
 
-    if (!criterion) return c.json({ error: 'config.criterion is required' }, 400)
+    if (!criterion) throw new ApiError('VALIDATION_FAILED', 'config.criterion is required')
     if (judgeProvider !== 'openai' && judgeProvider !== 'anthropic' && judgeProvider !== 'gemini') {
-      return c.json({ error: 'config.judge_provider must be "openai", "anthropic", or "gemini"' }, 400)
+      throw new ApiError('VALIDATION_FAILED', 'config.judge_provider must be "openai", "anthropic", or "gemini"')
     }
-    if (!judgeModel) return c.json({ error: 'config.judge_model is required' }, 400)
+    if (!judgeModel) throw new ApiError('VALIDATION_FAILED', 'config.judge_model is required')
     if (!(scaleMax > scaleMin)) {
-      return c.json({ error: 'config.scale_max must be greater than scale_min' }, 400)
+      throw new ApiError('VALIDATION_FAILED', 'config.scale_max must be greater than scale_min')
     }
     validatedConfig = { criterion, judge_provider: judgeProvider, judge_model: judgeModel, scale_min: scaleMin, scale_max: scaleMax }
   } else if (type === 'regex') {
     const pattern = typeof config.pattern === 'string' ? config.pattern : ''
     const flags = typeof config.flags === 'string' ? config.flags : ''
-    if (!pattern) return c.json({ error: 'config.pattern is required' }, 400)
+    if (!pattern) throw new ApiError('VALIDATION_FAILED', 'config.pattern is required')
     // Compile-test the pattern at create time so a typo can't lurk
     // until first eval run — same fail-fast pattern as score_configs
     // does for category validation.
@@ -84,7 +85,7 @@ evalsRouter.post('/evaluators', async (c) => {
   } else {
     // type === 'json_schema'
     if (!config.schema || typeof config.schema !== 'object' || Array.isArray(config.schema)) {
-      return c.json({ error: 'config.schema must be a JSON Schema object' }, 400)
+      throw new ApiError('VALIDATION_FAILED', 'config.schema must be a JSON Schema object')
     }
     validatedConfig = { schema: config.schema }
   }
@@ -95,7 +96,7 @@ evalsRouter.post('/evaluators', async (c) => {
     .select('id', { count: 'exact', head: true })
     .eq('organization_id', orgId)
     .eq('name', promptName)
-  if (!promptCount) return c.json({ error: 'Prompt not found' }, 404)
+  if (!promptCount) throw new ApiError('NOT_FOUND', 'Prompt not found')
 
   // Optional score config — only meaningful for LLM-as-judge runs.
   // Verified to belong to the same org so a caller can't bind an
@@ -114,7 +115,7 @@ evalsRouter.post('/evaluators', async (c) => {
       .eq('organization_id', orgId)
       .is('archived_at', null)
       .maybeSingle()
-    if (!sc) return c.json({ error: 'scoreConfigId not found' }, 404)
+    if (!sc) throw new ApiError('NOT_FOUND', 'scoreConfigId not found')
     scoreConfigId = sc.id
   }
 
@@ -141,7 +142,7 @@ evalsRouter.post('/evaluators', async (c) => {
 // GET /api/v1/evaluators?promptName=...
 evalsRouter.get('/evaluators', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const promptName = c.req.query('promptName')
 
@@ -168,7 +169,7 @@ evalsRouter.get('/evaluators', async (c) => {
 // already render-ready.
 evalsRouter.get('/evaluator-templates', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const { data, error } = await supabaseAdmin
     .from('evaluator_templates')
@@ -177,14 +178,14 @@ evalsRouter.get('/evaluator-templates', async (c) => {
     .order('category', { ascending: true })
     .order('display_order', { ascending: true })
 
-  if (error) return c.json({ error: 'Failed to load templates' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to load templates')
   return c.json({ success: true, data: data ?? [] })
 })
 
 // DELETE /api/v1/evaluators/:id — soft delete (archive)
 evalsRouter.delete('/evaluators/:id', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const id = c.req.param('id')
   const { error } = await supabaseAdmin
@@ -203,7 +204,7 @@ evalsRouter.delete('/evaluators/:id', async (c) => {
 evalsRouter.post('/eval-runs', async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: {
     evaluatorId?: unknown
@@ -219,7 +220,7 @@ evalsRouter.post('/eval-runs', async (c) => {
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   const evaluatorId = typeof body.evaluatorId === 'string' ? body.evaluatorId.trim() : ''
@@ -230,13 +231,13 @@ evalsRouter.post('/eval-runs', async (c) => {
   const sampleFrom = typeof body.sampleFrom === 'string' ? body.sampleFrom : null
   const sampleTo = typeof body.sampleTo === 'string' ? body.sampleTo : null
 
-  if (!evaluatorId) return c.json({ error: 'evaluatorId is required' }, 400)
-  if (!promptVersionId) return c.json({ error: 'promptVersionId is required' }, 400)
+  if (!evaluatorId) throw new ApiError('VALIDATION_FAILED', 'evaluatorId is required')
+  if (!promptVersionId) throw new ApiError('VALIDATION_FAILED', 'promptVersionId is required')
   if (sampleSize < 1 || sampleSize > 1000) {
-    return c.json({ error: 'sampleSize must be between 1 and 1000' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'sampleSize must be between 1 and 1000')
   }
   if (source === 'dataset' && !datasetId) {
-    return c.json({ error: 'datasetId is required when source = dataset' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'datasetId is required when source = dataset')
   }
 
   // Dataset evals run the prompt against each item's input before judging.
@@ -247,8 +248,8 @@ evalsRouter.post('/eval-runs', async (c) => {
       : null
   const runModel = typeof body.runModel === 'string' ? body.runModel.trim() : null
   if (source === 'dataset') {
-    if (!runProvider) return c.json({ error: 'runProvider is required when source = dataset' }, 400)
-    if (!runModel) return c.json({ error: 'runModel is required when source = dataset' }, 400)
+    if (!runProvider) throw new ApiError('VALIDATION_FAILED', 'runProvider is required when source = dataset')
+    if (!runModel) throw new ApiError('VALIDATION_FAILED', 'runModel is required when source = dataset')
   }
 
   // Verify both belong to org
@@ -259,7 +260,7 @@ evalsRouter.post('/eval-runs', async (c) => {
     .eq('organization_id', orgId)
     .is('archived_at', null)
     .maybeSingle()
-  if (!evaluator) return c.json({ error: 'Evaluator not found' }, 404)
+  if (!evaluator) throw new ApiError('NOT_FOUND', 'Evaluator not found')
 
   const { data: pv } = await supabaseAdmin
     .from('prompt_versions')
@@ -267,7 +268,7 @@ evalsRouter.post('/eval-runs', async (c) => {
     .eq('id', promptVersionId)
     .eq('organization_id', orgId)
     .maybeSingle()
-  if (!pv) return c.json({ error: 'Prompt version not found' }, 404)
+  if (!pv) throw new ApiError('NOT_FOUND', 'Prompt version not found')
 
   // Verify dataset belongs to org if requested
   if (source === 'dataset' && datasetId) {
@@ -278,7 +279,7 @@ evalsRouter.post('/eval-runs', async (c) => {
       .eq('organization_id', orgId)
       .is('archived_at', null)
       .maybeSingle()
-    if (!ds) return c.json({ error: 'Dataset not found' }, 404)
+    if (!ds) throw new ApiError('NOT_FOUND', 'Dataset not found')
   }
 
   const { data: run, error: runErr } = await supabaseAdmin
@@ -323,7 +324,7 @@ evalsRouter.post('/eval-runs', async (c) => {
 // GET /api/v1/eval-runs?evaluatorId=...&promptVersionId=...
 evalsRouter.get('/eval-runs', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const evaluatorId = c.req.query('evaluatorId')
   const promptVersionId = c.req.query('promptVersionId')
@@ -346,7 +347,7 @@ evalsRouter.get('/eval-runs', async (c) => {
 // GET /api/v1/eval-runs/:id
 evalsRouter.get('/eval-runs/:id', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const id = c.req.param('id')
   const { data, error } = await supabaseAdmin
@@ -356,14 +357,14 @@ evalsRouter.get('/eval-runs/:id', async (c) => {
     .eq('organization_id', orgId)
     .maybeSingle()
 
-  if (error || !data) return c.json({ error: 'Eval run not found' }, 404)
+  if (error || !data) throw new ApiError('NOT_FOUND', 'Eval run not found')
   return c.json({ success: true, data })
 })
 
 // GET /api/v1/eval-runs/:id/results
 evalsRouter.get('/eval-runs/:id/results', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const runId = c.req.param('id')
 
@@ -374,7 +375,7 @@ evalsRouter.get('/eval-runs/:id/results', async (c) => {
     .eq('id', runId)
     .eq('organization_id', orgId)
     .maybeSingle()
-  if (!run) return c.json({ error: 'Eval run not found' }, 404)
+  if (!run) throw new ApiError('NOT_FOUND', 'Eval run not found')
 
   const { data, error } = await supabaseAdmin
     .from('eval_results')
@@ -392,7 +393,7 @@ evalsRouter.post('/eval-runs/estimate', async (c) => {
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
   const sampleSize = typeof body.sampleSize === 'number' ? Math.round(body.sampleSize) : 50
   const judgeModel = typeof body.judgeModel === 'string' ? body.judgeModel : 'gpt-4o-mini'

--- a/apps/server/src/api/experiments.ts
+++ b/apps/server/src/api/experiments.ts
@@ -3,6 +3,7 @@ import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { runExperiment } from '../lib/experiment-runner.js'
 import { fireAndForget } from '../lib/wait-until.js'
+import { ApiError } from '../lib/errors.js'
 
 export const experimentsRouter = new Hono<JwtContext>()
 
@@ -12,7 +13,7 @@ experimentsRouter.use('*', authJwt)
 experimentsRouter.post('/', async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: {
     name?: unknown
@@ -27,7 +28,7 @@ experimentsRouter.post('/', async (c) => {
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   const name = typeof body.name === 'string' ? body.name.trim() : ''
@@ -43,12 +44,12 @@ experimentsRouter.post('/', async (c) => {
     : 'openai'
   const runModel = typeof body.runModel === 'string' ? body.runModel.trim() : ''
 
-  if (!name) return c.json({ error: 'name is required' }, 400)
-  if (!promptName) return c.json({ error: 'promptName is required' }, 400)
-  if (!versionAId || !versionBId) return c.json({ error: 'versionAId and versionBId are required' }, 400)
-  if (versionAId === versionBId) return c.json({ error: 'versionA and versionB must differ' }, 400)
-  if (!datasetId) return c.json({ error: 'datasetId is required' }, 400)
-  if (!runModel) return c.json({ error: 'runModel is required' }, 400)
+  if (!name) throw new ApiError('VALIDATION_FAILED', 'name is required')
+  if (!promptName) throw new ApiError('VALIDATION_FAILED', 'promptName is required')
+  if (!versionAId || !versionBId) throw new ApiError('BAD_REQUEST', 'versionAId and versionBId are required')
+  if (versionAId === versionBId) throw new ApiError('BAD_REQUEST', 'versionA and versionB must differ')
+  if (!datasetId) throw new ApiError('VALIDATION_FAILED', 'datasetId is required')
+  if (!runModel) throw new ApiError('VALIDATION_FAILED', 'runModel is required')
 
   // Verify ownership
   const { data: versions } = await supabaseAdmin
@@ -57,7 +58,7 @@ experimentsRouter.post('/', async (c) => {
     .eq('organization_id', orgId)
     .in('id', [versionAId, versionBId])
   if (!versions || versions.length !== 2) {
-    return c.json({ error: 'Prompt versions not found' }, 404)
+    throw new ApiError('NOT_FOUND', 'Prompt versions not found')
   }
 
   const { data: dataset } = await supabaseAdmin
@@ -67,7 +68,7 @@ experimentsRouter.post('/', async (c) => {
     .eq('organization_id', orgId)
     .is('archived_at', null)
     .maybeSingle()
-  if (!dataset) return c.json({ error: 'Dataset not found' }, 404)
+  if (!dataset) throw new ApiError('NOT_FOUND', 'Dataset not found')
 
   if (evaluatorId) {
     const { data: ev } = await supabaseAdmin
@@ -77,7 +78,7 @@ experimentsRouter.post('/', async (c) => {
       .eq('organization_id', orgId)
       .is('archived_at', null)
       .maybeSingle()
-    if (!ev) return c.json({ error: 'Evaluator not found' }, 404)
+    if (!ev) throw new ApiError('NOT_FOUND', 'Evaluator not found')
   }
 
   const { data: exp, error: expErr } = await supabaseAdmin
@@ -119,7 +120,7 @@ experimentsRouter.post('/', async (c) => {
 // GET /api/v1/experiments?promptName=...
 experimentsRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const promptName = c.req.query('promptName')
 
@@ -140,7 +141,7 @@ experimentsRouter.get('/', async (c) => {
 // GET /api/v1/experiments/:id
 experimentsRouter.get('/:id', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const id = c.req.param('id')
   const { data, error } = await supabaseAdmin
@@ -150,14 +151,14 @@ experimentsRouter.get('/:id', async (c) => {
     .eq('organization_id', orgId)
     .maybeSingle()
 
-  if (error || !data) return c.json({ error: 'Experiment not found' }, 404)
+  if (error || !data) throw new ApiError('NOT_FOUND', 'Experiment not found')
   return c.json({ success: true, data })
 })
 
 // GET /api/v1/experiments/:id/results
 experimentsRouter.get('/:id/results', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const id = c.req.param('id')
 
@@ -168,7 +169,7 @@ experimentsRouter.get('/:id/results', async (c) => {
     .eq('id', id)
     .eq('organization_id', orgId)
     .maybeSingle()
-  if (!exp) return c.json({ error: 'Experiment not found' }, 404)
+  if (!exp) throw new ApiError('NOT_FOUND', 'Experiment not found')
 
   const { data, error } = await supabaseAdmin
     .from('experiment_results')

--- a/apps/server/src/api/prompt-experiments.ts
+++ b/apps/server/src/api/prompt-experiments.ts
@@ -10,6 +10,7 @@ import {
   welchTest,
   type StatResult,
 } from '../lib/prompt-experiment-stats.js'
+import { ApiError } from '../lib/errors.js'
 
 const requireEdit = requireRole('admin', 'editor')
 
@@ -31,7 +32,7 @@ promptExperimentsRouter.use('*', authJwt)
 
 promptExperimentsRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const promptName = c.req.query('promptName')
   const status = c.req.query('status') // 'running' | 'concluded' | 'stopped'
@@ -49,7 +50,7 @@ promptExperimentsRouter.get('/', async (c) => {
   if (status) query = query.eq('status', status)
 
   const { data, error } = await query
-  if (error) return c.json({ error: 'Failed to fetch experiments' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to fetch experiments')
 
   return c.json({ success: true, data: data ?? [] })
 })
@@ -59,7 +60,7 @@ promptExperimentsRouter.get('/', async (c) => {
 promptExperimentsRouter.post('/', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: {
     promptName?: unknown
@@ -72,22 +73,22 @@ promptExperimentsRouter.post('/', requireEdit, async (c) => {
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   const promptName = typeof body.promptName === 'string' ? body.promptName.trim() : ''
   const versionAId = typeof body.versionAId === 'string' ? body.versionAId.trim() : ''
   const versionBId = typeof body.versionBId === 'string' ? body.versionBId.trim() : ''
 
-  if (!promptName) return c.json({ error: 'promptName is required' }, 400)
-  if (!versionAId) return c.json({ error: 'versionAId is required' }, 400)
-  if (!versionBId) return c.json({ error: 'versionBId is required' }, 400)
-  if (versionAId === versionBId) return c.json({ error: 'versionAId and versionBId must differ' }, 400)
+  if (!promptName) throw new ApiError('VALIDATION_FAILED', 'promptName is required')
+  if (!versionAId) throw new ApiError('VALIDATION_FAILED', 'versionAId is required')
+  if (!versionBId) throw new ApiError('VALIDATION_FAILED', 'versionBId is required')
+  if (versionAId === versionBId) throw new ApiError('BAD_REQUEST', 'versionAId and versionBId must differ')
 
   const trafficSplit =
     typeof body.trafficSplit === 'number' ? Math.round(body.trafficSplit) : 50
   if (trafficSplit < 1 || trafficSplit > 99)
-    return c.json({ error: 'trafficSplit must be between 1 and 99' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'trafficSplit must be between 1 and 99')
 
   const endsAt = typeof body.endsAt === 'string' ? body.endsAt : null
   const projectId = typeof body.projectId === 'string' ? body.projectId : null
@@ -100,7 +101,7 @@ promptExperimentsRouter.post('/', requireEdit, async (c) => {
     .in('id', [versionAId, versionBId])
 
   if (!versions || versions.length !== 2)
-    return c.json({ error: 'One or both prompt versions not found in this organization' }, 404)
+    throw new ApiError('NOT_FOUND', 'One or both prompt versions not found in this organization')
 
   for (const v of versions) {
     if (v.name !== promptName)
@@ -125,8 +126,8 @@ promptExperimentsRouter.post('/', requireEdit, async (c) => {
   if (error) {
     // Unique partial index violation → already running experiment
     if (error.code === '23505')
-      return c.json({ error: 'An experiment is already running for this prompt' }, 409)
-    return c.json({ error: 'Failed to create experiment' }, 500)
+      throw new ApiError('CONFLICT', 'An experiment is already running for this prompt')
+    throw new ApiError('INTERNAL_ERROR', 'Failed to create experiment')
   }
 
   // Invalidate the resolve cache: the next `name@latest` request must see
@@ -152,7 +153,7 @@ promptExperimentsRouter.post('/', requireEdit, async (c) => {
 
 promptExperimentsRouter.get('/:id', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
   const id = c.req.param('id')
 
   const { data: exp, error } = await supabaseAdmin
@@ -162,7 +163,7 @@ promptExperimentsRouter.get('/:id', async (c) => {
     .eq('id', id)
     .maybeSingle()
 
-  if (error || !exp) return c.json({ error: 'Experiment not found' }, 404)
+  if (error || !exp) throw new ApiError('NOT_FOUND', 'Experiment not found')
 
   // Fetch request metrics for both arms from ClickHouse.
   const sinceTs = (exp.started_at as string).replace('T', ' ').replace('Z', '')
@@ -275,7 +276,7 @@ promptExperimentsRouter.get('/:id', async (c) => {
 
 promptExperimentsRouter.patch('/:id', requireEdit, async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
   const id = c.req.param('id')
 
   let body: {
@@ -286,14 +287,14 @@ promptExperimentsRouter.patch('/:id', requireEdit, async (c) => {
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   const updates: Record<string, unknown> = {}
 
   if (typeof body.status === 'string') {
     if (!['concluded', 'stopped'].includes(body.status))
-      return c.json({ error: 'status must be "concluded" or "stopped"' }, 400)
+      throw new ApiError('VALIDATION_FAILED', 'status must be "concluded" or "stopped"')
     updates.status = body.status
     if (body.status === 'concluded') {
       updates.concluded_at = new Date().toISOString()
@@ -307,7 +308,7 @@ promptExperimentsRouter.patch('/:id', requireEdit, async (c) => {
   }
 
   if (Object.keys(updates).length === 0)
-    return c.json({ error: 'No valid fields to update' }, 400)
+    throw new ApiError('BAD_REQUEST', 'No valid fields to update')
 
   const { data, error } = await supabaseAdmin
     .from('prompt_ab_experiments')
@@ -317,7 +318,7 @@ promptExperimentsRouter.patch('/:id', requireEdit, async (c) => {
     .select()
     .maybeSingle()
 
-  if (error || !data) return c.json({ error: 'Failed to update experiment' }, 500)
+  if (error || !data) throw new ApiError('INTERNAL_ERROR', 'Failed to update experiment')
 
   // Status change (concluded/stopped) flips traffic back to plain `latest`,
   // so the cached experiment metadata must be dropped.
@@ -354,7 +355,7 @@ promptExperimentsRouter.patch('/:id', requireEdit, async (c) => {
 
 promptExperimentsRouter.delete('/:id', requireRole('admin'), async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
   const id = c.req.param('id')
 
   // Only allow deleting non-running experiments
@@ -365,9 +366,9 @@ promptExperimentsRouter.delete('/:id', requireRole('admin'), async (c) => {
     .eq('id', id)
     .maybeSingle()
 
-  if (!exp) return c.json({ error: 'Experiment not found' }, 404)
+  if (!exp) throw new ApiError('NOT_FOUND', 'Experiment not found')
   if (exp.status === 'running')
-    return c.json({ error: 'Stop or conclude the experiment before deleting' }, 409)
+    throw new ApiError('CONFLICT', 'Stop or conclude the experiment before deleting')
 
   const { error } = await supabaseAdmin
     .from('prompt_ab_experiments')
@@ -375,7 +376,7 @@ promptExperimentsRouter.delete('/:id', requireRole('admin'), async (c) => {
     .eq('organization_id', orgId)
     .eq('id', id)
 
-  if (error) return c.json({ error: 'Failed to delete experiment' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to delete experiment')
   // Belt-and-braces: PATCH already invalidated when status moved to
   // stopped/concluded, but a direct delete (e.g. backfill cleanup) still
   // needs the cache flushed in case anything raced.

--- a/apps/server/src/api/prompts.ts
+++ b/apps/server/src/api/prompts.ts
@@ -8,6 +8,7 @@ import { enqueueDeletion } from '../lib/pending-deletions.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
 import { requestsScope, selectRequests } from '../lib/requests-query.js'
 import { parsePositiveFloat } from '../lib/params.js'
+import { ApiError } from '../lib/errors.js'
 
 const requireEdit = requireRole('admin', 'editor')
 
@@ -52,7 +53,7 @@ const EMPTY_STATS: PromptStats = {
 // GET /  — latest version of every named prompt, with 24h usage stats inline
 promptsRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const projectId = c.req.query('projectId')
 
@@ -66,7 +67,7 @@ promptsRouter.get('/', async (c) => {
   if (projectId) query = query.eq('project_id', projectId)
 
   const { data, error } = await query
-  if (error) return c.json({ error: 'Failed to fetch prompts' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to fetch prompts')
 
   const allRows = data ?? []
 
@@ -193,7 +194,7 @@ promptsRouter.get('/', async (c) => {
 // GET /:name — all versions of a named prompt
 promptsRouter.get('/:name', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
   const name = c.req.param('name')
 
   const { data, error } = await supabaseAdmin
@@ -203,14 +204,14 @@ promptsRouter.get('/:name', async (c) => {
     .eq('name', name)
     .order('version', { ascending: false })
 
-  if (error) return c.json({ error: 'Failed to fetch versions' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to fetch versions')
   return c.json({ success: true, data: data ?? [] })
 })
 
 // GET /:name/compare — per-version metrics for A/B comparison
 promptsRouter.get('/:name/compare', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
   const name = c.req.param('name')
   const sinceHours = parsePositiveFloat(c.req.query('sinceHours'), 24 * 30)
 
@@ -221,11 +222,11 @@ promptsRouter.get('/:name/compare', async (c) => {
 // GET /:name/:version — one specific version
 promptsRouter.get('/:name/:version', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
   const name = c.req.param('name')
   const version = Number(c.req.param('version'))
   if (!Number.isInteger(version) || version < 1) {
-    return c.json({ error: 'Invalid version' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'Invalid version')
   }
 
   const { data, error } = await supabaseAdmin
@@ -236,7 +237,7 @@ promptsRouter.get('/:name/:version', async (c) => {
     .eq('version', version)
     .maybeSingle()
 
-  if (error || !data) return c.json({ error: 'Version not found' }, 404)
+  if (error || !data) throw new ApiError('NOT_FOUND', 'Version not found')
   return c.json({ success: true, data })
 })
 
@@ -244,7 +245,7 @@ promptsRouter.get('/:name/:version', async (c) => {
 promptsRouter.post('/', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: {
     name?: unknown
@@ -256,15 +257,15 @@ promptsRouter.post('/', requireEdit, async (c) => {
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   const name = typeof body.name === 'string' ? body.name.trim() : ''
   const content = typeof body.content === 'string' ? body.content : ''
-  if (!name) return c.json({ error: 'name is required' }, 400)
-  if (!content) return c.json({ error: 'content is required' }, 400)
-  if (name.length > 128) return c.json({ error: 'name too long (max 128)' }, 400)
-  if (content.length > 100_000) return c.json({ error: 'content too long (max 100K)' }, 400)
+  if (!name) throw new ApiError('VALIDATION_FAILED', 'name is required')
+  if (!content) throw new ApiError('VALIDATION_FAILED', 'content is required')
+  if (name.length > 128) throw new ApiError('VALIDATION_FAILED', 'name too long (max 128)')
+  if (content.length > 100_000) throw new ApiError('VALIDATION_FAILED', 'content too long (max 100K)')
 
   const variables: PromptVariable[] = Array.isArray(body.variables)
     ? (body.variables as PromptVariable[]).filter(
@@ -302,7 +303,7 @@ promptsRouter.post('/', requireEdit, async (c) => {
     .select('id, name, version, content, variables, metadata, project_id, created_at, created_by')
     .single()
 
-  if (error || !data) return c.json({ error: 'Failed to create version' }, 500)
+  if (error || !data) throw new ApiError('INTERNAL_ERROR', 'Failed to create version')
   // Invalidate resolve-prompt-version cache for this prompt name so the new
   // latest version is served immediately on the next proxy call.
   await invalidatePromptName(orgId, name)
@@ -327,11 +328,11 @@ promptsRouter.post('/', requireEdit, async (c) => {
 promptsRouter.post('/:name/:version/rollback', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
   const name = c.req.param('name')
   const version = Number(c.req.param('version'))
   if (!Number.isInteger(version) || version < 1) {
-    return c.json({ error: 'Invalid version' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'Invalid version')
   }
 
   const { data: source, error: fetchErr } = await supabaseAdmin
@@ -342,7 +343,7 @@ promptsRouter.post('/:name/:version/rollback', requireEdit, async (c) => {
     .eq('version', version)
     .maybeSingle()
 
-  if (fetchErr || !source) return c.json({ error: 'Version not found' }, 404)
+  if (fetchErr || !source) throw new ApiError('NOT_FOUND', 'Version not found')
 
   const { data: latest } = await supabaseAdmin
     .from('prompt_versions')
@@ -370,7 +371,7 @@ promptsRouter.post('/:name/:version/rollback', requireEdit, async (c) => {
     .select('id, name, version, content, variables, metadata, project_id, created_at, created_by')
     .single()
 
-  if (error || !data) return c.json({ error: 'Failed to create rollback version' }, 500)
+  if (error || !data) throw new ApiError('INTERNAL_ERROR', 'Failed to create rollback version')
   await invalidatePromptName(orgId, name)
 
   void recordAuditEvent(c, {
@@ -398,11 +399,11 @@ promptsRouter.post('/:name/:version/rollback', requireEdit, async (c) => {
 promptsRouter.delete('/:name/:version', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
   const name = c.req.param('name')
   const version = Number(c.req.param('version'))
   if (!Number.isInteger(version) || version < 1) {
-    return c.json({ error: 'Invalid version' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'Invalid version')
   }
 
   const { data: snapshot } = await supabaseAdmin
@@ -412,7 +413,7 @@ promptsRouter.delete('/:name/:version', requireEdit, async (c) => {
     .eq('name', name)
     .eq('version', version)
     .maybeSingle()
-  if (!snapshot) return c.json({ error: 'Version not found' }, 404)
+  if (!snapshot) throw new ApiError('NOT_FOUND', 'Version not found')
 
   const enqueued = await enqueueDeletion({
     organizationId: orgId,
@@ -424,7 +425,7 @@ promptsRouter.delete('/:name/:version', requireEdit, async (c) => {
 
   if (!enqueued.ok) {
     if (enqueued.code === 'ALREADY_PENDING') {
-      return c.json({ error: 'Already queued for deletion' }, 409)
+      throw new ApiError('CONFLICT', 'Already queued for deletion')
     }
     return c.json({ error: enqueued.error ?? 'Failed to queue deletion' }, 500)
   }


### PR DESCRIPTION
Batch 2 of Sprint 8 error envelope migration. 123 of 145 legacy sites auto-migrated across evals / datasets / experiments / prompts / prompt-experiments.