### PR TITLE
fix(server): mount feedbackRouter before evalsRouter wildcard (R-32)

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -208,6 +208,15 @@ app.route('/api/v1/recommendations', recommendationsRouter)
 app.route('/api/v1/pending-deletions', pendingDeletionsRouter)
 // scoreConfigs has the same wildcard-collision concern as the routes above.
 app.route('/api/v1/score-configs',  scoreConfigsRouter)
+// feedback must be mounted BEFORE evalsRouter/humanEvalsRouter for the same
+// reason as recommendations / pending-deletions / score-configs above.
+// `feedbackRouter`'s GET / is intentionally PUBLIC (anonymous roadmap list);
+// mounting after the `/api/v1` wildcard routers lets their `.use('*', authJwt)`
+// catch the request first and 401 every anonymous visitor with "Missing or
+// invalid Authorization header" — exactly what production dogfood after
+// PR #304 surfaced. Per-route authJwt inside feedbackRouter only fires for
+// requests that actually reach this router.
+app.route('/api/v1/feedback',       feedbackRouter)
 app.route('/api/v1',                evalsRouter)
 app.route('/api/v1/datasets',       datasetsRouter)
 app.route('/api/v1/experiments',    experimentsRouter)
@@ -225,7 +234,6 @@ app.route('/api/v1/models',         modelsRouter)    // JWT-auth — model catal
 app.route('/api/v1/webhooks',       webhooksRouter)
 app.route('/api/v1/exports',        exportsRouter)
 app.route('/api/v1/system',         systemRouter)
-app.route('/api/v1/feedback',       feedbackRouter)
 app.route('/api/v1/shares',         sharesRouter)   // PLG Loop ① — owner-side CRUD
 
 // ── Admin routes (authJwt + requireSystemAdmin via SPANLENS_ADMIN_EMAILS) ──


### PR DESCRIPTION
## Summary
PR #304 made \`GET /api/v1/feedback\` anonymous-safe at the router level, but production still 401'd with \"Missing or invalid Authorization header\".

Root cause: \`app.route('/api/v1', evalsRouter)\` mounts at the broad \`/api/v1\` prefix with \`.use('*', authJwt)\`. \`feedbackRouter\` was mounted AFTER it (line 228), so Hono's first-match-wins routing handed every \`/api/v1/feedback\` GET to the evalsRouter wildcard before \`feedbackRouter\` ever saw it.

CLAUDE.md \"새 기능 추가 시 흐름\" documents this exact pattern (recommendations / pending-deletions / score-configs were all moved above evalsRouter on 2026-06-04 for the same reason).

## Fix
Move \`app.route('/api/v1/feedback', feedbackRouter)\` to just before \`evalsRouter\`, with an inline comment explaining the public-roadmap rationale.

## Validation
- \`pnpm --filter server typecheck\` clean
- \`pnpm --filter server test\` — 867 pass
- Production verification after merge: \`curl -i https://server.spanlens.io/api/v1/feedback\` must return 200 with JSON list (no Authorization header)