### PR TITLE
fix(server): detect-missing-model-prices await logCronRun (gotcha #8)

### DIFF
--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -805,7 +805,16 @@ cronRouter.get('/detect-missing-model-prices', async (c) => {
     })
 
     if (insertError) {
-      logCronRun(
+      // gotcha #8: await before returning. The ClickHouse query in this
+      // handler can take 30s on a cold-start ClickHouse Cloud instance,
+      // eating into the lambda's budget. An unawaited supabase INSERT
+      // racing the lambda shutdown loses the cron_job_runs row, which is
+      // exactly what self-monitor watches — silent failures slip past.
+      // The other cron handlers use the same .catch() pattern and got
+      // away with it because their happy paths are sub-second; this one
+      // can't. Inner .catch swallows logger failures so they don't mask
+      // the original error in the response.
+      await logCronRun(
         'detect-missing-model-prices',
         'error',
         Date.now() - start,
@@ -814,11 +823,11 @@ cronRouter.get('/detect-missing-model-prices', async (c) => {
       return c.json({ ok: false, error: 'failed to insert alert' }, 500)
     }
 
-    logCronRun('detect-missing-model-prices', 'ok', Date.now() - start).catch(console.error)
+    await logCronRun('detect-missing-model-prices', 'ok', Date.now() - start).catch(console.error)
     return c.json({ ok: true, missing: models.length, models })
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
-    logCronRun('detect-missing-model-prices', 'error', Date.now() - start, message).catch(console.error)
+    await logCronRun('detect-missing-model-prices', 'error', Date.now() - start, message).catch(console.error)
     return c.json({ ok: false, error: message }, 500)
   }
 })


### PR DESCRIPTION
## Summary

While verifying PR #314 (the cron fixes for \`aggregate-usage\` / \`prune-logs\`), the workflow_dispatch tick at 02:00 UTC showed \`detect-missing-model-prices\` returning **500** with \`{"ok":false,"error":"Timeout error."}\` after ~33s on a ClickHouse cold start. The handler entered its catch block but **no row landed in \`cron_job_runs\`** — so \`self-monitor\` (which scans \`cron_job_runs\` for failures) never picked the error up. Silent failure exactly where the watchdog is supposed to catch it.

### Root cause — gotcha #8

The handler did \`logCronRun(...).catch(console.error)\` fire-and-forget before \`return c.json({...}, 500)\`. On Vercel Node runtime the lambda terminates right after the response goes out; an unawaited promise gets dropped at shutdown. The other cron handlers use the same pattern and got away with it because their happy paths run sub-second, leaving the trailing INSERT enough time to drain. This handler's ClickHouse \`GROUP BY model\` over the last hour can spend the full 30s waiting on a cold-pool wake-up — no budget left for the logger.

### Fix

\`await logCronRun(...).catch(console.error)\` in all three response paths (insert-error, ok, outer catch). Inner \`.catch\` swallows logger failures so they don't mask the original 500. Cron has no human-latency budget — awaiting is the right pricing.

### Scope

Same pattern lives in the other cron handlers in \`cron.ts\` but only this one has been observed losing rows. Keeping the PR tight to the observed case; if another handler starts dropping rows, it gets the same treatment.

## Test plan
- [x] Existing 7 unit tests in \`detect-missing-model-prices.test.ts\` still pass (await doesn't change call semantics)
- [x] \`pnpm --filter server typecheck\` / \`lint\` / \`test\` (897 pass)
- [ ] CI green → merge → next hourly tick of \`/cron/detect-missing-model-prices\` logs to \`cron_job_runs\` even on the 500/timeout path