### PR TITLE
feat(server): R-12 Phase 3.1+3.2 — per-org events read switch + route-level env gates

### DIFF
--- a/apps/server/src/api/requests.ts
+++ b/apps/server/src/api/requests.ts
@@ -18,7 +18,7 @@ import {
   selectGenerationsAsRequests,
   countGenerations,
 } from '../lib/events-query.js'
-import { useEventsForRequests } from '../lib/feature-flags.js'
+import { useEventsForRequests } from '../lib/events-read-flag.js'
 import { fromClickhouseTimestamp } from '../lib/clickhouse.js'
 import { ApiError } from '../lib/errors.js'
 
@@ -123,8 +123,9 @@ requestsRouter.get('/', async (c) => {
     let rows: RequestRow[]
     let total: number
 
-    if (useEventsForRequests) {
+    if (await useEventsForRequests(orgId)) {
       // Phase 5.1 Stage 3 — read from the unified events table.
+      // R-12 Phase 3.2: resolved per-org (env gate OR organizations.read_from_events).
       //
       // Safety net: if the events path throws for ANY reason — schema
       // drift, missing column, retention edge case — fall back to the

--- a/apps/server/src/api/traces.ts
+++ b/apps/server/src/api/traces.ts
@@ -4,7 +4,7 @@ import { authJwtOrApiKey } from '../middleware/authJwtOrApiKey.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { computeCriticalPath } from '../lib/critical-path.js'
 import { parsePageLimit } from '../lib/params.js'
-import { useEventsForRequests } from '../lib/feature-flags.js'
+import { useEventsForTraces } from '../lib/events-read-flag.js'
 import {
   listTracesFromEvents,
   getTraceWithSpansFromEvents,
@@ -36,7 +36,8 @@ tracesRouter.get('/', async (c) => {
   // table via traces_view/spans_view. Catch-and-fall-back to Postgres
   // so a regression on the events side degrades to "same behaviour as
   // before Stage 3" rather than 500.
-  if (useEventsForRequests) {
+  // R-12 Phase 3.2: resolved per-org (env gate OR organizations.read_from_events).
+  if (await useEventsForTraces(orgId)) {
     try {
       const result = await listTracesFromEvents({
         organizationId: orgId,
@@ -113,7 +114,7 @@ tracesRouter.get('/:id', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
-  if (useEventsForRequests) {
+  if (await useEventsForTraces(orgId)) {
     try {
       const { trace, spans } = await getTraceWithSpansFromEvents(traceId, orgId)
       if (!trace) throw new ApiError('NOT_FOUND', 'Trace not found')

--- a/apps/server/src/lib/events-query.ts
+++ b/apps/server/src/lib/events-query.ts
@@ -157,6 +157,7 @@ export async function selectGenerationsAsRequests<T>(opts: {
   const query = `
     SELECT
       toString(event_id)                          AS id,
+      project_id,
       provider,
       model,
       toUInt32OrZero(toString(usage_details['prompt_tokens']))     AS prompt_tokens,

--- a/apps/server/src/lib/events-read-flag.test.ts
+++ b/apps/server/src/lib/events-read-flag.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * R-12 Phase 3.2 — per-org events read switch.
+ *
+ * The module composes module-load env gates (feature-flags.ts) with a
+ * cached `organizations.read_from_events` lookup, so every test resets
+ * the module registry, sets env, then dynamic-imports a fresh copy.
+ */
+
+interface DbResult {
+  data: { read_from_events: boolean } | null
+  error: { message: string } | null
+}
+
+const state = vi.hoisted(() => ({
+  dbResult: { data: null, error: null } as DbResult,
+  singleCalls: 0,
+}))
+
+vi.mock('./db.js', () => ({
+  supabaseAdmin: {
+    from: (_table: string) => ({
+      select: (_cols: string) => ({
+        eq: (_col: string, _val: string) => ({
+          single: async () => {
+            state.singleCalls++
+            return state.dbResult
+          },
+        }),
+      }),
+    }),
+  },
+}))
+
+const ORG = '00000000-0000-4000-8000-000000000001'
+
+const EVENT_FLAG_VARS = [
+  'USE_EVENTS_FOR_REQUESTS',
+  'USE_EVENTS_FOR_STATS',
+  'USE_EVENTS_FOR_TRACES',
+  'EVENTS_BACKFILL_COMPLETE',
+] as const
+
+async function freshModule() {
+  vi.resetModules()
+  return import('./events-read-flag.js')
+}
+
+describe('events-read-flag', () => {
+  beforeEach(() => {
+    state.dbResult = { data: null, error: null }
+    state.singleCalls = 0
+  })
+
+  afterEach(() => {
+    for (const v of EVENT_FLAG_VARS) delete process.env[v]
+    vi.resetModules()
+  })
+
+  it('resolves false everywhere when env gates are off and the DB flag is false', async () => {
+    state.dbResult = { data: { read_from_events: false }, error: null }
+    const mod = await freshModule()
+    await expect(mod.useEventsForRequests(ORG)).resolves.toBe(false)
+    await expect(mod.useEventsForStats(ORG)).resolves.toBe(false)
+    await expect(mod.useEventsForTraces(ORG)).resolves.toBe(false)
+    // All three served by one cached lookup.
+    expect(state.singleCalls).toBe(1)
+  })
+
+  it('flips ALL route families when the per-org DB flag is true (no env gates)', async () => {
+    state.dbResult = { data: { read_from_events: true }, error: null }
+    const mod = await freshModule()
+    await expect(mod.useEventsForRequests(ORG)).resolves.toBe(true)
+    await expect(mod.useEventsForStats(ORG)).resolves.toBe(true)
+    await expect(mod.useEventsForTraces(ORG)).resolves.toBe(true)
+  })
+
+  it('route-differentiated env gate: requests on, stats/traces still consult the DB flag', async () => {
+    process.env['USE_EVENTS_FOR_REQUESTS'] = '1'
+    process.env['EVENTS_BACKFILL_COMPLETE'] = '1'
+    state.dbResult = { data: { read_from_events: false }, error: null }
+    const mod = await freshModule()
+    await expect(mod.useEventsForRequests(ORG)).resolves.toBe(true)
+    // Env gate short-circuits — the requests call never hits the DB.
+    expect(state.singleCalls).toBe(0)
+    await expect(mod.useEventsForStats(ORG)).resolves.toBe(false)
+    await expect(mod.useEventsForTraces(ORG)).resolves.toBe(false)
+    expect(state.singleCalls).toBe(1)
+  })
+
+  it('env gate without the backfill ack stays off (double-gate preserved)', async () => {
+    process.env['USE_EVENTS_FOR_STATS'] = '1'
+    state.dbResult = { data: { read_from_events: false }, error: null }
+    const mod = await freshModule()
+    await expect(mod.useEventsForStats(ORG)).resolves.toBe(false)
+  })
+
+  it('resolves false on lookup error (missing row / column not yet migrated)', async () => {
+    state.dbResult = { data: null, error: { message: 'column organizations.read_from_events does not exist' } }
+    const mod = await freshModule()
+    await expect(mod.useEventsForRequests(ORG)).resolves.toBe(false)
+  })
+
+  it('caches the DB flag for subsequent calls (single Supabase round-trip)', async () => {
+    state.dbResult = { data: { read_from_events: true }, error: null }
+    const mod = await freshModule()
+    await mod.orgReadsFromEvents(ORG)
+    await mod.orgReadsFromEvents(ORG)
+    await mod.orgReadsFromEvents(ORG)
+    expect(state.singleCalls).toBe(1)
+  })
+
+  it('coalesces concurrent cold-cache callers onto one in-flight fetch', async () => {
+    state.dbResult = { data: { read_from_events: true }, error: null }
+    const mod = await freshModule()
+    const results = await Promise.all([
+      mod.orgReadsFromEvents(ORG),
+      mod.orgReadsFromEvents(ORG),
+      mod.orgReadsFromEvents(ORG),
+    ])
+    expect(results).toEqual([true, true, true])
+    expect(state.singleCalls).toBe(1)
+  })
+
+  it('resetOrgReadsFromEventsCache() forces a fresh lookup', async () => {
+    state.dbResult = { data: { read_from_events: false }, error: null }
+    const mod = await freshModule()
+    await expect(mod.orgReadsFromEvents(ORG)).resolves.toBe(false)
+    // Operator flips the org on; cache reset makes it visible immediately.
+    state.dbResult = { data: { read_from_events: true }, error: null }
+    mod.resetOrgReadsFromEventsCache()
+    await expect(mod.orgReadsFromEvents(ORG)).resolves.toBe(true)
+    expect(state.singleCalls).toBe(2)
+  })
+
+  it('caches per organization, not globally', async () => {
+    const ORG_B = '00000000-0000-4000-8000-000000000002'
+    state.dbResult = { data: { read_from_events: true }, error: null }
+    const mod = await freshModule()
+    await expect(mod.orgReadsFromEvents(ORG)).resolves.toBe(true)
+    state.dbResult = { data: { read_from_events: false }, error: null }
+    await expect(mod.orgReadsFromEvents(ORG_B)).resolves.toBe(false)
+    // ORG's cached true is untouched by ORG_B's lookup.
+    await expect(mod.orgReadsFromEvents(ORG)).resolves.toBe(true)
+    expect(state.singleCalls).toBe(2)
+  })
+})

--- a/apps/server/src/lib/events-read-flag.ts
+++ b/apps/server/src/lib/events-read-flag.ts
@@ -1,0 +1,103 @@
+/**
+ * R-12 Phase 3.2 — per-organization events read switch.
+ *
+ * Resolves whether a given org's ClickHouse reads should hit the unified
+ * `events` table (or its `events_as_requests` projection view) instead of
+ * the legacy `requests` table. Two inputs, OR-composed per route family:
+ *
+ *   1. Env gates (`envUseEventsForRequests` / `Stats` / `Traces` from
+ *      `feature-flags.ts`) — fleet-wide, double-gated on
+ *      `EVENTS_BACKFILL_COMPLETE`, flips require a redeploy.
+ *
+ *   2. `organizations.read_from_events` (migration 20260610120000) —
+ *      per-org, flips at runtime within the 30s cache TTL. This is the
+ *      gradual-cutover lever for Phase 3.3 (dogfood -> 10% -> 50% -> 100%).
+ *
+ * The DB flag deliberately bypasses the backfill double-gate: setting it is
+ * a targeted operator action on one org (after verifying that org's events
+ * data), not a blunt env flip. The env gates keep their double-gate.
+ *
+ * The DB flag flips ALL THREE route families for the org at once — per-org
+ * granularity is "which tenant", per-env granularity is "which route".
+ * Mixing both axes per-org-per-route was considered and rejected: three
+ * boolean columns invite drift and the cutover plan never needs it.
+ *
+ * Caching mirrors `getOrgPlan` (requests-query.ts): 30s TTL + in-flight
+ * coalescing so a cold dashboard load costs one Supabase round-trip per
+ * org, not one per concurrent query. Lookup failures resolve to `false`
+ * (keep reading the legacy table) — the conservative direction while
+ * `requests` remains the canonical store.
+ */
+
+import { supabaseAdmin } from './db.js'
+import {
+  envUseEventsForRequests,
+  envUseEventsForStats,
+  envUseEventsForTraces,
+} from './feature-flags.js'
+
+interface CachedFlag {
+  value: boolean
+  expiresAt: number
+}
+
+const READ_FLAG_CACHE_TTL_MS = 30 * 1000 // 30s — rollbacks take effect quickly
+const flagCache = new Map<string, CachedFlag>()
+const flagInflight = new Map<string, Promise<boolean>>()
+
+/**
+ * Raw DB flag lookup (cached). Exported for tests and the /health/deep
+ * style diagnostics — route handlers should use the `useEventsForX`
+ * wrappers below so the env OR is never forgotten.
+ */
+export async function orgReadsFromEvents(organizationId: string): Promise<boolean> {
+  const cached = flagCache.get(organizationId)
+  if (cached && cached.expiresAt > Date.now()) return cached.value
+
+  const existing = flagInflight.get(organizationId)
+  if (existing) return existing
+
+  const fetchPromise = (async (): Promise<boolean> => {
+    try {
+      const { data, error } = await supabaseAdmin
+        .from('organizations')
+        .select('read_from_events')
+        .eq('id', organizationId)
+        .single()
+      // Missing row, missing column (migration not yet applied), or any
+      // lookup error all resolve to false — never flip an org onto the
+      // events path by accident.
+      const value = !error && data?.read_from_events === true
+      flagCache.set(organizationId, {
+        value,
+        expiresAt: Date.now() + READ_FLAG_CACHE_TTL_MS,
+      })
+      return value
+    } finally {
+      flagInflight.delete(organizationId)
+    }
+  })()
+  flagInflight.set(organizationId, fetchPromise)
+  return fetchPromise
+}
+
+/** Test/escape hatch — flush cached values AND any in-flight fetch. */
+export function resetOrgReadsFromEventsCache(): void {
+  flagCache.clear()
+  flagInflight.clear()
+}
+
+/** `/api/v1/requests` list — events read switch for this org. */
+export async function useEventsForRequests(organizationId: string): Promise<boolean> {
+  return envUseEventsForRequests || orgReadsFromEvents(organizationId)
+}
+
+/** Stats pipeline (`lib/stats-queries.ts`) — events read switch for this org. */
+export async function useEventsForStats(organizationId: string): Promise<boolean> {
+  return envUseEventsForStats || orgReadsFromEvents(organizationId)
+}
+
+/** `/api/v1/traces` list + detail — events read switch for this org. */
+export async function useEventsForTraces(organizationId: string): Promise<boolean> {
+  return envUseEventsForTraces || orgReadsFromEvents(organizationId)
+}

--- a/apps/server/src/lib/events-requests-parity.test.ts
+++ b/apps/server/src/lib/events-requests-parity.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * R-12 Phase 3.2 — signature/contract compatibility matrix between the
+ * legacy `requests` query layer and the `events` query layer. The Phase 3.3
+ * cutover flips orgs between the two at runtime, so any drift between them
+ * surfaces as a per-org behaviour difference that unit tests on either
+ * module alone would miss.
+ *
+ * | requests-query.ts                  | events-query.ts                    | contract                                              |
+ * |------------------------------------|------------------------------------|--------------------------------------------------------|
+ * | requestsScope(orgId, opts)         | eventsScope(orgId, opts)           | identical whereScope + scopeParams + plan              |
+ * | selectRequests({scope, select,...})| selectGenerationsAsRequests({...}) | shim's fixed SELECT covers every /requests list column |
+ * | countRequests({scope, filters})    | countGenerations({scope, filters}) | same count contract; events side adds event_type gate  |
+ * | streamRequests (CSV/JSONL exports) | (none)                             | KNOWN GAP — exports read `requests` until Phase 4      |
+ * | (table: requests)                  | (view: events_as_requests)         | stats pipeline parity enforced by the view, see        |
+ * |                                    |                                    | clickhouse/migrations/005_create_events_as_requests_view.sql |
+ *
+ * The `streamRequests` gap is deliberate: `/api/v1/exports` stays on the
+ * legacy table until `events` becomes the only store (R-12 Phase 4,
+ * Sprint 15). Revisit this matrix when that lands.
+ */
+
+const { mockQuery } = vi.hoisted(() => ({
+  mockQuery: vi.fn(async (_opts: { query: string }) => ({
+    json: async () => [] as unknown[],
+    stream: () => [],
+    close: () => undefined,
+  })),
+}))
+
+vi.mock('./clickhouse.js', () => ({
+  unscopedClickhouse: () => ({ query: mockQuery }),
+}))
+
+// getOrgPlan (shared by both scope helpers) hits Supabase — pin it to 'free'.
+vi.mock('./db.js', () => ({
+  supabaseAdmin: {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: async () => ({ data: { plan: 'free' }, error: null }),
+        }),
+      }),
+    }),
+  },
+}))
+
+import { requestsScope, selectRequests, countRequests, resetOrgPlanCache } from './requests-query.js'
+import {
+  eventsScope,
+  selectGenerationsAsRequests,
+  countGenerations,
+} from './events-query.js'
+
+const ORG = '00000000-0000-4000-8000-000000000001'
+
+/**
+ * The /api/v1/requests list contract (LIST_COLUMNS in api/requests.ts +
+ * the RequestRow interface). Every name here must come back from the
+ * events shim or the dashboard sees `undefined` fields when an org flips.
+ */
+const REQUESTS_LIST_COLUMNS = [
+  'id',
+  'project_id',
+  'provider',
+  'model',
+  'prompt_tokens',
+  'completion_tokens',
+  'total_tokens',
+  'cache_read_tokens',
+  'cache_write_tokens',
+  'cost_usd',
+  'latency_ms',
+  'status_code',
+  'error_message',
+  'trace_id',
+  'span_id',
+  'provider_key_id',
+  'user_id',
+  'session_id',
+  'truncated',
+  'created_at',
+] as const
+
+/** Pulls the output column names out of a captured `SELECT ... FROM` SQL string. */
+function selectedColumns(sql: string): Set<string> {
+  const selectBody = sql.slice(sql.indexOf('SELECT') + 'SELECT'.length, sql.indexOf('FROM'))
+  const cols = new Set<string>()
+  for (const rawLine of selectBody.split('\n')) {
+    const line = rawLine.trim().replace(/,$/, '')
+    if (!line || line.startsWith('--')) continue
+    const aliasMatch = /\bAS\s+(\w+)\s*$/i.exec(line)
+    if (aliasMatch?.[1]) {
+      cols.add(aliasMatch[1])
+    } else if (/^\w+$/.test(line)) {
+      cols.add(line) // bare column reference
+    }
+  }
+  return cols
+}
+
+describe('requests-query ↔ events-query compatibility', () => {
+  beforeEach(() => {
+    mockQuery.mockClear()
+    resetOrgPlanCache()
+  })
+
+  it('scope helpers produce identical whereScope, scopeParams, and plan', async () => {
+    const r = await requestsScope(ORG)
+    const e = await eventsScope(ORG)
+    expect(e.whereScope).toBe(r.whereScope)
+    expect(e.scopeParams).toEqual(r.scopeParams)
+    expect(e.plan).toBe(r.plan)
+  })
+
+  it('scope helpers agree on the ignoreRetention escape hatch', async () => {
+    const r = await requestsScope(ORG, { ignoreRetention: true })
+    const e = await eventsScope(ORG, { ignoreRetention: true })
+    expect(e.whereScope).toBe(r.whereScope)
+    expect(e.whereScope).not.toContain('retentionDays')
+  })
+
+  it('events shim returns every /requests list column the dashboard contract needs', async () => {
+    const scope = await eventsScope(ORG)
+    await selectGenerationsAsRequests({ scope, limit: 1 })
+
+    expect(mockQuery).toHaveBeenCalledTimes(1)
+    const sql = mockQuery.mock.calls[0]![0]!.query
+    const cols = selectedColumns(sql)
+    for (const required of REQUESTS_LIST_COLUMNS) {
+      expect(cols.has(required), `events shim is missing column "${required}"`).toBe(true)
+    }
+  })
+
+  it('events shim and count gate on event_type=generation; requests side reads the raw table', async () => {
+    const eScope = await eventsScope(ORG)
+    await selectGenerationsAsRequests({ scope: eScope })
+    await countGenerations({ scope: eScope })
+
+    const rScope = await requestsScope(ORG)
+    await selectRequests({ scope: rScope, select: 'id' })
+    await countRequests({ scope: rScope })
+
+    const [shimSql, countEventsSql, selectReqSql, countReqSql] = mockQuery.mock.calls.map(
+      (call) => call[0]!.query,
+    )
+    expect(shimSql).toContain("event_type = 'generation'")
+    expect(countEventsSql).toContain("event_type = 'generation'")
+    expect(shimSql).toContain('FROM events')
+    expect(selectReqSql).toContain('FROM requests')
+    expect(selectReqSql).not.toContain('event_type')
+    expect(countReqSql).toContain('FROM requests')
+  })
+
+  it('both query layers accept the same filter/order/paging surface', async () => {
+    const opts = {
+      filters: 'provider = {provider:String}',
+      params: { provider: 'openai' },
+      orderBy: 'created_at DESC',
+      limit: 50,
+      offset: 100,
+    }
+    const eScope = await eventsScope(ORG)
+    await selectGenerationsAsRequests({ scope: eScope, ...opts })
+    const rScope = await requestsScope(ORG)
+    await selectRequests({ scope: rScope, select: 'id', ...opts })
+
+    for (const call of mockQuery.mock.calls) {
+      const { query, query_params } = call[0] as unknown as {
+        query: string
+        query_params: Record<string, unknown>
+      }
+      expect(query).toContain('provider = {provider:String}')
+      expect(query).toContain('ORDER BY created_at DESC')
+      expect(query).toContain('LIMIT 50')
+      expect(query).toContain('OFFSET 100')
+      expect(query_params['provider']).toBe('openai')
+      expect(query_params['orgId']).toBe(ORG)
+    }
+  })
+})

--- a/apps/server/src/lib/feature-flags.test.ts
+++ b/apps/server/src/lib/feature-flags.test.ts
@@ -3,40 +3,73 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 /**
  * The feature-flags module reads env vars once at import time. Tests
  * use vi.resetModules() so each describe block sees a fresh snapshot.
+ *
+ * R-12 Phase 3.2 split the read switch into three per-route env gates
+ * (REQUESTS / STATS / TRACES), all double-gated on
+ * EVENTS_BACKFILL_COMPLETE. The per-org DB flag composition lives in
+ * events-read-flag.ts and is tested there.
  */
+
+const EVENT_FLAG_VARS = [
+  'USE_EVENTS_FOR_REQUESTS',
+  'USE_EVENTS_FOR_STATS',
+  'USE_EVENTS_FOR_TRACES',
+  'EVENTS_BACKFILL_COMPLETE',
+] as const
+
 describe('feature-flags', () => {
   afterEach(() => {
-    delete process.env['USE_EVENTS_FOR_REQUESTS']
-    delete process.env['EVENTS_BACKFILL_COMPLETE']
+    for (const v of EVENT_FLAG_VARS) delete process.env[v]
     vi.resetModules()
   })
 
-  it('defaults useEventsForRequests to false when both env vars are missing', async () => {
+  it('defaults every env gate to false when no env vars are set', async () => {
     vi.resetModules()
     const mod = await import('./feature-flags.js')
-    expect(mod.useEventsForRequests).toBe(false)
+    expect(mod.envUseEventsForRequests).toBe(false)
+    expect(mod.envUseEventsForStats).toBe(false)
+    expect(mod.envUseEventsForTraces).toBe(false)
   })
 
-  it('stays disabled when only USE_EVENTS_FOR_REQUESTS=1 (backfill ack missing)', async () => {
+  it('stays disabled when only the route var is set (backfill ack missing)', async () => {
     process.env['USE_EVENTS_FOR_REQUESTS'] = '1'
+    process.env['USE_EVENTS_FOR_STATS'] = '1'
+    process.env['USE_EVENTS_FOR_TRACES'] = '1'
     vi.resetModules()
     const mod = await import('./feature-flags.js')
-    expect(mod.useEventsForRequests).toBe(false)
+    expect(mod.envUseEventsForRequests).toBe(false)
+    expect(mod.envUseEventsForStats).toBe(false)
+    expect(mod.envUseEventsForTraces).toBe(false)
   })
 
   it('stays disabled when only EVENTS_BACKFILL_COMPLETE=1 (rollout not asked for)', async () => {
     process.env['EVENTS_BACKFILL_COMPLETE'] = '1'
     vi.resetModules()
     const mod = await import('./feature-flags.js')
-    expect(mod.useEventsForRequests).toBe(false)
+    expect(mod.envUseEventsForRequests).toBe(false)
+    expect(mod.envUseEventsForStats).toBe(false)
+    expect(mod.envUseEventsForTraces).toBe(false)
   })
 
-  it('enables useEventsForRequests only when BOTH env vars are the literal "1"', async () => {
+  it('gates each route independently — requests on, stats/traces stay off', async () => {
     process.env['USE_EVENTS_FOR_REQUESTS'] = '1'
     process.env['EVENTS_BACKFILL_COMPLETE'] = '1'
     vi.resetModules()
     const mod = await import('./feature-flags.js')
-    expect(mod.useEventsForRequests).toBe(true)
+    expect(mod.envUseEventsForRequests).toBe(true)
+    expect(mod.envUseEventsForStats).toBe(false)
+    expect(mod.envUseEventsForTraces).toBe(false)
+  })
+
+  it('enables stats and traces gates with their own vars + backfill ack', async () => {
+    process.env['USE_EVENTS_FOR_STATS'] = '1'
+    process.env['USE_EVENTS_FOR_TRACES'] = '1'
+    process.env['EVENTS_BACKFILL_COMPLETE'] = '1'
+    vi.resetModules()
+    const mod = await import('./feature-flags.js')
+    expect(mod.envUseEventsForRequests).toBe(false)
+    expect(mod.envUseEventsForStats).toBe(true)
+    expect(mod.envUseEventsForTraces).toBe(true)
   })
 
   it('rejects truthy-looking strings other than "1" so dev / CI / prod stay consistent', async () => {
@@ -45,7 +78,7 @@ describe('feature-flags', () => {
       process.env['EVENTS_BACKFILL_COMPLETE'] = v
       vi.resetModules()
       const mod = await import('./feature-flags.js')
-      expect(mod.useEventsForRequests, `expected ${v} to be rejected`).toBe(false)
+      expect(mod.envUseEventsForRequests, `expected ${v} to be rejected`).toBe(false)
     }
   })
 
@@ -56,8 +89,12 @@ describe('feature-flags', () => {
     const mod = await import('./feature-flags.js')
     expect(mod.snapshotFlags()).toEqual({
       USE_EVENTS_FOR_REQUESTS: true,
+      USE_EVENTS_FOR_STATS: false,
+      USE_EVENTS_FOR_TRACES: false,
       EVENTS_BACKFILL_COMPLETE: true,
-      useEventsForRequests: true,
+      envUseEventsForRequests: true,
+      envUseEventsForStats: false,
+      envUseEventsForTraces: false,
     })
   })
 })

--- a/apps/server/src/lib/feature-flags.ts
+++ b/apps/server/src/lib/feature-flags.ts
@@ -17,6 +17,12 @@
  *
  * Add new flags as exported constants here so a `git grep` from a code
  * review finds every flag the server reads.
+ *
+ * NOTE (R-12 Phase 3.2): the constants below are the ENV side only.
+ * The per-organization read switch (`organizations.read_from_events`)
+ * lives in `lib/events-read-flag.ts`, which composes these constants
+ * with a cached DB lookup. Route handlers should call THOSE async
+ * functions, not these constants directly.
  */
 
 function envBool(name: string): boolean {
@@ -24,31 +30,47 @@ function envBool(name: string): boolean {
 }
 
 /**
- * Phase 5.1 Stage 3 — when set, `/api/v1/requests` reads from the
- * new unified `events` table (event_type='generation') instead of
- * `requests`. Turning the flag off must remain a safe operation that
- * falls all the way back to the original code path; we don't drop
- * `requests` writes until Stage 4 (post-cutover).
+ * Phase 5.1 Stage 3 / R-12 Phase 3.2 — per-route env gates for reading
+ * from the unified `events` table instead of `requests`.
  *
- * Activation env var: `USE_EVENTS_FOR_REQUESTS=1`
+ * Each route family gets its own activation var so the cutover can be
+ * staged route-by-route:
  *
- * Operational guard: also requires `EVENTS_BACKFILL_COMPLETE=1`.
- * Activating the read switch BEFORE the backfill finishes shows an
- * empty list to the operator (events only has rows from the
- * dual-write start onward, so 99% of `requests` is missing).
- * Production hit this footgun once already during the rollout —
- * the double-gate prevents an env-flip from going live without
- * the matching "I confirmed the backfill" acknowledgement.
+ *   - `USE_EVENTS_FOR_REQUESTS=1` — `/api/v1/requests` list reads
+ *   - `USE_EVENTS_FOR_STATS=1`    — stats pipeline (`lib/stats-queries.ts`)
+ *   - `USE_EVENTS_FOR_TRACES=1`   — `/api/v1/traces` list + detail
+ *
+ * Operational guard: all three also require `EVENTS_BACKFILL_COMPLETE=1`.
+ * Activating a read switch BEFORE the backfill finishes shows an empty
+ * list to the operator (events only has rows from the dual-write start
+ * onward, so 99% of `requests` is missing). Production hit this footgun
+ * once already during the rollout — the double-gate prevents an env-flip
+ * from going live without the matching "I confirmed the backfill"
+ * acknowledgement.
+ *
+ * Turning a flag off must remain a safe operation that falls all the
+ * way back to the original code path; we don't drop `requests` writes
+ * until Phase 4 (post-cutover).
  */
-export const useEventsForRequests =
+export const envUseEventsForRequests =
   envBool('USE_EVENTS_FOR_REQUESTS') && envBool('EVENTS_BACKFILL_COMPLETE')
+
+export const envUseEventsForStats =
+  envBool('USE_EVENTS_FOR_STATS') && envBool('EVENTS_BACKFILL_COMPLETE')
+
+export const envUseEventsForTraces =
+  envBool('USE_EVENTS_FOR_TRACES') && envBool('EVENTS_BACKFILL_COMPLETE')
 
 /** Diagnostics view — used by `/health/deep` to surface what's on. */
 export function snapshotFlags(): Record<string, boolean> {
   return {
     USE_EVENTS_FOR_REQUESTS: envBool('USE_EVENTS_FOR_REQUESTS'),
+    USE_EVENTS_FOR_STATS: envBool('USE_EVENTS_FOR_STATS'),
+    USE_EVENTS_FOR_TRACES: envBool('USE_EVENTS_FOR_TRACES'),
     EVENTS_BACKFILL_COMPLETE: envBool('EVENTS_BACKFILL_COMPLETE'),
-    /** The composed flag the requests router actually branches on. */
-    useEventsForRequests,
+    /** The composed env gates the per-org resolver ORs with the DB flag. */
+    envUseEventsForRequests,
+    envUseEventsForStats,
+    envUseEventsForTraces,
   }
 }

--- a/apps/server/src/lib/stats-queries.ts
+++ b/apps/server/src/lib/stats-queries.ts
@@ -49,7 +49,10 @@ export async function getStatsOverview(
   organizationId: string,
   options: OverviewOptions = {},
 ): Promise<OverviewRow> {
-  const scope = await requestsScope(organizationId)
+  const [scope, source] = await Promise.all([
+    requestsScope(organizationId),
+    statsSource(organizationId),
+  ])
   const filters: string[] = []
   const params: Record<string, unknown> = { ...scope.scopeParams }
 
@@ -82,7 +85,7 @@ export async function getStatsOverview(
       sum(prompt_tokens)                     AS prompt_tokens,
       sum(completion_tokens)                 AS completion_tokens,
       avg(latency_ms)                        AS avg_latency_ms
-    FROM ${statsSource()}
+    FROM ${source}
     WHERE ${where}`
 
   const result = await unscopedClickhouse().query({
@@ -125,7 +128,10 @@ export async function getStatsModels(
   organizationId: string,
   options: ModelsOptions,
 ): Promise<ModelsRow[]> {
-  const scope = await requestsScope(organizationId)
+  const [scope, source] = await Promise.all([
+    requestsScope(organizationId),
+    statsSource(organizationId),
+  ])
   const filters: string[] = []
   const params: Record<string, unknown> = {
     ...scope.scopeParams,
@@ -145,7 +151,7 @@ export async function getStatsModels(
       sum(cost_usd)                                    AS total_cost_usd,
       avg(latency_ms)                                  AS avg_latency_ms,
       avg(if(status_code >= 400, 1.0, 0.0))            AS error_rate
-    FROM ${statsSource()}
+    FROM ${source}
     WHERE ${where}
     GROUP BY provider, model
     ORDER BY total_cost_usd DESC`
@@ -211,7 +217,10 @@ export async function getStatsTimeseries(
   const granularity = options.granularity ?? 'day'
   const bucket = granularity === 'hour' ? 'toStartOfHour' : 'toStartOfDay'
 
-  const scope = await requestsScope(organizationId)
+  const [scope, source] = await Promise.all([
+    requestsScope(organizationId),
+    statsSource(organizationId),
+  ])
   const filters: string[] = []
   const params: Record<string, unknown> = { ...scope.scopeParams }
   if (options.projectId) {
@@ -247,7 +256,7 @@ export async function getStatsTimeseries(
       countIf(status_code >= 500)                                AS errors_5xx,
       quantile(0.5)(latency_ms)                                  AS p50_latency_ms,
       quantile(0.95)(latency_ms)                                 AS p95_latency_ms
-    FROM ${statsSource()}
+    FROM ${source}
     WHERE ${where}
     GROUP BY day
     ORDER BY day ASC`
@@ -284,7 +293,10 @@ export async function getTimeseriesBreakdown(
   const granularity = options.granularity ?? 'day'
   const bucket = granularity === 'hour' ? 'toStartOfHour' : 'toStartOfDay'
 
-  const scope = await requestsScope(organizationId)
+  const [scope, source] = await Promise.all([
+    requestsScope(organizationId),
+    statsSource(organizationId),
+  ])
   const filters: string[] = []
   const params: Record<string, unknown> = { ...scope.scopeParams }
   if (options.projectId) {
@@ -313,7 +325,7 @@ export async function getTimeseriesBreakdown(
         'status' AS kind,
         toString(status_code) AS value,
         count() AS c
-      FROM ${statsSource()}
+      FROM ${source}
       WHERE ${where}
       GROUP BY day, value
       UNION ALL
@@ -322,7 +334,7 @@ export async function getTimeseriesBreakdown(
         'model' AS kind,
         concat(provider, ' / ', model) AS value,
         count() AS c
-      FROM ${statsSource()}
+      FROM ${source}
       WHERE ${where}
       GROUP BY day, value
     )
@@ -398,7 +410,10 @@ export async function getUserAnalytics(
   organizationId: string,
   options: UserAnalyticsOptions,
 ): Promise<UserAnalyticsRow[]> {
-  const scope = await requestsScope(organizationId)
+  const [scope, source] = await Promise.all([
+    requestsScope(organizationId),
+    statsSource(organizationId),
+  ])
 
   // Whitelist sort inputs — they're concatenated into SQL below.
   const sortCol = USER_SORT_COL[options.sortBy] ?? 'total_cost_usd'
@@ -440,7 +455,7 @@ export async function getUserAnalytics(
       countIf(status_code >= 400)                      AS error_requests,
       uniqExact(model)                                 AS distinct_models,
       count() OVER ()                                  AS total_count
-    FROM ${statsSource()}
+    FROM ${source}
     WHERE ${where}
     GROUP BY user_id
     ORDER BY ${sortCol} ${sortDir} NULLS LAST
@@ -515,7 +530,10 @@ export async function getSessionAnalytics(
   organizationId: string,
   options: SessionAnalyticsOptions,
 ): Promise<SessionAnalyticsRow[]> {
-  const scope = await requestsScope(organizationId)
+  const [scope, source] = await Promise.all([
+    requestsScope(organizationId),
+    statsSource(organizationId),
+  ])
 
   // Whitelist sort inputs — they're concatenated into SQL below.
   const sortCol = SESSION_SORT_COL[options.sortBy] ?? 'last_seen'
@@ -563,7 +581,7 @@ export async function getSessionAnalytics(
       countIf(status_code >= 400)                      AS error_requests,
       uniqExact(model)                                 AS distinct_models,
       count() OVER ()                                  AS total_count
-    FROM ${statsSource()}
+    FROM ${source}
     WHERE ${where}
     GROUP BY session_id
     ORDER BY ${sortCol} ${sortDir} NULLS LAST
@@ -609,13 +627,16 @@ export async function getSecuritySummary(
   organizationId: string,
   hours: number,
 ): Promise<SecuritySummaryRow[]> {
-  const scope = await requestsScope(organizationId, { ignoreRetention: true })
+  const [scope, source] = await Promise.all([
+    requestsScope(organizationId, { ignoreRetention: true }),
+    statsSource(organizationId),
+  ])
   const sql = `
     SELECT
       JSONExtractString(flag, 'type')    AS flag_type,
       JSONExtractString(flag, 'pattern') AS pattern,
       count()                            AS count
-    FROM ${statsSource()}
+    FROM ${source}
     ARRAY JOIN JSONExtractArrayRaw(flags) AS flag
     WHERE ${scope.whereScope}
       AND has_security_flags = 1
@@ -659,7 +680,10 @@ export async function getLatencyPercentiles(
   organizationId: string,
   hours: number,
 ): Promise<LatencyPercentilesRow> {
-  const scope = await requestsScope(organizationId)
+  const [scope, source] = await Promise.all([
+    requestsScope(organizationId),
+    statsSource(organizationId),
+  ])
   const sinceTs = fmt(new Date(Date.now() - hours * 3_600_000).toISOString())!
   const sql = `
     SELECT
@@ -673,7 +697,7 @@ export async function getLatencyPercentiles(
       quantileIf(0.95)(proxy_overhead_ms, isNotNull(proxy_overhead_ms))        AS p95_overhead,
       quantileIf(0.99)(proxy_overhead_ms, isNotNull(proxy_overhead_ms))        AS p99_overhead,
       avgIf(proxy_overhead_ms, isNotNull(proxy_overhead_ms))                   AS avg_overhead
-    FROM ${statsSource()}
+    FROM ${source}
     WHERE ${scope.whereScope}
       AND created_at >= parseDateTime64BestEffort({sinceTs:String})`
 

--- a/apps/server/src/lib/stats-source.test.ts
+++ b/apps/server/src/lib/stats-source.test.ts
@@ -1,30 +1,37 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * R-12 Phase 3.2 — statsSource() is now per-org: it delegates to
+ * useEventsForStats(orgId) (env gate OR organizations.read_from_events).
+ * The flag-resolution logic itself is covered in events-read-flag.test.ts;
+ * here we only assert the table-name mapping.
+ */
+
+const { mockUseEventsForStats } = vi.hoisted(() => ({
+  mockUseEventsForStats: vi.fn<(orgId: string) => Promise<boolean>>(),
+}))
+
+vi.mock('./events-read-flag.js', () => ({
+  useEventsForStats: mockUseEventsForStats,
+}))
+
+import { statsSource } from './stats-source.js'
+
+const ORG = '00000000-0000-4000-8000-000000000001'
 
 describe('statsSource', () => {
-  afterEach(() => {
-    delete process.env['USE_EVENTS_FOR_REQUESTS']
-    delete process.env['EVENTS_BACKFILL_COMPLETE']
-    vi.resetModules()
+  beforeEach(() => {
+    mockUseEventsForStats.mockReset()
   })
 
-  it('defaults to the legacy requests table when no flag is set', async () => {
-    vi.resetModules()
-    const mod = await import('./stats-source.js')
-    expect(mod.statsSource()).toBe('requests')
+  it('returns the legacy requests table when the org flag resolves false', async () => {
+    mockUseEventsForStats.mockResolvedValue(false)
+    await expect(statsSource(ORG)).resolves.toBe('requests')
+    expect(mockUseEventsForStats).toHaveBeenCalledWith(ORG)
   })
 
-  it('switches to events_as_requests when both flags are 1', async () => {
-    process.env['USE_EVENTS_FOR_REQUESTS'] = '1'
-    process.env['EVENTS_BACKFILL_COMPLETE'] = '1'
-    vi.resetModules()
-    const mod = await import('./stats-source.js')
-    expect(mod.statsSource()).toBe('events_as_requests')
-  })
-
-  it('stays on requests when only the dashboard flag is set (backfill ack missing)', async () => {
-    process.env['USE_EVENTS_FOR_REQUESTS'] = '1'
-    vi.resetModules()
-    const mod = await import('./stats-source.js')
-    expect(mod.statsSource()).toBe('requests')
+  it('returns events_as_requests when the org flag resolves true', async () => {
+    mockUseEventsForStats.mockResolvedValue(true)
+    await expect(statsSource(ORG)).resolves.toBe('events_as_requests')
   })
 })

--- a/apps/server/src/lib/stats-source.ts
+++ b/apps/server/src/lib/stats-source.ts
@@ -1,19 +1,22 @@
 /**
- * Phase 5.1 Stage 3 — single-source-of-truth for which ClickHouse table
- * the stats pipeline reads from.
+ * Phase 5.1 Stage 3 / R-12 Phase 3.2 — single-source-of-truth for which
+ * ClickHouse table the stats pipeline reads from.
  *
- * `lib/stats-queries.ts` interpolates this into every FROM clause so a
- * Vercel env flip swaps the data source for the whole stats pipeline
- * at once. Both `requests` and `events_as_requests` (a view defined in
- * `clickhouse/migrations/005_create_events_as_requests_view.sql`) expose
- * the same column shape, so the rest of each query is unchanged.
+ * `lib/stats-queries.ts` resolves this once per call and interpolates it
+ * into every FROM clause. Both `requests` and `events_as_requests` (a view
+ * defined in `clickhouse/migrations/005_create_events_as_requests_view.sql`)
+ * expose the same column shape, so the rest of each query is unchanged.
  *
- * Flipping back is byte-identical to today: drop the env var and
- * redeploy.
+ * R-12 Phase 3.2 made this per-org: the source now depends on the calling
+ * organization's `read_from_events` flag OR the `USE_EVENTS_FOR_STATS` env
+ * gate (see `lib/events-read-flag.ts`). Flipping the fleet back is still
+ * byte-identical to before: drop the env var, zero the DB flags, redeploy.
  */
 
-import { useEventsForRequests } from './feature-flags.js'
+import { useEventsForStats } from './events-read-flag.js'
 
-export function statsSource(): string {
-  return useEventsForRequests ? 'events_as_requests' : 'requests'
+export type StatsSource = 'requests' | 'events_as_requests'
+
+export async function statsSource(organizationId: string): Promise<StatsSource> {
+  return (await useEventsForStats(organizationId)) ? 'events_as_requests' : 'requests'
 }

--- a/supabase/migrations/20260610120000_org_read_from_events.sql
+++ b/supabase/migrations/20260610120000_org_read_from_events.sql
@@ -1,0 +1,16 @@
+-- R-12 Phase 3.1 — per-org events read switch.
+--
+-- `read_from_events = true` flips every ClickHouse read path (requests list,
+-- traces, stats) for that organization onto the unified `events` table,
+-- independent of the global USE_EVENTS_FOR_* env flags. This is the gradual
+-- cutover lever: dogfood org first, then 10% -> 50% -> 100% (Phase 3.3).
+--
+-- The per-org flag deliberately bypasses the EVENTS_BACKFILL_COMPLETE env
+-- double-gate that guards the env flags: setting a row here is a targeted
+-- operator action (UPDATE on one org after verifying that org's events data),
+-- not a blunt fleet-wide env flip. See apps/server/src/lib/events-read-flag.ts.
+--
+-- Additive + idempotent (gotcha #25): NOT NULL + DEFAULT false backfills
+-- existing rows automatically; reruns are no-ops.
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS read_from_events boolean NOT NULL DEFAULT false;

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -1528,6 +1528,7 @@ export type Database = {
           plan: string
           quota_warning_100_sent_at: string | null
           quota_warning_80_sent_at: string | null
+          read_from_events: boolean
           security_alert_enabled: boolean
           stale_key_alerts_enabled: boolean
           stale_key_threshold_days: number
@@ -1547,6 +1548,7 @@ export type Database = {
           plan?: string
           quota_warning_100_sent_at?: string | null
           quota_warning_80_sent_at?: string | null
+          read_from_events?: boolean
           security_alert_enabled?: boolean
           stale_key_alerts_enabled?: boolean
           stale_key_threshold_days?: number
@@ -1566,6 +1568,7 @@ export type Database = {
           plan?: string
           quota_warning_100_sent_at?: string | null
           quota_warning_80_sent_at?: string | null
+          read_from_events?: boolean
           security_alert_enabled?: boolean
           stale_key_alerts_enabled?: boolean
           stale_key_threshold_days?: number


### PR DESCRIPTION
## Summary

Sprint 9 (R-12 Phase 3.1 + 3.2) — the gradual-cutover lever for moving ClickHouse reads from `requests` to the unified `events` table, per organization.

### Phase 3.1 — per-org DB flag
- New migration `20260610120000_org_read_from_events.sql`: `organizations.read_from_events boolean NOT NULL DEFAULT false` (additive + idempotent).
- `true` flips ALL ClickHouse read paths (requests list, traces, stats) for that org onto `events` at runtime (30s cache TTL) — no redeploy.
- Deliberately bypasses the `EVENTS_BACKFILL_COMPLETE` double-gate: setting a row is a targeted operator action, not a blunt env flip. Env gates keep their double-gate.

### Phase 3.2 — route-level env gates + per-org resolution
- `feature-flags.ts`: the single `useEventsForRequests` boolean is replaced by three composed env gates: `envUseEventsForRequests` / `envUseEventsForStats` / `envUseEventsForTraces` (each requires its own `USE_EVENTS_FOR_*=1` AND `EVENTS_BACKFILL_COMPLETE=1`). `snapshotFlags()` surfaces all of them.
- New `lib/events-read-flag.ts`: `useEventsForRequests/Stats/Traces(orgId): Promise<boolean>` = env gate OR cached DB flag. Cache mirrors `getOrgPlan` (30s TTL + in-flight coalescing); lookup failures resolve to `false` (keep reading the legacy table).
- Call sites: `api/requests.ts`, `api/traces.ts` (2 sites), `stats-source.ts` → `statsSource(orgId): Promise`, all 8 `stats-queries.ts` functions resolve the source per call via `Promise.all` with `requestsScope`.

### Bug found by the new parity suite
- `selectGenerationsAsRequests` (events shim for the `/requests` list) was missing `project_id` in its SELECT — the events path returned rows violating the `RequestRow` contract. Fixed.

### Compatibility matrix + tests
- `events-requests-parity.test.ts` locks the `requests-query` ↔ `events-query` contract: scope parity (incl. `ignoreRetention`), shim column coverage vs the dashboard list contract, `event_type='generation'` gating, identical filter/order/paging surface. The `streamRequests`/exports gap is documented as deliberate until Phase 4 (Sprint 15).
- `events-read-flag.test.ts`: env/DB OR-composition, route differentiation, double-gate, error fallback, cache TTL, coalescing, per-org isolation (9 tests).
- `feature-flags.test.ts` / `stats-source.test.ts` rewritten for the new shape.

## Test plan
- [x] `pnpm --filter server typecheck` / `lint` / `test` (881 passed)
- [x] `pnpm typecheck` (full monorepo, supabase/types.ts is cross-package)
- [x] Migration applied locally + `supabase gen types` (+3 lines, Row/Insert/Update only)
- [ ] CI green
- [ ] deploy-server.yml: migrate job → deploy job (migration lands before code, gotcha #25)
- [ ] Post-merge: dogfood org `read_from_events=true` + 24h monitoring (Sprint 9 마지막 단계)