### PR TITLE
fix(envelope): Chrome MCP production test caught 8 legacy multi-line sites + INJECTION_BLOCKED catalog

### DIFF
--- a/apps/server/src/__tests__/auth-api-key.test.ts
+++ b/apps/server/src/__tests__/auth-api-key.test.ts
@@ -118,10 +118,10 @@ describe('authApiKey — rejected transports', () => {
   test('?key= query string returns 401 (key must not be in URL)', async () => {
     const res = await app.request(`/probe?key=${VALID_KEY}`)
     expect(res.status).toBe(401)
-    const body = (await res.json()) as { error: string }
+    const body = (await res.json()) as { error: { code: string; message: string } }
     // Should mention the supported header transports, not ?key=
-    expect(body.error).toContain('x-goog-api-key')
-    expect(body.error).not.toContain('?key=')
+    expect(body.error.message).toContain('x-goog-api-key')
+    expect(body.error.message).not.toContain('?key=')
   })
 
   test('no key returns 401', async () => {

--- a/apps/server/src/__tests__/middleware-quota.test.ts
+++ b/apps/server/src/__tests__/middleware-quota.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { installOnError } from './helpers/install-on-error.js'
 import { Hono } from 'hono'
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -33,6 +34,10 @@ function makeApp(orgId: string | null) {
   // Cast satisfies ApiKeyContext shape requirement
   app.use('*', enforceQuota as unknown as Parameters<typeof app.use>[1])
   app.get('/probe', (c) => c.json({ ok: true }))
+  // Sprint 8 hotfix: enforceQuota now throws ApiError (was: return c.json).
+  // Without the onError serialiser the thrown error surfaces as a generic
+  // 500 and assertions like expect(res.status).toBe(429) fail.
+  installOnError(app)
   return app
 }
 
@@ -89,12 +94,12 @@ describe('enforceQuota — Free plan (hard block at limit)', () => {
     const res = await makeApp('org_1').request('/probe')
     expect(res.status).toBe(429)
     const body = await res.json() as Record<string, unknown>
-    expect(body['reason']).toBe('free_limit')
-    expect(body['plan']).toBe('free')
-    expect(body['used']).toBe(50_000)
-    expect(body['limit']).toBe(50_000)
-    expect(body['hard_cap']).toBe(50_000) // limit × capMultiplier(1)
-    expect(body['upgrade_url']).toBe('https://www.spanlens.io/billing')
+    expect((body['error'] as { details: { reason: string } }).details.reason).toBe('free_limit')
+    expect((body['error'] as { details: Record<string, unknown> }).details['plan']).toBe('free')
+    expect((body['error'] as { details: Record<string, unknown> }).details['used']).toBe(50_000)
+    expect((body['error'] as { details: { limit: number } }).details.limit).toBe(50_000)
+    expect((body['error'] as { details: Record<string, unknown> }).details['hard_cap']).toBe(50_000) // limit × capMultiplier(1)
+    expect((body['error'] as { details: Record<string, unknown> }).details['upgrade_url']).toBe('https://www.spanlens.io/billing')
     expect(res.headers.get('X-RateLimit-Remaining')).toBe('0')
   })
 })
@@ -111,8 +116,8 @@ describe('enforceQuota — Paid plan with overage disabled', () => {
     const res = await makeApp('org_1').request('/probe')
     expect(res.status).toBe(429)
     const body = await res.json() as Record<string, unknown>
-    expect(body['reason']).toBe('overage_disabled')
-    expect(body['plan']).toBe('pro')
+    expect((body['error'] as { details: { reason: string } }).details.reason).toBe('overage_disabled')
+    expect((body['error'] as { details: Record<string, unknown> }).details['plan']).toBe('pro')
   })
 })
 
@@ -143,8 +148,8 @@ describe('enforceQuota — Paid plan with overage allowed', () => {
     const res = await makeApp('org_1').request('/probe')
     expect(res.status).toBe(429)
     const body = await res.json() as Record<string, unknown>
-    expect(body['reason']).toBe('hard_cap')
-    expect(body['hard_cap']).toBe(500_000)
+    expect((body['error'] as { details: { reason: string } }).details.reason).toBe('hard_cap')
+    expect((body['error'] as { details: Record<string, unknown> }).details['hard_cap']).toBe(500_000)
   })
 })
 

