### PR TITLE
feat(sprint-8 final): 100% migration — codemod v3 templates + manual multi-field cleanup

### DIFF
--- a/apps/server/scripts/migrate-errors.ts
+++ b/apps/server/scripts/migrate-errors.ts
@@ -211,7 +211,12 @@ const EXPRESSION_PATTERN = /return\s+c\.json\(\s*\{\s*error:\s*([^\s,{}'"`][^,{}
 //   - balanced single-pair: `${expr}` where expr has no `}`
 // Nested objects inside `${}` still bail out — those stay multi-line
 // manual cleanup.
-const TEMPLATE_PATTERN = /return\s+c\.json\(\s*\{\s*error:\s*(`(?:[^`\\]|\\.|\$\{[^{}]*\})*`)\s*\}\s*,\s*(\d{3})\s*\)/g
+//
+// The body alternatives are mutually exclusive (no overlap between
+// `[^`\\$]`, `\\.`, `\${...}`, and `$(?!\{)`) so the regex engine
+// cannot exponentially backtrack on adversarial input like
+// `return c.json({error:\`${{}}${{}}...\`` (CodeQL js/redos).
+const TEMPLATE_PATTERN = /return\s+c\.json\(\s*\{\s*error:\s*(`(?:[^`\\$]|\\.|\$\{[^{}]*\}|\$(?!\{))*`)\s*\}\s*,\s*(\d{3})\s*\)/g
 
 // ─── per-file transform ────────────────────────────────────────
 interface FileResult {

--- a/apps/server/scripts/migrate-errors.ts
+++ b/apps/server/scripts/migrate-errors.ts
@@ -201,7 +201,17 @@ const SIMPLE_PATTERN = /return\s+c\.json\(\s*\{\s*error:\s*('([^'\\]|\\.)*'|"([^
 // field objects (`error: 'a', detail: b`) never match — those need
 // the codemod to emit `ApiError.from(code, { details: { ... } })` by
 // hand, not be auto-transformed.
-const EXPRESSION_PATTERN = /return\s+c\.json\(\s*\{\s*error:\s*([^\s,{}'"][^,{}]*?)\s*\}\s*,\s*(\d{3})\s*\)/g
+const EXPRESSION_PATTERN = /return\s+c\.json\(\s*\{\s*error:\s*([^\s,{}'"`][^,{}]*?)\s*\}\s*,\s*(\d{3})\s*\)/g
+
+// TEMPLATE_PATTERN matches template literals specifically — backtick
+// strings whose body can contain `${...}` substitutions. v2's
+// EXPRESSION_PATTERN's `[^,{}]` body rule rejects the `{` inside
+// `${var}` so this needs its own pass. Allowed substitution shapes:
+//   - simple identifier or member access: `${row.status as string}`
+//   - balanced single-pair: `${expr}` where expr has no `}`
+// Nested objects inside `${}` still bail out — those stay multi-line
+// manual cleanup.
+const TEMPLATE_PATTERN = /return\s+c\.json\(\s*\{\s*error:\s*(`(?:[^`\\]|\\.|\$\{[^{}]*\})*`)\s*\}\s*,\s*(\d{3})\s*\)/g
 
 // ─── per-file transform ────────────────────────────────────────
 interface FileResult {
@@ -249,6 +259,41 @@ function transformFile(filePath: string): FileResult {
 
     result.transformed++
     return `throw new ApiError('${mapping.code}', ${jsString(decoded)})`
+  })
+
+  // Template-literal pass — same status-driven mapping as the
+  // expression pass but only matches backtick strings with `${}`
+  // substitutions (which v2 EXPRESSION_PATTERN can't catch because
+  // its body rule forbids the `{` in `${`).
+  content = content.replace(TEMPLATE_PATTERN, (match, template, statusStr) => {
+    const status = Number(statusStr)
+    const code = (() => {
+      switch (status) {
+        case 400: return 'VALIDATION_FAILED'
+        case 401: return 'UNAUTHORIZED'
+        case 403: return 'FORBIDDEN'
+        case 404: return 'NOT_FOUND'
+        case 409: return 'CONFLICT'
+        case 410: return 'NOT_FOUND'
+        case 429: return 'RATE_LIMIT'
+        case 500: return 'INTERNAL_ERROR'
+        case 502: return 'UPSTREAM_FAILED'
+        case 503: return 'INTERNAL_ERROR'
+        case 504: return 'UPSTREAM_TIMEOUT'
+        default: return null
+      }
+    })()
+    if (!code) {
+      result.manual++
+      result.manualSites.push({
+        line: lineNumberOf(content, match),
+        reason: `unmapped status ${status}`,
+        snippet: match,
+      })
+      return `// TODO(sprint-8): manual migration (unmapped status ${status})\n    ${match}`
+    }
+    result.transformed++
+    return `throw new ApiError('${code}', ${template})`
   })
 
   // Second pass: variable / template-literal message expressions.

--- a/apps/server/src/api/admin/backgroundMigrations.ts
+++ b/apps/server/src/api/admin/backgroundMigrations.ts
@@ -95,7 +95,7 @@ adminBackgroundMigrationsRouter.post('/:name/cancel', async (c) => {
   if (loadErr) throw new ApiError('INTERNAL_ERROR', 'Failed to load row')
   if (!row) throw new ApiError('NOT_FOUND', 'Not found')
   if (row.status !== 'pending' && row.status !== 'running') {
-    return c.json({ error: `Cannot cancel row in status=${row.status as string}` }, 409)
+    throw new ApiError('CONFLICT', `Cannot cancel row in status=${row.status as string}`)
   }
 
   const { error } = await supabaseAdmin
@@ -121,7 +121,7 @@ adminBackgroundMigrationsRouter.post('/:name/retry', async (c) => {
   if (loadErr) throw new ApiError('INTERNAL_ERROR', 'Failed to load row')
   if (!row) throw new ApiError('NOT_FOUND', 'Not found')
   if (row.status !== 'failed' && row.status !== 'cancelled') {
-    return c.json({ error: `Cannot retry row in status=${row.status as string}` }, 409)
+    throw new ApiError('CONFLICT', `Cannot retry row in status=${row.status as string}`)
   }
 
   // Reset the runtime fields. Leaves `attempts` alone — the count is

--- a/apps/server/src/api/admin/modelPrices.ts
+++ b/apps/server/src/api/admin/modelPrices.ts
@@ -130,7 +130,7 @@ adminModelPricesRouter.post('/', async (c) => {
     .select()
     .single()
 
-  if (error) return c.json({ error: `Upsert failed: ${error.message}` }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', `Upsert failed: ${error.message}`)
 
   // Refresh cache so the new price is visible immediately on this instance.
   // Other instances pick it up within their TTL (≤5 min).
@@ -169,7 +169,7 @@ adminModelPricesRouter.delete('/:id', async (c) => {
     .delete()
     .eq('id', id)
 
-  if (error) return c.json({ error: `Delete failed: ${error.message}` }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', `Delete failed: ${error.message}`)
 
   await refreshPricesNow()
 

--- a/apps/server/src/api/admin/modelRecommendations.ts
+++ b/apps/server/src/api/admin/modelRecommendations.ts
@@ -132,7 +132,7 @@ adminModelRecommendationsRouter.post('/', async (c) => {
     .select()
     .single()
 
-  if (error) return c.json({ error: `Upsert failed: ${error.message}` }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', `Upsert failed: ${error.message}`)
 
   // Make the new rule visible on this instance immediately. Others pick it up
   // within TTL (≤5 min).
@@ -166,7 +166,7 @@ adminModelRecommendationsRouter.delete('/:id', async (c) => {
     .delete()
     .eq('id', id)
 
-  if (error) return c.json({ error: `Delete failed: ${error.message}` }, 500)
+  if (error) throw new ApiError('INTERNAL_ERROR', `Delete failed: ${error.message}`)
 
   await refreshRulesNow()
 

--- a/apps/server/src/api/billing.ts
+++ b/apps/server/src/api/billing.ts
@@ -77,7 +77,7 @@ billingRouter.post('/checkout', async (c) => {
   }
   const priceId = priceIdByPlan[plan]
   if (!priceId) {
-    return c.json({ error: `Unknown or unconfigured plan: ${plan}` }, 400)
+    throw new ApiError('VALIDATION_FAILED', `Unknown or unconfigured plan: ${plan}`)
   }
 
   // Look up the user's email + org's paddle_customer_id
@@ -107,7 +107,7 @@ billingRouter.post('/checkout', async (c) => {
         paddleCustomerId = created.id
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'unknown error'
-        return c.json({ error: `Paddle customer create failed: ${msg}` }, 502)
+        throw new ApiError('UPSTREAM_FAILED', `Paddle customer create failed: ${msg}`)
       }
     }
     await supabaseAdmin
@@ -136,7 +136,7 @@ billingRouter.post('/checkout', async (c) => {
     return c.json({ success: true, data: { url: tx.checkout.url, transactionId: tx.id } })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown error'
-    return c.json({ error: `Paddle checkout create failed: ${msg}` }, 502)
+    throw new ApiError('UPSTREAM_FAILED', `Paddle checkout create failed: ${msg}`)
   }
 })
 
@@ -169,6 +169,6 @@ billingRouter.post('/cancel', async (c) => {
     return c.json({ success: true })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown error'
-    return c.json({ error: `Paddle cancel failed: ${msg}` }, 502)
+    throw new ApiError('UPSTREAM_FAILED', `Paddle cancel failed: ${msg}`)
   }
 })

--- a/apps/server/src/api/datasets.ts
+++ b/apps/server/src/api/datasets.ts
@@ -265,7 +265,7 @@ datasetsRouter.post('/:id/items/bulk', async (c) => {
   }
 
   if (rows.length === 0) {
-    return c.json({ error: 'No valid items in upload', skipped }, 400)
+    throw new ApiError('VALIDATION_FAILED', 'No valid items in upload', { skipped })
   }
 
   const { error } = await supabaseAdmin.from('dataset_items').insert(rows)

--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -79,7 +79,7 @@ evalsRouter.post('/evaluators', async (c) => {
       new RegExp(pattern, flags)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      return c.json({ error: `invalid regex pattern: ${message}` }, 400)
+      throw new ApiError('VALIDATION_FAILED', `invalid regex pattern: ${message}`)
     }
     validatedConfig = { pattern, flags }
   } else {

--- a/apps/server/src/api/feedback.ts
+++ b/apps/server/src/api/feedback.ts
@@ -63,7 +63,7 @@ feedbackRouter.post('/', async (c) => {
     throw new ApiError('VALIDATION_FAILED', 'Message is too short')
   }
   if (message.length > MAX_MESSAGE_LEN) {
-    return c.json({ error: `Message must be ${MAX_MESSAGE_LEN} characters or fewer` }, 400)
+    throw new ApiError('VALIDATION_FAILED', `Message must be ${MAX_MESSAGE_LEN} characters or fewer`)
   }
 
   const category =

--- a/apps/server/src/api/ingest.ts
+++ b/apps/server/src/api/ingest.ts
@@ -94,7 +94,7 @@ ingestRouter.post('/traces', async (c) => {
     .single()
 
   if (error || !data) {
-    return c.json({ error: 'Failed to create trace', detail: error?.message }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to create trace', { detail: error?.message })
   }
 
   // Phase 5.1 dual-write to events. Best-effort — events is the shadow
@@ -285,7 +285,7 @@ ingestRouter.post('/traces/:id/spans', async (c) => {
     .single()
 
   if (error || !data) {
-    return c.json({ error: 'Failed to create span', detail: error?.message }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to create span', { detail: error?.message })
   }
 
   // Phase 5.1 dual-write to events — awaited for the same reason as the

--- a/apps/server/src/api/models.ts
+++ b/apps/server/src/api/models.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { supabaseAdmin } from '../lib/db.js'
+import { ApiError } from '../lib/errors.js'
 
 /**
  * GET /api/v1/models — list of all priced models, grouped by provider.
@@ -59,7 +60,7 @@ modelsRouter.get('/', async (c) => {
     .order('model', { ascending: true })
 
   if (error) {
-    return c.json({ error: 'Failed to load models', detail: error.message }, 500)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to load models', { detail: error.message })
   }
 
   const groups: ModelsResponse = { openai: [], anthropic: [], gemini: [] }

--- a/apps/server/src/api/organizations.ts
+++ b/apps/server/src/api/organizations.ts
@@ -295,7 +295,7 @@ organizationsRouter.post('/bootstrap', async (c) => {
     .eq('user_id', userId)
     .maybeSingle()
   if (existingMember) {
-    return c.json({ error: 'Already onboarded', organizationId: existingMember.organization_id }, 409)
+    throw new ApiError('CONFLICT', 'Already onboarded', { organizationId: existingMember.organization_id })
   }
 
   // Body parse — body is OPTIONAL on this endpoint (legacy clients send

--- a/apps/server/src/api/pendingDeletions.ts
+++ b/apps/server/src/api/pendingDeletions.ts
@@ -126,9 +126,13 @@ pendingDeletionsRouter.post('/:id/restore', requireEdit, async (c) => {
   if (!row) throw new ApiError('NOT_FOUND', 'Pending deletion not found')
   if (row.organization_id !== orgId) throw new ApiError('FORBIDDEN', 'Access denied')
   if (row.executed_at) {
-    // TODO(sprint-8): manual migration (unmapped status 410)
-    // TODO(sprint-8): manual migration (unmapped status 410)
-    return c.json({ error: 'Already hard-deleted; cannot restore' }, 410)
+    // Status 410 (Gone) is semantically "the resource existed but has
+    // been permanently removed". The closest catalog code is NOT_FOUND
+    // (404 status) — slight semantic loss but the SDK contract stays
+    // typed and SpanlensApiError.code === 'NOT_FOUND' is what the
+    // caller can switch on. The original message preserves the
+    // "hard-deleted; cannot restore" nuance.
+    throw new ApiError('NOT_FOUND', 'Already hard-deleted; cannot restore')
   }
   if (row.cancelled_at) {
     throw new ApiError('CONFLICT', 'Already restored')

--- a/apps/server/src/api/prompt-experiments.ts
+++ b/apps/server/src/api/prompt-experiments.ts
@@ -105,7 +105,7 @@ promptExperimentsRouter.post('/', requireEdit, async (c) => {
 
   for (const v of versions) {
     if (v.name !== promptName)
-      return c.json({ error: `Version ${v.id} belongs to prompt "${v.name}", not "${promptName}"` }, 400)
+      throw new ApiError('VALIDATION_FAILED', `Version ${v.id} belongs to prompt "${v.name}", not "${promptName}"`)
   }
 
   const { data, error } = await supabaseAdmin

--- a/apps/server/src/api/prompts-playground.ts
+++ b/apps/server/src/api/prompts-playground.ts
@@ -147,7 +147,7 @@ promptsPlaygroundRouter.post('/run', async (c) => {
       const text = await upstreamRes.text().catch(() => '')
       span.end({ status: 'error', errorMessage: `OpenAI ${upstreamRes.status}` })
       internalTrace.end({ status: 'error', errorMessage: `OpenAI ${upstreamRes.status}` })
-      return c.json({ error: `OpenAI error: ${text}`, upstreamStatus: upstreamRes.status }, 502)
+      throw new ApiError('UPSTREAM_FAILED', `OpenAI error: ${text}`, { upstreamStatus: upstreamRes.status })
     }
 
     const json = await upstreamRes.json() as {
@@ -212,7 +212,7 @@ promptsPlaygroundRouter.post('/run', async (c) => {
     const text = await upstreamRes.text().catch(() => '')
     span.end({ status: 'error', errorMessage: `Anthropic ${upstreamRes.status}` })
     internalTrace.end({ status: 'error', errorMessage: `Anthropic ${upstreamRes.status}` })
-    return c.json({ error: `Anthropic error: ${text}`, upstreamStatus: upstreamRes.status }, 502)
+    throw new ApiError('UPSTREAM_FAILED', `Anthropic error: ${text}`, { upstreamStatus: upstreamRes.status })
   }
 
   const json = await upstreamRes.json() as {

--- a/apps/server/src/api/requests.ts
+++ b/apps/server/src/api/requests.ts
@@ -463,7 +463,7 @@ requestsRouter.post('/:id/replay/run', requireRole('admin', 'editor'), async (c)
     upstreamUrl = `https://generativelanguage.googleapis.com/v1beta/${geminiModel}:generateContent?key=${providerKey.plaintext}`
     upstreamHeaders = { 'Content-Type': 'application/json' }
   } else {
-    return c.json({ error: `Unsupported provider for run: ${provider}` }, 400)
+    throw new ApiError('VALIDATION_FAILED', `Unsupported provider for run: ${provider}`)
   }
 
   // ── Call upstream ─────────────────────────────────────────────────────────
@@ -476,7 +476,7 @@ requestsRouter.post('/:id/replay/run', requireRole('admin', 'editor'), async (c)
       body: JSON.stringify(replayBody),
     })
   } catch (fetchErr) {
-    return c.json({ error: `Failed to reach upstream: ${String(fetchErr)}` }, 502)
+    throw new ApiError('UPSTREAM_FAILED', `Failed to reach upstream: ${String(fetchErr)}`)
   }
 
   const latencyMs = Date.now() - startMs
@@ -485,6 +485,13 @@ requestsRouter.post('/:id/replay/run', requireRole('admin', 'editor'), async (c)
 
   if (!upstreamRes.ok) {
     const errMsg = (resBody.error as Record<string, unknown> | undefined)?.message as string | undefined
+    // Proxy passthrough — preserve the upstream status code dynamically
+    // rather than mapping into the ApiError catalog (which would lock
+    // the response to a fixed 502 UPSTREAM_FAILED status). The dashboard
+    // "Run again" feature shows the original upstream status next to
+    // the original message, so this single endpoint intentionally keeps
+    // the legacy c.json shape. Marked here so the next migration sweep
+    // does not "fix" it.
     return c.json({ error: errMsg ?? `Provider returned ${statusCode}`, statusCode }, statusCode as 400)
   }
 

--- a/apps/server/src/api/scoreConfigs.ts
+++ b/apps/server/src/api/scoreConfigs.ts
@@ -110,7 +110,7 @@ scoreConfigsRouter.post('/', async (c) => {
 
   const data_type = typeof body.data_type === 'string' ? body.data_type.toUpperCase() : ''
   if (!ALLOWED_TYPES.includes(data_type as (typeof ALLOWED_TYPES)[number])) {
-    return c.json({ error: `data_type must be one of ${ALLOWED_TYPES.join(', ')}` }, 400)
+    throw new ApiError('VALIDATION_FAILED', `data_type must be one of ${ALLOWED_TYPES.join(', ')}`)
   }
 
   const min_value = normaliseNullableNumber(body.min_value)

--- a/apps/server/src/proxy/azure.ts
+++ b/apps/server/src/proxy/azure.ts
@@ -114,10 +114,10 @@ azureProxy.all('/*', async (c) => {
     clearTimeout(upstreamTimer)
     const msg = err instanceof Error ? err.message : 'Unknown error'
     if (err instanceof Error && err.name === 'AbortError') {
-      return c.json({ error: `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms` }, 504)
+      throw new ApiError('UPSTREAM_TIMEOUT', `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms`)
     }
     console.error('[azure-proxy] upstream fetch error:', msg)
-    return c.json({ error: `Upstream request failed: ${msg}` }, 502)
+    throw new ApiError('UPSTREAM_FAILED', `Upstream request failed: ${msg}`)
   }
   clearTimeout(upstreamTimer)
   const latencyMs = Date.now() - startMs


### PR DESCRIPTION
Final Sprint 8 PR. 543 of 544 sites migrated (99.8%); the 1 remaining is an intentional proxy passthrough at requests.ts:495 (preserves upstream status code dynamically).