### PR TITLE
fix(server): block SSRF in webhook URLs + clamp page param

### DIFF
--- a/apps/server/src/api/webhooks.ts
+++ b/apps/server/src/api/webhooks.ts
@@ -7,6 +7,7 @@ import { dispatchWebhookEvent } from '../lib/webhook-dispatch.js'
 import { invalidateWebhookCache } from '../lib/webhook-emit.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
 import { ApiError } from '../lib/errors.js'
+import { validateOutboundUrl } from '../lib/safe-url.js'
 
 export const webhooksRouter = new Hono<JwtContext>()
 webhooksRouter.use('*', authJwt)
@@ -54,8 +55,15 @@ webhooksRouter.post('/', requireEdit, async (c) => {
   if (typeof body.name !== 'string' || body.name.trim().length === 0) {
     throw new ApiError('VALIDATION_FAILED', 'name is required')
   }
-  if (typeof body.url !== 'string' || !body.url.startsWith('https://')) {
-    throw new ApiError('BAD_REQUEST', 'url must start with https://')
+  if (typeof body.url !== 'string') {
+    throw new ApiError('BAD_REQUEST', 'url is required')
+  }
+  // SSRF defense — phase-2 (DNS-aware) validation at registration time.
+  // dispatch-time validation in lib/webhook-dispatch.ts catches DNS rebinding
+  // where the same hostname resolves to a private IP later.
+  const urlCheck = await validateOutboundUrl(body.url)
+  if (!urlCheck.ok) {
+    throw new ApiError('BAD_REQUEST', urlCheck.message, { reason: urlCheck.reason })
   }
 
   const events: string[] = Array.isArray(body.events)
@@ -119,7 +127,13 @@ webhooksRouter.patch('/:id', requireEdit, async (c) => {
   if (typeof body.name === 'string' && body.name.trim().length > 0) {
     updates['name'] = body.name.trim()
   }
-  if (typeof body.url === 'string' && body.url.startsWith('https://')) {
+  if (typeof body.url === 'string' && body.url.length > 0) {
+    // Same SSRF defense as POST — caller may be moving the webhook to a new
+    // target so the full DNS-aware check must run here too.
+    const urlCheck = await validateOutboundUrl(body.url)
+    if (!urlCheck.ok) {
+      throw new ApiError('BAD_REQUEST', urlCheck.message, { reason: urlCheck.reason })
+    }
     updates['url'] = body.url.trim()
   }
   if (Array.isArray(body.events)) {

--- a/apps/server/src/lib/params.test.ts
+++ b/apps/server/src/lib/params.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'vitest'
+import { parsePageLimit } from './params.js'
+
+/**
+ * `parsePageLimit` is shared by every paginated read endpoint (requests,
+ * traces, sessions, users). The clamps protect ClickHouse from
+ * cost-multiplying inputs:
+ *   - limit clamp prevents per-query result-set blowup
+ *   - page clamp prevents O(offset) deep-pagination scans
+ * A regression here lets an attacker burn ClickHouse seconds with a single
+ * crafted query string.
+ */
+
+describe('parsePageLimit — defaults', () => {
+  test('missing inputs → page=1, limit=50, offset=0', () => {
+    expect(parsePageLimit(undefined, undefined)).toEqual({ page: 1, limit: 50, offset: 0 })
+  })
+
+  test('valid inputs round-trip', () => {
+    expect(parsePageLimit('3', '20')).toEqual({ page: 3, limit: 20, offset: 40 })
+  })
+})
+
+describe('parsePageLimit — limit clamping', () => {
+  test('limit > maxLimit is clamped to maxLimit (100 default)', () => {
+    expect(parsePageLimit('1', '500').limit).toBe(100)
+  })
+
+  test('limit ≤ 0 stays within the safe range [1, maxLimit]', () => {
+    // `0` falls back to defaultLimit via JS truthiness (`0 || 50 → 50`).
+    // `-5` is truthy, so Math.max(1, -5) clamps to 1. Different code paths,
+    // but both end inside the safe range — that's what we actually need
+    // to enforce, not the exact fallback target.
+    const fromZero = parsePageLimit('1', '0').limit
+    const fromNegative = parsePageLimit('1', '-5').limit
+    expect(fromZero).toBeGreaterThanOrEqual(1)
+    expect(fromZero).toBeLessThanOrEqual(100)
+    expect(fromNegative).toBeGreaterThanOrEqual(1)
+    expect(fromNegative).toBeLessThanOrEqual(100)
+  })
+
+  test('non-numeric limit falls back to defaultLimit', () => {
+    expect(parsePageLimit('1', 'banana').limit).toBe(50)
+  })
+
+  test('custom maxLimit honored', () => {
+    expect(parsePageLimit('1', '5000', 100, 200).limit).toBe(200)
+  })
+})
+
+describe('parsePageLimit — page clamping (SSRF/DoS defense)', () => {
+  test('page < 1 is clamped to 1', () => {
+    expect(parsePageLimit('0', '10').page).toBe(1)
+    expect(parsePageLimit('-99', '10').page).toBe(1)
+  })
+
+  test('page > maxPage (10000 default) is clamped to maxPage', () => {
+    // Regression for "ClickHouse OFFSET 9.99B" DoS — without the clamp,
+    // ?page=99999999 produces an unbounded offset.
+    const { page, offset } = parsePageLimit('99999999', '100')
+    expect(page).toBe(10_000)
+    expect(offset).toBe(999_900) // (10000 - 1) * 100
+  })
+
+  test('page exactly at maxPage is honored', () => {
+    expect(parsePageLimit('10000', '100').page).toBe(10_000)
+  })
+
+  test('custom maxPage honored', () => {
+    expect(parsePageLimit('99999999', '100', 50, 100, 5).page).toBe(5)
+  })
+
+  test('worst-case offset under defaults is bounded (1M rows)', () => {
+    // 10000 (max page) * 100 (max limit) - 100 = 999_900
+    const { offset } = parsePageLimit('99999999', '99999999')
+    expect(offset).toBeLessThanOrEqual(1_000_000)
+  })
+
+  test('non-numeric page falls back to 1, not maxPage', () => {
+    expect(parsePageLimit('banana', '10').page).toBe(1)
+  })
+})

--- a/apps/server/src/lib/params.ts
+++ b/apps/server/src/lib/params.ts
@@ -41,16 +41,25 @@ export function parseIntMin(raw: string | undefined, fallback: number, min: numb
 
 /**
  * Parse the standard `page` + `limit` pagination params.
- * Returns `{ page, limit, offset }` with page ≥ 1 and limit clamped to
- * [1, maxLimit].
+ * Returns `{ page, limit, offset }` with `page` clamped to [1, maxPage] and
+ * `limit` clamped to [1, maxLimit].
+ *
+ * Why maxPage exists: ClickHouse OFFSET is O(offset) on sorted results, so a
+ * malicious `?page=99999999` would force ClickHouse to materialize-and-skip
+ * billions of rows per request. With maxPage=10000 and the default
+ * maxLimit=100 the worst case is 1M-row skip — still cheap on indexed scans
+ * and within the ClickHouse query budget. Callers needing deeper pagination
+ * must move to a cursor (`?after=<id>`) which is O(log n) instead of O(n).
  */
 export function parsePageLimit(
   pageRaw: string | undefined,
   limitRaw: string | undefined,
   defaultLimit = 50,
   maxLimit = 100,
+  maxPage = 10_000,
 ): { page: number; limit: number; offset: number } {
-  const page = Math.max(1, parseInt(pageRaw ?? '1', 10) || 1)
+  const rawPage = Math.max(1, parseInt(pageRaw ?? '1', 10) || 1)
+  const page = Math.min(maxPage, rawPage)
   const limit = Math.min(maxLimit, Math.max(1, parseInt(limitRaw ?? String(defaultLimit), 10) || defaultLimit))
   return { page, limit, offset: (page - 1) * limit }
 }

--- a/apps/server/src/lib/safe-url.test.ts
+++ b/apps/server/src/lib/safe-url.test.ts
@@ -1,0 +1,280 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  isBlockedIPv4,
+  isBlockedIPv6,
+  validateOutboundUrlSync,
+  validateOutboundUrl,
+} from './safe-url.js'
+
+/**
+ * SSRF (Server-Side Request Forgery) defense suite. Each test maps to a
+ * documented exploit pattern — if a check regresses, the matching test
+ * fails with the original threat in its description.
+ *
+ * Reference incidents:
+ *   - Capital One 2019: AWS IMDS at 169.254.169.254 → IAM credential theft
+ *   - GCP metadata at metadata.google.internal / 169.254.169.254
+ *   - DNS rebinding: hostname flips from public IP to private IP between
+ *     registration and use → caught by phase-2 dispatch-time check, here
+ *     covered by the BLOCKED_HOSTNAMES path.
+ */
+
+describe('isBlockedIPv4 — CIDR ranges', () => {
+  test.each([
+    ['10.0.0.1', '10.0.0.0/8'],         // RFC 1918 private
+    ['10.255.255.255', '10.0.0.0/8'],
+    ['127.0.0.1', '127.0.0.0/8'],       // loopback
+    ['127.99.99.99', '127.0.0.0/8'],
+    ['169.254.169.254', '169.254.0.0/16'], // AWS IMDS — Capital One
+    ['169.254.0.1', '169.254.0.0/16'],
+    ['172.16.0.1', '172.16.0.0/12'],    // RFC 1918 private
+    ['172.31.255.255', '172.16.0.0/12'],
+    ['192.168.1.1', '192.168.0.0/16'],  // RFC 1918 private (home routers)
+    ['100.64.0.1', '100.64.0.0/10'],    // CGNAT
+    ['0.0.0.0', '0.0.0.0/8'],
+    ['224.0.0.1', '224.0.0.0/4'],       // multicast
+    // 255.255.255.255 (broadcast) is also covered by the 240.0.0.0/4 reserved
+    // range, which the blocklist scans first — assertion targets that label.
+    ['255.255.255.255', '240.0.0.0/4'],
+  ])('blocks %s as %s', (ip, expectedRange) => {
+    const r = isBlockedIPv4(ip)
+    expect(r.blocked).toBe(true)
+    expect(r.range).toBe(expectedRange)
+  })
+
+  test.each([
+    '8.8.8.8',         // public Google DNS
+    '1.1.1.1',         // public Cloudflare DNS
+    '172.15.255.255',  // just outside 172.16.0.0/12
+    '172.32.0.1',      // just outside 172.16.0.0/12 high
+    '169.253.255.255', // just outside 169.254/16
+    '169.255.0.0',     // just outside 169.254/16
+    '11.0.0.1',        // just outside 10/8
+    '99.99.99.99',     // outside CGNAT
+    '128.0.0.1',       // just outside 127/8
+  ])('allows public IP %s', (ip) => {
+    expect(isBlockedIPv4(ip).blocked).toBe(false)
+  })
+
+  test('rejects malformed IP as blocked (fail closed)', () => {
+    expect(isBlockedIPv4('not.an.ip.address').blocked).toBe(true)
+    expect(isBlockedIPv4('999.999.999.999').blocked).toBe(true)
+    expect(isBlockedIPv4('10.0.0').blocked).toBe(true)
+  })
+
+  test('rejects leading-zero octets (octal-interpretation smuggling)', () => {
+    // Some OS resolvers read "010" as octal 8, so attackers could pass
+    // "010.0.0.1" to dodge a string-prefix block. We reject the form outright.
+    expect(isBlockedIPv4('010.0.0.1').blocked).toBe(true)
+  })
+})
+
+describe('isBlockedIPv6 — special ranges', () => {
+  test.each([
+    ['::1', '::1/128'],
+    ['0:0:0:0:0:0:0:1', '::1/128'],
+    ['fe80::1', 'fe80::/10'],         // link-local
+    ['fc00::1', 'fc00::/7'],          // unique local (fc/fd prefix only)
+    ['fd12:3456::1', 'fc00::/7'],
+    ['ff02::1', 'ff00::/8'],          // multicast
+  ])('blocks %s as %s', (ip, expectedRange) => {
+    const r = isBlockedIPv6(ip)
+    expect(r.blocked).toBe(true)
+    expect(r.range).toBe(expectedRange)
+  })
+
+  test('blocks v4-mapped private IP (::ffff:169.254.169.254 = IMDS smuggle)', () => {
+    // Without v4-mapped unwrap, a pure-v4 blocklist misses this form.
+    const r = isBlockedIPv6('::ffff:169.254.169.254')
+    expect(r.blocked).toBe(true)
+    expect(r.range).toContain('169.254')
+  })
+
+  test('blocks v4-mapped loopback (::ffff:127.0.0.1)', () => {
+    expect(isBlockedIPv6('::ffff:127.0.0.1').blocked).toBe(true)
+  })
+
+  test('allows public IPv6 (2001:4860:: Google DNS)', () => {
+    expect(isBlockedIPv6('2001:4860:4860::8888').blocked).toBe(false)
+  })
+
+  test('allows v4-mapped public IP (::ffff:8.8.8.8)', () => {
+    expect(isBlockedIPv6('::ffff:8.8.8.8').blocked).toBe(false)
+  })
+})
+
+describe('validateOutboundUrlSync — format + scheme + hostname', () => {
+  test('rejects empty / non-string input', () => {
+    expect(validateOutboundUrlSync('').ok).toBe(false)
+    expect(validateOutboundUrlSync(undefined as unknown as string).ok).toBe(false)
+  })
+
+  test('rejects malformed URL', () => {
+    const r = validateOutboundUrlSync('not a url')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('INVALID_FORMAT')
+  })
+
+  test('rejects http:// (https only)', () => {
+    const r = validateOutboundUrlSync('http://example.com/hook')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('INVALID_SCHEME')
+  })
+
+  test('rejects file:// and ftp://', () => {
+    expect(validateOutboundUrlSync('file:///etc/passwd').ok).toBe(false)
+    expect(validateOutboundUrlSync('ftp://internal.example.com/').ok).toBe(false)
+  })
+
+  test('rejects localhost hostname', () => {
+    const r = validateOutboundUrlSync('https://localhost:8080/admin')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('BLOCKED_HOSTNAME')
+  })
+
+  test('rejects metadata.google.internal (case-insensitive)', () => {
+    expect(validateOutboundUrlSync('https://metadata.google.internal/').ok).toBe(false)
+    expect(validateOutboundUrlSync('https://Metadata.Google.Internal/').ok).toBe(false)
+  })
+
+  test('rejects literal IPv4 in private range without DNS', () => {
+    const r = validateOutboundUrlSync('https://10.0.0.5/internal')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('BLOCKED_IP')
+  })
+
+  test('rejects literal IMDS IPv4 (169.254.169.254)', () => {
+    const r = validateOutboundUrlSync('https://169.254.169.254/latest/meta-data/')
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.reason).toBe('BLOCKED_IP')
+      expect(r.message).toContain('169.254')
+    }
+  })
+
+  test('rejects literal IPv6 loopback ([::1])', () => {
+    expect(validateOutboundUrlSync('https://[::1]:8080/').ok).toBe(false)
+  })
+
+  test('accepts well-formed public https URL with hostname (DNS deferred)', () => {
+    const r = validateOutboundUrlSync('https://hooks.example.com/webhook')
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.resolvedIps).toEqual([])
+  })
+
+  test('accepts literal public IPv4 without DNS', () => {
+    const r = validateOutboundUrlSync('https://8.8.8.8/')
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.resolvedIps).toEqual(['8.8.8.8'])
+  })
+
+  test('does not suffix-match metadata.google.internal.example.com', () => {
+    // BLOCKED_HOSTNAMES is exact match — this attacker-controlled lookalike
+    // domain must pass the sync check (the DNS phase will catch it if it
+    // resolves to a private IP).
+    expect(validateOutboundUrlSync('https://metadata.google.internal.example.com/').ok).toBe(true)
+  })
+})
+
+// --- DNS-aware phase: mock node:dns/promises -------------------------------
+
+const resolve4Mock = vi.fn<(host: string) => Promise<string[]>>()
+const resolve6Mock = vi.fn<(host: string) => Promise<string[]>>()
+
+vi.mock('node:dns', () => ({
+  promises: {
+    resolve4: (host: string) => resolve4Mock(host),
+    resolve6: (host: string) => resolve6Mock(host),
+  },
+}))
+
+beforeEach(() => {
+  resolve4Mock.mockReset()
+  resolve6Mock.mockReset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('validateOutboundUrl — DNS-aware (phase 2)', () => {
+  test('hostname resolves to public IP → ok with both A + AAAA captured', async () => {
+    resolve4Mock.mockResolvedValue(['8.8.8.8'])
+    resolve6Mock.mockResolvedValue(['2001:4860:4860::8888'])
+
+    const r = await validateOutboundUrl('https://hooks.example.com/x')
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      expect(r.resolvedIps).toContain('8.8.8.8')
+      expect(r.resolvedIps).toContain('2001:4860:4860::8888')
+    }
+  })
+
+  test('DNS rebinding: hostname resolves to 169.254.169.254 → BLOCKED_IP', async () => {
+    // The classic SSRF-via-rebinding attack: registration-time the hostname
+    // returned a public IP, but at dispatch time it returns IMDS. The
+    // dispatch-time call into validateOutboundUrl catches this.
+    resolve4Mock.mockResolvedValue(['169.254.169.254'])
+    resolve6Mock.mockRejectedValue(new Error('no AAAA'))
+
+    const r = await validateOutboundUrl('https://attacker.example.com/webhook')
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.reason).toBe('BLOCKED_IP')
+      expect(r.message).toContain('169.254')
+    }
+  })
+
+  test('hostname resolves to a mix of public and private IPs → BLOCKED (any-private wins)', async () => {
+    // Round-robin DNS that puts one private IP in the answer set is just as
+    // dangerous as an all-private answer — the next connection may land on it.
+    resolve4Mock.mockResolvedValue(['8.8.8.8', '10.0.0.1'])
+    resolve6Mock.mockRejectedValue(new Error('no AAAA'))
+
+    const r = await validateOutboundUrl('https://attacker.example.com/')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('BLOCKED_IP')
+  })
+
+  test('IPv6 resolves to v4-mapped private (::ffff:127.0.0.1) → BLOCKED', async () => {
+    resolve4Mock.mockRejectedValue(new Error('no A'))
+    resolve6Mock.mockResolvedValue(['::ffff:127.0.0.1'])
+
+    const r = await validateOutboundUrl('https://attacker.example.com/')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('BLOCKED_IP')
+  })
+
+  test('DNS resolution fails for both families → DNS_FAILED', async () => {
+    resolve4Mock.mockRejectedValue(new Error('NXDOMAIN'))
+    resolve6Mock.mockRejectedValue(new Error('NXDOMAIN'))
+
+    const r = await validateOutboundUrl('https://does-not-exist.example.com/')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('DNS_FAILED')
+  })
+
+  test('sync phase rejection short-circuits before DNS is consulted', async () => {
+    const r = await validateOutboundUrl('http://example.com/')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('INVALID_SCHEME')
+    expect(resolve4Mock).not.toHaveBeenCalled()
+    expect(resolve6Mock).not.toHaveBeenCalled()
+  })
+
+  test('literal IP host bypasses DNS (sync phase decision is authoritative)', async () => {
+    const r = await validateOutboundUrl('https://8.8.8.8/')
+    expect(r.ok).toBe(true)
+    expect(resolve4Mock).not.toHaveBeenCalled()
+    expect(resolve6Mock).not.toHaveBeenCalled()
+  })
+
+  test('hostname resolves only via IPv6 (AAAA only) is supported', async () => {
+    resolve4Mock.mockRejectedValue(new Error('no A record'))
+    resolve6Mock.mockResolvedValue(['2606:4700:4700::1111'])
+
+    const r = await validateOutboundUrl('https://v6-only.example.com/')
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.resolvedIps).toEqual(['2606:4700:4700::1111'])
+  })
+})

--- a/apps/server/src/lib/safe-url.ts
+++ b/apps/server/src/lib/safe-url.ts
@@ -1,0 +1,296 @@
+/**
+ * SSRF (Server-Side Request Forgery) defense for outbound URLs.
+ *
+ * Spanlens stores user-supplied URLs in two paths:
+ *   - api/webhooks.ts — customer registers a webhook target
+ *   - lib/webhook-dispatch.ts — outbound POST fires that URL on every event
+ *
+ * Without validation, an attacker can register a URL pointing at an internal
+ * service (loopback, private IP, cloud metadata) and trick the Vercel/Fly
+ * worker into hitting it on their behalf. The classic exploit is AWS IMDS at
+ * 169.254.169.254 — Capital One 2019 lost 100M records to that exact pattern.
+ *
+ * Two phases of validation:
+ *   1. `validateOutboundUrlSync` — format + scheme + hostname only. Fast,
+ *      runs on the request-handling hot path (webhook CRUD).
+ *   2. `validateOutboundUrl` — adds DNS resolution + per-IP CIDR check.
+ *      MUST run again at dispatch time too, because the DNS answer for a
+ *      hostname can flip between registration and use (DNS rebinding).
+ *
+ * The deny list covers RFC 1918 private ranges, loopback, link-local
+ * (including 169.254 cloud-metadata), CGNAT, multicast, and the
+ * IPv6 equivalents. v4-mapped-into-v6 (::ffff:10.0.0.1) is normalized
+ * back to v4 before checking so attackers can't smuggle private IPs
+ * through the v6 path.
+ */
+
+import { promises as dns } from 'node:dns'
+import { isIP } from 'node:net'
+
+/** Reasons the URL was rejected. Used as the ApiError detail.code. */
+export type SafeUrlReason =
+  | 'INVALID_FORMAT'
+  | 'INVALID_SCHEME'
+  | 'BLOCKED_HOSTNAME'
+  | 'BLOCKED_IP'
+  | 'DNS_FAILED'
+
+export type SafeUrlResult =
+  | { ok: true; resolvedIps: string[] }
+  | { ok: false; reason: SafeUrlReason; message: string }
+
+/**
+ * Hostnames that resolve to cloud-provider metadata services or are common
+ * internal aliases. Even when DNS resolution lands somewhere harmless these
+ * names indicate intent — a legitimate customer never points a webhook at
+ * `metadata.google.internal`. Match is exact + case-insensitive, no suffix
+ * match (otherwise `metadata.google.internal.example.com` would block).
+ */
+const BLOCKED_HOSTNAMES = new Set<string>([
+  'localhost',
+  'metadata.google.internal',
+  'metadata.goog',
+  // AWS doesn't publish a hostname for IMDS, but customers sometimes alias it.
+  'metadata.aws',
+  'metadata.aws.internal',
+  // Azure IMDS hostname
+  'metadata.azure.internal',
+])
+
+/** Returns a 32-bit unsigned integer for a dotted-quad IPv4 string, or null if malformed. */
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return null
+  let n = 0
+  for (const part of parts) {
+    const octet = Number(part)
+    if (!Number.isInteger(octet) || octet < 0 || octet > 255) return null
+    // Avoid `'01'` being read as octal — we already coerced via Number(),
+    // but reject strings with leading zeros that an OS might interpret
+    // as octal (some C-flavored resolvers still do).
+    if (part.length > 1 && part.startsWith('0')) return null
+    n = (n << 8) | octet
+  }
+  // Force unsigned interpretation (>>> 0).
+  return n >>> 0
+}
+
+/** [networkInt, prefixLen] for each blocked IPv4 range. */
+const BLOCKED_IPV4: Array<{ net: number; prefix: number; label: string }> = [
+  // 0.0.0.0/8 — "this network", non-routable
+  { net: ipv4ToInt('0.0.0.0')!,       prefix: 8,  label: '0.0.0.0/8' },
+  // 10.0.0.0/8 — RFC 1918 private
+  { net: ipv4ToInt('10.0.0.0')!,      prefix: 8,  label: '10.0.0.0/8' },
+  // 100.64.0.0/10 — CGNAT (RFC 6598). Often used inside hyperscaler VPCs.
+  { net: ipv4ToInt('100.64.0.0')!,    prefix: 10, label: '100.64.0.0/10' },
+  // 127.0.0.0/8 — loopback
+  { net: ipv4ToInt('127.0.0.0')!,     prefix: 8,  label: '127.0.0.0/8' },
+  // 169.254.0.0/16 — link-local. Contains AWS IMDS (169.254.169.254).
+  { net: ipv4ToInt('169.254.0.0')!,   prefix: 16, label: '169.254.0.0/16' },
+  // 172.16.0.0/12 — RFC 1918 private
+  { net: ipv4ToInt('172.16.0.0')!,    prefix: 12, label: '172.16.0.0/12' },
+  // 192.0.0.0/24 — IETF protocol assignments
+  { net: ipv4ToInt('192.0.0.0')!,     prefix: 24, label: '192.0.0.0/24' },
+  // 192.0.2.0/24 — TEST-NET-1 (documentation)
+  { net: ipv4ToInt('192.0.2.0')!,     prefix: 24, label: '192.0.2.0/24' },
+  // 192.168.0.0/16 — RFC 1918 private
+  { net: ipv4ToInt('192.168.0.0')!,   prefix: 16, label: '192.168.0.0/16' },
+  // 198.18.0.0/15 — benchmark testing
+  { net: ipv4ToInt('198.18.0.0')!,    prefix: 15, label: '198.18.0.0/15' },
+  // 198.51.100.0/24 — TEST-NET-2
+  { net: ipv4ToInt('198.51.100.0')!,  prefix: 24, label: '198.51.100.0/24' },
+  // 203.0.113.0/24 — TEST-NET-3
+  { net: ipv4ToInt('203.0.113.0')!,   prefix: 24, label: '203.0.113.0/24' },
+  // 224.0.0.0/4 — multicast
+  { net: ipv4ToInt('224.0.0.0')!,     prefix: 4,  label: '224.0.0.0/4' },
+  // 240.0.0.0/4 — reserved
+  { net: ipv4ToInt('240.0.0.0')!,     prefix: 4,  label: '240.0.0.0/4' },
+  // 255.255.255.255 — broadcast
+  { net: ipv4ToInt('255.255.255.255')!, prefix: 32, label: '255.255.255.255/32' },
+]
+
+/** True if the given dotted-quad IPv4 is inside any blocked CIDR. */
+export function isBlockedIPv4(ip: string): { blocked: boolean; range?: string } {
+  const int = ipv4ToInt(ip)
+  if (int === null) return { blocked: true, range: 'malformed' }
+  for (const { net, prefix, label } of BLOCKED_IPV4) {
+    // mask of `prefix` high bits set
+    const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0
+    if ((int & mask) === (net & mask)) {
+      return { blocked: true, range: label }
+    }
+  }
+  return { blocked: false }
+}
+
+/**
+ * Normalize an IPv6 address to lowercase canonical form. Node's `dns.resolve6`
+ * already returns canonical lowercase, but inputs we read from URLs may be
+ * mixed case or include the optional `[...]` brackets — strip those first.
+ */
+function canonicalizeIPv6(raw: string): string {
+  return raw.replace(/^\[/, '').replace(/\]$/, '').toLowerCase()
+}
+
+/**
+ * True if the IPv6 address is loopback/link-local/unique-local/multicast,
+ * OR if it's a v4-mapped (::ffff:a.b.c.d) form whose embedded v4 is blocked.
+ * The v4-mapped check is the trap that catches attackers who pass
+ * `::ffff:169.254.169.254` to evade a pure-v4 IMDS filter.
+ */
+export function isBlockedIPv6(raw: string): { blocked: boolean; range?: string } {
+  const ip = canonicalizeIPv6(raw)
+
+  // ::1 loopback
+  if (ip === '::1' || ip === '0:0:0:0:0:0:0:1') return { blocked: true, range: '::1/128' }
+  // :: unspecified
+  if (ip === '::' || ip === '0:0:0:0:0:0:0:0') return { blocked: true, range: '::/128' }
+
+  // v4-mapped: ::ffff:a.b.c.d  → unwrap and check as IPv4
+  const v4mapped = /^::ffff:((?:\d{1,3}\.){3}\d{1,3})$/i.exec(ip)
+  if (v4mapped) {
+    const v4 = v4mapped[1]!
+    const v4Result = isBlockedIPv4(v4)
+    if (v4Result.blocked) {
+      return { blocked: true, range: `::ffff:${v4Result.range ?? v4}` }
+    }
+  }
+
+  // fc00::/7 — unique local
+  if (ip.startsWith('fc') || ip.startsWith('fd')) return { blocked: true, range: 'fc00::/7' }
+  // fe80::/10 — link-local
+  if (/^fe[89ab]/.test(ip)) return { blocked: true, range: 'fe80::/10' }
+  // ff00::/8 — multicast
+  if (ip.startsWith('ff')) return { blocked: true, range: 'ff00::/8' }
+
+  return { blocked: false }
+}
+
+/**
+ * Phase 1 validation: format + scheme + hostname only. No DNS.
+ *
+ * Use at registration time to give the customer fast feedback. Always pair
+ * with `validateOutboundUrl` at dispatch time — phase 1 cannot stop a
+ * hostname that resolves to a private IP, only obviously-bad inputs.
+ */
+export function validateOutboundUrlSync(raw: string): SafeUrlResult {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return { ok: false, reason: 'INVALID_FORMAT', message: 'url is required' }
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(raw)
+  } catch {
+    return { ok: false, reason: 'INVALID_FORMAT', message: 'url is not a valid URL' }
+  }
+
+  if (parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'INVALID_SCHEME', message: 'url must use https://' }
+  }
+
+  // Node's URL parser keeps the `[...]` brackets on IPv6 hostnames
+  // (`new URL('https://[::1]/').hostname === '[::1]'`). Strip them so the
+  // isIP / blocklist checks see the literal address.
+  const hostname = parsed.hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '')
+
+  if (BLOCKED_HOSTNAMES.has(hostname)) {
+    return {
+      ok: false,
+      reason: 'BLOCKED_HOSTNAME',
+      message: `url hostname "${hostname}" is not allowed (internal/metadata target)`,
+    }
+  }
+
+  // If the hostname IS a literal IP, check it now without DNS.
+  const ipKind = isIP(hostname)
+  if (ipKind === 4) {
+    const r = isBlockedIPv4(hostname)
+    if (r.blocked) {
+      return {
+        ok: false,
+        reason: 'BLOCKED_IP',
+        message: `url resolves to a blocked IP range (${r.range ?? 'unknown'})`,
+      }
+    }
+  } else if (ipKind === 6) {
+    const r = isBlockedIPv6(hostname)
+    if (r.blocked) {
+      return {
+        ok: false,
+        reason: 'BLOCKED_IP',
+        message: `url resolves to a blocked IPv6 range (${r.range ?? 'unknown'})`,
+      }
+    }
+  }
+
+  return { ok: true, resolvedIps: ipKind ? [hostname] : [] }
+}
+
+/**
+ * Phase 2 validation: full check including DNS resolution.
+ *
+ * Resolves A + AAAA records for the hostname and rejects if ANY of them is in
+ * a blocked range. Even one bad IP is enough — DNS round-robin would let an
+ * attacker land on the bad one even if siblings look clean.
+ *
+ * `dns.resolve4/6` throws on NXDOMAIN; both throws are caught and surfaced
+ * as DNS_FAILED so callers can distinguish "DNS broken" from "DNS clean but
+ * landed on a private IP".
+ */
+export async function validateOutboundUrl(raw: string): Promise<SafeUrlResult> {
+  const syncResult = validateOutboundUrlSync(raw)
+  if (!syncResult.ok) return syncResult
+
+  // Hostname was already a literal IP and passed phase 1 — done.
+  if (syncResult.resolvedIps.length > 0) return syncResult
+
+  let parsed: URL
+  try {
+    parsed = new URL(raw)
+  } catch {
+    return { ok: false, reason: 'INVALID_FORMAT', message: 'url is not a valid URL' }
+  }
+  // Same bracket-strip rationale as the sync path.
+  const hostname = parsed.hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '')
+
+  // Resolve both families in parallel; at least one must succeed.
+  const [v4Settled, v6Settled] = await Promise.allSettled([
+    dns.resolve4(hostname),
+    dns.resolve6(hostname),
+  ])
+
+  const v4 = v4Settled.status === 'fulfilled' ? v4Settled.value : []
+  const v6 = v6Settled.status === 'fulfilled' ? v6Settled.value : []
+
+  if (v4.length === 0 && v6.length === 0) {
+    return {
+      ok: false,
+      reason: 'DNS_FAILED',
+      message: `url hostname "${hostname}" could not be resolved`,
+    }
+  }
+
+  for (const ip of v4) {
+    const r = isBlockedIPv4(ip)
+    if (r.blocked) {
+      return {
+        ok: false,
+        reason: 'BLOCKED_IP',
+        message: `url resolves to a blocked IP range (${r.range ?? ip})`,
+      }
+    }
+  }
+  for (const ip of v6) {
+    const r = isBlockedIPv6(ip)
+    if (r.blocked) {
+      return {
+        ok: false,
+        reason: 'BLOCKED_IP',
+        message: `url resolves to a blocked IPv6 range (${r.range ?? ip})`,
+      }
+    }
+  }
+
+  return { ok: true, resolvedIps: [...v4, ...v6] }
+}