--- a/apps/server/src/__tests__/middleware-rate-limit.test.ts
+++ b/apps/server/src/__tests__/middleware-rate-limit.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { Hono } from 'hono'
+import { installOnError } from './helpers/install-on-error.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Tests for the two rate-limit middlewares (proxyRateLimit + apiRateLimit).
@@ -54,6 +55,8 @@ function makeProxyApp(orgId: string | null, plan: string | null = null) {
   })
   app.use('*', proxyRateLimit as unknown as Parameters<typeof app.use>[1])
   app.get('/probe', (c) => c.json({ ok: true }))
+  // Sprint 8 hotfix — proxyRateLimit throws ApiError now.
+  installOnError(app)
   return app
 }
 
@@ -83,9 +86,9 @@ describe('proxyRateLimit', () => {
     const res = await makeProxyApp('org_1', 'free').request('/probe')
     expect(res.status).toBe(429)
     const body = await res.json() as Record<string, unknown>
-    expect(body['limit']).toBe(60)
-    expect(body['window']).toBe('60s')
-    expect(body['upgrade_url']).toBe('https://www.spanlens.io/pricing')
+    expect((body['error'] as { details: { limit: number } }).details.limit).toBe(60)
+    expect((body['error'] as { details: Record<string, unknown> }).details['window']).toBe('60s')
+    expect((body['error'] as { details: Record<string, unknown> }).details['upgrade_url']).toBe('https://www.spanlens.io/pricing')
     expect(res.headers.get('Retry-After')).toBe('60')
     expect(res.headers.get('X-RateLimit-Remaining')).toBe('0')
   })
@@ -120,6 +123,8 @@ function makeApiApp() {
   const app = new Hono()
   app.use('*', apiRateLimit as unknown as Parameters<typeof app.use>[1])
   app.get('/probe', (c) => c.json({ ok: true }))
+  // Sprint 8 hotfix — apiRateLimit throws ApiError now.
+  installOnError(app)
   return app
 }
 
@@ -157,8 +162,8 @@ describe('apiRateLimit', () => {
     })
     expect(res.status).toBe(429)
     const body = await res.json() as Record<string, unknown>
-    expect(body['limit']).toBe(120)
-    expect(body['window']).toBe('60s')
+    expect((body['error'] as { details: { limit: number } }).details.limit).toBe(120)
+    expect((body['error'] as { details: Record<string, unknown> }).details['window']).toBe('60s')
     expect(res.headers.get('Retry-After')).toBe('60')
   })
 

