### PR TITLE
chore(web): rename /feedback page from "Roadmap" to "Feedback"

### DIFF
--- a/apps/web/app/feedback/page.tsx
+++ b/apps/web/app/feedback/page.tsx
@@ -3,11 +3,18 @@ import { Footer } from '@/components/layout/footer'
 import { FeedbackRoadmapClient } from './feedback-roadmap-client'
 
 /**
- * R-32 Phase C — public roadmap.
+ * R-32 Phase C — public feedback page.
  *
- * Anyone (logged-in or not) can read the roadmap. Voting and submitting
- * require a Spanlens account; the client component shows a "Sign in to vote"
- * pill in place of the vote button for unauthenticated visitors.
+ * Anyone (logged-in or not) can read the list. Voting and submitting require
+ * a Spanlens account; the client component shows a "Sign in to vote" pill in
+ * place of the vote button for unauthenticated visitors.
+ *
+ * Naming note: the page was briefly titled "Roadmap" right after launch, but
+ * the URL is /feedback and the sidebar label is "Feedback" — keeping a
+ * "Roadmap" header produced an instant inconsistency for anyone clicking the
+ * sidebar link. Renamed to "Feedback" so URL, sidebar, and page agree.
+ * The status enum (new -> planned -> in_progress -> shipped -> declined) and
+ * the vote pill are unchanged; only the framing is softer.
  *
  * Previously /feedback rendered a logged-in-only submission form
  * (apps/web/app/(dashboard)/feedback/...). That form is now embedded inside
@@ -15,22 +22,22 @@ import { FeedbackRoadmapClient } from './feedback-roadmap-client'
  * surface — the sidebar link still resolves to the same URL.
  */
 export const metadata = {
-  title: 'Roadmap · Spanlens',
+  title: 'Feedback · Spanlens',
   description:
-    'See what is being built next in Spanlens. Upvote features you want, submit new ideas, and follow each item from new through shipped.',
+    'Tell us what to build next. Vote on what others suggested. Track each item from new to shipped.',
   alternates: { canonical: '/feedback' },
 }
 
 export default function FeedbackPage() {
   return (
     <div className="min-h-screen bg-bg">
-      <MarketingNav subtitle="Roadmap" />
+      <MarketingNav subtitle="Feedback" />
       <main className="max-w-3xl mx-auto px-6 py-12">
         <header className="mb-10">
-          <h1 className="text-4xl font-bold tracking-tight mb-3">Roadmap</h1>
+          <h1 className="text-4xl font-bold tracking-tight mb-3">Feedback</h1>
           <p className="text-lg text-text-muted">
-            See what is being built next. Upvote features you want and submit new ideas;
-            we ship in the order that has the most demand.
+            Tell us what to build next. Vote on what others suggested. Track each
+            item from new to shipped.
           </p>
         </header>
         <FeedbackRoadmapClient />


### PR DESCRIPTION
## Summary
URL is \`/feedback\` and sidebar label is \"Feedback\" — keeping a \"Roadmap\" header produced an instant inconsistency.

## Changes
- \`metadata.title\`: \`Roadmap · Spanlens\` → \`Feedback · Spanlens\`
- \`metadata.description\`: softer copy, no implicit \"we ship in demand order\" promise (was a foot-gun if priorities ever shift)
- MarketingNav subtitle: \`Roadmap\` → \`Feedback\`
- H1 + body copy: same

New body copy: *Tell us what to build next. Vote on what others suggested. Track each item from new to shipped.*

Status enum (new → planned → in_progress → shipped → declined) and vote pill behaviour unchanged; only framing is softer.

## Validation
- \`pnpm --filter web typecheck\` clean
- \`pnpm --filter web lint\` clean