### PR TITLE
test(server,web): proxy integration suite + web component test setup

### DIFF
--- a/apps/server/src/__tests__/helpers/proxy-mocks.ts
+++ b/apps/server/src/__tests__/helpers/proxy-mocks.ts
@@ -1,0 +1,196 @@
+import { vi } from 'vitest'
+
+/**
+ * Shared state + helpers for the proxy-{openai,anthropic,gemini,azure}
+ * integration tests. The mocks themselves are declared *inline* in each test
+ * file because `vi.mock` calls are hoisted — they must syntactically appear at
+ * the top of the test file, and a factory imported from a helper cannot run
+ * at hoist time. This module exposes the shared *state* the inline mocks read
+ * from (key id, scope, decrypted key, captured logger args, captured fetch
+ * calls) plus a `mockUpstream(...)` fetch installer and a `resetProxyMocks()`
+ * reset, so the per-provider test files stay tiny.
+ *
+ * The pattern:
+ *   - proxyState.* — what the mocks return / capture
+ *   - mockUpstream(resp) — installs fetch spy that records call + returns resp
+ *   - drainPendingTasks() — awaits fire-and-forget logger inserts so tests
+ *     can assert `proxyState.loggerCalls` right after `app.request(...)`
+ */
+
+export interface FetchCall {
+  url: string
+  method: string
+  headers: Headers
+  body: string | null
+}
+
+export interface ProxyState {
+  /** Set by mocked authApiKey middleware onto Hono context. */
+  apiKeyId: string
+  organizationId: string
+  projectId: string
+  scope: 'full' | 'public'
+  /** Returned by mocked getDecryptedProviderKey. Empty string → return null. */
+  decryptedKey: string
+  providerKeyId: string
+  /** For azure only — populated as provider_metadata.resource_url. */
+  resourceUrl: string
+  /** True → isBlockingEnabled returns true (lets the injection-block 422 path fire). */
+  blockingEnabled: boolean
+  /** Captured outbound fetches (post header-stripping, with provider auth applied). */
+  fetchCalls: FetchCall[]
+  /** Captured logRequestAsync invocations (after fire-and-forget settles). */
+  loggerCalls: Record<string, unknown>[]
+  /** Background tasks queued via fireAndForget — awaited in drainPendingTasks. */
+  pendingTasks: Promise<unknown>[]
+}
+
+export const proxyState: ProxyState = {
+  apiKeyId: 'key_test',
+  organizationId: 'org_test',
+  projectId: 'proj_test',
+  scope: 'full',
+  decryptedKey: 'sk-decrypted-test-key',
+  providerKeyId: 'pk_test',
+  resourceUrl: '',
+  blockingEnabled: false,
+  fetchCalls: [],
+  loggerCalls: [],
+  pendingTasks: [],
+}
+
+export function resetProxyMocks(): void {
+  proxyState.apiKeyId = 'key_test'
+  proxyState.organizationId = 'org_test'
+  proxyState.projectId = 'proj_test'
+  proxyState.scope = 'full'
+  proxyState.decryptedKey = 'sk-decrypted-test-key'
+  proxyState.providerKeyId = 'pk_test'
+  proxyState.resourceUrl = ''
+  proxyState.blockingEnabled = false
+  proxyState.fetchCalls = []
+  proxyState.loggerCalls = []
+  proxyState.pendingTasks = []
+}
+
+/** Build a JSON 200 response for OpenAI/Azure-shaped chat completions. */
+export function openAIChatResponse(opts: {
+  model?: string
+  promptTokens?: number
+  completionTokens?: number
+  content?: string
+} = {}): Response {
+  const model = opts.model ?? 'gpt-4o-mini-2024-07-18'
+  const body = {
+    id: 'chatcmpl-test',
+    object: 'chat.completion',
+    model,
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content: opts.content ?? 'hello back' },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: {
+      prompt_tokens: opts.promptTokens ?? 10,
+      completion_tokens: opts.completionTokens ?? 5,
+      total_tokens: (opts.promptTokens ?? 10) + (opts.completionTokens ?? 5),
+    },
+  }
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+/** Build a JSON 200 response for Anthropic-shaped Messages API. */
+export function anthropicMessagesResponse(opts: {
+  model?: string
+  inputTokens?: number
+  outputTokens?: number
+} = {}): Response {
+  const body = {
+    id: 'msg_test',
+    type: 'message',
+    role: 'assistant',
+    model: opts.model ?? 'claude-sonnet-4-6',
+    content: [{ type: 'text', text: 'hello back' }],
+    stop_reason: 'end_turn',
+    usage: {
+      input_tokens: opts.inputTokens ?? 20,
+      output_tokens: opts.outputTokens ?? 7,
+    },
+  }
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+/** Build a JSON 200 response for Gemini generateContent. */
+export function geminiResponse(opts: {
+  model?: string
+  promptTokens?: number
+  completionTokens?: number
+} = {}): Response {
+  const body = {
+    candidates: [
+      {
+        content: { parts: [{ text: 'hello back' }], role: 'model' },
+        finishReason: 'STOP',
+      },
+    ],
+    modelVersion: opts.model ?? 'gemini-1.5-pro',
+    usageMetadata: {
+      promptTokenCount: opts.promptTokens ?? 12,
+      candidatesTokenCount: opts.completionTokens ?? 4,
+      totalTokenCount: (opts.promptTokens ?? 12) + (opts.completionTokens ?? 4),
+    },
+  }
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+/**
+ * Install a fetch spy that records the call into proxyState.fetchCalls and
+ * returns the configured response. Pass a function to vary per-call (e.g.
+ * upstream 401 vs 200). Returns the spy for fine-grained assertions.
+ */
+export function mockUpstream(
+  responder: Response | ((call: FetchCall) => Response | Promise<Response>),
+): void {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url
+    const method = init?.method ?? 'GET'
+    const headers = new Headers(init?.headers as HeadersInit | undefined)
+    let body: string | null = null
+    if (init?.body) {
+      body = typeof init.body === 'string' ? init.body : String(init.body)
+    }
+    const call: FetchCall = { url, method, headers, body }
+    proxyState.fetchCalls.push(call)
+    const resp = typeof responder === 'function' ? await responder(call) : responder
+    // Clone so multiple consumers (proxy body read + assertion) get independent
+    // streams even though most tests only read once.
+    return resp.clone()
+  })
+}
+
+/** Await any pending fire-and-forget tasks queued via the wait-until mock. */
+export async function drainPendingTasks(): Promise<void> {
+  // Two flushes — the logger mock awaits internally, but if a test chains
+  // additional micro-tasks one round can leave a trailing promise.
+  for (let i = 0; i < 2; i++) {
+    if (proxyState.pendingTasks.length === 0) break
+    const tasks = proxyState.pendingTasks.splice(0)
+    await Promise.all(tasks)
+  }
+}

