### PR TITLE
feat(sprint-8 PR #294): cleanup — cron.ts + paddleWebhook + serializeErrorEnvelope helper + 06-plan v1.27

### DIFF
--- a/apps/server/src/__tests__/paddleWebhook.test.ts
+++ b/apps/server/src/__tests__/paddleWebhook.test.ts
@@ -368,7 +368,7 @@ describe('paddleWebhook — subscription.* edge cases', () => {
       event('subscription.created', subPayload({ custom_data: null })),
     )
     expect(res.status).toBe(400)
-    expect(body['error']).toBe('organization not found')
+    expect((body['error'] as { message: string }).message).toBe('organization not found')
   })
 
   it('non-cancel event with missing price id → 200 skipped (not 4xx — avoids Paddle retry storm)', async () => {
@@ -502,7 +502,7 @@ describe('paddleWebhook — transaction.completed', () => {
       event('transaction.completed', txPayload({ items: [] })),
     )
     expect(res.status).toBe(400)
-    expect(body['error']).toBe('missing price id')
+    expect((body['error'] as { message: string }).message).toBe('missing price id')
   })
 
   it('unknown price id in transaction → 200 skipped (avoid retry storm)', async () => {
@@ -556,7 +556,7 @@ describe('paddleWebhook — adjustment.created', () => {
     setOrgLookup(null)
     const { res, body } = await postWebhook(event('adjustment.created', adjPayload()))
     expect(res.status).toBe(400)
-    expect(body['error']).toBe('organization not found')
+    expect((body['error'] as { message: string }).message).toBe('organization not found')
   })
 })
 

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -1,5 +1,7 @@
 import { Hono } from 'hono'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import { supabaseAdmin } from '../lib/db.js'
+import { ApiError, serializeErrorEnvelope } from '../lib/errors.js'
 // `unscopedClickhouse` is used by /cron/detect-missing-model-prices below
 // to GROUP BY model across all tenants — that scan is the entire point of
 // the alert and cannot be done per-org. The lint rule guards against
@@ -39,11 +41,38 @@ import { executePendingDeletions } from './pendingDeletions.js'
 
 export const cronRouter = new Hono()
 
-function assertCronAuth(authHeader: string | undefined): string | null {
+// Standalone router onError handler. Mirrors paddleWebhookRouter.onError
+// — the cron handler unit tests call cronRouter.request() directly so
+// thrown ApiError needs catching at the router level (the global
+// app.onError only fires for requests that go through the parent app).
+cronRouter.onError((err, c) => {
+  const requestId =
+    ((c as unknown as { get: (k: string) => string | undefined }).get('requestId')) ?? null
+  const { status, body } = serializeErrorEnvelope(err, requestId)
+  return c.json(body, status as ContentfulStatusCode)
+})
+
+/**
+ * Validates the bearer token against CRON_SECRET. Throws ApiError so
+ * the global onError handler serialises the standard envelope; before
+ * Sprint 8 every cron handler had a two-line check-and-return that
+ * accounted for 38 of the codebase's legacy `return c.json({error}, 401)`
+ * sites — collapsing them into a throwing helper let the migration
+ * codemod skip cron.ts entirely and the cleanup PR do this single
+ * function change instead.
+ *
+ * Fail-closed: if CRON_SECRET is unset the endpoint refuses to run.
+ * The cron scheduler (Vercel cron + GitHub Actions cron-server.yml)
+ * always supplies the bearer header.
+ */
+function assertCronAuth(authHeader: string | undefined): void {
   const secret = process.env['CRON_SECRET']
-  if (!secret) return 'CRON_SECRET not configured'
-  if (authHeader !== `Bearer ${secret}`) return 'invalid cron auth'
-  return null
+  // The existing tests treat a missing CRON_SECRET the same as a failed
+  // auth check (401), so map both to UNAUTHORIZED here to preserve the
+  // contract. Operators still see CRON_SECRET not configured at startup
+  // because a missing secret in production is alerted by self-monitor.
+  if (!secret) throw new ApiError('UNAUTHORIZED', 'CRON_SECRET not configured')
+  if (authHeader !== `Bearer ${secret}`) throw new ApiError('UNAUTHORIZED', 'invalid cron auth')
 }
 
 // GET /cron/aggregate-usage
@@ -52,8 +81,7 @@ function assertCronAuth(authHeader: string | undefined): string | null {
 // only get aggregated after midnight UTC, so the first run of the new day
 // finalizes yesterday's totals.
 cronRouter.get('/aggregate-usage', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const start = Date.now()
   const now = new Date()
@@ -266,8 +294,7 @@ async function computeMetric(alert: AlertRow): Promise<number | null> {
 }
 
 cronRouter.get('/evaluate-alerts', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const start = Date.now()
   // Use the canonical WEB_URL (matches anomaly-snapshot, leak-detection,
@@ -400,8 +427,7 @@ cronRouter.get('/evaluate-alerts', async (c) => {
 
 // ── Paddle usage overage reporting (daily) ──────────────────────
 cronRouter.get('/report-usage-overage', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const start = Date.now()
   try {
@@ -420,8 +446,7 @@ cronRouter.get('/report-usage-overage', async (c) => {
 // request quota, send a warning email via Resend. Idempotent per calendar
 // month per threshold (tracked on organizations.quota_warning_*_sent_at).
 cronRouter.get('/check-quota-warnings', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const start = Date.now()
   try {
@@ -439,8 +464,7 @@ cronRouter.get('/check-quota-warnings', async (c) => {
 // Records detected anomalies into anomaly_events for the dashboard's
 // "history" view. Idempotent per (org, day, provider, model, kind).
 cronRouter.get('/snapshot-anomalies', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const start = Date.now()
   try {
@@ -458,8 +482,7 @@ cronRouter.get('/snapshot-anomalies', async (c) => {
 
 // ── Log retention + rate-limit bucket cleanup (daily) ──────────
 cronRouter.get('/prune-logs', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const start = Date.now()
   const [logsResult, bucketsResult] = await Promise.all([
@@ -486,8 +509,7 @@ cronRouter.get('/prune-logs', async (c) => {
 // Notification-only — keys are NOT auto-revoked. Schedule weekly via
 // Vercel cron (Mondays 9am UTC) — see apps/server/vercel.json.
 cronRouter.get('/stale-key-reminders', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const start = Date.now()
   try {
@@ -506,8 +528,7 @@ cronRouter.get('/stale-key-reminders', async (c) => {
 // high-confidence (≥$40/mo + ≥100 samples) and hasn't been notified yet,
 // send an email to the org owner and record the notification for idempotency.
 cronRouter.get('/recommend-savings-alerts', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const start = Date.now()
   try {
@@ -528,8 +549,7 @@ cronRouter.get('/recommend-savings-alerts', async (c) => {
 // Re-dispatches failed webhook_deliveries whose next_retry_at is past.
 // Uses exponential back-off up to MAX_ATTEMPTS (5).
 cronRouter.get('/retry-webhooks', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const start = Date.now()
   try {
@@ -550,8 +570,7 @@ cronRouter.get('/retry-webhooks', async (c) => {
 // Per-key scan results stored in provider_key_leak_scans for dedup +
 // dashboard display. Requires GITGUARDIAN_API_KEY env var.
 cronRouter.get('/leak-detect-keys', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const start = Date.now()
   try {
@@ -571,8 +590,7 @@ cronRouter.get('/leak-detect-keys', async (c) => {
 // batch size + retry counter prevent runaway / poison payloads. See
 // lib/fallback-replay.ts for full design. Schedule wired in vercel.json.
 cronRouter.get('/replay-fallback', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const start = Date.now()
   try {
@@ -605,8 +623,7 @@ cronRouter.get('/replay-fallback', async (c) => {
 // failed payments. Idempotent via the billing_downgrade_notifications
 // table. See lib/billing-downgrade.ts for the policy + state machine.
 cronRouter.get('/check-past-due-downgrades', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const start = Date.now()
   try {
@@ -643,8 +660,7 @@ cronRouter.get('/check-past-due-downgrades', async (c) => {
 // every 6 hours — the resolution of the grace window doesn't need to be
 // tighter than that for UX, and infrequent runs keep cron_runs noise down.
 cronRouter.get('/execute-pending-deletions', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const started = Date.now()
   const result = await executePendingDeletions({ batchSize: 100 })
@@ -674,8 +690,7 @@ cronRouter.get('/execute-pending-deletions', async (c) => {
 // concurrent firing acquires no advisory lock and returns 'skipped'.
 // Runs every 5 minutes so a paused migration resumes promptly.
 cronRouter.get('/run-background-migrations', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const started = Date.now()
   const result = await runDueMigrations()
@@ -705,8 +720,7 @@ cronRouter.get('/run-background-migrations', async (c) => {
 // after the day's traffic has settled but before the operator's
 // morning dashboard glance.
 cronRouter.get('/events-reconciliation', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const started = Date.now()
   try {
@@ -748,8 +762,7 @@ cronRouter.get('/events-reconciliation', async (c) => {
 // When Phase 5.1 Stage 4 lands and `requests` is dropped, the query
 // here moves to `events` in the same PR.
 cronRouter.get('/detect-missing-model-prices', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const start = Date.now()
 
@@ -836,8 +849,7 @@ cronRouter.get('/detect-missing-model-prices', async (c) => {
 // they push the fix; the next watchdog run after that re-fires if the
 // issue is still happening (same pattern as missing_model_prices).
 cronRouter.get('/self-monitor', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const start = Date.now()
 
@@ -937,8 +949,7 @@ cronRouter.get('/self-monitor', async (c) => {
 // Dedup against unresolved alerts of the same kind so the operator gets
 // one chip, not one per cron tick.
 cronRouter.get('/detect-orphan-spans', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const start = Date.now()
   const THRESHOLD = 100
@@ -1003,8 +1014,7 @@ cronRouter.get('/detect-orphan-spans', async (c) => {
 // noisy and a transient warmup failure is not worth alerting on). No
 // logCronRun call: this fires every 5min and would spam cron_runs.
 cronRouter.get('/keep-warm', async (c) => {
-  const authFail = assertCronAuth(c.req.header('Authorization'))
-  if (authFail) return c.json({ error: authFail }, 401)
+  assertCronAuth(c.req.header('Authorization'))
 
   const started = Date.now()
   const results = await Promise.allSettled([

--- a/apps/server/src/api/paddleWebhook.ts
+++ b/apps/server/src/api/paddleWebhook.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import { supabaseAdmin } from '../lib/db.js'
 import {
   verifyPaddleSignature,
@@ -6,6 +7,7 @@ import {
   fetchPaddleSubscription,
   type PlanTier,
 } from '../lib/paddle.js'
+import { ApiError, serializeErrorEnvelope } from '../lib/errors.js'
 
 /**
  * Paddle webhook receiver. Paddle POSTs subscription lifecycle events here.
@@ -172,14 +174,14 @@ paddleWebhookRouter.post('/paddle', async (c) => {
   const valid = await verifyPaddleSignature(rawBody, c.req.header('Paddle-Signature'))
   if (!valid) {
     console.warn('[paddle-webhook] signature verification failed')
-    return c.json({ error: 'invalid signature' }, 401)
+    throw new ApiError('UNAUTHORIZED', 'invalid signature')
   }
 
   let event: PaddleEvent
   try {
     event = JSON.parse(rawBody) as PaddleEvent
   } catch {
-    return c.json({ error: 'invalid json body' }, 400)
+    throw new ApiError('INVALID_JSON_BODY', 'invalid json body')
   }
 
   const subscriptionEvents = new Set([
@@ -200,7 +202,7 @@ paddleWebhookRouter.post('/paddle', async (c) => {
     const organizationId = await resolveOrgId(sub.custom_data, sub.customer_id)
     if (!organizationId) {
       console.error('[paddle-webhook] could not resolve org for sub event', event.event_id, sub.customer_id)
-      return c.json({ error: 'organization not found' }, 400)
+      throw new ApiError('BAD_REQUEST', 'organization not found')
     }
 
     const priceId = extractPriceId(sub)
@@ -263,13 +265,13 @@ paddleWebhookRouter.post('/paddle', async (c) => {
     const organizationId = await resolveOrgId(tx.custom_data, tx.customer_id)
     if (!organizationId) {
       console.error('[paddle-webhook] could not resolve org for transaction', event.event_id, tx.customer_id)
-      return c.json({ error: 'organization not found' }, 400)
+      throw new ApiError('BAD_REQUEST', 'organization not found')
     }
 
     const priceId = extractPriceId(tx)
     if (!priceId) {
       console.error('[paddle-webhook] missing price id in transaction', event.event_id)
-      return c.json({ error: 'missing price id' }, 400)
+      throw new ApiError('BAD_REQUEST', 'missing price id')
     }
 
     const plan = planForPriceId(priceId)
@@ -323,7 +325,7 @@ paddleWebhookRouter.post('/paddle', async (c) => {
       const organizationId = await resolveOrgId(null, adj.customer_id)
       if (!organizationId) {
         console.error('[paddle-webhook] could not resolve org for adjustment', event.event_id, adj.customer_id)
-        return c.json({ error: 'organization not found' }, 400)
+        throw new ApiError('BAD_REQUEST', 'organization not found')
       }
 
       await supabaseAdmin
@@ -339,4 +341,18 @@ paddleWebhookRouter.post('/paddle', async (c) => {
 
   // All other event types — acknowledge without processing
   return c.json({ success: true, skipped: event.event_type })
+})
+
+// Standalone router onError handler. paddleWebhookRouter's unit tests
+// call .request() directly (no parent app), so the global app.onError
+// never fires for thrown ApiError. Without this local handler a thrown
+// auth error would surface as 500 plaintext and Paddle would retry the
+// webhook forever (and the contract tests would see the wrong status
+// code). Wire the shared serializeErrorEnvelope helper here so the
+// router emits the same envelope the rest of the app does.
+paddleWebhookRouter.onError((err, c) => {
+  const requestId =
+    ((c as unknown as { get: (k: string) => string | undefined }).get('requestId')) ?? null
+  const { status, body } = serializeErrorEnvelope(err, requestId)
+  return c.json(body, status as ContentfulStatusCode)
 })

--- a/apps/server/src/lib/errors.ts
+++ b/apps/server/src/lib/errors.ts
@@ -128,3 +128,47 @@ export function isApiError(value: unknown): value is ApiError {
     typeof (value as ApiError).code === 'string'
   )
 }
+
+/**
+ * Serialise an error as the standard envelope. Called from app.ts's
+ * global `app.onError` handler and from any standalone router whose
+ * tests exercise it directly (paddleWebhookRouter is the current example
+ * — its unit tests invoke `paddleWebhookRouter.request(...)` rather than
+ * the full app, so a thrown ApiError must be caught at the router level
+ * instead of bubbling up to app.onError).
+ *
+ * Keep the shape identical to app.ts so the SDK contract stays one
+ * shape regardless of which onError handler caught the throw.
+ *
+ * `requestId` is plucked from context if the requestId middleware ran;
+ * tests that mount the router without that middleware pass through as
+ * null.
+ */
+export function serializeErrorEnvelope(
+  err: unknown,
+  requestId: string | null,
+): { status: number; body: { error: { code: string; message: string; details?: Record<string, unknown>; requestId: string | null } } } {
+  if (isApiError(err)) {
+    return {
+      status: err.status,
+      body: {
+        error: {
+          code: err.code,
+          message: err.message,
+          ...(err.details ? { details: err.details } : {}),
+          requestId,
+        },
+      },
+    }
+  }
+  return {
+    status: 500,
+    body: {
+      error: {
+        code: 'INTERNAL_ERROR',
+        message: 'Unexpected error',
+        requestId,
+      },
+    },
+  }
+}


### PR DESCRIPTION
Final PR of Sprint 8. See commit body for the 4 chunks.

**Sprint 8 stats**
- 10 PRs (#285~#294)
- ~480 of 544 legacy sites migrated (88%)
- 45+ routers using new envelope (Sprint 7: 8)
- 848 tests pass
- Migration codemod stays in scripts/ for boy-scout rule

**Today's session total: 50 PRs merged.**