### PR TITLE
fix(server): traces events path returns ISO UTC timestamps (gotcha #18)

### DIFF
--- a/apps/server/src/lib/traces-events-queries.test.ts
+++ b/apps/server/src/lib/traces-events-queries.test.ts
@@ -20,6 +20,10 @@ const { mockQuery } = vi.hoisted(() => ({
 
 vi.mock('./clickhouse.js', () => ({
   unscopedClickhouse: () => ({ query: mockQuery }),
+  // Real implementation is a pure string transform — inline it so the
+  // timestamp-conversion assertions test actual behaviour.
+  fromClickhouseTimestamp: (s: string | null | undefined) =>
+    s ? s.replace(' ', 'T') + 'Z' : null,
 }))
 
 import { listTracesFromEvents, getTraceWithSpansFromEvents } from './traces-events-queries.js'
@@ -70,6 +74,95 @@ describe('traces-events-queries dedupe', () => {
     // Display order is still chronological — the dedupe must not leak
     // its created_at ordering into the rendered span tree.
     expect(spansSql!.trim().endsWith('ORDER BY started_at ASC')).toBe(true)
+  })
+
+  it('converts ClickHouse timestamps to ISO UTC at the API boundary (gotcha #18)', async () => {
+    // ClickHouse DateTime64 has no T/Z — without conversion a KST browser
+    // parses it as local time and renders every trace "9 hours ago".
+    mockQuery.mockResolvedValueOnce({
+      json: async () => [
+        {
+          id: TRACE,
+          project_id: '00000000-0000-4000-8000-00000000000b',
+          name: 'agent_run',
+          status: 'completed',
+          started_at: '2026-06-10 12:36:41.452',
+          ended_at: '2026-06-10 12:37:01.465',
+          duration_ms: '20013',
+          span_count: '1',
+          total_tokens: '100',
+          total_cost_usd: '0.001',
+          error_message: null,
+          created_at: '2026-06-10 12:36:41.452',
+        },
+      ],
+    })
+    mockQuery.mockResolvedValueOnce({ json: async () => [{ c: '1' }] })
+
+    const result = await listTracesFromEvents({ organizationId: ORG, limit: 50, offset: 0 })
+    const row = result.rows[0]!
+    expect(row.started_at).toBe('2026-06-10T12:36:41.452Z')
+    expect(row.ended_at).toBe('2026-06-10T12:37:01.465Z')
+    expect(row.created_at).toBe('2026-06-10T12:36:41.452Z')
+    // null ended_at stays null, not the string 'null'
+    mockQuery.mockResolvedValueOnce({
+      json: async () => [
+        {
+          id: TRACE,
+          name: 'running_trace',
+          status: 'running',
+          started_at: '2026-06-10 12:36:41.452',
+          ended_at: null,
+          created_at: '2026-06-10 12:36:41.452',
+        },
+      ],
+    })
+    mockQuery.mockResolvedValueOnce({ json: async () => [{ c: '1' }] })
+    const running = await listTracesFromEvents({ organizationId: ORG, limit: 50, offset: 0 })
+    expect(running.rows[0]!.ended_at).toBeNull()
+  })
+
+  it('detail path converts trace and span timestamps too', async () => {
+    mockQuery.mockResolvedValueOnce({
+      json: async () => [
+        {
+          id: TRACE,
+          organization_id: ORG,
+          name: 'agent_run',
+          status: 'completed',
+          started_at: '2026-06-10 12:36:41.452',
+          ended_at: '2026-06-10 12:37:01.465',
+          created_at: '2026-06-10 12:36:41.452',
+          updated_at: '2026-06-10 12:37:01.465',
+          duration_ms: '20013',
+          span_count: '1',
+          total_tokens: '100',
+          total_cost_usd: '0.001',
+        },
+      ],
+    })
+    mockQuery.mockResolvedValueOnce({
+      json: async () => [
+        {
+          id: '00000000-0000-4000-8000-00000000000c',
+          name: 'llm_call',
+          started_at: '2026-06-10 12:36:42.000',
+          ended_at: null,
+          duration_ms: null,
+          prompt_tokens: '10',
+          completion_tokens: '5',
+          total_tokens: '15',
+          cost_usd: null,
+        },
+      ],
+    })
+
+    const { trace, spans } = await getTraceWithSpansFromEvents(TRACE, ORG)
+    expect(trace?.started_at).toBe('2026-06-10T12:36:41.452Z')
+    expect(trace?.ended_at).toBe('2026-06-10T12:37:01.465Z')
+    expect(trace?.updated_at).toBe('2026-06-10T12:37:01.465Z')
+    expect(spans[0]!.started_at).toBe('2026-06-10T12:36:42.000Z')
+    expect(spans[0]!.ended_at).toBeNull()
   })
 
   it('every subquery stays org-scoped (no RLS in ClickHouse)', async () => {

--- a/apps/server/src/lib/traces-events-queries.ts
+++ b/apps/server/src/lib/traces-events-queries.ts
@@ -19,7 +19,7 @@
  * doesn't carry them as first-class columns.
  */
 
-import { unscopedClickhouse } from './clickhouse.js'
+import { unscopedClickhouse, fromClickhouseTimestamp } from './clickhouse.js'
 
 export interface TraceListOptions {
   organizationId: string
@@ -178,10 +178,16 @@ export async function listTracesFromEvents(opts: TraceListOptions): Promise<Trac
   const total = Number(countRows[0]?.c ?? 0)
 
   // CH returns Decimal/UInt64 as strings on JSON output (gotcha #19);
-  // coerce here so the API contract stays numeric.
+  // coerce here so the API contract stays numeric. Timestamps come back
+  // as 'YYYY-MM-DD HH:MM:SS.fff' with no T/Z — JS new Date() parses that
+  // as LOCAL time, so a KST dashboard showed every trace "9 hours ago"
+  // (gotcha #18; the Postgres path returns timezone-aware ISO strings).
   return {
     rows: rows.map((r) => ({
       ...r,
+      started_at: fromClickhouseTimestamp(r.started_at) ?? r.started_at,
+      ended_at: r.ended_at == null ? null : fromClickhouseTimestamp(r.ended_at),
+      created_at: fromClickhouseTimestamp(r.created_at) ?? r.created_at,
       duration_ms: r.duration_ms == null ? null : Number(r.duration_ms),
       span_count: Number(r.span_count) || 0,
       total_tokens: Number(r.total_tokens) || 0,
@@ -319,9 +325,15 @@ export async function getTraceWithSpansFromEvents(
   const traceRows = (await traceRes.json()) as TraceDetailRow[]
   const spanRows = (await spansRes.json()) as SpanDetailRow[]
 
+  // Same ISO-UTC conversion rationale as the list path (gotcha #18).
   const trace = traceRows[0]
     ? {
         ...traceRows[0],
+        started_at: fromClickhouseTimestamp(traceRows[0].started_at) ?? traceRows[0].started_at,
+        ended_at:
+          traceRows[0].ended_at == null ? null : fromClickhouseTimestamp(traceRows[0].ended_at),
+        created_at: fromClickhouseTimestamp(traceRows[0].created_at) ?? traceRows[0].created_at,
+        updated_at: fromClickhouseTimestamp(traceRows[0].updated_at) ?? traceRows[0].updated_at,
         duration_ms:
           traceRows[0].duration_ms == null ? null : Number(traceRows[0].duration_ms),
         span_count: Number(traceRows[0].span_count) || 0,
@@ -332,6 +344,8 @@ export async function getTraceWithSpansFromEvents(
 
   const spans = spanRows.map((s) => ({
     ...s,
+    started_at: fromClickhouseTimestamp(s.started_at) ?? s.started_at,
+    ended_at: s.ended_at == null ? null : fromClickhouseTimestamp(s.ended_at),
     duration_ms: s.duration_ms == null ? null : Number(s.duration_ms),
     prompt_tokens: Number(s.prompt_tokens) || 0,
     completion_tokens: Number(s.completion_tokens) || 0,


### PR DESCRIPTION
## Summary

Live dogfood catch #4: a trace created seconds ago displayed as "9 hours ago" on /traces — exactly the KST offset.

The traces events read path returned ClickHouse `DateTime64` strings raw (`2026-06-10 12:36:41.452`, no `T`/`Z`). JS `new Date()` parses that as **local** time, so a KST browser shifts every timestamp back 9 hours. The legacy Postgres path returns timezone-aware ISO strings, so this only bites orgs flipped to `read_from_events` (currently: dogfood org only).

Fix: `fromClickhouseTimestamp()` on `started_at` / `ended_at` / `created_at` / `updated_at` for trace list rows, trace detail, and span rows — the same gotcha #18 treatment `requests.ts` / `sessions.ts` / `security.ts` / `exports.ts` already apply at their API boundaries. Nullable `ended_at` stays `null`.

Side note from the same dogfood pass: the new trace appeared on the events path as `completed` / span_count 1 within seconds — first production proof that the PR #310 PATCH dual-write works on live traffic.

## Test plan
- [x] +2 tests (list + detail conversion, null `ended_at` passthrough) — 890 pass
- [x] typecheck / lint clean
- [ ] CI green → merge → production: /traces top row shows relative time correctly