--- a/apps/server/src/__tests__/proxy-anthropic.test.ts
+++ b/apps/server/src/__tests__/proxy-anthropic.test.ts
@@ -1,0 +1,302 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { Context, MiddlewareHandler, Next } from 'hono'
+import { anthropicMessagesResponse, drainPendingTasks, mockUpstream, proxyState, resetProxyMocks } from './helpers/proxy-mocks.js'
+import { installOnError } from './helpers/install-on-error.js'
+
+/**
+ * End-to-end integration tests for the Anthropic proxy. The shape mirrors
+ * proxy-openai.test.ts but pins the Anthropic-specific contract:
+ *   1. Auth uses `x-api-key` (NOT Authorization Bearer). Any incoming
+ *      Authorization MUST be deleted (defense in depth for SDK quirks).
+ *   2. `anthropic-version` header defaults to '2023-06-01' if caller omits it
+ *      and passes through verbatim if supplied.
+ *   3. Response usage shape differs from OpenAI: input_tokens/output_tokens
+ *      live in `usage` — the proxy maps them to prompt/completion tokens
+ *      before logging.
+ */
+
+vi.mock('../middleware/authApiKey.js', async () => {
+  const actual = await vi.importActual<typeof import('../middleware/authApiKey.js')>(
+    '../middleware/authApiKey.js',
+  )
+  return {
+    ...actual,
+    authApiKey: (async (c: Context, next: Next) => {
+      c.set('apiKeyId', proxyState.apiKeyId)
+      c.set('organizationId', proxyState.organizationId)
+      c.set('projectId', proxyState.projectId)
+      c.set('apiKeyScope', proxyState.scope)
+      await next()
+    }) as MiddlewareHandler,
+  }
+})
+
+vi.mock('../middleware/requireFullScope.js', () => ({
+  requireFullScope: (async (_c: Context, next: Next) => {
+    if (proxyState.scope === 'public') {
+      const { ApiError } = await import('../lib/errors.js')
+      throw new ApiError('PUBLIC_KEY_WRITE_FORBIDDEN', 'Public API key cannot write')
+    }
+    await next()
+  }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/rateLimit.js', () => ({
+  proxyRateLimit: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/quota.js', () => ({
+  enforceQuota: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../proxy/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../proxy/utils.js')>(
+    '../proxy/utils.js',
+  )
+  return {
+    ...actual,
+    getDecryptedProviderKey: vi.fn(async () => {
+      if (proxyState.decryptedKey === '') return null
+      return {
+        plaintext: proxyState.decryptedKey,
+        id: proxyState.providerKeyId,
+        metadata: {},
+      }
+    }),
+    isBlockingEnabled: vi.fn(async () => proxyState.blockingEnabled),
+  }
+})
+
+vi.mock('../lib/logger.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/logger.js')>(
+    '../lib/logger.js',
+  )
+  return {
+    ...actual,
+    logRequestAsync: vi.fn(async (data: Record<string, unknown>) => {
+      proxyState.loggerCalls.push(data)
+    }),
+  }
+})
+
+vi.mock('../lib/resolve-prompt-version.js', () => ({
+  resolvePromptVersion: vi.fn(async () => null),
+}))
+
+vi.mock('../lib/wait-until.js', () => ({
+  fireAndForget: (_c: Context, promise: Promise<unknown>) => {
+    proxyState.pendingTasks.push(promise.catch(() => undefined))
+  },
+}))
+
+async function buildApp() {
+  const { Hono } = await import('hono')
+  const { anthropicProxy } = await import('../proxy/anthropic.js')
+  const app = new Hono()
+  app.route('/proxy/anthropic', anthropicProxy)
+  installOnError(app)
+  return app
+}
+
+beforeEach(() => {
+  resetProxyMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('anthropic proxy — auth header shape', () => {
+  test('upstream receives x-api-key (NOT Authorization Bearer) with decrypted key', async () => {
+    proxyState.decryptedKey = 'sk-ant-real-anthropic-xyz'
+    mockUpstream(anthropicMessagesResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/anthropic/v1/messages', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer sl_live_customer_key',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ model: 'claude-sonnet-4-6', max_tokens: 100, messages: [] }),
+    })
+    await drainPendingTasks()
+
+    const sent = proxyState.fetchCalls[0]!
+    expect(sent.headers.get('x-api-key')).toBe('sk-ant-real-anthropic-xyz')
+    // Authorization explicitly deleted by the handler even though
+    // buildUpstreamHeaders already strips it — defense in depth.
+    expect(sent.headers.get('authorization')).toBeNull()
+  })
+
+  test('anthropic-version defaults to 2023-06-01 when caller omits it', async () => {
+    mockUpstream(anthropicMessagesResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/anthropic/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'claude-sonnet-4-6', max_tokens: 100, messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(proxyState.fetchCalls[0]!.headers.get('anthropic-version')).toBe('2023-06-01')
+  })
+
+  test('anthropic-version passes through verbatim when caller supplies it', async () => {
+    mockUpstream(anthropicMessagesResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/anthropic/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'anthropic-version': '2024-10-22',
+      },
+      body: JSON.stringify({ model: 'claude-sonnet-4-6', max_tokens: 100, messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(proxyState.fetchCalls[0]!.headers.get('anthropic-version')).toBe('2024-10-22')
+  })
+
+  test('x-spanlens-* headers stripped before reaching upstream', async () => {
+    mockUpstream(anthropicMessagesResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/anthropic/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-spanlens-user': 'usr_internal',
+        'x-spanlens-session': 'sess_internal',
+      },
+      body: JSON.stringify({ model: 'claude-sonnet-4-6', max_tokens: 100, messages: [] }),
+    })
+    await drainPendingTasks()
+
+    proxyState.fetchCalls[0]!.headers.forEach((_v, k) => {
+      expect(k.toLowerCase().startsWith('x-spanlens-')).toBe(false)
+    })
+  })
+
+  test('upstream URL strips the /proxy/anthropic prefix correctly', async () => {
+    mockUpstream(anthropicMessagesResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/anthropic/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'claude-sonnet-4-6', max_tokens: 100, messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(proxyState.fetchCalls[0]!.url).toBe('https://api.anthropic.com/v1/messages')
+  })
+})
+
+describe('anthropic proxy — provider key + scope guards', () => {
+  test('NO_PROVIDER_KEY 400 with provider:"anthropic" detail when no key registered', async () => {
+    proxyState.decryptedKey = ''
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/anthropic/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'claude-sonnet-4-6', max_tokens: 100, messages: [] }),
+    })
+
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: { code: string; details: { provider: string } } }
+    expect(body.error.code).toBe('NO_PROVIDER_KEY')
+    expect(body.error.details.provider).toBe('anthropic')
+    expect(proxyState.fetchCalls).toHaveLength(0)
+  })
+
+  test('public-scope key returns 403 PUBLIC_KEY_WRITE_FORBIDDEN', async () => {
+    proxyState.scope = 'public'
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/anthropic/v1/messages', {
+      method: 'POST',
+      body: JSON.stringify({ model: 'claude-sonnet-4-6', max_tokens: 100, messages: [] }),
+    })
+
+    expect(res.status).toBe(403)
+    expect(proxyState.fetchCalls).toHaveLength(0)
+  })
+})
+
+describe('anthropic proxy — logging + token mapping', () => {
+  test('input_tokens / output_tokens are mapped to promptTokens / completionTokens in the log row', async () => {
+    mockUpstream(anthropicMessagesResponse({
+      model: 'claude-sonnet-4-6',
+      inputTokens: 1_000_000,
+      outputTokens: 500_000,
+    }))
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/anthropic/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'claude-sonnet-4-6', max_tokens: 100, messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(res.status).toBe(200)
+    expect(proxyState.loggerCalls).toHaveLength(1)
+    const row = proxyState.loggerCalls[0]!
+    expect(row['provider']).toBe('anthropic')
+    expect(row['model']).toBe('claude-sonnet-4-6')
+    expect(row['promptTokens']).toBe(1_000_000)
+    expect(row['completionTokens']).toBe(500_000)
+    expect(row['totalTokens']).toBe(1_500_000)
+    expect(row['providerKeyId']).toBe(proxyState.providerKeyId)
+    // claude-sonnet-4-6: $3/M prompt + $15/M completion → 3 + 7.5 = 10.5
+    expect(row['costUsd']).toBeCloseTo(10.5, 4)
+  })
+
+  test('upstream 401 status passes through and is recorded with errorMessage', async () => {
+    mockUpstream(new Response(
+      JSON.stringify({ type: 'error', error: { type: 'authentication_error', message: 'Invalid API key' } }),
+      { status: 401, headers: { 'content-type': 'application/json' } },
+    ))
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/anthropic/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'claude-sonnet-4-6', max_tokens: 100, messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(res.status).toBe(401)
+    const row = proxyState.loggerCalls[0]!
+    expect(row['statusCode']).toBe(401)
+    expect(row['errorMessage']).toContain('Invalid API key')
+  })
+
+  test('response body is forwarded to caller verbatim', async () => {
+    const upstreamBody = JSON.stringify({
+      id: 'msg_passthrough',
+      type: 'message',
+      model: 'claude-sonnet-4-6',
+      content: [{ type: 'text', text: 'verbatim' }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    })
+    mockUpstream(new Response(upstreamBody, {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/anthropic/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'claude-sonnet-4-6', max_tokens: 100, messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(await res.text()).toBe(upstreamBody)
+  })
+})

--- a/apps/server/src/__tests__/proxy-azure.test.ts
+++ b/apps/server/src/__tests__/proxy-azure.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { Context, MiddlewareHandler, Next } from 'hono'
+import { drainPendingTasks, mockUpstream, openAIChatResponse, proxyState, resetProxyMocks } from './helpers/proxy-mocks.js'
+import { installOnError } from './helpers/install-on-error.js'
+
+/**
+ * End-to-end integration tests for the Azure OpenAI proxy. Azure is the only
+ * provider where the upstream BASE URL is per-key (the customer's Azure
+ * resource) rather than a fixed constant. The handler-specific contract:
+ *   1. Upstream URL is built from provider_metadata.resource_url + /openai/v1.
+ *   2. resource_url MUST be present — missing → 500 INTERNAL_ERROR with a
+ *      clear "re-register it" message (Azure rows have a DB CHECK forcing it,
+ *      this is defense in depth if a future migration drops the constraint).
+ *   3. Auth header is `api-key`, NOT Authorization Bearer. Any incoming
+ *      Authorization is deleted.
+ *   4. Response shape is OpenAI-compatible so the OpenAI parser is reused
+ *      and `calculateCost('openai', ...)` is invoked even though the
+ *      logged provider is 'azure'.
+ */
+
+vi.mock('../middleware/authApiKey.js', async () => {
+  const actual = await vi.importActual<typeof import('../middleware/authApiKey.js')>(
+    '../middleware/authApiKey.js',
+  )
+  return {
+    ...actual,
+    authApiKey: (async (c: Context, next: Next) => {
+      c.set('apiKeyId', proxyState.apiKeyId)
+      c.set('organizationId', proxyState.organizationId)
+      c.set('projectId', proxyState.projectId)
+      c.set('apiKeyScope', proxyState.scope)
+      await next()
+    }) as MiddlewareHandler,
+  }
+})
+
+vi.mock('../middleware/requireFullScope.js', () => ({
+  requireFullScope: (async (_c: Context, next: Next) => {
+    if (proxyState.scope === 'public') {
+      const { ApiError } = await import('../lib/errors.js')
+      throw new ApiError('PUBLIC_KEY_WRITE_FORBIDDEN', 'Public API key cannot write')
+    }
+    await next()
+  }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/rateLimit.js', () => ({
+  proxyRateLimit: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/quota.js', () => ({
+  enforceQuota: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../proxy/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../proxy/utils.js')>(
+    '../proxy/utils.js',
+  )
+  return {
+    ...actual,
+    getDecryptedProviderKey: vi.fn(async () => {
+      if (proxyState.decryptedKey === '') return null
+      return {
+        plaintext: proxyState.decryptedKey,
+        id: proxyState.providerKeyId,
+        metadata: proxyState.resourceUrl ? { resource_url: proxyState.resourceUrl } : {},
+      }
+    }),
+    isBlockingEnabled: vi.fn(async () => proxyState.blockingEnabled),
+  }
+})
+
+vi.mock('../lib/logger.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/logger.js')>(
+    '../lib/logger.js',
+  )
+  return {
+    ...actual,
+    logRequestAsync: vi.fn(async (data: Record<string, unknown>) => {
+      proxyState.loggerCalls.push(data)
+    }),
+  }
+})
+
+vi.mock('../lib/resolve-prompt-version.js', () => ({
+  resolvePromptVersion: vi.fn(async () => null),
+}))
+
+vi.mock('../lib/wait-until.js', () => ({
+  fireAndForget: (_c: Context, promise: Promise<unknown>) => {
+    proxyState.pendingTasks.push(promise.catch(() => undefined))
+  },
+}))
+
+async function buildApp() {
+  const { Hono } = await import('hono')
+  const { azureProxy } = await import('../proxy/azure.js')
+  const app = new Hono()
+  app.route('/proxy/azure', azureProxy)
+  installOnError(app)
+  return app
+}
+
+const TEST_RESOURCE_URL = 'https://my-resource.openai.azure.com'
+
+beforeEach(() => {
+  resetProxyMocks()
+  proxyState.resourceUrl = TEST_RESOURCE_URL
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('azure proxy — resource_url URL building', () => {
+  test('upstream URL = {resource_url}/openai/v1{path}', async () => {
+    mockUpstream(openAIChatResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/azure/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(proxyState.fetchCalls[0]!.url).toBe(
+      `${TEST_RESOURCE_URL}/openai/v1/chat/completions`,
+    )
+  })
+
+  test('different resource_url values produce different upstream origins (per-key routing)', async () => {
+    mockUpstream(openAIChatResponse())
+    proxyState.resourceUrl = 'https://customer-a.openai.azure.com'
+    const app = await buildApp()
+
+    await app.request('/proxy/azure/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(proxyState.fetchCalls[0]!.url).toContain('customer-a.openai.azure.com')
+  })
+
+  test('missing resource_url → 500 INTERNAL_ERROR with actionable message', async () => {
+    proxyState.resourceUrl = '' // metadata returned will be {} so resource_url is falsy
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/azure/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+
+    expect(res.status).toBe(500)
+    const body = (await res.json()) as { error: { code: string; message: string } }
+    expect(body.error.code).toBe('INTERNAL_ERROR')
+    expect(body.error.message.toLowerCase()).toContain('resource_url')
+    // Upstream MUST NOT be reached when the URL would be malformed
+    expect(proxyState.fetchCalls).toHaveLength(0)
+  })
+})
+
+describe('azure proxy — auth header (api-key) shape', () => {
+  test('upstream receives api-key header (NOT Authorization) with decrypted key', async () => {
+    proxyState.decryptedKey = 'azure-api-key-real-xyz'
+    mockUpstream(openAIChatResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/azure/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer sl_live_customer_should_not_leak',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    const sent = proxyState.fetchCalls[0]!
+    expect(sent.headers.get('api-key')).toBe('azure-api-key-real-xyz')
+    expect(sent.headers.get('authorization')).toBeNull()
+  })
+
+  test('x-spanlens-* headers stripped before reaching upstream', async () => {
+    mockUpstream(openAIChatResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/azure/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-spanlens-user': 'usr_internal',
+      },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    proxyState.fetchCalls[0]!.headers.forEach((_v, k) => {
+      expect(k.toLowerCase().startsWith('x-spanlens-')).toBe(false)
+    })
+  })
+})
+
+describe('azure proxy — provider key + scope guards', () => {
+  test('NO_PROVIDER_KEY 400 when no active Azure key exists', async () => {
+    proxyState.decryptedKey = ''
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/azure/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('NO_PROVIDER_KEY')
+    expect(proxyState.fetchCalls).toHaveLength(0)
+  })
+
+  test('public-scope key returns 403 PUBLIC_KEY_WRITE_FORBIDDEN', async () => {
+    proxyState.scope = 'public'
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/azure/chat/completions', {
+      method: 'POST',
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+
+    expect(res.status).toBe(403)
+    expect(proxyState.fetchCalls).toHaveLength(0)
+  })
+})
+
+describe('azure proxy — logging records provider:"azure" with OpenAI-priced cost', () => {
+  test('log row has provider="azure" but cost uses OpenAI price table (azure exposes openai models)', async () => {
+    mockUpstream(openAIChatResponse({
+      model: 'gpt-4o-mini-2024-07-18',
+      promptTokens: 1_000_000,
+      completionTokens: 500_000,
+    }))
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/azure/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(res.status).toBe(200)
+    expect(proxyState.loggerCalls).toHaveLength(1)
+    const row = proxyState.loggerCalls[0]!
+    expect(row['provider']).toBe('azure') // tag distinguishes upstream
+    expect(row['model']).toBe('gpt-4o-mini-2024-07-18')
+    // Same OpenAI prices as in proxy-openai.test.ts: 0.15 + 0.30 = 0.45
+    expect(row['costUsd']).toBeCloseTo(0.45, 4)
+  })
+
+  test('upstream non-2xx is passed through and recorded with errorMessage', async () => {
+    mockUpstream(new Response(
+      JSON.stringify({ error: { code: 'DeploymentNotFound', message: 'Deployment xyz not found' } }),
+      { status: 404, headers: { 'content-type': 'application/json' } },
+    ))
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/azure/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(res.status).toBe(404)
+    expect(proxyState.loggerCalls[0]!['statusCode']).toBe(404)
+    expect((proxyState.loggerCalls[0]!['errorMessage'] as string)).toContain('Deployment xyz not found')
+  })
+})

--- a/apps/server/src/__tests__/proxy-gemini.test.ts
+++ b/apps/server/src/__tests__/proxy-gemini.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { Context, MiddlewareHandler, Next } from 'hono'
+import { drainPendingTasks, geminiResponse, mockUpstream, proxyState, resetProxyMocks } from './helpers/proxy-mocks.js'
+import { installOnError } from './helpers/install-on-error.js'
+
+/**
+ * End-to-end integration tests for the Gemini proxy. Gemini's wire protocol
+ * is uniquely query-param-based — the API key rides in `?key=...` on the URL,
+ * not in a header. The handler-specific contract:
+ *   1. Decrypted provider key is placed in `?key=` on the upstream URL.
+ *   2. Any incoming `?key=` from the caller is OVERWRITTEN (the proxy's
+ *      decrypted key wins — a caller can't smuggle their own credential).
+ *   3. Authorization header (if present) is deleted before upstream.
+ *   4. Other query params (e.g. `?alt=sse`) are preserved.
+ *   5. Model name is extracted from the URL path (`/models/<model>:<op>`),
+ *      not the request body.
+ *   6. Token usage shape is camelCase (`promptTokenCount` etc).
+ */
+
+vi.mock('../middleware/authApiKey.js', async () => {
+  const actual = await vi.importActual<typeof import('../middleware/authApiKey.js')>(
+    '../middleware/authApiKey.js',
+  )
+  return {
+    ...actual,
+    authApiKey: (async (c: Context, next: Next) => {
+      c.set('apiKeyId', proxyState.apiKeyId)
+      c.set('organizationId', proxyState.organizationId)
+      c.set('projectId', proxyState.projectId)
+      c.set('apiKeyScope', proxyState.scope)
+      await next()
+    }) as MiddlewareHandler,
+  }
+})
+
+vi.mock('../middleware/requireFullScope.js', () => ({
+  requireFullScope: (async (_c: Context, next: Next) => {
+    if (proxyState.scope === 'public') {
+      const { ApiError } = await import('../lib/errors.js')
+      throw new ApiError('PUBLIC_KEY_WRITE_FORBIDDEN', 'Public API key cannot write')
+    }
+    await next()
+  }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/rateLimit.js', () => ({
+  proxyRateLimit: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/quota.js', () => ({
+  enforceQuota: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../proxy/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../proxy/utils.js')>(
+    '../proxy/utils.js',
+  )
+  return {
+    ...actual,
+    getDecryptedProviderKey: vi.fn(async () => {
+      if (proxyState.decryptedKey === '') return null
+      return {
+        plaintext: proxyState.decryptedKey,
+        id: proxyState.providerKeyId,
+        metadata: {},
+      }
+    }),
+    isBlockingEnabled: vi.fn(async () => proxyState.blockingEnabled),
+  }
+})
+
+vi.mock('../lib/logger.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/logger.js')>(
+    '../lib/logger.js',
+  )
+  return {
+    ...actual,
+    logRequestAsync: vi.fn(async (data: Record<string, unknown>) => {
+      proxyState.loggerCalls.push(data)
+    }),
+  }
+})
+
+vi.mock('../lib/resolve-prompt-version.js', () => ({
+  resolvePromptVersion: vi.fn(async () => null),
+}))
+
+vi.mock('../lib/wait-until.js', () => ({
+  fireAndForget: (_c: Context, promise: Promise<unknown>) => {
+    proxyState.pendingTasks.push(promise.catch(() => undefined))
+  },
+}))
+
+async function buildApp() {
+  const { Hono } = await import('hono')
+  const { geminiProxy } = await import('../proxy/gemini.js')
+  const app = new Hono()
+  app.route('/proxy/gemini', geminiProxy)
+  installOnError(app)
+  return app
+}
+
+beforeEach(() => {
+  resetProxyMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('gemini proxy — query-param key handling (security critical)', () => {
+  test('decrypted provider key is placed in ?key= on the upstream URL', async () => {
+    proxyState.decryptedKey = 'AIza-real-gemini-key-xyz'
+    mockUpstream(geminiResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/gemini/v1/models/gemini-1.5-pro:generateContent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contents: [{ role: 'user', parts: [{ text: 'hi' }] }] }),
+    })
+    await drainPendingTasks()
+
+    const upstreamUrl = new URL(proxyState.fetchCalls[0]!.url)
+    expect(upstreamUrl.searchParams.get('key')).toBe('AIza-real-gemini-key-xyz')
+  })
+
+  test("caller's incoming ?key=... is overwritten with our decrypted key (no smuggling)", async () => {
+    proxyState.decryptedKey = 'AIza-real-server-key'
+    mockUpstream(geminiResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/gemini/v1/models/gemini-1.5-pro:generateContent?key=AIza-attacker-supplied', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contents: [] }),
+    })
+    await drainPendingTasks()
+
+    const upstreamUrl = new URL(proxyState.fetchCalls[0]!.url)
+    expect(upstreamUrl.searchParams.get('key')).toBe('AIza-real-server-key')
+    expect(upstreamUrl.searchParams.get('key')).not.toContain('attacker')
+  })
+
+  test('other query params (alt=sse) are preserved on the upstream URL', async () => {
+    mockUpstream(geminiResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/gemini/v1/models/gemini-1.5-pro:generateContent?alt=sse', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contents: [] }),
+    })
+    await drainPendingTasks()
+
+    const upstreamUrl = new URL(proxyState.fetchCalls[0]!.url)
+    expect(upstreamUrl.searchParams.get('alt')).toBe('sse')
+  })
+
+  test('any Authorization header from the caller is deleted before upstream', async () => {
+    mockUpstream(geminiResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/gemini/v1/models/gemini-1.5-pro:generateContent', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer sl_live_should_not_appear',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ contents: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(proxyState.fetchCalls[0]!.headers.get('authorization')).toBeNull()
+  })
+
+  test('x-spanlens-* headers stripped before reaching upstream', async () => {
+    mockUpstream(geminiResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/gemini/v1/models/gemini-1.5-pro:generateContent', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-spanlens-user': 'usr_internal',
+      },
+      body: JSON.stringify({ contents: [] }),
+    })
+    await drainPendingTasks()
+
+    proxyState.fetchCalls[0]!.headers.forEach((_v, k) => {
+      expect(k.toLowerCase().startsWith('x-spanlens-')).toBe(false)
+    })
+  })
+
+  test('upstream URL strips the /proxy/gemini prefix correctly', async () => {
+    mockUpstream(geminiResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/gemini/v1/models/gemini-1.5-pro:generateContent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contents: [] }),
+    })
+    await drainPendingTasks()
+
+    const u = new URL(proxyState.fetchCalls[0]!.url)
+    expect(u.origin).toBe('https://generativelanguage.googleapis.com')
+    expect(u.pathname).toBe('/v1/models/gemini-1.5-pro:generateContent')
+  })
+})
+
+describe('gemini proxy — provider key + scope guards', () => {
+  test('NO_PROVIDER_KEY 400 with provider:"gemini" detail', async () => {
+    proxyState.decryptedKey = ''
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/gemini/v1/models/gemini-1.5-pro:generateContent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contents: [] }),
+    })
+
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: { code: string; details: { provider: string } } }
+    expect(body.error.code).toBe('NO_PROVIDER_KEY')
+    expect(body.error.details.provider).toBe('gemini')
+    expect(proxyState.fetchCalls).toHaveLength(0)
+  })
+
+  test('public-scope key returns 403 PUBLIC_KEY_WRITE_FORBIDDEN', async () => {
+    proxyState.scope = 'public'
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/gemini/v1/models/gemini-1.5-pro:generateContent', {
+      method: 'POST',
+      body: JSON.stringify({ contents: [] }),
+    })
+
+    expect(res.status).toBe(403)
+    expect(proxyState.fetchCalls).toHaveLength(0)
+  })
+})
+
+describe('gemini proxy — model extraction + logging', () => {
+  test('model is extracted from URL path, not body, and forwarded to log row', async () => {
+    mockUpstream(geminiResponse({ model: 'gemini-1.5-pro', promptTokens: 12, completionTokens: 4 }))
+    const app = await buildApp()
+
+    await app.request('/proxy/gemini/v1/models/gemini-1.5-pro:generateContent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contents: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(proxyState.loggerCalls).toHaveLength(1)
+    const row = proxyState.loggerCalls[0]!
+    expect(row['provider']).toBe('gemini')
+    expect(row['model']).toBe('gemini-1.5-pro')
+    expect(row['promptTokens']).toBe(12)
+    expect(row['completionTokens']).toBe(4)
+    expect(row['totalTokens']).toBe(16)
+    expect(row['providerKeyId']).toBe(proxyState.providerKeyId)
+  })
+
+  test('upstream error status passes through and is recorded', async () => {
+    mockUpstream(new Response(
+      JSON.stringify({ error: { code: 401, message: 'API key not valid' } }),
+      { status: 401, headers: { 'content-type': 'application/json' } },
+    ))
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/gemini/v1/models/gemini-1.5-pro:generateContent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contents: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(res.status).toBe(401)
+    expect(proxyState.loggerCalls[0]!['statusCode']).toBe(401)
+    expect((proxyState.loggerCalls[0]!['errorMessage'] as string)).toContain('API key not valid')
+  })
+})

--- a/apps/server/src/__tests__/proxy-openai.test.ts
+++ b/apps/server/src/__tests__/proxy-openai.test.ts
@@ -1,0 +1,349 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { Context, MiddlewareHandler, Next } from 'hono'
+import { drainPendingTasks, mockUpstream, openAIChatResponse, proxyState, resetProxyMocks } from './helpers/proxy-mocks.js'
+import { installOnError } from './helpers/install-on-error.js'
+
+/**
+ * End-to-end integration tests for the OpenAI proxy handler. The four proxy
+ * files (openai/anthropic/gemini/azure) share the same shape; this file pins
+ * the openai-specific contract:
+ *   1. Customer's incoming Spanlens key (Authorization header) is REPLACED
+ *      with the decrypted provider key before reaching upstream.
+ *   2. `x-spanlens-*` internal metadata never leaks upstream (CLAUDE.md rule).
+ *   3. Response token usage is parsed and forwarded to logRequestAsync along
+ *      with calculated cost — i.e. the dashboard receives the row it needs.
+ *   4. Provider key absent → 500 NO_PROVIDER_KEY (not 200, not silent).
+ *   5. Upstream non-2xx is passed through, error truncated for the log row.
+ *
+ * Mocking strategy: middleware are no-op'd / replaced (auth, scope, quota,
+ * rate-limit) so the test exercises ONLY the handler body. supabase/clickhouse
+ * are mocked via getDecryptedProviderKey + logRequestAsync. Global fetch is
+ * spied. fireAndForget queues into proxyState.pendingTasks so the test can
+ * await background log writes before asserting.
+ */
+
+// === Mocks — must be hoisted (vi.mock is) ==================================
+
+vi.mock('../middleware/authApiKey.js', async () => {
+  const actual = await vi.importActual<typeof import('../middleware/authApiKey.js')>(
+    '../middleware/authApiKey.js',
+  )
+  return {
+    ...actual,
+    authApiKey: (async (c: Context, next: Next) => {
+      c.set('apiKeyId', proxyState.apiKeyId)
+      c.set('organizationId', proxyState.organizationId)
+      c.set('projectId', proxyState.projectId)
+      c.set('apiKeyScope', proxyState.scope)
+      await next()
+    }) as MiddlewareHandler,
+  }
+})
+
+vi.mock('../middleware/requireFullScope.js', () => ({
+  requireFullScope: (async (_c: Context, next: Next) => {
+    if (proxyState.scope === 'public') {
+      const { ApiError } = await import('../lib/errors.js')
+      throw new ApiError('PUBLIC_KEY_WRITE_FORBIDDEN', 'Public API key cannot write')
+    }
+    await next()
+  }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/rateLimit.js', () => ({
+  proxyRateLimit: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/quota.js', () => ({
+  enforceQuota: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../proxy/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../proxy/utils.js')>(
+    '../proxy/utils.js',
+  )
+  return {
+    ...actual,
+    getDecryptedProviderKey: vi.fn(async () => {
+      if (proxyState.decryptedKey === '') return null
+      return {
+        plaintext: proxyState.decryptedKey,
+        id: proxyState.providerKeyId,
+        metadata: proxyState.resourceUrl ? { resource_url: proxyState.resourceUrl } : {},
+      }
+    }),
+    isBlockingEnabled: vi.fn(async () => proxyState.blockingEnabled),
+  }
+})
+
+vi.mock('../lib/logger.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/logger.js')>(
+    '../lib/logger.js',
+  )
+  return {
+    ...actual,
+    logRequestAsync: vi.fn(async (data: Record<string, unknown>) => {
+      proxyState.loggerCalls.push(data)
+    }),
+  }
+})
+
+vi.mock('../lib/resolve-prompt-version.js', () => ({
+  resolvePromptVersion: vi.fn(async () => null),
+}))
+
+vi.mock('../lib/wait-until.js', () => ({
+  fireAndForget: (_c: Context, promise: Promise<unknown>) => {
+    proxyState.pendingTasks.push(promise.catch(() => undefined))
+  },
+}))
+
+// === App harness ===========================================================
+
+async function buildApp() {
+  const { Hono } = await import('hono')
+  const { openaiProxy } = await import('../proxy/openai.js')
+  const app = new Hono()
+  app.route('/proxy/openai', openaiProxy)
+  installOnError(app)
+  return app
+}
+
+// === Tests =================================================================
+
+beforeEach(() => {
+  resetProxyMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('openai proxy — auth header rewrite (security critical)', () => {
+  test('upstream Authorization carries DECRYPTED provider key, not the customer Spanlens key', async () => {
+    proxyState.decryptedKey = 'sk-real-openai-abc123'
+    mockUpstream(openAIChatResponse())
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer sl_live_customerkey_THIS_MUST_NOT_LEAK',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [{ role: 'user', content: 'hi' }] }),
+    })
+    await drainPendingTasks()
+
+    expect(res.status).toBe(200)
+    expect(proxyState.fetchCalls).toHaveLength(1)
+    const sent = proxyState.fetchCalls[0]!
+    expect(sent.headers.get('authorization')).toBe('Bearer sk-real-openai-abc123')
+    // Defense in depth: the customer key MUST NOT appear anywhere in upstream headers
+    sent.headers.forEach((value) => {
+      expect(value).not.toContain('sl_live_')
+    })
+  })
+
+  test('every x-spanlens-* header is stripped before reaching upstream (CLAUDE.md rule)', async () => {
+    mockUpstream(openAIChatResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer sl_live_irrelevant',
+        'Content-Type': 'application/json',
+        'x-spanlens-user': 'usr_customer_internal',
+        'x-spanlens-session': 'sess_customer',
+        'x-spanlens-prompt-version': 'greeter@1',
+        'x-spanlens-log-body': 'meta',
+      },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    const sent = proxyState.fetchCalls[0]!
+    const leaked: string[] = []
+    sent.headers.forEach((_v, k) => {
+      if (k.toLowerCase().startsWith('x-spanlens-')) leaked.push(k)
+    })
+    expect(leaked).toEqual([])
+  })
+
+  test('upstream URL strips the /proxy/openai prefix correctly', async () => {
+    mockUpstream(openAIChatResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(proxyState.fetchCalls[0]!.url).toBe('https://api.openai.com/v1/chat/completions')
+  })
+})
+
+describe('openai proxy — provider key resolution', () => {
+  test('NO_PROVIDER_KEY 400 when no active OpenAI key exists for this Spanlens key', async () => {
+    proxyState.decryptedKey = '' // signal: getDecryptedProviderKey returns null
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: { code: string; details: { provider: string } } }
+    expect(body.error.code).toBe('NO_PROVIDER_KEY')
+    expect(body.error.details.provider).toBe('openai')
+    // Upstream MUST NOT be called when no provider key is available
+    expect(proxyState.fetchCalls).toHaveLength(0)
+  })
+
+  test('public-scope Spanlens key is rejected with 403 PUBLIC_KEY_WRITE_FORBIDDEN', async () => {
+    proxyState.scope = 'public'
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/openai/v1/chat/completions', {
+      method: 'POST',
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+
+    expect(res.status).toBe(403)
+    const body = (await res.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('PUBLIC_KEY_WRITE_FORBIDDEN')
+    expect(proxyState.fetchCalls).toHaveLength(0)
+  })
+})
+
+describe('openai proxy — logging + cost calculation', () => {
+  test('parsed tokens, model, and cost are forwarded to logRequestAsync', async () => {
+    mockUpstream(openAIChatResponse({
+      model: 'gpt-4o-mini-2024-07-18', // dated variant — exercises gotcha #2 prefix fallback
+      promptTokens: 1_000_000,
+      completionTokens: 500_000,
+    }))
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [{ role: 'user', content: 'hi' }] }),
+    })
+    await drainPendingTasks()
+
+    expect(res.status).toBe(200)
+    expect(proxyState.loggerCalls).toHaveLength(1)
+    const row = proxyState.loggerCalls[0]!
+    expect(row['organizationId']).toBe(proxyState.organizationId)
+    expect(row['projectId']).toBe(proxyState.projectId)
+    expect(row['provider']).toBe('openai')
+    expect(row['model']).toBe('gpt-4o-mini-2024-07-18')
+    expect(row['promptTokens']).toBe(1_000_000)
+    expect(row['completionTokens']).toBe(500_000)
+    expect(row['totalTokens']).toBe(1_500_000)
+    expect(row['providerKeyId']).toBe(proxyState.providerKeyId)
+    // gpt-4o-mini priced at $0.15/M prompt + $0.60/M completion = 0.15 + 0.30 = 0.45
+    expect(row['costUsd']).toBeCloseTo(0.45, 4)
+    expect(row['statusCode']).toBe(200)
+    expect(row['errorMessage']).toBeNull()
+  })
+
+  test('upstream 401 is passed through to caller and recorded in log with errorMessage', async () => {
+    mockUpstream(
+      new Response(JSON.stringify({ error: { message: 'Incorrect API key provided' } }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    // Status must pass through transparently — the proxy is not a CORS wall
+    expect(res.status).toBe(401)
+    expect(proxyState.loggerCalls).toHaveLength(1)
+    const row = proxyState.loggerCalls[0]!
+    expect(row['statusCode']).toBe(401)
+    expect(typeof row['errorMessage']).toBe('string')
+    expect((row['errorMessage'] as string).length).toBeLessThanOrEqual(1000)
+    expect(row['errorMessage']).toContain('Incorrect API key')
+  })
+
+  test('logBodyMode parsed from x-spanlens-log-body header (defaults to "full" for unknown)', async () => {
+    mockUpstream(openAIChatResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-spanlens-log-body': 'meta',
+      },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(proxyState.loggerCalls[0]!['logBodyMode']).toBe('meta')
+  })
+
+  test('trace/span/user/session identifiers from request headers flow into the log row', async () => {
+    mockUpstream(openAIChatResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-trace-id': 'trace_test_123',
+        'x-span-id': 'span_test_456',
+        'x-spanlens-user': 'usr_end_customer',
+        'x-spanlens-session': 'sess_abc',
+      },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    const row = proxyState.loggerCalls[0]!
+    expect(row['traceId']).toBe('trace_test_123')
+    expect(row['spanId']).toBe('span_test_456')
+    expect(row['userId']).toBe('usr_end_customer')
+    expect(row['sessionId']).toBe('sess_abc')
+  })
+})
+
+describe('openai proxy — response passthrough', () => {
+  test('response body bytes are returned verbatim to caller', async () => {
+    const upstreamBody = JSON.stringify({
+      id: 'chatcmpl-passthrough-test',
+      object: 'chat.completion',
+      model: 'gpt-4o',
+      choices: [{ message: { role: 'assistant', content: 'verbatim' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    })
+    mockUpstream(new Response(upstreamBody, {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-4o', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(await res.text()).toBe(upstreamBody)
+  })
+})

--- a/apps/server/src/__tests__/proxy-utils-headers.test.ts
+++ b/apps/server/src/__tests__/proxy-utils-headers.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from 'vitest'
+import { buildUpstreamHeaders, buildDownstreamHeaders } from '../proxy/utils.js'
+
+/**
+ * proxy/utils.ts header rewriting is shared by all 4 proxy handlers
+ * (openai / anthropic / gemini / azure). A regression here can:
+ *   (1) leak the customer's Spanlens API key upstream (Authorization not stripped),
+ *   (2) forward `x-spanlens-*` internal metadata to OpenAI/Anthropic — violates
+ *       the CLAUDE.md "X-Spanlens-* never leaves the proxy" contract,
+ *   (3) ship a stale content-length so undici rejects the request, or
+ *   (4) return content-encoding to the client for an already-decoded body.
+ *
+ * These are exactly the failure modes the unit tests below pin down.
+ */
+
+function headersFromObject(obj: Record<string, string>): Headers {
+  const h = new Headers()
+  for (const [k, v] of Object.entries(obj)) h.set(k, v)
+  return h
+}
+
+describe('buildUpstreamHeaders — sensitive header stripping', () => {
+  test('strips the incoming Authorization header (customer Spanlens key never leaks upstream)', () => {
+    const incoming = headersFromObject({
+      Authorization: 'Bearer sl_live_customerkey123',
+      'Content-Type': 'application/json',
+    })
+    const out = buildUpstreamHeaders(incoming, {
+      Authorization: 'Bearer sk-real-openai-key',
+    })
+    expect(out.get('Authorization')).toBe('Bearer sk-real-openai-key')
+    expect(out.get('Authorization')).not.toContain('sl_live_')
+  })
+
+  test('overrides win over incoming (case-insensitive in HTTP Headers)', () => {
+    const incoming = headersFromObject({ 'Content-Type': 'text/plain' })
+    const out = buildUpstreamHeaders(incoming, {
+      'content-type': 'application/json',
+    })
+    expect(out.get('content-type')).toBe('application/json')
+  })
+
+  test('strips hop-by-hop + length-related headers (host, connection, content-length, transfer-encoding, te, upgrade)', () => {
+    const incoming = headersFromObject({
+      host: 'api.spanlens.io',
+      connection: 'keep-alive',
+      'keep-alive': 'timeout=5',
+      'transfer-encoding': 'chunked',
+      'content-length': '12345',
+      te: 'trailers',
+      upgrade: 'websocket',
+      'proxy-authorization': 'Basic xxx',
+      'proxy-connection': 'keep-alive',
+    })
+    const out = buildUpstreamHeaders(incoming, {})
+    for (const name of [
+      'host',
+      'connection',
+      'keep-alive',
+      'transfer-encoding',
+      'content-length',
+      'te',
+      'upgrade',
+      'proxy-authorization',
+      'proxy-connection',
+    ]) {
+      expect(out.get(name), `expected ${name} to be stripped`).toBeNull()
+    }
+  })
+
+  test('strips every x-spanlens-* header (internal metadata never reaches upstream)', () => {
+    const incoming = headersFromObject({
+      'x-spanlens-project': 'proj_123',
+      'x-spanlens-prompt-version': 'greeter@3',
+      'x-spanlens-user': 'usr_456',
+      'x-spanlens-session': 'sess_789',
+      'x-spanlens-log-body': 'meta',
+      'X-Spanlens-Custom': 'mixed-case-still-stripped',
+      'Content-Type': 'application/json',
+    })
+    const out = buildUpstreamHeaders(incoming, {})
+    // Iterate to confirm none of the x-spanlens-* survived
+    const surviving: string[] = []
+    out.forEach((_v, k) => {
+      if (k.toLowerCase().startsWith('x-spanlens-')) surviving.push(k)
+    })
+    expect(surviving).toEqual([])
+    // Content-Type still passes through
+    expect(out.get('content-type')).toBe('application/json')
+  })
+
+  test('passes through innocuous headers untouched (user-agent, accept, custom non-spanlens)', () => {
+    const incoming = headersFromObject({
+      'user-agent': 'spanlens-sdk/0.6.1',
+      accept: 'application/json',
+      'x-request-id': 'req_abc',
+    })
+    const out = buildUpstreamHeaders(incoming, {})
+    expect(out.get('user-agent')).toBe('spanlens-sdk/0.6.1')
+    expect(out.get('accept')).toBe('application/json')
+    expect(out.get('x-request-id')).toBe('req_abc')
+  })
+
+  test('strips Authorization even when only override provides replacement (defense in depth)', () => {
+    // Without the override, Authorization should still be removed —
+    // a misconfigured proxy must never accidentally forward the user key.
+    const incoming = headersFromObject({
+      authorization: 'Bearer sl_live_leak_me',
+    })
+    const out = buildUpstreamHeaders(incoming, {})
+    expect(out.get('authorization')).toBeNull()
+  })
+
+  test('empty incoming + empty overrides → empty output (no defaults injected)', () => {
+    const out = buildUpstreamHeaders(new Headers(), {})
+    let count = 0
+    out.forEach(() => count++)
+    expect(count).toBe(0)
+  })
+})
+
+describe('buildDownstreamHeaders — response header stripping', () => {
+  test('strips content-encoding (body has already been decoded by fetch)', () => {
+    // gotcha: undici/fetch returns the decoded body but the upstream response
+    // still says `content-encoding: gzip`. If we forward that header the
+    // browser tries to decompress an already-decompressed body → corrupt.
+    const upstream = headersFromObject({
+      'content-encoding': 'gzip',
+      'content-type': 'application/json',
+    })
+    const out = buildDownstreamHeaders(upstream)
+    expect(out.get('content-encoding')).toBeNull()
+    expect(out.get('content-type')).toBe('application/json')
+  })
+
+  test('strips hop-by-hop headers from response (connection, keep-alive, transfer-encoding, te)', () => {
+    const upstream = headersFromObject({
+      connection: 'close',
+      'keep-alive': 'timeout=5',
+      'transfer-encoding': 'chunked',
+      te: 'trailers',
+      'x-request-id': 'upstream-req-id',
+    })
+    const out = buildDownstreamHeaders(upstream)
+    expect(out.get('connection')).toBeNull()
+    expect(out.get('keep-alive')).toBeNull()
+    expect(out.get('transfer-encoding')).toBeNull()
+    expect(out.get('te')).toBeNull()
+    // Non-hop-by-hop passes through so callers can correlate requests
+    expect(out.get('x-request-id')).toBe('upstream-req-id')
+  })
+
+  test('preserves rate-limit + provider-specific headers (so SDKs can see them)', () => {
+    const upstream = headersFromObject({
+      'x-ratelimit-limit-requests': '500',
+      'x-ratelimit-remaining-requests': '499',
+      'openai-organization': 'org-abc',
+      'anthropic-ratelimit-tokens-remaining': '12345',
+    })
+    const out = buildDownstreamHeaders(upstream)
+    expect(out.get('x-ratelimit-limit-requests')).toBe('500')
+    expect(out.get('x-ratelimit-remaining-requests')).toBe('499')
+    expect(out.get('openai-organization')).toBe('org-abc')
+    expect(out.get('anthropic-ratelimit-tokens-remaining')).toBe('12345')
+  })
+})

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -8,14 +8,16 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],
-      // Ratchet threshold — set just below the current baseline (P2.3 measured
-      // 17.94% lines) so this run passes, and any future PR that drops
-      // coverage fails locally with `pnpm test --coverage`. CI runs `pnpm test`
-      // without the coverage flag, so this only gates opt-in measurement.
-      // Bump the floor each PR that adds meaningful coverage; the master
-      // plan's P2.3 target is 80% on Tier 1 modules. See
+      // Ratchet threshold — set just below the current baseline (measured
+      // 35.34% lines after the 49-test proxy integration + utils header
+      // pass landed; prior baseline was 17.94%) so this run passes, and
+      // any future PR that drops coverage fails locally with
+      // `pnpm test --coverage`. CI runs `pnpm test` without the coverage
+      // flag, so this only gates opt-in measurement. Bump the floor each
+      // PR that adds meaningful coverage; the master plan's P2.3 target
+      // is 80% on Tier 1 modules. See
       // docs/plans/launch-readiness-master-plan.md.
-      thresholds: { lines: 17 },
+      thresholds: { lines: 35 },
     },
   },
 })

--- a/apps/web/components/ui/button.test.tsx
+++ b/apps/web/components/ui/button.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { describe, expect, test, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Button, buttonVariants } from './button.js'
+
+/**
+ * Button is the most widely-reused interactive primitive in the dashboard.
+ * The tests pin:
+ *   1. variants × sizes produce the expected utility classes (so a Tailwind
+ *      purge regression that drops one would be caught),
+ *   2. asChild forwards props to the child element (Slot semantics),
+ *   3. onClick fires, and disabled blocks both onClick + visual state.
+ */
+
+describe('Button — variants + sizes', () => {
+  test('default variant + size renders as a <button> with the primary classes', () => {
+    render(<Button>Save</Button>)
+    const btn = screen.getByRole('button', { name: 'Save' })
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn).toHaveClass('bg-primary')
+    expect(btn).toHaveClass('h-9')
+  })
+
+  test('destructive variant gets the destructive background class', () => {
+    render(<Button variant="destructive">Delete</Button>)
+    expect(screen.getByRole('button')).toHaveClass('bg-destructive')
+  })
+
+  test('outline variant gets the border class', () => {
+    render(<Button variant="outline">Cancel</Button>)
+    expect(screen.getByRole('button')).toHaveClass('border')
+  })
+
+  test('size=sm gets compact height + text', () => {
+    render(<Button size="sm">Small</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn).toHaveClass('h-8')
+    expect(btn).toHaveClass('text-xs')
+  })
+
+  test('size=icon gets equal width/height for square hit target', () => {
+    render(<Button size="icon" aria-label="Settings">⚙</Button>)
+    const btn = screen.getByRole('button', { name: 'Settings' })
+    expect(btn).toHaveClass('h-9')
+    expect(btn).toHaveClass('w-9')
+  })
+
+  test('custom className is merged via cn() — base classes survive', () => {
+    render(<Button className="my-custom-class">Save</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn).toHaveClass('my-custom-class')
+    expect(btn).toHaveClass('bg-primary') // default still applied
+  })
+})
+
+describe('Button — asChild (Slot)', () => {
+  test('asChild renders the child element (e.g. <a>) with the button styling applied', () => {
+    render(
+      <Button asChild>
+        <a href="/dest">Go</a>
+      </Button>,
+    )
+    const link = screen.getByRole('link', { name: 'Go' })
+    expect(link.tagName).toBe('A')
+    expect(link).toHaveAttribute('href', '/dest')
+    // The button styling must reach the child via Slot
+    expect(link).toHaveClass('bg-primary')
+  })
+})
+
+describe('Button — interaction', () => {
+  test('onClick fires when clicked', async () => {
+    const onClick = vi.fn()
+    const user = userEvent.setup()
+    render(<Button onClick={onClick}>Click me</Button>)
+    await user.click(screen.getByRole('button'))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  test('disabled prevents onClick and applies the disabled styling', async () => {
+    const onClick = vi.fn()
+    const user = userEvent.setup()
+    render(<Button onClick={onClick} disabled>Disabled</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn).toBeDisabled()
+    expect(btn).toHaveClass('disabled:opacity-50')
+    await user.click(btn)
+    expect(onClick).not.toHaveBeenCalled()
+  })
+})
+
+describe('buttonVariants — class helper export', () => {
+  test('exported variant generator returns deterministic strings (consumers reuse it for non-button slots)', () => {
+    const cls = buttonVariants({ variant: 'outline', size: 'sm' })
+    expect(cls).toContain('border')
+    expect(cls).toContain('h-8')
+  })
+})

--- a/apps/web/components/ui/empty-state.test.tsx
+++ b/apps/web/components/ui/empty-state.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { describe, expect, test, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { EmptyState, FilterEmptyState, FirstInstallEmptyState } from './empty-state.js'
+
+/**
+ * EmptyState is the shared blank-data shell used across every list page
+ * (requests, traces, prompts, evals, datasets, …). A regression here changes
+ * the empty UX for every page at once, so it's worth pinning the rendered
+ * shape + the two callback wrappers (FilterEmptyState/FirstInstallEmptyState).
+ *
+ * These are the first @testing-library/react tests in apps/web — the
+ * `// @vitest-environment jsdom` pragma at the top opts this file into the
+ * DOM environment without affecting the pure-helper tests in lib/.
+ */
+
+describe('EmptyState — base shell', () => {
+  test('renders the title text', () => {
+    render(<EmptyState title="No results" />)
+    expect(screen.getByText('No results')).toBeInTheDocument()
+  })
+
+  test('renders description when supplied', () => {
+    render(<EmptyState title="No results" description="Try a wider time range." />)
+    expect(screen.getByText('Try a wider time range.')).toBeInTheDocument()
+  })
+
+  test('omits the description block entirely when not supplied (not an empty <p>)', () => {
+    const { container } = render(<EmptyState title="No results" />)
+    // Only the title <p> should be in the tree — there must be no orphan
+    // description paragraph that would create vertical space and a screen-reader
+    // pause for a missing description.
+    const paragraphs = container.querySelectorAll('p')
+    expect(paragraphs).toHaveLength(1)
+  })
+
+  test('renders action node when supplied', () => {
+    render(
+      <EmptyState
+        title="No results"
+        action={<button type="button">Retry</button>}
+      />,
+    )
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+  })
+
+  test('merges custom className with default layout classes', () => {
+    const { container } = render(
+      <EmptyState title="No results" className="custom-empty-marker" />,
+    )
+    const root = container.firstChild as HTMLElement
+    expect(root).toHaveClass('custom-empty-marker')
+    // The default centering classes are still applied — cn() must merge, not replace.
+    expect(root).toHaveClass('flex')
+    expect(root).toHaveClass('text-center')
+  })
+})
+
+describe('FilterEmptyState — filter-specific variant', () => {
+  test('uses the "No results" copy with a filter-clear hint', () => {
+    render(<FilterEmptyState onClear={() => undefined} />)
+    expect(screen.getByText('No results')).toBeInTheDocument()
+    expect(
+      screen.getByText(/no results\. try adjusting your filters/i),
+    ).toBeInTheDocument()
+  })
+
+  test('fires onClear when the clear-filters button is clicked', async () => {
+    const onClear = vi.fn()
+    const user = userEvent.setup()
+    render(<FilterEmptyState onClear={onClear} />)
+
+    await user.click(screen.getByRole('button', { name: /clear filters/i }))
+    expect(onClear).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('FirstInstallEmptyState — onboarding variant', () => {
+  test('renders the connect-first-project CTA pointing to /projects', () => {
+    render(<FirstInstallEmptyState />)
+    const cta = screen.getByRole('link', { name: /connect your first project/i })
+    expect(cta).toBeInTheDocument()
+    expect(cta).toHaveAttribute('href', '/projects')
+  })
+})

--- a/apps/web/lib/pii-mask.test.ts
+++ b/apps/web/lib/pii-mask.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from 'vitest'
+import { maskApiKeys, maskPii, maskPiiDeep } from './pii-mask.js'
+
+/**
+ * lib/pii-mask.ts is the client-side display masker for the /requests
+ * drawer. The server (apps/server/src/lib/pii-mask.ts) handles the
+ * authoritative key masking before persistence; this client copy gives
+ * users an opt-in "mask PII in preview" toggle for emails/phones/cards
+ * that the server intentionally never inspects.
+ *
+ * Pinning the patterns here so a regression in the regexes (the kind of
+ * change that's easy to miss in review) breaks CI instead of silently
+ * leaking secrets onto a customer's screen.
+ */
+
+describe('maskApiKeys', () => {
+  test('masks Spanlens sl_live_ keys (full scope)', () => {
+    const out = maskApiKeys('use key sl_live_abcdef0123456789 to call us')
+    expect(out).toBe('use key sl_live_*** to call us')
+  })
+
+  test('masks Spanlens sl_live_pub_ keys via the sl_live_ pattern (CLAUDE.md scope note)', () => {
+    // The CLAUDE.md note says "existing sl_live_ pattern automatically covers
+    // sl_live_pub_*". Pin that here so anyone tightening the regex sees the
+    // public-key case break first.
+    const out = maskApiKeys('readonly sl_live_pub_xyzabc0123456789 here')
+    expect(out).toContain('sl_live_***')
+    expect(out).not.toContain('sl_live_pub_xyz')
+  })
+
+  test('masks Anthropic sk-ant-* keys', () => {
+    const out = maskApiKeys('Authorization: Bearer sk-ant-api03-abcdef0123456789')
+    expect(out).toBe('Authorization: Bearer sk-ant-***')
+  })
+
+  test('masks OpenAI sk-proj-* keys', () => {
+    const out = maskApiKeys('OPENAI_API_KEY=sk-proj-abcdef0123456789xyz')
+    expect(out).toContain('sk-proj-***')
+  })
+
+  test('masks generic OpenAI sk-* keys', () => {
+    const out = maskApiKeys('key sk-abcdef0123456789xyz')
+    expect(out).toContain('sk-***')
+  })
+
+  test('masks Google AIza-prefixed keys', () => {
+    const out = maskApiKeys('GEMINI_API_KEY=AIzaSyAbcdef0123456789xyz')
+    expect(out).toContain('AIza***')
+  })
+
+  test('does NOT touch innocuous strings that happen to start with a key prefix but are too short', () => {
+    // KEY_MIN = 12 — a prefix alone or with <12 trailing chars stays intact
+    expect(maskApiKeys('sk-short')).toBe('sk-short')
+  })
+
+  test('leaves non-key content untouched', () => {
+    const input = 'hello world, no keys here, just prose'
+    expect(maskApiKeys(input)).toBe(input)
+  })
+})
+
+describe('maskPii — email/phone/card patterns', () => {
+  test('masks emails preserving 2-char prefix + obscured local + domain head', () => {
+    expect(maskPii('contact user@example.com today')).toContain('us***@***.com')
+  })
+
+  test('masks 10+ digit phone numbers (NANP with separators)', () => {
+    const out = maskPii('call +1 (555) 123-4567 please')
+    // 10+ digits trigger the mask; the inner digits should be hidden
+    expect(out).not.toContain('5551234567')
+    expect(out).not.toContain('123-4567')
+    expect(out).toMatch(/\*\*\*/)
+  })
+
+  test('masks credit-card-shaped 16-digit runs (with separators)', () => {
+    const out = maskPii('paid with 4111-1111-1111-1111 yesterday')
+    expect(out).not.toContain('1111-1111-1111-1111')
+    expect(out).toContain('4111')
+    expect(out).toContain('1111') // last 4 preserved
+    expect(out).toContain('****')
+  })
+
+  test('layers maskApiKeys on top — an email AND an API key both get masked', () => {
+    const out = maskPii('contact ops@spanlens.io with key sl_live_abcdef0123456789')
+    expect(out).toContain('op***@***.io')
+    expect(out).toContain('sl_live_***')
+  })
+
+  test('innocuous text passes through unchanged', () => {
+    const input = 'The quick brown fox jumps over the lazy dog.'
+    expect(maskPii(input)).toBe(input)
+  })
+})
+
+describe('maskPiiDeep — recursive object walking', () => {
+  test('masks strings nested inside arrays', () => {
+    const out = maskPiiDeep(['hello', 'sl_live_abcdef0123456789', { nested: 'sk-abcdef0123456789' }])
+    expect(out[0]).toBe('hello')
+    expect(out[1]).toBe('sl_live_***')
+    expect((out[2] as { nested: string }).nested).toBe('sk-***')
+  })
+
+  test('masks strings nested in objects (used for OpenAI message arrays)', () => {
+    const input = {
+      messages: [
+        { role: 'user', content: 'My email is alice@example.com' },
+        { role: 'assistant', content: 'Got it.' },
+      ],
+      apiKey: 'sl_live_abcdef0123456789',
+    }
+    const out = maskPiiDeep(input)
+    expect(out.messages[0]!.content).toContain('***@***.com')
+    expect(out.messages[1]!.content).toBe('Got it.')
+    expect(out.apiKey).toBe('sl_live_***')
+  })
+
+  test('non-string leaves (numbers, booleans, null) pass through unchanged', () => {
+    const input = { count: 42, ok: true, missing: null, ratio: 0.5 }
+    expect(maskPiiDeep(input)).toEqual(input)
+  })
+
+  test('preserves object key names (only values are scanned)', () => {
+    const out = maskPiiDeep({ sk_proj_abcdef0123456789: 'value' })
+    expect(Object.keys(out)).toEqual(['sk_proj_abcdef0123456789'])
+  })
+})

--- a/apps/web/lib/utils.test.ts
+++ b/apps/web/lib/utils.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest'
+import { cn, formatDate, formatDateTime, formatTime } from './utils.js'
+
+/**
+ * lib/utils.ts owns the en-US-pinned date formatters that defend the
+ * dashboard against React #418 hydration mismatches (CLAUDE.md gotcha #22).
+ * Any drift in the locale, options, or null handling re-opens that bug
+ * across every page that renders timestamps. Tests pin the output shape.
+ */
+
+describe('cn — class merger', () => {
+  test('joins truthy class names', () => {
+    expect(cn('a', 'b')).toBe('a b')
+  })
+
+  test('drops falsy / undefined / null inputs', () => {
+    expect(cn('a', undefined, null, false, '', 'b')).toBe('a b')
+  })
+
+  test('tailwind-merge collapses conflicting utilities (last wins)', () => {
+    // text-sm and text-lg are mutually exclusive in tailwind — tailwind-merge
+    // must pick the last one declared.
+    expect(cn('text-sm', 'text-lg')).toBe('text-lg')
+  })
+
+  test('preserves non-conflicting classes through conflict resolution', () => {
+    expect(cn('px-2 text-sm', 'text-lg')).toBe('px-2 text-lg')
+  })
+})
+
+describe('formatDate — en-US locale lock', () => {
+  test('null input renders the placeholder em-dash-substitute', () => {
+    expect(formatDate(null)).toBe('—')
+  })
+
+  test('formats a known ISO timestamp as "Mon D, YYYY"', () => {
+    // 2026-05-18 (May 18, 2026) — chose a non-ambiguous date so test fails
+    // loudly if someone switches the locale to anything that swaps day/month.
+    // We pick a noon-UTC time so any reasonable runner TZ still lands on
+    // the 18th — defending the test from the same TZ flakiness that broke
+    // earlier date-rendering attempts in /demo (gotcha #22 history).
+    const out = formatDate('2026-05-18T12:00:00.000Z')
+    expect(out).toBe('May 18, 2026')
+  })
+
+  test('output is locale-stable: no "5/18/2026" en-US numeric or "2026. 5. 18." ko-KR shape', () => {
+    const out = formatDate('2026-05-18T12:00:00.000Z')
+    expect(out).not.toMatch(/^\d+\/\d+\/\d+$/)
+    expect(out).not.toContain('. ')
+  })
+})
+
+describe('formatDateTime — en-US locale + 12h clock', () => {
+  test('null input renders the em-dash', () => {
+    expect(formatDateTime(null)).toBe('—')
+  })
+
+  test('output includes month, day, year, time, and AM/PM marker', () => {
+    const out = formatDateTime('2026-05-18T15:24:00.000Z')
+    expect(out).toContain('2026')
+    expect(out).toContain('May')
+    expect(out).toMatch(/\d{1,2}:\d{2}/)
+    expect(out).toMatch(/AM|PM/)
+  })
+})
+
+describe('formatTime — 24h en-US clock', () => {
+  test('null input renders the em-dash', () => {
+    expect(formatTime(null)).toBe('—')
+  })
+
+  test('output is HH:mm with no AM/PM (hour12 disabled)', () => {
+    const out = formatTime('2026-05-18T15:24:00.000Z')
+    expect(out).toMatch(/^\d{2}:\d{2}$/)
+    expect(out).not.toMatch(/AM|PM/)
+  })
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,8 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "analyze": "ANALYZE=true next build",
     "clean": "rm -rf .next"
   },
@@ -53,8 +55,13 @@
     "eslint-config-next": "16.2.7",
     "hono": "^4.12.23",
     "postcss": "^8",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
+    "jsdom": "^25.0.1",
     "server": "workspace:*",
     "tailwindcss": "^4.3.0",
-    "typescript": "^6"
+    "typescript": "^6",
+    "vitest": "^3.2.6"
   }
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig } from 'vitest/config'
+import path from 'node:path'
+
+// tsconfig.json has `jsx: preserve` so Next.js's compiler can handle JSX. The
+// app code never imports React explicitly because Next sets the automatic
+// runtime at build time. Vitest uses esbuild instead of the Next compiler, so
+// we mirror the automatic runtime here — without it, JSX expands to
+// `React.createElement(...)` and component tests fail with "React is not
+// defined".
+
+// Vitest configuration for apps/web.
+//
+// Two test environments are configured here, distinguished by file location
+// + naming convention so the right environment loads automatically:
+//
+//   - lib/**/*.test.ts(x)         → node env. Pure helpers (formatters, PII
+//                                   masking, query-string utils). Faster
+//                                   startup; no DOM globals.
+//   - components/**/*.test.tsx    → jsdom env (via per-file pragma). React
+//                                   component tests using @testing-library/
+//                                   react. Pragma is at the top of each
+//                                   component test file:
+//                                       // @vitest-environment jsdom
+//
+// Why a pragma instead of forking config: Vitest 3 supports only a single
+// `environment` option per project. Splitting into two projects is heavier
+// than this needs. The pragma is the documented escape hatch and lets new
+// component tests opt in without config edits.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    setupFiles: ['./vitest.setup.ts'],
+    include: [
+      'lib/**/*.test.ts',
+      'lib/**/*.test.tsx',
+      'components/**/*.test.ts',
+      'components/**/*.test.tsx',
+    ],
+    exclude: ['**/node_modules/**', '__e2e__/**', '.next/**'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname),
+    },
+  },
+  esbuild: {
+    jsx: 'automatic',
+  },
+})

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,0 +1,5 @@
+// Wires @testing-library/jest-dom matchers (toBeInTheDocument, toHaveClass,
+// toHaveAttribute, …) onto Vitest's `expect`. Component tests rely on these
+// for readable assertions; pure-helper tests in lib/ never call them so the
+// extra setup cost is one require() at boot.
+import '@testing-library/jest-dom/vitest'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
         version: 8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.6(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4))
+        version: 3.2.4(vitest@3.2.6(@types/node@25.8.0)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4))
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.7.0)
@@ -89,7 +89,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
+        version: 3.2.6(@types/node@25.8.0)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
 
   apps/web:
     dependencies:
