### PR TITLE
fix(server): R-32 GET /feedback must be anonymous-safe

### DIFF
--- a/apps/server/src/__tests__/feedback-phase2.test.ts
+++ b/apps/server/src/__tests__/feedback-phase2.test.ts
@@ -109,7 +109,11 @@ vi.mock('../lib/wait-until.js', () => ({
   fireAndForget: vi.fn(),
 }))
 
-// authJwt: every request comes through as user-1 (admin@spanlens.io).
+// authJwt: write endpoints (POST submit, vote, un-vote, admin PATCH) come
+// through as admin-user (matches the supabaseClient.auth.getUser mock above).
+// The public GET handler now resolves its userId from the Bearer token via
+// supabaseClient.auth.getUser, so tests that need has_voted=true must send
+// `Authorization: Bearer <anything>` and rely on the same getUser mock.
 vi.mock('../middleware/authJwt.js', () => ({
   authJwt: async (
     c: {
@@ -118,7 +122,7 @@ vi.mock('../middleware/authJwt.js', () => ({
     },
     next: () => Promise<unknown>,
   ) => {
-    c.set('userId', 'user-1')
+    c.set('userId', 'admin-user')
     c.set('orgId', 'org-1')
     c.set('email', 'admin@spanlens.io')
     return next()
@@ -186,7 +190,14 @@ describe('GET /feedback — public roadmap', () => {
       error: null,
     }
 
-    const res = await makePublicApp().request('/feedback')
+    // Authorization header is required for has_voted resolution — the public
+    // GET handler is anonymous-safe but only populates has_voted when a valid
+    // Bearer token surfaces a userId via supabaseClient.auth.getUser (mocked
+    // above to return admin-user). Without the header has_voted would be
+    // false for every row.
+    const res = await makePublicApp().request('/feedback', {
+      headers: { Authorization: 'Bearer fake' },
+    })
     expect(res.status).toBe(200)
     const body = (await res.json()) as {
       success: boolean
@@ -198,6 +209,36 @@ describe('GET /feedback — public roadmap', () => {
     expect(body.data[0]?.vote_count).toBe(12)
     expect(body.data[0]?.has_voted).toBe(true)
     expect(body.data[1]?.has_voted).toBe(false)
+  })
+
+  test('anonymous caller (no Authorization) → list returns but has_voted=false', async () => {
+    dbResponses['select:feedback'] = {
+      data: [
+        {
+          id: 'f-1',
+          message: 'Anonymous-visible item',
+          category: 'feature',
+          status: 'planned',
+          response_message: null,
+          changelog_url: null,
+          responded_at: null,
+          created_at: '2026-06-09T00:00:00Z',
+          feedback_votes: [{ count: 3 }],
+        },
+      ],
+      error: null,
+    }
+    // No `select:feedback_votes` configured — anonymous path must skip that
+    // query entirely. Test ensures we don't 500 by trying to dereference an
+    // absent vote-set.
+
+    const res = await makePublicApp().request('/feedback')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      data: Array<{ id: string; vote_count: number; has_voted: boolean }>
+    }
+    expect(body.data[0]?.vote_count).toBe(3)
+    expect(body.data[0]?.has_voted).toBe(false)
   })
 
   test('rejects invalid status filter with VALIDATION_FAILED envelope', async () => {

--- a/apps/server/src/api/feedback.ts
+++ b/apps/server/src/api/feedback.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
-import { supabaseAdmin } from '../lib/db.js'
+import { supabaseAdmin, supabaseClient } from '../lib/db.js'
 import { sendEmail } from '../lib/resend.js'
 import { fireAndForget } from '../lib/wait-until.js'
 import { ApiError } from '../lib/errors.js'
@@ -22,20 +22,20 @@ function getOpsEmails(): string[] {
  *
  * Phase 2 (R-32, this file + 20260609180000_feedback_phase2.sql) turns the
  * submission box into a public roadmap:
- *   GET    /                 — list submissions ranked by community vote
- *   POST   /                 — submit a suggestion (unchanged from Phase 1)
- *   POST   /:id/vote         — upvote (idempotent)
- *   DELETE /:id/vote         — un-vote
+ *   GET    /                 — list submissions ranked by community vote (PUBLIC)
+ *   POST   /                 — submit a suggestion (auth required)
+ *   POST   /:id/vote         — upvote (auth required, idempotent)
+ *   DELETE /:id/vote         — un-vote (auth required, idempotent)
  *
  * Admin response surface lives in apps/server/src/api/admin/feedback.ts.
  *
- * Auth: every endpoint requires authJwt — only logged-in users see, vote on,
- * or submit feedback. This doubles as spam defense (no anon writes) and as
- * the natural place to hang `hasVoted` per-row.
+ * Auth model: GET is public so anonymous visitors can see the roadmap.
+ * Write endpoints (POST/DELETE) attach authJwt per-route via Hono's
+ * route-level middleware syntax. This used to be a router-wide
+ * `feedbackRouter.use('*', authJwt)` but that 401'd anonymous list
+ * requests, breaking the public-roadmap promise. PR #303 hotfix.
  */
 export const feedbackRouter = new Hono<JwtContext>()
-
-feedbackRouter.use('*', authJwt)
 
 const VALID_CATEGORIES = new Set(['feature', 'bug', 'other'])
 const VALID_STATUSES = new Set(['new', 'planned', 'in_progress', 'shipped', 'declined'])
@@ -61,7 +61,27 @@ function escapeHtml(s: string): string {
     .replace(/"/g, '&quot;')
 }
 
-// ── GET /api/v1/feedback — public roadmap list ────────────────────────────────
+/**
+ * Optional userId resolution for the public GET handler.
+ *
+ * If the caller sent a Bearer token we validate it against Supabase Auth and
+ * return the user id so `has_voted` can be populated per row. If the token is
+ * missing or invalid we return null and serve the row list without per-user
+ * vote state — anonymous visitors still see the roadmap.
+ *
+ * Why not authJwt: that middleware throws on a missing/invalid token. Here a
+ * 401 would defeat the whole purpose of a public roadmap.
+ */
+async function resolveOptionalUserId(authHeader: string | undefined): Promise<string | null> {
+  if (!authHeader?.startsWith('Bearer ')) return null
+  const token = authHeader.slice(7).trim()
+  if (!token) return null
+  const { data, error } = await supabaseClient.auth.getUser(token)
+  if (error || !data.user?.id) return null
+  return data.user.id
+}
+
+// ── GET /api/v1/feedback — PUBLIC roadmap list ────────────────────────────────
 //
 // Query params:
 //   ?status=new|planned|in_progress|shipped|declined   filter (default: all)
@@ -72,9 +92,10 @@ function escapeHtml(s: string): string {
 // PostgREST does not expose ORDER BY on a referenced relation aggregate).
 //
 // hasVoted per-row: derived from a single follow-up query keyed by the page's
-// feedback ids, not a per-row N+1.
+// feedback ids, not a per-row N+1. Anonymous callers (no Bearer token) get
+// has_voted=false for every row without the extra query.
 feedbackRouter.get('/', async (c) => {
-  const userId = c.get('userId')
+  const userId = await resolveOptionalUserId(c.req.header('Authorization'))
 
   const rawLimit = parseInt(c.req.query('limit') ?? '', 10)
   const limit =
@@ -122,7 +143,7 @@ feedbackRouter.get('/', async (c) => {
   const ids = rows.map((r) => r.id)
 
   // Single follow-up query for "did THIS user vote on these page rows".
-  // Empty page → skip the round-trip.
+  // Empty page or anonymous caller → skip the round-trip.
   let votedSet: Set<string> = new Set()
   if (ids.length > 0 && userId) {
     const { data: voted, error: votedError } = await supabaseAdmin
@@ -158,8 +179,8 @@ feedbackRouter.get('/', async (c) => {
   return c.json({ success: true, data: items })
 })
 
-// POST /api/v1/feedback — submit a suggestion.
-feedbackRouter.post('/', async (c) => {
+// POST /api/v1/feedback — submit a suggestion. Auth required.
+feedbackRouter.post('/', authJwt, async (c) => {
   const userId = c.get('userId')
   const orgId = c.get('orgId')
   const email = c.get('email')
@@ -226,14 +247,14 @@ feedbackRouter.post('/', async (c) => {
   return c.json({ success: true })
 })
 
-// ── POST /api/v1/feedback/:id/vote — idempotent upvote ────────────────────────
+// ── POST /api/v1/feedback/:id/vote — idempotent upvote (auth required) ────────
 //
 // One vote per (user, feedback). Idempotency is enforced by the
 // (feedback_id, user_id) UNIQUE constraint on feedback_votes; we INSERT
 // unconditionally and treat a unique-violation as success. That keeps the
 // happy path one round-trip (no SELECT-then-INSERT) and is race-safe under
 // concurrent double-clicks.
-feedbackRouter.post('/:id/vote', async (c) => {
+feedbackRouter.post('/:id/vote', authJwt, async (c) => {
   const userId = c.get('userId')
   if (!userId) {
     // authJwt should have already rejected this; defensive throw keeps the
@@ -273,8 +294,8 @@ feedbackRouter.post('/:id/vote', async (c) => {
   return c.json({ success: true })
 })
 
-// ── DELETE /api/v1/feedback/:id/vote — un-vote (also idempotent) ──────────────
-feedbackRouter.delete('/:id/vote', async (c) => {
+// ── DELETE /api/v1/feedback/:id/vote — un-vote (auth required, also idempotent) ──
+feedbackRouter.delete('/:id/vote', authJwt, async (c) => {
   const userId = c.get('userId')
   if (!userId) {
     throw new ApiError('UNAUTHORIZED', 'Authentication required to un-vote')


### PR DESCRIPTION
## Summary
Hotfix surfaced during production dogfood of #302 (Phase C+D).

Anonymous visitors hitting \`/feedback\` saw "Could not load the roadmap. Refresh to try again." because Phase B (#299) put \`authJwt\` as router-wide middleware on \`feedbackRouter\` — every GET 401'd.

## Fix
- Drop \`feedbackRouter.use('*', authJwt)\`.
- Attach \`authJwt\` per-route on the three write endpoints (\`POST /\`, \`POST /:id/vote\`, \`DELETE /:id/vote\`).
- \`GET /\` resolves \`userId\` optionally via new \`resolveOptionalUserId\` (Bearer token → supabaseClient.auth.getUser; missing/invalid → null with \`has_voted=false\`).

## Verified
- 18 unit tests pass (1 new: anonymous caller skips feedback_votes follow-up).
- Full server suite: **867 pass** (+1 from main).
- Production dogfood plan after merge: re-open \`https://www.spanlens.io/feedback\` in incognito and confirm list loads + vote pill shows sign-in link.