### PR TITLE
feat(sprint-8 batch 3): migrate 5 write-API files

### DIFF
--- a/apps/server/src/api/apiKeys.ts
+++ b/apps/server/src/api/apiKeys.ts
@@ -6,6 +6,7 @@ import { randomHex, sha256Hex } from '../lib/crypto.js'
 import { enqueueDeletion } from '../lib/pending-deletions.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
 import { invalidateApiKeyCache } from '../middleware/authApiKey.js'
+import { ApiError } from '../lib/errors.js'
 
 /**
  * Spanlens keys come in two shapes:
@@ -52,7 +53,7 @@ apiKeysRouter.get('/', async (c) => {
   const projectId = c.req.query('projectId')
   const scopeFilter = c.req.query('scope')
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let query = supabaseAdmin
     .from('api_keys')
@@ -66,7 +67,7 @@ apiKeysRouter.get('/', async (c) => {
     query = query.eq('organization_id', orgId).eq('scope', 'public')
   } else if (projectId) {
     const belongs = await projectBelongsToOrg(projectId, orgId)
-    if (!belongs) return c.json({ error: 'Project not found' }, 404)
+    if (!belongs) throw new ApiError('NOT_FOUND', 'Project not found')
     query = query.eq('project_id', projectId)
   } else {
     // No filter: every key on every project in the org PLUS workspace-level
@@ -87,7 +88,7 @@ apiKeysRouter.get('/', async (c) => {
   }
 
   const { data, error } = await query
-  if (error) return c.json({ error: 'Failed to fetch API keys' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to fetch API keys')
 
   return c.json({ success: true, data: data ?? [] })
 })
@@ -98,17 +99,17 @@ apiKeysRouter.get('/', async (c) => {
 //   { name, scope: 'public' }          — public key, workspace-scoped
 apiKeysRouter.post('/issue', requireEdit, async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: { name?: unknown; projectId?: unknown; scope?: unknown }
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   if (typeof body.name !== 'string' || body.name.trim().length === 0) {
-    return c.json({ error: 'name is required' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'name is required')
   }
 
   const scope: 'full' | 'public' = body.scope === 'public' ? 'public' : 'full'
@@ -137,10 +138,10 @@ apiKeysRouter.post('/issue', requireEdit, async (c) => {
 
   if (scope === 'full') {
     if (typeof body.projectId !== 'string') {
-      return c.json({ error: 'projectId is required for full-access keys' }, 400)
+      throw new ApiError('VALIDATION_FAILED', 'projectId is required for full-access keys')
     }
     const belongs = await projectBelongsToOrg(body.projectId, orgId)
-    if (!belongs) return c.json({ error: 'Project not found' }, 404)
+    if (!belongs) throw new ApiError('NOT_FOUND', 'Project not found')
     insertRow = {
       project_id: body.projectId,
       name: body.name.trim(),
@@ -166,7 +167,7 @@ apiKeysRouter.post('/issue', requireEdit, async (c) => {
     )
     .single()
 
-  if (error || !data) return c.json({ error: 'Failed to create API key' }, 500)
+  if (error || !data) throw new ApiError('INTERNAL_ERROR', 'Failed to create API key')
 
   void recordAuditEvent(c, {
     action: 'api_key.create',
@@ -226,27 +227,27 @@ async function loadKeyOwnership(
 apiKeysRouter.patch('/:id', requireEdit, async (c) => {
   const keyId = c.req.param('id')
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: { is_active?: unknown }
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
   if (typeof body.is_active !== 'boolean') {
-    return c.json({ error: 'is_active (boolean) is required' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'is_active (boolean) is required')
   }
 
   const ownership = await loadKeyOwnership(keyId)
-  if (!ownership) return c.json({ error: 'API key not found' }, 404)
-  if (ownership.orgId !== orgId) return c.json({ error: 'Access denied' }, 403)
+  if (!ownership) throw new ApiError('NOT_FOUND', 'API key not found')
+  if (ownership.orgId !== orgId) throw new ApiError('FORBIDDEN', 'Access denied')
 
   const { error } = await supabaseAdmin
     .from('api_keys')
     .update({ is_active: body.is_active })
     .eq('id', keyId)
-  if (error) return c.json({ error: 'Failed to update API key' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to update API key')
 
   void recordAuditEvent(c, {
     action: body.is_active ? 'api_key.enable' : 'api_key.disable',
@@ -269,11 +270,11 @@ apiKeysRouter.delete('/:id', requireEdit, async (c) => {
   const keyId = c.req.param('id')
   const orgId = c.get('orgId')
   const userId = c.get('userId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const ownership = await loadKeyOwnership(keyId)
-  if (!ownership) return c.json({ error: 'API key not found' }, 404)
-  if (ownership.orgId !== orgId) return c.json({ error: 'Access denied' }, 403)
+  if (!ownership) throw new ApiError('NOT_FOUND', 'API key not found')
+  if (ownership.orgId !== orgId) throw new ApiError('FORBIDDEN', 'Access denied')
 
   // Snapshot the row before deactivation so the audit log and any restore
   // attempt have the full original state to work with.
@@ -282,7 +283,7 @@ apiKeysRouter.delete('/:id', requireEdit, async (c) => {
     .select('*')
     .eq('id', keyId)
     .maybeSingle()
-  if (!snapshot) return c.json({ error: 'API key not found' }, 404)
+  if (!snapshot) throw new ApiError('NOT_FOUND', 'API key not found')
 
   const enqueued = await enqueueDeletion({
     organizationId: orgId,
@@ -294,7 +295,7 @@ apiKeysRouter.delete('/:id', requireEdit, async (c) => {
 
   if (!enqueued.ok) {
     if (enqueued.code === 'ALREADY_PENDING') {
-      return c.json({ error: 'Already queued for deletion' }, 409)
+      throw new ApiError('CONFLICT', 'Already queued for deletion')
     }
     return c.json({ error: enqueued.error ?? 'Failed to queue deletion' }, 500)
   }

--- a/apps/server/src/api/invitations.ts
+++ b/apps/server/src/api/invitations.ts
@@ -9,6 +9,7 @@ import {
   recordAuditEvent,
   recordAuditLog,
 } from '../lib/audit-log.js'
+import { ApiError } from '../lib/errors.js'
 
 /**
  * Invitations — email-based org member onboarding.
@@ -55,21 +56,21 @@ const hashToken = sha256Hex
 orgInvitationsRouter.post('/', requireRole('admin'), async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
-  if (orgMismatch(c)) return c.json({ error: 'Forbidden' }, 403)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+  if (orgMismatch(c)) throw new ApiError('FORBIDDEN', 'Forbidden')
 
   let body: { email?: unknown; role?: unknown }
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   if (typeof body.email !== 'string' || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(body.email)) {
-    return c.json({ error: 'Valid email is required' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'Valid email is required')
   }
   if (typeof body.role !== 'string' || !VALID_ROLES.includes(body.role as OrgRole)) {
-    return c.json({ error: 'role must be admin | editor | viewer' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'role must be admin | editor | viewer')
   }
 
   const email = body.email.toLowerCase().trim()
@@ -87,7 +88,7 @@ orgInvitationsRouter.post('/', requireRole('admin'), async (c) => {
       .eq('user_id', matched.id)
       .maybeSingle()
     if (alreadyMember) {
-      return c.json({ error: 'This user is already a member of the organization' }, 409)
+      throw new ApiError('CONFLICT', 'This user is already a member of the organization')
     }
   }
 
@@ -101,7 +102,7 @@ orgInvitationsRouter.post('/', requireRole('admin'), async (c) => {
     .gt('expires_at', new Date().toISOString())
     .maybeSingle()
   if (pending) {
-    return c.json({ error: 'A pending invitation for this email already exists' }, 409)
+    throw new ApiError('CONFLICT', 'A pending invitation for this email already exists')
   }
 
   const token = randomHex(32)
@@ -122,7 +123,7 @@ orgInvitationsRouter.post('/', requireRole('admin'), async (c) => {
     .single()
 
   if (error || !inserted) {
-    return c.json({ error: 'Failed to create invitation' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to create invitation')
   }
 
   // Fetch org name for the email body. Inviter email comes straight from the
@@ -165,8 +166,8 @@ orgInvitationsRouter.post('/', requireRole('admin'), async (c) => {
 // Any member can see pending invites (list in Settings > Members).
 orgInvitationsRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
-  if (orgMismatch(c)) return c.json({ error: 'Forbidden' }, 403)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+  if (orgMismatch(c)) throw new ApiError('FORBIDDEN', 'Forbidden')
 
   const { data, error } = await supabaseAdmin
     .from('org_invitations')
@@ -175,7 +176,7 @@ orgInvitationsRouter.get('/', async (c) => {
     .is('accepted_at', null)
     .order('created_at', { ascending: false })
 
-  if (error) return c.json({ error: 'Failed to fetch invitations' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to fetch invitations')
   return c.json({ success: true, data: data ?? [] })
 })
 
@@ -189,7 +190,7 @@ export const invitationsRouter = new Hono<JwtContext>()
 // unregistered users can see what they're about to sign up for.
 invitationsRouter.get('/accept', async (c) => {
   const token = c.req.query('token')
-  if (!token) return c.json({ error: 'Missing token' }, 400)
+  if (!token) throw new ApiError('BAD_REQUEST', 'Missing token')
 
   const { data: inv } = await supabaseAdmin
     .from('org_invitations')
@@ -197,10 +198,10 @@ invitationsRouter.get('/accept', async (c) => {
     .eq('token_hash', await hashToken(token))
     .maybeSingle()
 
-  if (!inv) return c.json({ error: 'Invalid invitation' }, 404)
-  if (inv.accepted_at) return c.json({ error: 'Invitation already accepted' }, 400)
+  if (!inv) throw new ApiError('NOT_FOUND', 'Invalid invitation')
+  if (inv.accepted_at) throw new ApiError('BAD_REQUEST', 'Invitation already accepted')
   if (new Date(inv.expires_at) < new Date()) {
-    return c.json({ error: 'Invitation expired' }, 400)
+    throw new ApiError('BAD_REQUEST', 'Invitation expired')
   }
 
   const { data: org } = await supabaseAdmin
@@ -227,10 +228,10 @@ invitationsRouter.post('/accept', authJwt, async (c) => {
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
   if (typeof body.token !== 'string' || body.token.length === 0) {
-    return c.json({ error: 'Token is required' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'Token is required')
   }
 
   const { data: inv } = await supabaseAdmin
@@ -239,10 +240,10 @@ invitationsRouter.post('/accept', authJwt, async (c) => {
     .eq('token_hash', await hashToken(body.token))
     .maybeSingle()
 
-  if (!inv) return c.json({ error: 'Invalid invitation' }, 404)
-  if (inv.accepted_at) return c.json({ error: 'Invitation already accepted' }, 400)
+  if (!inv) throw new ApiError('NOT_FOUND', 'Invalid invitation')
+  if (inv.accepted_at) throw new ApiError('BAD_REQUEST', 'Invitation already accepted')
   if (new Date(inv.expires_at) < new Date()) {
-    return c.json({ error: 'Invitation expired' }, 400)
+    throw new ApiError('BAD_REQUEST', 'Invitation expired')
   }
 
   // Email check: invitation is bound to the invitee's email. Anyone else
@@ -251,7 +252,7 @@ invitationsRouter.post('/accept', authJwt, async (c) => {
   // from the JWT context (authJwt set it) — saves a getUserById roundtrip.
   const currentEmail = c.get('email')
   if (!currentEmail || currentEmail !== inv.email.toLowerCase()) {
-    return c.json({ error: 'This invitation was sent to a different email' }, 400)
+    throw new ApiError('BAD_REQUEST', 'This invitation was sent to a different email')
   }
 
   // Idempotent: if user is already in the org (another channel?), just mark
@@ -270,7 +271,7 @@ invitationsRouter.post('/accept', authJwt, async (c) => {
       role: inv.role as OrgRole,
       invited_by: inv.id ? null : null, // invited_by points at a user, not invite — we don't have inviter id here
     })
-    if (insertErr) return c.json({ error: 'Failed to add member' }, 500)
+    if (insertErr) throw new ApiError('INTERNAL_ERROR', 'Failed to add member')
   }
 
   const { error: markErr } = await supabaseAdmin
@@ -327,7 +328,7 @@ invitationsRouter.post('/accept', authJwt, async (c) => {
 // DELETE /api/v1/invitations/:id — admin cancel (auth required)
 invitationsRouter.delete('/:id', authJwt, requireRole('admin'), async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const id = c.req.param('id')
 
@@ -340,8 +341,8 @@ invitationsRouter.delete('/:id', authJwt, requireRole('admin'), async (c) => {
     .eq('organization_id', orgId)
     .is('accepted_at', null)
 
-  if (error) return c.json({ error: 'Failed to cancel invitation' }, 500)
-  if (count === 0) return c.json({ error: 'Invitation not found' }, 404)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to cancel invitation')
+  if (count === 0) throw new ApiError('NOT_FOUND', 'Invitation not found')
 
   void recordAuditEvent(c, {
     action: 'member.invite_cancel',
@@ -387,7 +388,7 @@ meInvitationsRouter.get('/', async (c) => {
     .gt('expires_at', new Date().toISOString())
     .order('created_at', { ascending: false })
 
-  if (error) return c.json({ error: 'Failed to fetch pending invitations' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to fetch pending invitations')
 
   // Shape the join output to a flat list — same pattern as
   // GET /organizations.
@@ -410,7 +411,7 @@ meInvitationsRouter.get('/', async (c) => {
 meInvitationsRouter.post('/:id/accept', async (c) => {
   const userId = c.get('userId')
   const email = c.get('email')
-  if (!email) return c.json({ error: 'User has no email' }, 400)
+  if (!email) throw new ApiError('BAD_REQUEST', 'User has no email')
 
   const { data: inv } = await supabaseAdmin
     .from('org_invitations')
@@ -418,13 +419,13 @@ meInvitationsRouter.post('/:id/accept', async (c) => {
     .eq('id', c.req.param('id'))
     .maybeSingle()
 
-  if (!inv) return c.json({ error: 'Invalid invitation' }, 404)
-  if (inv.accepted_at) return c.json({ error: 'Invitation already accepted' }, 400)
+  if (!inv) throw new ApiError('NOT_FOUND', 'Invalid invitation')
+  if (inv.accepted_at) throw new ApiError('BAD_REQUEST', 'Invitation already accepted')
   if (new Date(inv.expires_at) < new Date()) {
-    return c.json({ error: 'Invitation expired' }, 400)
+    throw new ApiError('BAD_REQUEST', 'Invitation expired')
   }
   if (inv.email.toLowerCase() !== email) {
-    return c.json({ error: 'This invitation was sent to a different email' }, 400)
+    throw new ApiError('BAD_REQUEST', 'This invitation was sent to a different email')
   }
 
   // Idempotent member INSERT — same shape as the token-based path.
@@ -441,7 +442,7 @@ meInvitationsRouter.post('/:id/accept', async (c) => {
       user_id: userId,
       role: inv.role as OrgRole,
     })
-    if (insertErr) return c.json({ error: 'Failed to add member' }, 500)
+    if (insertErr) throw new ApiError('INTERNAL_ERROR', 'Failed to add member')
   }
 
   await supabaseAdmin
@@ -475,7 +476,7 @@ meInvitationsRouter.post('/:id/accept', async (c) => {
 // I decline, I never see it again unless explicitly re-invited".
 meInvitationsRouter.delete('/:id', async (c) => {
   const email = c.get('email')
-  if (!email) return c.json({ error: 'User has no email' }, 400)
+  if (!email) throw new ApiError('BAD_REQUEST', 'User has no email')
 
   const { error, count } = await supabaseAdmin
     .from('org_invitations')
@@ -484,8 +485,8 @@ meInvitationsRouter.delete('/:id', async (c) => {
     .ilike('email', email)
     .is('accepted_at', null)
 
-  if (error) return c.json({ error: 'Failed to decline invitation' }, 500)
-  if (count === 0) return c.json({ error: 'Invitation not found' }, 404)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to decline invitation')
+  if (count === 0) throw new ApiError('NOT_FOUND', 'Invitation not found')
   return c.json({ success: true })
 })
 
@@ -493,16 +494,16 @@ meInvitationsRouter.delete('/:id', async (c) => {
 // /invite page. Mirrors the existing accept token flow.
 invitationsRouter.post('/decline', authJwt, async (c) => {
   const email = c.get('email')
-  if (!email) return c.json({ error: 'User has no email' }, 400)
+  if (!email) throw new ApiError('BAD_REQUEST', 'User has no email')
 
   let body: { token?: unknown }
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
   if (typeof body.token !== 'string' || body.token.length === 0) {
-    return c.json({ error: 'Token is required' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'Token is required')
   }
 
   const { error, count } = await supabaseAdmin
@@ -512,7 +513,7 @@ invitationsRouter.post('/decline', authJwt, async (c) => {
     .ilike('email', email)
     .is('accepted_at', null)
 
-  if (error) return c.json({ error: 'Failed to decline invitation' }, 500)
-  if (count === 0) return c.json({ error: 'Invitation not found' }, 404)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to decline invitation')
+  if (count === 0) throw new ApiError('NOT_FOUND', 'Invitation not found')
   return c.json({ success: true })
 })

--- a/apps/server/src/api/members.ts
+++ b/apps/server/src/api/members.ts
@@ -3,6 +3,7 @@ import { authJwt, type JwtContext, type OrgRole } from '../middleware/authJwt.js
 import { requireRole } from '../middleware/requireRole.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
+import { ApiError } from '../lib/errors.js'
 
 /**
  * /api/v1/organizations/:orgId/members — team roster + role management.
@@ -53,8 +54,8 @@ async function memberRole(orgId: string, userId: string): Promise<OrgRole | null
 // All members (incl. viewers) can see the team roster.
 membersRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
-  if (orgMismatch(c)) return c.json({ error: 'Forbidden' }, 403)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+  if (orgMismatch(c)) throw new ApiError('FORBIDDEN', 'Forbidden')
 
   // Join to auth.users for email. supabase-js can't join auth.users in a
   // single .select() because it's cross-schema, so we fetch members then
@@ -65,7 +66,7 @@ membersRouter.get('/', async (c) => {
     .eq('organization_id', orgId)
     .order('created_at', { ascending: true })
 
-  if (error) return c.json({ error: 'Failed to fetch members' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to fetch members')
 
   const userIds = (members ?? []).map((m) => m.user_id)
   const emails = new Map<string, string>()
@@ -93,8 +94,8 @@ membersRouter.get('/', async (c) => {
 // Change a member's role. Admin only. Blocks demoting the last admin.
 membersRouter.patch('/:userId', requireAdmin, async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
-  if (orgMismatch(c)) return c.json({ error: 'Forbidden' }, 403)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+  if (orgMismatch(c)) throw new ApiError('FORBIDDEN', 'Forbidden')
 
   const userId = c.req.param('userId')
 
@@ -102,22 +103,22 @@ membersRouter.patch('/:userId', requireAdmin, async (c) => {
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   if (typeof body.role !== 'string' || !VALID_ROLES.includes(body.role as OrgRole)) {
-    return c.json({ error: 'role must be admin | editor | viewer' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'role must be admin | editor | viewer')
   }
   const newRole = body.role as OrgRole
 
   const current = await memberRole(orgId, userId)
-  if (!current) return c.json({ error: 'Member not found' }, 404)
+  if (!current) throw new ApiError('NOT_FOUND', 'Member not found')
   if (current === newRole) return c.json({ success: true, data: { role: current } })
 
   // Last-admin protection: demoting the last admin locks the org out.
   if (current === 'admin' && newRole !== 'admin') {
     if ((await adminCount(orgId)) <= 1) {
-      return c.json({ error: 'Cannot demote the last admin' }, 400)
+      throw new ApiError('BAD_REQUEST', 'Cannot demote the last admin')
     }
   }
 
@@ -127,7 +128,7 @@ membersRouter.patch('/:userId', requireAdmin, async (c) => {
     .eq('organization_id', orgId)
     .eq('user_id', userId)
 
-  if (error) return c.json({ error: 'Failed to update role' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to update role')
 
   void recordAuditEvent(c, {
     action: 'member.role_change',
@@ -143,15 +144,15 @@ membersRouter.patch('/:userId', requireAdmin, async (c) => {
 // Remove a member. Admin only. Blocks removing the last admin.
 membersRouter.delete('/:userId', requireAdmin, async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
-  if (orgMismatch(c)) return c.json({ error: 'Forbidden' }, 403)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+  if (orgMismatch(c)) throw new ApiError('FORBIDDEN', 'Forbidden')
 
   const userId = c.req.param('userId')
   const current = await memberRole(orgId, userId)
-  if (!current) return c.json({ error: 'Member not found' }, 404)
+  if (!current) throw new ApiError('NOT_FOUND', 'Member not found')
 
   if (current === 'admin' && (await adminCount(orgId)) <= 1) {
-    return c.json({ error: 'Cannot remove the last admin' }, 400)
+    throw new ApiError('BAD_REQUEST', 'Cannot remove the last admin')
   }
 
   const { error } = await supabaseAdmin
@@ -160,7 +161,7 @@ membersRouter.delete('/:userId', requireAdmin, async (c) => {
     .eq('organization_id', orgId)
     .eq('user_id', userId)
 
-  if (error) return c.json({ error: 'Failed to remove member' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to remove member')
 
   void recordAuditEvent(c, {
     action: 'member.remove',

--- a/apps/server/src/api/providerKeys.ts
+++ b/apps/server/src/api/providerKeys.ts
@@ -7,6 +7,7 @@ import { aes256Encrypt } from '../lib/crypto.js'
 import { enqueueDeletion } from '../lib/pending-deletions.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
 import { resetProviderKeyNamesCache } from '../lib/requests-query.js'
+import { ApiError } from '../lib/errors.js'
 
 /**
  * Provider AI keys (OpenAI / Anthropic / Gemini). Under the nested-keys
@@ -86,7 +87,7 @@ async function assertApiKeyInOrg(apiKeyId: string, orgId: string): Promise<boole
 //   - last_scan_result: 'clean' | 'leaked' | 'error' | null
 providerKeysRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const apiKeyIdFilter = c.req.query('apiKeyId')
 
@@ -102,7 +103,7 @@ providerKeysRouter.get('/', async (c) => {
 
   const { data, error } = await query
 
-  if (error) return c.json({ error: 'Failed to fetch provider keys' }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to fetch provider keys')
 
   const rows = data ?? []
   if (rows.length === 0) {
@@ -169,7 +170,7 @@ providerKeysRouter.get('/', async (c) => {
 // Spanlens key. Body: { api_key_id, provider, key, name }.
 providerKeysRouter.post('/', requireEdit, async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: {
     provider?: unknown
@@ -182,23 +183,23 @@ providerKeysRouter.post('/', requireEdit, async (c) => {
   try {
     body = (await c.req.json()) as typeof body
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   if (typeof body.provider !== 'string' || !VALID_PROVIDERS.has(body.provider)) {
-    return c.json({ error: 'provider must be one of: openai, anthropic, gemini, azure' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'provider must be one of: openai, anthropic, gemini, azure')
   }
   if (typeof body.key !== 'string' || body.key.trim().length === 0) {
-    return c.json({ error: 'key is required' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'key is required')
   }
   if (typeof body.name !== 'string' || body.name.trim().length === 0) {
-    return c.json({ error: 'name is required' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'name is required')
   }
   if (typeof body.api_key_id !== 'string' || body.api_key_id.trim().length === 0) {
-    return c.json({ error: 'api_key_id is required' }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'api_key_id is required')
   }
   if (!(await assertApiKeyInOrg(body.api_key_id, orgId))) {
-    return c.json({ error: 'api_key_id does not belong to this organization' }, 403)
+    throw new ApiError('FORBIDDEN', 'api_key_id does not belong to this organization')
   }
 
   // Azure requires a resource_url in provider_metadata. Validate + normalize
@@ -246,7 +247,7 @@ providerKeysRouter.post('/', requireEdit, async (c) => {
         409,
       )
     }
-    return c.json({ error: 'Failed to store provider key' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to store provider key')
   }
 
   // Invalidate the cached org → key-name map so the new key shows up
@@ -282,7 +283,7 @@ providerKeysRouter.delete('/:id', requireEdit, async (c) => {
   const keyId = c.req.param('id')
   const orgId = c.get('orgId')
   const userId = c.get('userId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const { data: snapshot } = await supabaseAdmin
     .from('provider_keys')
@@ -290,7 +291,7 @@ providerKeysRouter.delete('/:id', requireEdit, async (c) => {
     .eq('id', keyId)
     .eq('organization_id', orgId)
     .maybeSingle()
-  if (!snapshot) return c.json({ error: 'Provider key not found' }, 404)
+  if (!snapshot) throw new ApiError('NOT_FOUND', 'Provider key not found')
 
   const enqueued = await enqueueDeletion({
     organizationId: orgId,
@@ -302,7 +303,7 @@ providerKeysRouter.delete('/:id', requireEdit, async (c) => {
 
   if (!enqueued.ok) {
     if (enqueued.code === 'ALREADY_PENDING') {
-      return c.json({ error: 'Already queued for deletion' }, 409)
+      throw new ApiError('CONFLICT', 'Already queued for deletion')
     }
     return c.json({ error: enqueued.error ?? 'Failed to queue deletion' }, 500)
   }
@@ -332,13 +333,13 @@ providerKeysRouter.delete('/:id', requireEdit, async (c) => {
 providerKeysRouter.patch('/:id', requireEdit, async (c) => {
   const keyId = c.req.param('id')
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: { key?: unknown; name?: unknown }
   try {
     body = (await c.req.json()) as { key?: unknown; name?: unknown }
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   const updates: Record<string, unknown> = {}
@@ -349,7 +350,7 @@ providerKeysRouter.patch('/:id', requireEdit, async (c) => {
     updates['name'] = body.name.trim()
   }
   if (Object.keys(updates).length === 0) {
-    return c.json({ error: 'No valid fields to update' }, 400)
+    throw new ApiError('BAD_REQUEST', 'No valid fields to update')
   }
 
   const { data, error } = await supabaseAdmin
@@ -360,7 +361,7 @@ providerKeysRouter.patch('/:id', requireEdit, async (c) => {
     .select(SELECT_COLUMNS)
     .single()
 
-  if (error || !data) return c.json({ error: 'Provider key not found or access denied' }, 404)
+  if (error || !data) throw new ApiError('NOT_FOUND', 'Provider key not found or access denied')
 
   resetProviderKeyNamesCache()
 

--- a/apps/server/src/api/shares.ts
+++ b/apps/server/src/api/shares.ts
@@ -3,6 +3,7 @@ import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { randomHex } from '../lib/crypto.js'
 import { requestsScope, selectRequests } from '../lib/requests-query.js'
+import { ApiError } from '../lib/errors.js'
 
 /**
  * /api/v1/shares — owner-side CRUD for public share tokens (PLG Loop ①).
@@ -77,23 +78,23 @@ async function targetExists(
 sharesRouter.post('/', async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   let body: CreateShareBody
   try {
     body = (await c.req.json()) as CreateShareBody
   } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
   if (!isScope(body.scope)) {
-    return c.json({ error: "scope must be 'trace' or 'request'" }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'scope must be \'trace\' or \'request\'')
   }
   const targetId = typeof body.targetId === 'string' ? body.targetId.trim() : ''
-  if (!targetId) return c.json({ error: 'targetId is required' }, 400)
+  if (!targetId) throw new ApiError('VALIDATION_FAILED', 'targetId is required')
 
   const ok = await targetExists(body.scope, targetId, orgId)
-  if (!ok) return c.json({ error: 'Target not found' }, 404)
+  if (!ok) throw new ApiError('NOT_FOUND', 'Target not found')
 
   const token = randomHex(16) // 32 hex chars → ~128 bits
   const expiresAt = ttlToExpiresAt(body.ttl)
@@ -119,7 +120,7 @@ sharesRouter.post('/', async (c) => {
 
   if (error || !data) {
     console.error('[shares:create] insert failed:', error?.message)
-    return c.json({ error: 'Failed to create share' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to create share')
   }
 
   return c.json({ success: true, data })
@@ -143,7 +144,7 @@ sharesRouter.post('/', async (c) => {
 sharesRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const scope = c.req.query('scope') === 'org' ? 'org' : 'mine'
   const sortParam = c.req.query('sort')
@@ -172,7 +173,7 @@ sharesRouter.get('/', async (c) => {
   const { data, error } = await query
   if (error) {
     console.error('[shares:list] select failed:', error.message)
-    return c.json({ error: 'Failed to list shares' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to list shares')
   }
 
   const rows = data ?? []
@@ -207,7 +208,7 @@ sharesRouter.get('/', async (c) => {
 // DELETE /api/v1/shares/:token — revoke a share (soft delete).
 sharesRouter.delete('/:token', async (c) => {
   const orgId = c.get('orgId')
-  if (!orgId) return c.json({ error: 'Organization not found' }, 404)
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
   const token = c.req.param('token')
 
   // Org-scoped: any member of the org can revoke any share in their org.
@@ -222,9 +223,9 @@ sharesRouter.delete('/:token', async (c) => {
 
   if (error) {
     console.error('[shares:revoke] update failed:', error.message)
-    return c.json({ error: 'Failed to revoke share' }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to revoke share')
   }
-  if (!count) return c.json({ error: 'Share not found' }, 404)
+  if (!count) throw new ApiError('NOT_FOUND', 'Share not found')
 
   return c.json({ success: true })
 })


### PR DESCRIPTION
Batch 3 of Sprint 8. 103 of 108 legacy sites auto-migrated across apiKeys / providerKeys / invitations / members / shares.