### PR TITLE
fix(server): R-12 traces events read path — dedupe + lifecycle dual-write + span project_id

### DIFF
--- a/apps/server/src/api/ingest.ts
+++ b/apps/server/src/api/ingest.ts
@@ -183,16 +183,46 @@ ingestRouter.patch('/traces/:id', async (c) => {
     }
   }
 
+  // Select the full trace state, not just the patched fields — the events
+  // dual-write below appends a complete snapshot row (the events store is
+  // append-only; readers keep the latest row per id, so a partial snapshot
+  // would erase fields the create event carried).
   const { data, error } = await supabaseAdmin
     .from('traces')
     .update(updates)
     .eq('id', traceId)
     .eq('organization_id', organizationId)
-    .select('id, status, ended_at, duration_ms')
+    .select(
+      'id, project_id, api_key_id, name, status, started_at, ended_at, duration_ms, error_message, metadata',
+    )
     .single()
 
   if (error || !data) {
     throw new ApiError('NOT_FOUND', 'Trace not found or access denied')
+  }
+
+  // R-12 Phase 3.2 — dual-write the lifecycle update to events. Without
+  // this the events read path (organizations.read_from_events) shows every
+  // trace frozen in its create-time state: status 'running' forever,
+  // ended_at/duration_ms never filled. Same awaited best-effort contract
+  // as the POST path above (gotcha #8).
+  try {
+    await writeTraceAsEvent({
+      traceId: data.id,
+      organizationId,
+      projectId: data.project_id,
+      apiKeyId: data.api_key_id ?? null,
+      name: data.name,
+      startedAt: data.started_at,
+      endedAt: data.ended_at ?? null,
+      status: data.status ?? null,
+      errorMessage: data.error_message ?? null,
+      metadata: (data.metadata as Record<string, unknown> | null) ?? null,
+      durationMs: data.duration_ms ?? null,
+      eventTime: new Date().toISOString(),
+    })
+  } catch (err) {
+    console.error('[ingest] trace update events shadow INSERT failed:', err instanceof Error ? err.message : err)
   }
 
   // Outbound webhook: trace.completed. fireAndForget so the SDK's PATCH