--- a/apps/server/src/lib/webhook-dispatch.ts
+++ b/apps/server/src/lib/webhook-dispatch.ts
@@ -9,6 +9,7 @@
  */
 
 import { supabaseAdmin } from './db.js'
+import { validateOutboundUrl } from './safe-url.js'
 
 export interface WebhookRow {
   id: string
@@ -63,6 +64,22 @@ export async function sendWebhook(
   let httpStatus: number | null = null
   let errorMessage: string | null = null
   let ok = false
+
+  // SSRF defense — validate at dispatch time even though registration also
+  // validated. DNS rebinding: the hostname's A record may have flipped to a
+  // private IP since registration. webhook_deliveries records the rejection
+  // (ok:false, errorMessage) so the retry cron will exhaust attempts and
+  // stop, instead of hammering an internal target on every retry tick.
+  const urlCheck = await validateOutboundUrl(url)
+  if (!urlCheck.ok) {
+    return {
+      ok: false,
+      httpStatus: null,
+      errorMessage: `URL rejected by SSRF guard: ${urlCheck.message}`,
+      durationMs: Date.now() - startMs,
+      payloadStr,
+    }
+  }
 
   try {
     const res = await fetch(url, {


### PR DESCRIPTION
## Summary

Two security hardenings from the post-launch audit:

1. **Webhook SSRF (HIGH)** — \`api/webhooks.ts\` only checked \`startsWith('https://')\`. Customers could register webhooks pointing at loopback / RFC 1918 / AWS IMDS (169.254.169.254) / GCP metadata, and the dispatch worker would POST org metadata to them. Same pattern that leaked 100M Capital One records in 2019. New \`lib/safe-url.ts\` validates outbound URLs with literal-IP checks (sync) + DNS resolution against a CIDR blocklist (async), applied at BOTH registration AND every dispatch (DNS rebinding defense).
2. **parsePageLimit page clamp (MEDIUM)** — \`limit\` was already clamped to ≤100, but \`page\` had no upper bound. \`?page=99999999\` produced OFFSET ~10B against ClickHouse. New \`maxPage=10000\` default bounds worst-case offset to 1M rows.

## Test plan

- [x] \`pnpm --filter server test\` — 1012/1012 (was 946)
- [x] \`pnpm --filter server typecheck\` — clean
- [x] 54 new SSRF tests (every CIDR, DNS rebinding reproducer, v4-mapped smuggle)
- [x] 12 new page-clamp tests (worst-case offset bound, regression for ClickHouse DoS)
- [ ] CI green on this branch

## Blocked ranges (for reviewer reference)

**IPv4**: 0/8, 10/8, 100.64/10 CGNAT, 127/8 loopback, **169.254/16 link-local + IMDS**, 172.16/12, 192.0.0/24, 192.0.2/24, 192.168/16, 198.18/15, 198.51.100/24, 203.0.113/24, 224/4 multicast, 240/4 reserved, 255.255.255.255/32 broadcast.

**IPv6**: ::1, ::, fc00::/7 unique local, fe80::/10 link-local, ff00::/8 multicast. v4-mapped \`::ffff:a.b.c.d\` is unwrapped before the v4 check so \`::ffff:169.254.169.254\` cannot slip through.

**Hostnames** (exact match): localhost, metadata.google.internal, metadata.goog, metadata.aws.internal, metadata.azure.internal.

## Notes

- Phase-1 (sync) validation gives fast rejection at registration; phase-2 (DNS-aware) runs at registration AND on every \`sendWebhook\` call. The latter is what catches DNS rebinding — without it, an attacker who controls a hostname's DNS can pass registration with a public IP, then flip the A record to 169.254.169.254 for the actual webhook delivery.
- \`webhook-dispatch.sendWebhook\` returns the SSRF rejection as \`ok:false\` with a clear error so it lands in \`webhook_deliveries\` and the retry cron exhausts attempts (does not hammer the internal target).
- Out of scope for this PR: 4.5MB Vercel body limit. That's a separate infrastructure decision tracked in user's notes.