### PR TITLE
feat(server): R-12 Phase 3.2b — OTLP /v1/traces events dual-write

### DIFF
--- a/apps/server/src/__tests__/otlp-events-dual-write.test.ts
+++ b/apps/server/src/__tests__/otlp-events-dual-write.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Sprint 10 R-12 Phase 3.2b — OTLP `/v1/traces` receiver dual-writes to
+ * the events store so orgs flipped to `read_from_events` see OTLP
+ * traces too. Pre-3.2b they only landed in Postgres and the events
+ * read path showed zero OTLP traces.
+ *
+ * The OTLP path is more constrained than the SDK ingest path:
+ *   - events.event_id MUST be UUID, OTLP carries hex span IDs → the
+ *     handler pre-assigns a Postgres UUID per span and threads it
+ *     through to both INSERT and the events shadow.
+ *   - parent_event_id MUST be UUID too → in-batch parent lookup via a
+ *     hex→UUID map; cross-batch parents stay null until a follow-up
+ *     events-side orphan-link migration.
+ *   - Spans the per-row fallback INSERT rejected must NOT appear on
+ *     the events side either (the two read paths stay consistent).
+ */
+
+const state = vi.hoisted(() => ({
+  traceUpsertResult: { data: { id: 'trace-uuid-1' }, error: null } as {
+    data: { id: string } | null
+    error: { message: string } | null
+  },
+  /** Per-row INSERT result queue (drained by single-row fallback). */
+  spanSingleInsertResults: [] as Array<{ error: { message: string } | null }>,
+  /** If true, the initial bulk INSERT fails and the handler falls back to per-row. */
+  bulkInsertFails: false,
+  /** Captured (table, payload) tuples in INSERT order. */
+  insertCalls: [] as Array<{ table: string; payload: unknown }>,
+  /** Auth: pretend a full-scope key resolved successfully. */
+  apiKeyRow: {
+    id: 'apikey-1',
+    organization_id: 'org-1',
+    scope: 'full',
+    project_id: 'project-1',
+    api_keys_to_projects: { project_id: 'project-1' },
+  } as unknown,
+}))
+
+const { writeTraceMock, writeSpanMock } = vi.hoisted(() => ({
+  writeTraceMock: vi.fn(async (_input: unknown) => undefined),
+  writeSpanMock: vi.fn(async (_input: unknown) => undefined),
+}))
+
+vi.mock('../lib/events-writer.js', () => ({
+  writeTraceAsEvent: writeTraceMock,
+  writeSpanAsEvent: writeSpanMock,
+}))
+
+// Bypass auth so we can hit the OTLP handler directly. The middleware
+// chain reads c.get(...) for organizationId / projectId / apiKeyId; we
+// inject those via a wrapper middleware below.
+vi.mock('../middleware/authApiKey.js', async (importOriginal) => {
+  const orig = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...orig,
+    authApiKey: async (
+      c: { set: (k: string, v: unknown) => void },
+      next: () => Promise<void>,
+    ) => {
+      c.set('organizationId', 'org-1')
+      c.set('projectId', 'project-1')
+      c.set('apiKeyId', 'apikey-1')
+      await next()
+    },
+  }
+})
+
+vi.mock('../middleware/requireFullScope.js', () => ({
+  requireFullScope: async (_c: unknown, next: () => Promise<void>) => {
+    await next()
+  },
+}))
+
+vi.mock('../lib/db.js', () => {
+  const buildChain = (table: string, payload: unknown): unknown => {
+    state.insertCalls.push({ table, payload })
+
+    if (table === 'traces') {
+      const chain = {
+        upsert: () => chain,
+        insert: () => chain,
+        select: () => chain,
+        single: async () => state.traceUpsertResult,
+      }
+      return chain
+    }
+
+    if (table === 'spans') {
+      // spans.insert is called either with an array (bulk) or a single row.
+      const isArray = Array.isArray(payload)
+      if (isArray) {
+        return {
+          // bulk INSERT — no .select chain in the handler
+          then: (onFulfilled: (v: { error: { message: string } | null }) => unknown) =>
+            Promise.resolve(state.bulkInsertFails ? { error: { message: 'bulk poisoned' } } : { error: null }).then(onFulfilled),
+        }
+      }
+      // single-row fallback INSERT
+      const result = state.spanSingleInsertResults.shift() ?? { error: null }
+      return {
+        then: (onFulfilled: (v: { error: { message: string } | null }) => unknown) =>
+          Promise.resolve(result).then(onFulfilled),
+      }
+    }
+
+    return {}
+  }
+
+  const supabaseAdmin = {
+    from: (table: string) => ({
+      upsert: (payload: unknown) => buildChain(table, payload),
+      insert: (payload: unknown) => buildChain(table, payload),
+    }),
+  }
+  return { supabaseAdmin, supabaseClient: {} }
+})
+
+import { otlpRouter } from '../api/otlp.js'
+
+const ORG = 'org-1'
+const TRACE_ID_HEX = '0123456789abcdef0123456789abcdef'
+
+function makeOtlpBody(spans: Array<{ spanId: string; parentSpanId?: string; name: string }>) {
+  return {
+    resourceSpans: [
+      {
+        scopeSpans: [
+          {
+            spans: spans.map((s) => ({
+              traceId: TRACE_ID_HEX,
+              spanId: s.spanId,
+              parentSpanId: s.parentSpanId ?? '',
+              name: s.name,
+              kind: 1,
+              startTimeUnixNano: '1718000000000000000',
+              endTimeUnixNano: '1718000001000000000',
+              status: { code: 1 },
+              attributes: [
+                { key: 'gen_ai.operation.name', value: { stringValue: 'chat' } },
+              ],
+            })),
+          },
+        ],
+      },
+    ],
+  }
+}
+
+async function postOtlp(body: unknown): Promise<Response> {
+  return otlpRouter.request('/v1/traces', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+describe('OTLP /v1/traces — events dual-write (R-12 Phase 3.2b)', () => {
+  beforeEach(() => {
+    state.traceUpsertResult = { data: { id: 'trace-uuid-1' }, error: null }
+    state.spanSingleInsertResults = []
+    state.bulkInsertFails = false
+    state.insertCalls = []
+    writeTraceMock.mockReset()
+    writeSpanMock.mockReset()
+  })
+
+  it('writes exactly one trace event per OTLP trace group', async () => {
+    const res = await postOtlp(makeOtlpBody([{ spanId: 'aaaaaaaaaaaaaaaa', name: 'root' }]))
+    expect(res.status).toBe(200)
+    expect(writeTraceMock).toHaveBeenCalledTimes(1)
+    const traceInput = writeTraceMock.mock.calls[0]![0] as Record<string, unknown>
+    expect(traceInput['traceId']).toBe('trace-uuid-1')
+    expect(traceInput['organizationId']).toBe(ORG)
+    expect(traceInput['name']).toBe('root')
+    expect(traceInput['status']).toBe('completed')
+  })
+
+  it('uses the Postgres-assigned UUID (not the OTLP hex span ID) as event_id', async () => {
+    await postOtlp(makeOtlpBody([{ spanId: 'aaaaaaaaaaaaaaaa', name: 'root' }]))
+    expect(writeSpanMock).toHaveBeenCalledTimes(1)
+    const spanInput = writeSpanMock.mock.calls[0]![0] as Record<string, unknown>
+    expect(spanInput['spanId']).toEqual(expect.stringMatching(UUID_RE))
+    expect(spanInput['spanId']).not.toBe('aaaaaaaaaaaaaaaa')
+    expect(spanInput['traceId']).toBe('trace-uuid-1')
+  })
+
+  it('links in-batch parents via hex→UUID and leaves cross-batch parents null', async () => {
+    await postOtlp(
+      makeOtlpBody([
+        { spanId: 'aaaaaaaaaaaaaaaa', name: 'root' },
+        { spanId: 'bbbbbbbbbbbbbbbb', parentSpanId: 'aaaaaaaaaaaaaaaa', name: 'child-in-batch' },
+        { spanId: 'cccccccccccccccc', parentSpanId: 'ffffffffffffffff', name: 'child-cross-batch' },
+      ]),
+    )
+    const spanCalls = writeSpanMock.mock.calls.map((c) => c[0] as Record<string, unknown>)
+    expect(spanCalls).toHaveLength(3)
+
+    const rootId = spanCalls[0]!['spanId']
+    expect(spanCalls[0]!['parentSpanId']).toBeNull() // root
+
+    // Same-batch parent: child references the root's UUID, not the hex span ID.
+    const child = spanCalls[1]!
+    expect(child['parentSpanId']).toBe(rootId)
+    expect(child['parentSpanId']).not.toBe('aaaaaaaaaaaaaaaa')
+
+    // Cross-batch parent: not in this OTLP export → stays null.
+    const cross = spanCalls[2]!
+    expect(cross['parentSpanId']).toBeNull()
+  })
+
+  it('inserts the same UUID into Postgres spans.id and events.event_id', async () => {
+    await postOtlp(makeOtlpBody([{ spanId: 'aaaaaaaaaaaaaaaa', name: 'root' }]))
+    const spansInsertCall = state.insertCalls.find((c) => c.table === 'spans')!
+    const pgRow = (spansInsertCall.payload as Array<{ id: string }>)[0]!
+    const eventSpanId = (writeSpanMock.mock.calls[0]![0] as Record<string, unknown>)['spanId']
+    expect(pgRow.id).toBe(eventSpanId)
+    expect(pgRow.id).toEqual(expect.stringMatching(UUID_RE))
+  })
+
+  it('skips events shadow writes for spans the per-row fallback rejected', async () => {
+    state.bulkInsertFails = true
+    state.spanSingleInsertResults = [
+      { error: null }, // span #1 succeeds
+      { error: { message: 'CHECK constraint violation' } }, // span #2 rejected
+    ]
+    const res = await postOtlp(
+      makeOtlpBody([
+        { spanId: 'aaaaaaaaaaaaaaaa', name: 'ok' },
+        { spanId: 'bbbbbbbbbbbbbbbb', name: 'bad' },
+      ]),
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { partialSuccess?: { rejectedSpans: number } }
+    expect(body.partialSuccess?.rejectedSpans).toBe(1)
+
+    // Only the surviving span flows into events.
+    expect(writeSpanMock).toHaveBeenCalledTimes(1)
+    const spanInput = writeSpanMock.mock.calls[0]![0] as Record<string, unknown>
+    expect(spanInput['name']).toBe('ok')
+  })
+
+  it('still returns 200 when events shadow writes throw (best-effort contract)', async () => {
+    writeTraceMock.mockRejectedValueOnce(new Error('CH unreachable'))
+    writeSpanMock.mockRejectedValueOnce(new Error('CH unreachable'))
+    const res = await postOtlp(makeOtlpBody([{ spanId: 'aaaaaaaaaaaaaaaa', name: 'root' }]))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    // No partialSuccess — the Postgres source-of-truth row landed cleanly.
+    expect(body['partialSuccess']).toBeUndefined()
+  })
+
+  it('propagates error status to the trace event when any span reports error', async () => {
+    const body = makeOtlpBody([{ spanId: 'aaaaaaaaaaaaaaaa', name: 'root' }])
+    // Mark the span as ERROR (status.code === 2).
+    body.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.status = { code: 2 }
+    await postOtlp(body)
+    const traceInput = writeTraceMock.mock.calls[0]![0] as Record<string, unknown>
+    expect(traceInput['status']).toBe('error')
+    expect(traceInput['errorMessage']).toBe('One or more spans reported errors')
+  })
+})

--- a/apps/server/src/api/otlp.ts
+++ b/apps/server/src/api/otlp.ts
@@ -18,6 +18,7 @@
  */
 
 import { Hono } from 'hono'
+import { randomUUID } from 'node:crypto'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
 import { requireFullScope } from '../middleware/requireFullScope.js'
 import { supabaseAdmin } from '../lib/db.js'
@@ -30,6 +31,7 @@ import {
   type OtlpExportRequest,
   type MappedSpanRow,
 } from '../lib/otlp-mapper.js'
+import { writeTraceAsEvent, writeSpanAsEvent } from '../lib/events-writer.js'
 import { ApiError } from '../lib/errors.js'
 
 export const otlpRouter = new Hono<ApiKeyContext>()
@@ -119,9 +121,31 @@ otlpRouter.post('/v1/traces', authApiKey, requireFullScope, async (c) => {
       const traceUuid = traceRow.id as string
 
       // ── 3. Build final span rows with the real trace UUID ──────────
-      const spanRows: MappedSpanRow[] = spans.map((s) =>
-        mapOtlpSpan(s, traceUuid, organizationId),
-      )
+      //
+      // R-12 Phase 3.2b: pre-assign a Postgres UUID per span so the same
+      // id can be threaded through to events.event_id. ClickHouse demands
+      // UUID for event_id / parent_event_id — we can't use the raw OTLP
+      // hex span_id there. The Postgres `spans.id` column has
+      // `DEFAULT gen_random_uuid()`, so supplying an explicit id is a
+      // no-op for existing behaviour. The in-batch hex→UUID map below
+      // also lets parent_event_id link spans whose parent arrived in the
+      // same OTLP export; cross-batch parents stay null in events (the
+      // existing orphan-span-link background migration only touches the
+      // Postgres side).
+      type SpanRowWithId = MappedSpanRow & { id: string }
+      const hexToUuid = new Map<string, string>()
+      const spanRows: SpanRowWithId[] = spans.map((s) => {
+        const row = mapOtlpSpan(s, traceUuid, organizationId) as SpanRowWithId
+        row.id = randomUUID()
+        if (row.external_span_id) hexToUuid.set(row.external_span_id, row.id)
+        return row
+      })
+
+      // Track which spans actually landed in Postgres so we don't
+      // dual-write events for rows the bulk + per-row INSERT both
+      // rejected. Keeps the two read paths consistent (rejected on
+      // legacy → also missing on events).
+      const insertedIds = new Set<string>(spanRows.map((r) => r.id))
 
       // ── 4. Bulk insert spans ───────────────────────────────────────
       const { error: bulkErr } = await supabaseAdmin.from('spans').insert(spanRows)
@@ -130,16 +154,95 @@ otlpRouter.post('/v1/traces', authApiKey, requireFullScope, async (c) => {
         // Bulk insert failed (e.g., a single bad row poisoned the batch).
         // Fall back to per-row inserts so we can count precise failures.
         console.warn('[otlp] bulk span insert failed, retrying individually:', bulkErr.message)
+        insertedIds.clear()
         for (const row of spanRows) {
           const { error: singleErr } = await supabaseAdmin.from('spans').insert(row)
           if (singleErr) {
             console.error('[otlp] single span insert failed:', singleErr.message)
             rejectedSpans++
+          } else {
+            insertedIds.add(row.id)
           }
         }
       }
 
-      // ── 5. Parent linkage runs asynchronously (R-14, Sprint 5) ─────
+      // ── 5. Events dual-write (R-12 Phase 3.2b) ─────────────────────
+      // Without this, orgs flipped to read_from_events lose every OTLP
+      // trace and its spans — the Postgres rows land but events stays
+      // empty. The SDK ingest path (api/ingest.ts) added this in PR #310;
+      // OTLP was the remaining gap that left the dogfood org with a
+      // 127-vs-113 trace-count drift between the two read paths.
+      //
+      // Best-effort: failures here log loudly but never reject the OTLP
+      // export — the source-of-truth Postgres rows already landed and
+      // the legacy read path keeps working. The events-writer queues
+      // failed inserts to `events_fallback` (logger.ts pattern) so the
+      // `/cron/replay-fallback` cron drains them when CH recovers.
+      try {
+        await writeTraceAsEvent({
+          traceId:        traceUuid,
+          organizationId,
+          projectId,
+          apiKeyId,
+          name:           traceName,
+          startedAt,
+          endedAt:        endedAt ?? null,
+          status:         traceStatus,
+          errorMessage:   hasError ? 'One or more spans reported errors' : null,
+          durationMs:     durationMs,
+        })
+      } catch (err) {
+        console.error('[otlp] trace events shadow INSERT failed:', err instanceof Error ? err.message : err)
+      }
+
+      // Map each successfully-inserted span to an event_type='span' row.
+      // We rely on the Postgres bulk INSERT having succeeded; spans the
+      // per-row fallback rejected stay out of events too (consistent
+      // with the Postgres read path).
+      //
+      // OTLP spans don't carry usage on every row — only LLM-kind spans
+      // (gen_ai.usage.*) have prompt/completion tokens. We just thread
+      // whatever the mapper produced; events-writer's default-zero
+      // behaviour keeps non-LLM spans well-formed.
+      for (const row of spanRows) {
+        if (!insertedIds.has(row.id)) continue
+        // parent_event_id MUST be a UUID. If the parent landed in the
+        // same OTLP batch we already know its assigned UUID; otherwise
+        // (cross-batch parent) leave null and let a future events-side
+        // orphan-link migration backfill it.
+        const parentEventId =
+          row.external_parent_span_id != null
+            ? (hexToUuid.get(row.external_parent_span_id) ?? null)
+            : null
+        try {
+          await writeSpanAsEvent({
+            spanId:         row.id,
+            traceId:        traceUuid,
+            parentSpanId:   parentEventId,
+            organizationId,
+            projectId,
+            apiKeyId,
+            name:           row.name,
+            spanType:       row.span_type,
+            startedAt:      row.started_at,
+            endedAt:        row.ended_at,
+            durationMs:     row.duration_ms,
+            status:         row.status,
+            errorMessage:   row.error_message,
+            input:          row.input,
+            output:         row.output,
+            metadata:       row.metadata,
+            promptTokens:   row.prompt_tokens,
+            completionTokens: row.completion_tokens,
+            totalTokens:    row.total_tokens,
+            costUsd:        row.cost_usd,
+          })
+        } catch (err) {
+          console.error('[otlp] span events shadow INSERT failed:', err instanceof Error ? err.message : err)
+        }
+      }
+
+      // ── 6. Parent linkage runs asynchronously (R-14, Sprint 5) ─────
       // The synchronous link_otlp_span_parents() RPC used to run here
       // turned each OTLP batch into N+1 round-trips on the spans table.
       // It now lives in the `orphan-span-link` background migration


### PR DESCRIPTION
## Summary

Sprint 10 first PR. Closes the OTLP gap [PR #310](https://github.com/spanlens/Spanlens/pull/310) explicitly deferred — without this, orgs flipped to \`read_from_events\` show **zero OTLP traces** (dogfood drift seen 2026-06-10: 127 Postgres traces vs 113 on the events read path). Must land before any Phase 3.3 cutover.

### Why the OTLP path needed extra plumbing vs SDK ingest
- \`events.event_id\` is a ClickHouse \`UUID\` column. OTLP carries **hex** span IDs (\`spanId: '0123abc...'\`), not UUIDs — they can't be used directly. The handler now pre-assigns a Postgres UUID per span (\`randomUUID()\`) and threads it through to both \`spans.id\` INSERT and \`events.event_id\`. The Postgres column has \`DEFAULT gen_random_uuid()\` so supplying explicit ids is a no-op for legacy reads.
- \`parent_event_id\` is also UUID. An in-batch \`hex → UUID\` map handles parents that arrived in the same OTLP export. Cross-batch parents stay \`null\` until a future events-side orphan-link migration (mirrors the existing Postgres-side R-14 \`orphan-span-link\` job).
- An \`insertedIds\` set tracks which spans actually landed in Postgres so the events shadow write skips rows the per-row fallback INSERT rejected. The two read paths stay consistent.
- Events writes are best-effort: failures log but never reject the OTLP export. \`events-writer\` queues failed inserts to \`events_fallback\`, so \`/cron/replay-fallback\` drains them when CH recovers.

## Test plan
- [x] +7 unit tests (\`otlp-events-dual-write.test.ts\`): exactly-one trace per group, UUID (not hex) as event_id, in-batch parent linking + cross-batch null, same UUID in pg+events, rejected-row skip, best-effort CH-down contract, error-status propagation
- [x] \`pnpm --filter server typecheck\` / \`lint\` / \`test\` (897 pass, +7 from 890)
- [ ] CI green → merge → production
- [ ] Post-deploy verification: send a test OTLP trace, confirm it appears on \`/api/v1/traces\` (events path) for the dogfood org