@@ -241,10 +271,12 @@ ingestRouter.post('/traces/:id/spans', async (c) => {
     throw new ApiError('VALIDATION_FAILED', 'name is required')
   }
 
-  // trace 소유권 확인 — 다른 org의 trace에 span 추가 시도 차단
+  // trace 소유권 확인 — 다른 org의 trace에 span 추가 시도 차단.
+  // project_id도 함께 가져옴: spans 테이블에는 project_id 컬럼이 없어서
+  // events dual-write의 project_id(UUID NOT NULL)는 부모 trace에서 와야 함.
   const { data: trace } = await supabaseAdmin
     .from('traces')
-    .select('id')
+    .select('id, project_id')
     .eq('id', traceId)
     .eq('organization_id', organizationId)
     .single()
@@ -296,7 +328,11 @@ ingestRouter.post('/traces/:id/spans', async (c) => {
       traceId,
       parentSpanId: insert.parent_span_id ?? null,
       organizationId,
-      projectId: (insert as { project_id?: string }).project_id ?? '',
+      // R-12 Phase 3.2 fix: this used to read `insert.project_id`, which
+      // NEVER exists (spans carry no project_id) — every span event was
+      // written with projectId '' and rejected by ClickHouse's UUID
+      // column, silently losing the whole span events stream.
+      projectId: trace.project_id,
       apiKeyId: null,
       name: insert.name,
       spanType: insert.span_type ?? null,
@@ -388,16 +424,60 @@ ingestRouter.patch('/spans/:id', async (c) => {
     }
   }
 
+  // Full snapshot select — same append-only rationale as the trace PATCH.
   const { data, error } = await supabaseAdmin
     .from('spans')
     .update(updates)
     .eq('id', spanId)
     .eq('organization_id', organizationId)
-    .select('id, status, ended_at, duration_ms, total_tokens, cost_usd')
+    .select(
+      'id, trace_id, parent_span_id, name, span_type, status, started_at, ended_at, duration_ms, input, output, metadata, error_message, prompt_tokens, completion_tokens, total_tokens, cost_usd',
+    )
     .single()
 
   if (error || !data) {
     throw new ApiError('NOT_FOUND', 'Span not found or access denied')
+  }
+
+  // R-12 Phase 3.2 — dual-write the span lifecycle update to events.
+  // This PATCH is where usage/cost/output land (the SDK creates the span
+  // empty, then fills it at end()), so skipping it left every span event
+  // with zero tokens forever. project_id comes from the parent trace —
+  // spans don't carry one.
+  try {
+    const { data: parentTrace } = await supabaseAdmin
+      .from('traces')
+      .select('project_id')
+      .eq('id', data.trace_id)
+      .eq('organization_id', organizationId)
+      .single()
+    if (parentTrace?.project_id) {
+      await writeSpanAsEvent({
+        spanId: data.id,
+        traceId: data.trace_id,
+        parentSpanId: data.parent_span_id ?? null,
+        organizationId,
+        projectId: parentTrace.project_id,
+        apiKeyId: null,
+        name: data.name,
+        spanType: data.span_type ?? null,
+        startedAt: data.started_at,
+        endedAt: data.ended_at ?? null,
+        durationMs: data.duration_ms ?? null,
+        status: data.status ?? null,
+        errorMessage: data.error_message ?? null,
+        input: data.input ?? undefined,
+        output: data.output ?? undefined,
+        metadata: (data.metadata as Record<string, unknown> | null) ?? null,
+        promptTokens: data.prompt_tokens ?? null,
+        completionTokens: data.completion_tokens ?? null,
+        totalTokens: data.total_tokens ?? null,
+        costUsd: data.cost_usd ?? null,
+        eventTime: new Date().toISOString(),
+      })
+    }
+  } catch (err) {
+    console.error('[ingest] span update events shadow INSERT failed:', err instanceof Error ? err.message : err)
   }
 
   return c.json({ success: true, data })

--- a/apps/server/src/lib/events-writer.test.ts
+++ b/apps/server/src/lib/events-writer.test.ts
@@ -133,7 +133,55 @@ describe('writeTraceAsEvent', () => {
   })
 })
 
+describe('writeTraceAsEvent — lifecycle update events (eventTime)', () => {
+  it('defaults created_at to start_time when no eventTime is given (create event)', async () => {
+    await writeTraceAsEvent({
+      traceId: 'trc-2',
+      organizationId: 'org-1',
+      projectId: 'prj-1',
+      name: 'agent_run',
+      startedAt: '2026-06-06T00:00:00.000Z',
+    })
+    const row = insertMock.mock.calls[0]?.[0].values[0]
+    expect(row.created_at).toBe(row.start_time)
+  })
+
+  it('stamps created_at with eventTime while start_time keeps startedAt (update event)', async () => {
+    await writeTraceAsEvent({
+      traceId: 'trc-2',
+      organizationId: 'org-1',
+      projectId: 'prj-1',
+      name: 'agent_run',
+      startedAt: '2026-06-06T00:00:00.000Z',
+      endedAt: '2026-06-06T00:00:05.000Z',
+      status: 'completed',
+      eventTime: '2026-06-06T00:00:05.100Z',
+    })
+    const row = insertMock.mock.calls[0]?.[0].values[0]
+    expect(row.start_time).toBe('2026-06-06 00:00:00.000')
+    // created_at later than start_time → the LIMIT 1 BY id dedupe in
+    // traces-events-queries picks this snapshot over the create event.
+    expect(row.created_at).toBe('2026-06-06 00:00:05.100')
+    expect(row.metadata['status']).toBe('completed')
+  })
+})
+
 describe('writeSpanAsEvent', () => {
+  it('stamps created_at with eventTime on update events (same contract as traces)', async () => {
+    await writeSpanAsEvent({
+      spanId: 'spn-2',
+      traceId: 'trc-1',
+      organizationId: 'org-1',
+      projectId: 'prj-1',
+      name: 'llm_call',
+      startedAt: '2026-06-06T00:00:00.000Z',
+      eventTime: '2026-06-06T00:00:09.000Z',
+    })
+    const row = insertMock.mock.calls[0]?.[0].values[0]
+    expect(row.start_time).toBe('2026-06-06 00:00:00.000')
+    expect(row.created_at).toBe('2026-06-06 00:00:09.000')
+  })
+
   it('writes a span row with parent_event_id pointing at the parent', async () => {
     await writeSpanAsEvent({
       spanId: 'spn-1',

--- a/apps/server/src/lib/events-writer.ts
+++ b/apps/server/src/lib/events-writer.ts
@@ -184,10 +184,21 @@ export interface TraceEventInput {
   errorMessage?: string | null
   metadata?: Record<string, unknown> | null
   durationMs?: number | null
+  /**
+   * R-12 Phase 3.2 — when this write represents a lifecycle UPDATE (the
+   * ingest PATCH path appending a fresh snapshot row), pass the update
+   * time here. The events store is append-only, so readers pick the
+   * latest row per event_id ordered by `created_at` (`LIMIT 1 BY id` in
+   * traces-events-queries.ts) — an update event MUST carry a created_at
+   * later than the create event's (which uses startedAt) or it loses
+   * the tie-break and the dashboard keeps showing the stale state.
+   */
+  eventTime?: string | null
 }
 
 export async function writeTraceAsEvent(input: TraceEventInput): Promise<void> {
-  const created = toClickhouseTimestamp(new Date(input.startedAt))
+  const startTs = toClickhouseTimestamp(new Date(input.startedAt))
+  const created = input.eventTime ? toClickhouseTimestamp(new Date(input.eventTime)) : startTs
   const metadata: Record<string, string> = { source: 'ingest_trace' }
   if (input.status) metadata['status'] = input.status
   if (input.metadata) {
@@ -210,7 +221,7 @@ export async function writeTraceAsEvent(input: TraceEventInput): Promise<void> {
     name: input.name,
     provider: '',
     model: '',
-    start_time: created,
+    start_time: startTs,
     end_time: input.endedAt ? toClickhouseTimestamp(new Date(input.endedAt)) : null,
     duration_ms: input.durationMs ?? null,
     input: input.metadata ? JSON.stringify(input.metadata) : '',
@@ -253,10 +264,13 @@ export interface SpanEventInput {
   completionTokens?: number | null
   totalTokens?: number | null
   costUsd?: number | null
+  /** Same semantics as TraceEventInput.eventTime — see that doc comment. */
+  eventTime?: string | null
 }
 
 export async function writeSpanAsEvent(input: SpanEventInput): Promise<void> {
-  const created = toClickhouseTimestamp(new Date(input.startedAt))
+  const startTs = toClickhouseTimestamp(new Date(input.startedAt))
+  const created = input.eventTime ? toClickhouseTimestamp(new Date(input.eventTime)) : startTs
   const usageDetails: Record<string, number> = {}
   if (input.promptTokens != null) usageDetails['prompt_tokens'] = input.promptTokens
   if (input.completionTokens != null) usageDetails['completion_tokens'] = input.completionTokens
@@ -284,7 +298,7 @@ export async function writeSpanAsEvent(input: SpanEventInput): Promise<void> {
     name: input.name,
     provider: '',
     model: '',
-    start_time: created,
+    start_time: startTs,
     end_time: input.endedAt ? toClickhouseTimestamp(new Date(input.endedAt)) : null,
     duration_ms: input.durationMs ?? null,
     input: input.input != null ? JSON.stringify(input.input) : '',

--- a/apps/server/src/lib/traces-events-queries.test.ts
+++ b/apps/server/src/lib/traces-events-queries.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * R-12 Phase 3.2 — dedupe contract for the traces events read path.
+ *
+ * `events` is append-only: a trace/span accrues one row per lifecycle
+ * write (create, PATCH update, backfill re-insert), all sharing the
+ * same event_id. The 2026-06-10 dogfood flip surfaced the symptom:
+ * the /traces list rendered the same trace once per lifecycle row.
+ * Every query against traces_view / spans_view must therefore collapse
+ * to the latest snapshot per id (`ORDER BY created_at DESC LIMIT 1 BY id`)
+ * BEFORE filters, joins, or aggregates run.
+ */
+
+const { mockQuery } = vi.hoisted(() => ({
+  mockQuery: vi.fn(async (_opts: { query: string }) => ({
+    json: async () => [] as unknown[],
+  })),
+}))
+
+vi.mock('./clickhouse.js', () => ({
+  unscopedClickhouse: () => ({ query: mockQuery }),
+}))
+
+import { listTracesFromEvents, getTraceWithSpansFromEvents } from './traces-events-queries.js'
+
+const ORG = '00000000-0000-4000-8000-000000000001'
+const TRACE = '00000000-0000-4000-8000-00000000000a'
+
+const DEDUPE = /ORDER BY created_at DESC\s+LIMIT 1 BY id/g
+
+function countDedupes(sql: string): number {
+  return sql.match(DEDUPE)?.length ?? 0
+}
+
+describe('traces-events-queries dedupe', () => {
+  beforeEach(() => {
+    mockQuery.mockClear()
+  })
+
+  it('list query dedupes BOTH the trace rows and the span aggregate input', async () => {
+    await listTracesFromEvents({ organizationId: ORG, limit: 50, offset: 0 })
+    const [listSql, countSql] = mockQuery.mock.calls.map((c) => c[0]!.query)
+    expect(countDedupes(listSql!)).toBe(2) // traces_view subquery + spans_view subquery
+    expect(countDedupes(countSql!)).toBe(1)
+  })
+
+  it('count applies status filters AFTER the dedupe (latest snapshot wins)', async () => {
+    await listTracesFromEvents({
+      organizationId: ORG,
+      status: 'completed',
+      limit: 50,
+      offset: 0,
+    })
+    const countSql = mockQuery.mock.calls[1]![0]!.query
+    // The dedupe subquery must close before the status condition appears,
+    // otherwise a stale 'running' snapshot of a completed trace would
+    // still match the filter.
+    const dedupeIdx = countSql.search(DEDUPE)
+    const statusIdx = countSql.indexOf('t.status = {status:String}')
+    expect(dedupeIdx).toBeGreaterThan(-1)
+    expect(statusIdx).toBeGreaterThan(dedupeIdx)
+  })
+
+  it('detail queries dedupe the trace row, the span aggregate, and the span list', async () => {
+    await getTraceWithSpansFromEvents(TRACE, ORG)
+    const [traceSql, spansSql] = mockQuery.mock.calls.map((c) => c[0]!.query)
+    expect(countDedupes(traceSql!)).toBe(2) // trace subquery + span aggregate subquery
+    expect(countDedupes(spansSql!)).toBe(1)
+    // Display order is still chronological — the dedupe must not leak
+    // its created_at ordering into the rendered span tree.
+    expect(spansSql!.trim().endsWith('ORDER BY started_at ASC')).toBe(true)
+  })
+
+  it('every subquery stays org-scoped (no RLS in ClickHouse)', async () => {
+    await listTracesFromEvents({ organizationId: ORG, limit: 50, offset: 0 })
+    await getTraceWithSpansFromEvents(TRACE, ORG)
+    for (const call of mockQuery.mock.calls) {
+      const { query, query_params } = call[0] as unknown as {
+        query: string
+        query_params: Record<string, unknown>
+      }
+      expect(query).toContain('organization_id = {orgId:UUID}')
+      expect(query_params['orgId']).toBe(ORG)
+    }
+  })
+})

--- a/apps/server/src/lib/traces-events-queries.ts
+++ b/apps/server/src/lib/traces-events-queries.ts
@@ -100,6 +100,14 @@ export async function listTracesFromEvents(opts: TraceListOptions): Promise<Trac
   // Aggregate span totals per trace_id. LEFT JOIN so a trace with
   // zero recorded spans still appears (matches the Postgres view
   // where span_count starts at 0).
+  //
+  // DEDUPE (R-12 Phase 3.2): `events` is append-only — a trace accrues
+  // one row per lifecycle write (create, PATCH update, backfill re-insert),
+  // all sharing the same event_id. Without `LIMIT 1 BY id` the list shows
+  // the same trace once per lifecycle row (dogfood 2026-06-10 surfaced
+  // exactly this). `ORDER BY created_at DESC LIMIT 1 BY id` keeps the
+  // newest snapshot per trace; events-writer stamps update events with
+  // eventTime=now so they win this tie-break.
   const listQuery = `
     SELECT
       toString(t.id)                          AS id,
@@ -115,15 +123,24 @@ export async function listTracesFromEvents(opts: TraceListOptions): Promise<Trac
       toFloat64(coalesce(s.total_cost_usd, 0)) AS total_cost_usd,
       t.error_message,
       toString(t.created_at)                  AS created_at
-    FROM traces_view t
+    FROM (
+      SELECT * FROM traces_view
+      WHERE organization_id = {orgId:UUID}
+      ORDER BY created_at DESC
+      LIMIT 1 BY id
+    ) t
     LEFT JOIN (
       SELECT
         trace_id,
         count() AS span_count,
         sum(total_tokens) AS total_tokens,
         sum(coalesce(cost_usd, 0)) AS total_cost_usd
-      FROM spans_view
-      WHERE organization_id = {orgId:UUID}
+      FROM (
+        SELECT * FROM spans_view
+        WHERE organization_id = {orgId:UUID}
+        ORDER BY created_at DESC
+        LIMIT 1 BY id
+      )
       GROUP BY trace_id
     ) s ON s.trace_id = t.id
     WHERE ${where}
@@ -131,7 +148,16 @@ export async function listTracesFromEvents(opts: TraceListOptions): Promise<Trac
     LIMIT {lim:UInt32} OFFSET {off:UInt32}
   `.trim()
 
-  const countQuery = `SELECT count() AS c FROM traces_view t WHERE ${where}`
+  // Count over the deduped set — and the WHERE must apply AFTER the
+  // dedupe so a status filter sees each trace's latest snapshot only.
+  const countQuery = `
+    SELECT count() AS c FROM (
+      SELECT * FROM traces_view
+      WHERE organization_id = {orgId:UUID}
+      ORDER BY created_at DESC
+      LIMIT 1 BY id
+    ) t WHERE ${where}
+  `.trim()
 
   const ch = unscopedClickhouse()
   const [listRes, countRes] = await Promise.all([
@@ -231,18 +257,26 @@ export async function getTraceWithSpansFromEvents(
       toString(t.created_at)                               AS created_at,
       toString(t.updated_at)                               AS updated_at,
       t.external_trace_id                                  AS external_trace_id
-    FROM traces_view t
+    FROM (
+      SELECT * FROM traces_view
+      WHERE id = {traceId:UUID} AND organization_id = {orgId:UUID}
+      ORDER BY created_at DESC
+      LIMIT 1 BY id
+    ) t
     LEFT JOIN (
       SELECT
         trace_id,
         count() AS span_count,
         sum(total_tokens) AS total_tokens,
         sum(coalesce(cost_usd, 0)) AS total_cost_usd
-      FROM spans_view
-      WHERE organization_id = {orgId:UUID} AND trace_id = {traceId:UUID}
+      FROM (
+        SELECT * FROM spans_view
+        WHERE organization_id = {orgId:UUID} AND trace_id = {traceId:UUID}
+        ORDER BY created_at DESC
+        LIMIT 1 BY id
+      )
       GROUP BY trace_id
     ) s ON s.trace_id = t.id
-    WHERE t.id = {traceId:UUID} AND t.organization_id = {orgId:UUID}
     LIMIT 1
   `.trim()
 
@@ -268,8 +302,12 @@ export async function getTraceWithSpansFromEvents(
       completion_tokens,
       total_tokens,
       cost_usd
-    FROM spans_view
-    WHERE trace_id = {traceId:UUID} AND organization_id = {orgId:UUID}
+    FROM (
+      SELECT * FROM spans_view
+      WHERE trace_id = {traceId:UUID} AND organization_id = {orgId:UUID}
+      ORDER BY created_at DESC
+      LIMIT 1 BY id
+    )
     ORDER BY started_at ASC
   `.trim()
 


### PR DESCRIPTION
## Summary

Sprint 9 follow-up. Flipping the dogfood org's `read_from_events` (the final Sprint 9 step from #309) immediately surfaced three defects in the traces events read path. Requests list + stats showed **perfect parity** (50 rows, identical cost/latency); traces did not. The flag was rolled back to `false` pending this fix.

### Defect 1 — no dedupe (visible as duplicate rows in /traces)
`events` is append-only: create + PATCH update + backfill re-insert all share one `event_id`. The view queries returned every lifecycle row, so the same trace rendered 2x+ with conflicting statuses (`""` vs `running`). All five queries in `traces-events-queries.ts` now collapse to the latest snapshot per id via `ORDER BY created_at DESC LIMIT 1 BY id` before filters/joins/aggregates; the count query filters AFTER the dedupe.

### Defect 2 — PATCH handlers never dual-wrote
`PATCH /ingest/traces/:id` and `PATCH /ingest/spans/:id` (where status/ended_at/duration/usage/cost land) had no events write, so the events path froze every trace in its create-time state. Both now append a full-state snapshot event. `events-writer` takes an `eventTime` param so update events get `created_at = now` and win the dedupe tie-break.

### Defect 3 — span events silently lost since dual-write start 🔥
`POST /ingest/traces/:id/spans` dual-write passed `projectId: insert.project_id ?? ''` — but spans carry no `project_id` column, so it was ALWAYS `''`, which fails ClickHouse's UUID column, gets queued to `events_fallback`, and expires after 7d/100 retries. This is why the dogfood trace detail showed 0 spans. `project_id` now comes from the parent trace.

### Known remaining gaps (deliberately not in this PR)
- OTLP `/v1/traces` ingest doesn't dual-write events at all → part of the 127 vs 114 trace-count drift. Follow-up item.
- Historical span events lost to Defect 3 (2026-06-06 ~ now) need a `backfill-spans-from-supabase` re-run after this deploys (idempotent thanks to the dedupe).

## Test plan
- [x] `traces-events-queries.test.ts` (new, 4 tests): dedupe present in all 5 queries, filter-after-dedupe ordering, chronological span order preserved, org scoping on every subquery
- [x] `events-writer.test.ts` +3: eventTime stamps created_at while start_time keeps startedAt
- [x] server typecheck / lint / test (888 passed)
- [ ] CI green → merge → re-flip dogfood org → before/after re-verify → 24h monitoring