--- a/apps/server/src/lib/errors.contract.test.ts
+++ b/apps/server/src/lib/errors.contract.test.ts
@@ -50,6 +50,7 @@ describe('error contract: server ERROR_CODES ↔ @spanlens/api-types KnownApiErr
       'NOT_FOUND',
       'CONFLICT',
       'RATE_LIMIT',
+      'INJECTION_BLOCKED',
       'DECRYPT_FAILED',
       'INTERNAL_ERROR',
       'NO_PROVIDER_KEY',

--- a/apps/server/src/lib/errors.ts
+++ b/apps/server/src/lib/errors.ts
@@ -59,6 +59,18 @@ export const ERROR_CODES = {
   // this code so the SDK can switch on err.code === 'RATE_LIMIT'.
   RATE_LIMIT: { status: 429, message: 'Rate limit exceeded' },
 
+  // Security policy block. Proxy endpoints (proxy/openai|anthropic|azure|
+  // gemini) raise this when scanAll() detects a prompt-injection attempt
+  // in the request body AND the project has Spanlens security blocking
+  // enabled. Different from VALIDATION_FAILED (schema issue) and
+  // UNAUTHORIZED (auth issue) — the request is well-formed but the
+  // policy refuses to forward it upstream. 422 mirrors what most LLM
+  // proxies use for "well-formed but rejected" content.
+  INJECTION_BLOCKED: {
+    status: 422,
+    message: 'Request blocked by Spanlens security policy: prompt injection detected',
+  },
+
   // Upstream / infrastructure failures.
   DECRYPT_FAILED: {
     status: 503,

--- a/apps/server/src/middleware/authApiKey.ts
+++ b/apps/server/src/middleware/authApiKey.ts
@@ -164,12 +164,9 @@ function extractApiKey(c: Context): string | null {
 export const authApiKey = createMiddleware<ApiKeyContext>(async (c, next) => {
   const rawKey = extractApiKey(c)
   if (!rawKey) {
-    return c.json(
-      {
-        error:
-          'Missing API key. Pass sl_live_… via Authorization: Bearer (OpenAI SDK), x-api-key (Anthropic SDK), or x-goog-api-key (Google Generative AI SDK).',
-      },
-      401,
+    throw new ApiError(
+      'UNAUTHORIZED',
+      'Missing API key. Pass sl_live_… via Authorization: Bearer (OpenAI SDK), x-api-key (Anthropic SDK), or x-goog-api-key (Google Generative AI SDK).',
     )
   }
 

--- a/apps/server/src/middleware/quota.ts
+++ b/apps/server/src/middleware/quota.ts
@@ -2,6 +2,7 @@ import { createMiddleware } from 'hono/factory'
 import type { ApiKeyContext } from './authApiKey.js'
 import { checkMonthlyQuota } from '../lib/quota.js'
 import { evaluateQuotaPolicy, blockMessage } from '../lib/quota-policy.js'
+import { ApiError } from '../lib/errors.js'
 
 /**
  * Monthly request quota enforcement for `/proxy/*` (Pattern C policy).
@@ -42,9 +43,10 @@ export const enforceQuota = createMiddleware<ApiKeyContext>(async (c, next) => {
     c.header('X-RateLimit-Limit', String(check.limit ?? 0))
     c.header('X-RateLimit-Remaining', '0')
     c.header('X-RateLimit-Plan', check.plan)
-    return c.json(
+    throw new ApiError(
+      'RATE_LIMIT',
+      blockMessage(decision.reason),
       {
-        error: blockMessage(decision.reason),
         reason: decision.reason,
         plan: check.plan,
         used: check.usedThisMonth,
@@ -52,7 +54,6 @@ export const enforceQuota = createMiddleware<ApiKeyContext>(async (c, next) => {
         hard_cap: check.limit !== null ? check.limit * check.capMultiplier : null,
         upgrade_url: 'https://www.spanlens.io/billing',
       },
-      429,
     )
   }
 

--- a/apps/server/src/middleware/rateLimit.ts
+++ b/apps/server/src/middleware/rateLimit.ts
@@ -3,6 +3,7 @@ import { sha256Hex } from '../lib/crypto.js'
 import { checkRateLimit, PROXY_RATE_LIMITS, API_RATE_LIMIT } from '../lib/rate-limit.js'
 import type { ApiKeyContext } from './authApiKey.js'
 import type { JwtContext } from './authJwt.js'
+import { ApiError } from '../lib/errors.js'
 
 /**
  * Per-minute rate limit for proxy routes (plan-aware).
@@ -55,14 +56,14 @@ export const proxyRateLimit = createMiddleware<ApiKeyContext>(async (c, next) =>
   if (!allowed) {
     c.header('X-RateLimit-Remaining', '0')
     c.header('Retry-After', '60')
-    return c.json(
+    throw new ApiError(
+      'RATE_LIMIT',
+      `Rate limit exceeded: ${limit} requests/min on the ${plan} plan. Upgrade or retry after 60 seconds.`,
       {
-        error: `Rate limit exceeded: ${limit} requests/min on the ${plan} plan. Upgrade or retry after 60 seconds.`,
         limit,
         window: '60s',
         upgrade_url: 'https://www.spanlens.io/pricing',
       },
-      429,
     )
   }
 
@@ -107,13 +108,13 @@ export const apiRateLimit = createMiddleware<JwtContext>(async (c, next) => {
   if (!allowed) {
     c.header('X-RateLimit-Remaining', '0')
     c.header('Retry-After', '60')
-    return c.json(
+    throw new ApiError(
+      'RATE_LIMIT',
+      `API rate limit exceeded: ${API_RATE_LIMIT} requests/min. Retry after 60 seconds.`,
       {
-        error: `API rate limit exceeded: ${API_RATE_LIMIT} requests/min. Retry after 60 seconds.`,
         limit: API_RATE_LIMIT,
         window: '60s',
       },
-      429,
     )
   }
 

--- a/apps/server/src/proxy/anthropic.ts
+++ b/apps/server/src/proxy/anthropic.ts
@@ -56,10 +56,10 @@ anthropicProxy.all('/*', async (c) => {
   const requestFlags = scanAll(reqBodyJson)
   const hasInjection = requestFlags.some((f) => f.type === 'injection')
   if (hasInjection && await isBlockingEnabled(projectId)) {
-    return c.json({
-      error: 'Request blocked by Spanlens security policy: prompt injection detected.',
-      code: 'INJECTION_BLOCKED',
-    }, 422)
+    throw new ApiError(
+      'INJECTION_BLOCKED',
+      'Request blocked by Spanlens security policy: prompt injection detected.',
+    )
   }
 
   const path = c.req.path.replace(/^\/proxy\/anthropic/, '')

--- a/apps/server/src/proxy/azure.ts
+++ b/apps/server/src/proxy/azure.ts
@@ -82,10 +82,10 @@ azureProxy.all('/*', async (c) => {
   const requestFlags = scanAll(reqBodyJson)
   const hasInjection = requestFlags.some((f) => f.type === 'injection')
   if (hasInjection && await isBlockingEnabled(projectId)) {
-    return c.json({
-      error: 'Request blocked by Spanlens security policy: prompt injection detected.',
-      code: 'INJECTION_BLOCKED',
-    }, 422)
+    throw new ApiError(
+      'INJECTION_BLOCKED',
+      'Request blocked by Spanlens security policy: prompt injection detected.',
+    )
   }
 
   const path = c.req.path.replace(/^\/proxy\/azure/, '')

--- a/apps/server/src/proxy/gemini.ts
+++ b/apps/server/src/proxy/gemini.ts
@@ -68,10 +68,10 @@ geminiProxy.all('/*', async (c) => {
   const requestFlags = scanAll(reqBodyJson)
   const hasInjection = requestFlags.some((f) => f.type === 'injection')
   if (hasInjection && await isBlockingEnabled(projectId)) {
-    return c.json({
-      error: 'Request blocked by Spanlens security policy: prompt injection detected.',
-      code: 'INJECTION_BLOCKED',
-    }, 422)
+    throw new ApiError(
+      'INJECTION_BLOCKED',
+      'Request blocked by Spanlens security policy: prompt injection detected.',
+    )
   }
 
   const startMs = Date.now()

--- a/apps/server/src/proxy/openai.ts
+++ b/apps/server/src/proxy/openai.ts
@@ -80,10 +80,10 @@ openaiProxy.all('/*', async (c) => {
   const requestFlags = scanAll(reqBodyJson)
   const hasInjection = requestFlags.some((f) => f.type === 'injection')
   if (hasInjection && await isBlockingEnabled(projectId)) {
-    return c.json({
-      error: 'Request blocked by Spanlens security policy: prompt injection detected.',
-      code: 'INJECTION_BLOCKED',
-    }, 422)
+    throw new ApiError(
+      'INJECTION_BLOCKED',
+      'Request blocked by Spanlens security policy: prompt injection detected.',
+    )
   }
 
   const path = c.req.path.replace(/^\/proxy\/openai/, '')

--- a/apps/web/app/docs/api/errors/page.tsx
+++ b/apps/web/app/docs/api/errors/page.tsx
@@ -96,6 +96,12 @@ const ERROR_CATALOG_ROWS: CatalogRow[] = [
       'Per-key rate limit exceeded. The Retry-After header and X-RateLimit-* headers carry the remaining quota and reset time. Back off and retry.',
   },
   {
+    code: 'INJECTION_BLOCKED',
+    status: 422,
+    description:
+      'The proxy detected a prompt-injection attempt in the request body and the project has Spanlens security blocking enabled. The request is well-formed but the policy refused to forward it upstream. Inspect the prompt or disable security blocking on the project.',
+  },
+  {
     code: 'UPSTREAM_TIMEOUT',
     status: 504,
     description:

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -93,6 +93,7 @@ export type KnownApiErrorCode =
   | 'NOT_FOUND'
   | 'CONFLICT'
   | 'RATE_LIMIT'
+  | 'INJECTION_BLOCKED'
   | 'DECRYPT_FAILED'
   | 'INTERNAL_ERROR'
   | 'NO_PROVIDER_KEY'


### PR DESCRIPTION
Production end-to-end verification via Chrome MCP found auth/proxy endpoints returning legacy '{error: "string"}' shape. 8 sites converted, INJECTION_BLOCKED added (422). 849 tests pass.