@@ -125,7 +125,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@sentry/nextjs':
         specifier: ^10.56.0
-        version: 10.56.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.106.2(postcss@8.5.15))
+        version: 10.56.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.15))
       '@spanlens/api-types':
         specifier: workspace:*
         version: link:../../packages/api-types
@@ -190,6 +190,15 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.101.0
         version: 5.101.0(@tanstack/react-query@5.101.0(react@19.2.7))(react@19.2.7)
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^25
         version: 25.8.0
@@ -208,6 +217,9 @@ importers:
       hono:
         specifier: ^4.12.23
         version: 4.12.23
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
       postcss:
         specifier: ^8
         version: 8.5.15
@@ -220,6 +232,9 @@ importers:
       typescript:
         specifier: ^6
         version: 6.0.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@25.8.0)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
 
   packages/api-types:
     devDependencies:
@@ -250,7 +265,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
+        version: 3.2.6(@types/node@25.8.0)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
 
   packages/eslint-plugin:
     dependencies:
@@ -275,7 +290,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.6(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
+        version: 3.2.6(@types/node@22.19.19)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
 
   packages/mcp-server:
     dependencies:
@@ -297,7 +312,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
+        version: 3.2.6(@types/node@22.19.19)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
 
   packages/sdk:
     devDependencies:
@@ -318,9 +333,12 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
+        version: 3.2.6(@types/node@25.8.0)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -338,6 +356,9 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -445,6 +466,34 @@ packages:
   '@clickhouse/client@1.20.0':
     resolution: {integrity: sha512-LfHZ9bZZhc7KrNFVa9v73JMqwsP+m/5SgwdKMmxze4Urcw6pE0F7RNog3Lzx3GKRnJr3Hd15uDlIbqaDa9BbgA==}
     engines: {node: '>=16'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -2072,11 +2121,43 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@ts-morph/common@0.29.0':
     resolution: {integrity: sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==}
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -2543,6 +2624,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -2582,6 +2667,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -2595,6 +2684,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2645,6 +2737,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -2781,6 +2876,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -2840,10 +2939,17 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -2917,6 +3023,10 @@ packages:
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -2952,6 +3062,9 @@ packages:
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -2967,9 +3080,17 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -2981,6 +3102,12 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -3023,6 +3150,10 @@ packages:
   enhanced-resolve@5.22.2:
     resolution: {integrity: sha512-0rxICaFZ7NQho/sHely2bvOPRP0Eu2B0NZ9zM54YvRvWMn7jfz3DmnOZDR9LlXDdDcqntAVc6Hfy4gr/tdH/Ag==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -3331,6 +3462,10 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -3479,6 +3614,10 @@ packages:
     resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -3486,9 +3625,17 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -3497,6 +3644,10 @@ packages:
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -3527,6 +3678,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -3621,6 +3776,9 @@ packages:
   is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
@@ -3724,6 +3882,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -3948,6 +4115,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -3981,8 +4152,16 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -3992,6 +4171,10 @@ packages:
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -4093,6 +4276,9 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -4180,6 +4366,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -4292,6 +4481,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
@@ -4332,6 +4525,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -4394,6 +4590,10 @@ packages:
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -4450,6 +4650,12 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4467,6 +4673,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -4638,6 +4848,10 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -4674,6 +4888,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
@@ -4769,6 +4986,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -4781,8 +5005,16 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -5018,12 +5250,20 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
 
   webpack-bundle-analyzer@4.10.1:
     resolution: {integrity: sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==}
@@ -5043,6 +5283,19 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -5120,6 +5373,13 @@ packages:
     resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
     engines: {node: '>= 6.0'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -5164,6 +5424,8 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.5.0': {}
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.3.0':
@@ -5177,6 +5439,14 @@ snapshots:
       standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 4.4.3
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -5312,6 +5582,26 @@ snapshots:
   '@clickhouse/client@1.20.0':
     dependencies:
       '@clickhouse/client-common': 1.20.0
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@discoveryjs/json-ext@0.5.7': {}
 
@@ -6437,7 +6727,7 @@ snapshots:
 
   '@sentry/core@10.56.0': {}
 
-  '@sentry/nextjs@10.56.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.106.2(postcss@8.5.15))':
+  '@sentry/nextjs@10.56.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
@@ -6449,7 +6739,7 @@ snapshots:
       '@sentry/opentelemetry': 10.56.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
       '@sentry/react': 10.56.0(react@19.2.7)
       '@sentry/vercel-edge': 10.56.0
-      '@sentry/webpack-plugin': 5.3.0(webpack@5.106.2(postcss@8.5.15))
+      '@sentry/webpack-plugin': 5.3.0(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.15))
       next: 16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       rollup: 4.61.1
       stacktrace-parser: 0.1.11
@@ -6519,10 +6809,10 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@sentry/core': 10.56.0
 
-  '@sentry/webpack-plugin@5.3.0(webpack@5.106.2(postcss@8.5.15))':
+  '@sentry/webpack-plugin@5.3.0(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       '@sentry/bundler-plugin-core': 5.3.0
-      webpack: 5.106.2(postcss@8.5.15)
+      webpack: 5.106.2(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -6663,6 +6953,40 @@ snapshots:
       '@tanstack/query-core': 5.101.0
       react: 19.2.7
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.16
+      '@types/react-dom': 19.2.3(@types/react@19.2.16)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@ts-morph/common@0.29.0':
     dependencies:
       minimatch: 10.2.5
@@ -6673,6 +6997,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -6969,7 +7295,7 @@ snapshots:
       '@vercel/cli-config': 0.2.0
       '@vercel/cli-exec': 0.1.1
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.6(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.6(@types/node@25.8.0)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -6984,7 +7310,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.6(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
+      vitest: 3.2.6(@types/node@25.8.0)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -7172,6 +7498,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@7.1.4: {}
+
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -7207,6 +7535,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
@@ -7216,6 +7546,10 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -7297,6 +7631,8 @@ snapshots:
       js-tokens: 10.0.0
 
   async-function@1.0.0: {}
+
+  asynckit@0.4.0: {}
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -7436,6 +7772,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@2.20.3: {}
 
   commander@4.1.1: {}
@@ -7475,7 +7815,14 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
 
@@ -7545,6 +7892,11 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -7575,6 +7927,8 @@ snapshots:
 
   decimal.js-light@2.5.1: {}
 
+  decimal.js@10.6.0: {}
+
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
@@ -7591,7 +7945,11 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  delayed-stream@1.0.0: {}
+
   depd@2.0.0: {}
+
+  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
@@ -7600,6 +7958,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dotenv@16.6.1: {}
 
@@ -7634,6 +7996,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@6.0.1: {}
 
   es-abstract@1.24.2:
     dependencies:
@@ -8170,6 +8534,14 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
@@ -8307,6 +8679,10 @@ snapshots:
 
   hono@4.12.23: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
@@ -8317,6 +8693,13 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -8324,9 +8707,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   human-signals@2.1.0: {}
 
   iceberg-js@0.8.1: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.7.2:
     dependencies:
@@ -8353,6 +8747,8 @@ snapshots:
       module-details-from-path: 1.0.4
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
 
@@ -8444,6 +8840,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-plain-object@5.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
 
@@ -8553,6 +8951,34 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.20.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -8723,6 +9149,8 @@ snapshots:
     dependencies:
       react: 19.2.7
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -8752,13 +9180,21 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
 
   mimic-fn@2.1.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -8851,6 +9287,8 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  nwsapi@2.2.24: {}
 
   object-assign@4.1.1: {}
 
@@ -8946,6 +9384,10 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
@@ -9027,6 +9469,12 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   progress@2.0.3: {}
 
   prop-types@15.8.1:
@@ -9065,6 +9513,8 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
@@ -9127,6 +9577,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - redux
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
@@ -9223,6 +9678,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -9247,6 +9706,10 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -9497,6 +9960,10 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   strip-literal@3.1.0:
@@ -9530,20 +9997,23 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.0: {}
 
   tapable@2.3.3: {}
 
-  terser-webpack-plugin@5.6.1(postcss@8.5.15)(webpack@5.106.2(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.1(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.106.2(postcss@8.5.15)
+      webpack: 5.106.2(lightningcss@1.32.0)(postcss@8.5.15)
     optionalDependencies:
+      lightningcss: 1.32.0
       postcss: 8.5.15
 
   terser@5.48.0:
@@ -9584,6 +10054,12 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -9592,7 +10068,15 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -9880,7 +10364,7 @@ snapshots:
       terser: 5.48.0
       tsx: 4.22.4
 
-  vitest@3.2.6(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4):
+  vitest@3.2.6(@types/node@22.19.19)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -9907,6 +10391,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.19
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - jiti
       - less
@@ -9921,7 +10406,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.6(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4):
+  vitest@3.2.6(@types/node@25.8.0)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -9948,6 +10433,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.8.0
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - jiti
       - less
@@ -9962,12 +10448,18 @@ snapshots:
       - tsx
       - yaml
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   watchpack@2.5.1:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@7.0.0: {}
 
   webpack-bundle-analyzer@4.10.1:
     dependencies:
@@ -9990,7 +10482,7 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.106.2(postcss@8.5.15):
+  webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.15):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -10013,7 +10505,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(postcss@8.5.15)(webpack@5.106.2(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.1(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.15))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:
@@ -10029,6 +10521,17 @@ snapshots:
       - lightningcss
       - postcss
       - uglify-js
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -10103,8 +10606,7 @@ snapshots:
 
   ws@7.5.11: {}
 
-  ws@8.20.0:
-    optional: true
+  ws@8.20.0: {}
 
   xdg-app-paths@5.5.1:
     dependencies:
@@ -10114,6 +10616,10 @@ snapshots:
   xdg-portable@7.3.0:
     dependencies:
       os-paths: 4.4.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Summary

- Adds 39 end-to-end integration tests for the 4 proxy handlers (openai/anthropic/gemini/azure) covering auth header rewrite, x-spanlens-* stripping, NO_PROVIDER_KEY, public scope rejection, token→cost forwarding, and upstream non-2xx passthrough.
- Adds 18 first unit/component tests in apps/web — vitest + jsdom + @testing-library/react bootstrap, en-US date formatter tests (hydration #418 defense), PII mask tests, and Button/EmptyState component tests.
- Lifts the server coverage threshold ratchet 17 → 35 (measured 35.34% lines after this PR lands; prior baseline was 17.94%).

## Test plan

- [x] \`pnpm --filter server test\` — 946/946 (was 907)
- [x] \`pnpm --filter web test\` — 46/46 (was 0)
- [x] \`pnpm --filter server typecheck\` — clean
- [x] \`pnpm --filter web typecheck\` — clean
- [x] \`pnpm --filter server test --coverage\` — passes 35% threshold
- [ ] CI green on this branch

## Notes

- New shared helper \`__tests__/helpers/proxy-mocks.ts\` keeps each proxy test file small. \`vi.mock\` is hoisted per-file, but state objects + the fetch interceptor + the fire-and-forget drainer are reusable.
- apps/web uses a per-file \`// @vitest-environment jsdom\` pragma so lib/ tests stay in fast node env while components/ tests get the DOM. tsconfig is \`jsx: preserve\` for Next so vitest config sets \`esbuild.jsx: 'automatic'\` — without it components fail with "React is not defined".
- Out of scope: \`proxy/stream-logger.ts\` (2.89% covered) — streaming code path. Logical next ratchet target.