### PR TITLE
refactor(server,web): structured logger + fmtCost helpers (PR 1/4 tech-debt)

### DIFF
--- a/apps/server/src/lib/logger.ts
+++ b/apps/server/src/lib/logger.ts
@@ -6,6 +6,7 @@ import { scanAll, type SecurityFlag } from './security-scan.js'
 import { sendEmail, renderSecurityAlertEmail } from './resend.js'
 import { emitWebhookEvent } from './webhook-emit.js'
 import { writeRequestAsEvent } from './events-writer.js'
+import { logError } from './structured-logger.js'
 
 /**
  * Customer-controlled body logging mode (sent via the `x-spanlens-log-body`
@@ -192,8 +193,8 @@ async function maybeSendSecurityAlert(params: {
 
   const result = await sendEmail({ to: ownerEmail, subject, html })
   if (!result.sent && result.error) {
-    // Log only error message, not ownerEmail, to avoid PII in logs
-    console.error('[security-alert] sendEmail failed:', result.error)
+    // ownerEmail is intentionally NOT in context — keep PII out of error logs.
+    logError('UNCATEGORIZED', { orgId: organizationId, projectId, kind: 'security_alert_email' }, result.error)
   }
 }
 
@@ -291,10 +292,11 @@ export async function logRequestAsync(data: RequestLogData): Promise<void> {
     try {
       await writeRequestAsEvent(data, clickhouseRow)
     } catch (err) {
-      console.error(
-        '[logger] events shadow INSERT failed:',
-        err instanceof Error ? err.message : err,
-      )
+      logError('CH_INSERT_FAILED', {
+        orgId: data.organizationId,
+        provider: data.provider,
+        kind: 'events_shadow_insert',
+      }, err)
     }
   } catch (err) {
     // ── ClickHouse fallback (P2.6) ─────────────────────────────────────────
@@ -303,7 +305,11 @@ export async function logRequestAsync(data: RequestLogData): Promise<void> {
     // it later. Without this backstop every CH outage silently loses customer
     // billing data and dashboard entries.
     const message = err instanceof Error ? err.message : String(err)
-    console.error('[logger] ClickHouse insert failed, queueing to fallback:', message)
+    logError('CH_INSERT_FAILED', {
+      orgId: data.organizationId,
+      provider: data.provider,
+      kind: 'requests_insert_falling_back_to_supabase',
+    }, err)
 
     try {
       await supabaseAdmin.from('requests_fallback').insert({
@@ -312,12 +318,13 @@ export async function logRequestAsync(data: RequestLogData): Promise<void> {
         last_error: message.slice(0, 500),
       })
     } catch (fallbackErr) {
-      // Both DBs are down. Nothing more we can do — surface loudly so
-      // observability picks it up. The original CH error message is
-      // preserved in the log line above for triage.
-      const fallbackMessage =
-        fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)
-      console.error('[logger] Fallback INSERT also failed — row LOST:', fallbackMessage)
+      // Both DBs are down. Row is now lost — surface loudly. Original CH
+      // error is preserved in the previous log line for triage.
+      logError('FALLBACK_INSERT_FAILED', {
+        orgId: data.organizationId,
+        provider: data.provider,
+        kind: 'row_lost',
+      }, fallbackErr)
     }
   }
 
@@ -333,7 +340,11 @@ export async function logRequestAsync(data: RequestLogData): Promise<void> {
       requestFlags,
       responseFlags,
     }).catch((err) => {
-      console.error('[security-alert] failed:', err instanceof Error ? err.message : String(err))
+      logError('UNCATEGORIZED', {
+        orgId: data.organizationId,
+        projectId: data.projectId,
+        kind: 'security_alert_chain',
+      }, err)
     })
   }
 
@@ -358,6 +369,9 @@ export async function logRequestAsync(data: RequestLogData): Promise<void> {
       },
     })
   } catch (err) {
-    console.error('[logger] request.created webhook emit failed:', err instanceof Error ? err.message : err)
+    logError('WEBHOOK_DISPATCH_FAILED', {
+      orgId: data.organizationId,
+      eventType: 'request.created',
+    }, err)
   }
 }

--- a/apps/server/src/lib/structured-logger.test.ts
+++ b/apps/server/src/lib/structured-logger.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { logError, logWarn } from './structured-logger.js'
+
+/**
+ * Locks the structured-logger contract:
+ *   1. Output line starts with LEVEL[CODE] for grep-ability.
+ *   2. JSON payload contains the context fields verbatim.
+ *   3. String values pass through maskApiKeys (no plaintext sl_live_* or
+ *      sk-* in logs that get indexed by Sentry).
+ *   4. Error instances are serialized as {name, message, stack}.
+ */
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore()
+  consoleWarnSpy.mockRestore()
+})
+
+function lastErrorLine(): string {
+  expect(consoleErrorSpy).toHaveBeenCalled()
+  return consoleErrorSpy.mock.calls.at(-1)![0] as string
+}
+
+function lastErrorPayload(): Record<string, unknown> {
+  const line = lastErrorLine()
+  // Format: `ERROR[CODE] {json}` — split on the first " {"
+  const jsonStart = line.indexOf(' {')
+  return JSON.parse(line.slice(jsonStart + 1)) as Record<string, unknown>
+}
+
+describe('logError — output shape', () => {
+  test('starts with ERROR[CODE] prefix for grep', () => {
+    logError('CH_INSERT_FAILED', { orgId: 'org_1' })
+    expect(lastErrorLine()).toMatch(/^ERROR\[CH_INSERT_FAILED\] \{/)
+  })
+
+  test('payload contains level + code + ts + context fields', () => {
+    logError('CRON_JOB_FAILED', { jobName: 'aggregate-usage', orgId: 'org_2' })
+    const p = lastErrorPayload()
+    expect(p['level']).toBe('ERROR')
+    expect(p['code']).toBe('CRON_JOB_FAILED')
+    expect(p['jobName']).toBe('aggregate-usage')
+    expect(p['orgId']).toBe('org_2')
+    expect(typeof p['ts']).toBe('string')
+  })
+})
+
+describe('logError — PII masking', () => {
+  test('sl_live_* API keys in context strings are masked', () => {
+    logError('UPSTREAM_FETCH_FAILED', {
+      orgId: 'org_1',
+      hint: 'used key sl_live_abcdef0123456789 to call upstream',
+    })
+    const line = lastErrorLine()
+    expect(line).not.toContain('sl_live_abcdef0123456789')
+    expect(line).toContain('sl_live_***')
+  })
+
+  test('sk-ant-* keys are masked', () => {
+    logError('UNCATEGORIZED', { hint: 'sk-ant-api03-abcdef0123456789' })
+    expect(lastErrorLine()).toContain('sk-ant-***')
+    expect(lastErrorLine()).not.toContain('sk-ant-api03-abcdef')
+  })
+
+  test('keys nested in arrays/objects are masked', () => {
+    logError('UNCATEGORIZED', {
+      messages: [
+        { role: 'system', content: 'sl_live_abcdef0123456789' },
+      ],
+    })
+    expect(lastErrorLine()).not.toContain('sl_live_abcdef0123456789')
+    expect(lastErrorLine()).toContain('sl_live_***')
+  })
+
+  test('non-string values pass through untouched', () => {
+    logError('UNCATEGORIZED', {
+      count: 42,
+      flag: true,
+      nullable: null,
+    })
+    const p = lastErrorPayload()
+    expect(p['count']).toBe(42)
+    expect(p['flag']).toBe(true)
+    expect(p['nullable']).toBeNull()
+  })
+})
+
+describe('logError — Error serialization', () => {
+  test('Error instance serialized as {name, message, stack}', () => {
+    const err = new TypeError('boom')
+    logError('UPSTREAM_FETCH_FAILED', { provider: 'openai' }, err)
+    const p = lastErrorPayload()
+    const errPayload = p['err'] as { name: string; message: string; stack: string }
+    expect(errPayload.name).toBe('TypeError')
+    expect(errPayload.message).toBe('boom')
+    expect(typeof errPayload.stack).toBe('string')
+  })
+
+  test('Error message itself is PII-masked', () => {
+    const err = new Error('failed with key sl_live_abcdef0123456789')
+    logError('UPSTREAM_FETCH_FAILED', {}, err)
+    const p = lastErrorPayload()
+    expect((p['err'] as { message: string }).message).toContain('sl_live_***')
+  })
+
+  test('string error becomes { message }', () => {
+    logError('UNCATEGORIZED', {}, 'string error path')
+    const p = lastErrorPayload()
+    expect((p['err'] as { message: string }).message).toBe('string error path')
+  })
+})
+
+describe('logWarn — same shape, lower severity', () => {
+  test('uses console.warn and WARN[CODE] prefix', () => {
+    logWarn('CRON_PARTIAL_FAILURE', { jobName: 'replay-fallback', count: 3 })
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+    expect(consoleWarnSpy).toHaveBeenCalled()
+    const line = consoleWarnSpy.mock.calls.at(-1)![0] as string
+    expect(line).toMatch(/^WARN\[CRON_PARTIAL_FAILURE\] \{/)
+  })
+})

--- a/apps/server/src/lib/structured-logger.ts
+++ b/apps/server/src/lib/structured-logger.ts
@@ -1,0 +1,123 @@
+/**
+ * Structured logger for server-side error/warn paths.
+ *
+ * Why this exists: the codebase has 151 `console.error(...)` call sites
+ * across 45 files (audit 2026-06-12). Each one writes a free-form string,
+ * so Sentry sees "Failed to fetch org" with no orgId, requestId, or
+ * cron_job_name attached — and the operator has to grep server logs to
+ * figure out which tenant is affected. Worse, a few sites (notably
+ * lib/logger.ts:306) interpolate raw request bodies, which can leak PII
+ * into the search-indexed Sentry breadcrumbs.
+ *
+ * This module is the single replacement target:
+ *   - `logError(code, context, err?)` — structured emission with required
+ *     code + bag-of-context + optional Error. Auto-applies `maskApiKeys`
+ *     to every string value in the context before serialization.
+ *   - `logWarn(code, context, err?)` — same shape for non-error severity.
+ *
+ * Output format is one line per call, prefixed with the level + code so
+ * `grep -E "ERROR\\[CH_INSERT_FAILED\\]" server.log` works. JSON-encoded
+ * payload follows for parsability. Sentry's `captureException` is *not*
+ * called here — that's the responsibility of the global onError handler
+ * in app.ts so we don't double-capture.
+ *
+ * Migration policy: new code MUST use logError/logWarn. Old console.error
+ * sites are migrated opportunistically — the ESLint rule in CI flags new
+ * ones but doesn't rewrite existing ones (would balloon this PR).
+ */
+
+import { maskApiKeys } from './pii-mask.js'
+
+/** Stable error codes — extend the union as call sites are migrated. */
+export type LogCode =
+  // logger.ts hot path
+  | 'CH_INSERT_FAILED'
+  | 'FALLBACK_INSERT_FAILED'
+  // webhook delivery
+  | 'WEBHOOK_DISPATCH_FAILED'
+  | 'WEBHOOK_FETCH_FAILED'
+  // proxy upstream
+  | 'UPSTREAM_FETCH_FAILED'
+  // Paddle billing
+  | 'PADDLE_WEBHOOK_FAILED'
+  | 'PADDLE_API_FAILED'
+  // cron jobs (job_name on context distinguishes)
+  | 'CRON_JOB_FAILED'
+  | 'CRON_PARTIAL_FAILURE'
+  // catch-all for sites that haven't been categorized yet
+  | 'UNCATEGORIZED'
+
+/**
+ * Free-form context bag. Required fields (`orgId`, `requestId` etc.) are
+ * documented per-code in the call sites, not enforced here — making them
+ * mandatory would block the gradual migration. Strings are PII-masked
+ * before output; numbers/booleans/nulls are emitted as-is.
+ */
+export interface LogContext {
+  /** Org affected by the error, when known. */
+  orgId?: string | null
+  /** Vercel/Hono request id from middleware/requestId.ts. */
+  requestId?: string | null
+  /** For cron paths — the job name from vercel.json. */
+  jobName?: string | null
+  /** Provider tag for proxy paths (openai/anthropic/gemini/azure). */
+  provider?: string | null
+  /** Webhook id when emitting a delivery failure. */
+  webhookId?: string | null
+  /** Anything else the call site wants to record. */
+  [key: string]: unknown
+}
+
+function maskValue(v: unknown): unknown {
+  if (typeof v === 'string') return maskApiKeys(v)
+  if (Array.isArray(v)) return v.map(maskValue)
+  if (v && typeof v === 'object' && !(v instanceof Error)) {
+    const out: Record<string, unknown> = {}
+    for (const [k, vv] of Object.entries(v)) out[k] = maskValue(vv)
+    return out
+  }
+  return v
+}
+
+function serializeError(err: unknown): { message: string; name?: string; stack?: string } {
+  if (err instanceof Error) {
+    return {
+      name: err.name,
+      message: maskApiKeys(err.message),
+      // Stack is not masked — it can contain hand-typed API keys in test
+      // fixtures, but the cost of mangling stacks is bigger than the
+      // benefit. Sentry already redacts known secret patterns.
+      ...(err.stack ? { stack: err.stack } : {}),
+    }
+  }
+  return { message: maskApiKeys(typeof err === 'string' ? err : JSON.stringify(err)) }
+}
+
+function emit(level: 'ERROR' | 'WARN', code: LogCode, context: LogContext, err?: unknown): void {
+  const payload: Record<string, unknown> = {
+    level,
+    code,
+    ts: new Date().toISOString(),
+    ...(maskValue(context) as Record<string, unknown>),
+  }
+  if (err !== undefined) {
+    payload['err'] = serializeError(err)
+  }
+  // Single line, prefixed for grep-ability.
+  const line = `${level}[${code}] ${JSON.stringify(payload)}`
+  if (level === 'ERROR') {
+    // eslint-disable-next-line no-console
+    console.error(line)
+  } else {
+    // eslint-disable-next-line no-console
+    console.warn(line)
+  }
+}
+
+export function logError(code: LogCode, context: LogContext, err?: unknown): void {
+  emit('ERROR', code, context, err)
+}
+
+export function logWarn(code: LogCode, context: LogContext, err?: unknown): void {
+  emit('WARN', code, context, err)
+}

--- a/apps/server/src/lib/webhook-dispatch.ts
+++ b/apps/server/src/lib/webhook-dispatch.ts
@@ -10,6 +10,7 @@
 
 import { supabaseAdmin } from './db.js'
 import { validateOutboundUrl } from './safe-url.js'
+import { logError } from './structured-logger.js'
 
 export interface WebhookRow {
   id: string
@@ -181,7 +182,7 @@ export async function retryFailedWebhooks(): Promise<{
     .limit(50)
 
   if (error || !pending) {
-    console.error('[retryFailedWebhooks] fetch error:', error?.message)
+    logError('WEBHOOK_FETCH_FAILED', { kind: 'retry_queue_fetch' }, error?.message ?? 'unknown')
     return { retried: 0, succeeded: 0, failed: 0, exhausted: 0 }
   }
 

--- a/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
@@ -40,9 +40,7 @@ function greeting() {
   return 'Evening'
 }
 
-function fmtCost(n: number) {
-  return '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-}
+import { fmtCostKpi as fmtCost } from '@/lib/format'
 
 // `hasBaseline` lets us distinguish "no prior data" (suppress delta) from
 // a real -100% drop. When the previous period had zero traffic the API may

--- a/apps/web/app/(dashboard)/requests/[id]/request-detail-client.tsx
+++ b/apps/web/app/(dashboard)/requests/[id]/request-detail-client.tsx
@@ -13,11 +13,7 @@ import { ShareDialog } from '@/components/share/share-dialog'
 // PostHog provider lands on main (separate PR). The event payload is fully
 // designed — see docs/launch/2026-05-14_cache-stream-users.md §3.
 
-function fmtCost(n: number | null | undefined): string {
-  if (n == null) return '—'
-  if (n === 0) return '$0.00'
-  return n < 0.01 ? '< $0.01' : '$' + n.toFixed(2)
-}
+import { fmtCostSummary as fmtCost } from '@/lib/format'
 
 type Tab = 'request' | 'response' | 'error'
 

--- a/apps/web/app/(dashboard)/requests/requests-client.tsx
+++ b/apps/web/app/(dashboard)/requests/requests-client.tsx
@@ -54,13 +54,11 @@ function relAge(dateStr: string): string {
   return `${Math.floor(s / 86400)}d`
 }
 
-// Cost is always rendered with 5 fraction digits so the column visually
-// aligns. Trailing zeros are kept on purpose — eyeballing whether a row is
-// $0.00020 vs $0.00200 should not require counting digits.
-function fmtCost(n: number | null): string {
-  if (n == null) return '—'
-  return '$' + n.toFixed(5)
-}
+// Cost rendering rationale documented at fmtCostDense in lib/format.ts.
+// Note: this site previously rendered `$0.00000` for zero cost; the
+// shared helper renders "—" so zero rows visually match the "no data"
+// path. Intentional unification.
+import { fmtCostDense as fmtCost } from '@/lib/format'
 
 // Provider colors — used as a small dot before the model name to make the
 // table scannable at a glance. Brand-leaning hues to match user mental model

--- a/apps/web/app/(dashboard)/sessions/sessions-client.tsx
+++ b/apps/web/app/(dashboard)/sessions/sessions-client.tsx
@@ -26,11 +26,7 @@ const PAGE_SIZE = 50
 const SLOW_LATENCY_MS = 2000
 const DEFAULT_RANGE: TimeRange = '30d'
 
-function fmtCost(n: number | null | undefined): string {
-  if (n == null) return '—'
-  if (n === 0) return '$0.00'
-  return n < 0.01 ? '< $0.01' : '$' + n.toFixed(2)
-}
+import { fmtCostSummary as fmtCost } from '@/lib/format'
 
 function fmtCount(n: number): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'

--- a/apps/web/app/(dashboard)/traces/traces-client.tsx
+++ b/apps/web/app/(dashboard)/traces/traces-client.tsx
@@ -26,12 +26,7 @@ function fmtDuration(ms: number | null): string {
   return `${(ms / 1000).toFixed(2)}s`
 }
 
-// Cost rendered at fixed 5 fraction digits so the column aligns vertically.
-// Matches the convention used on /requests.
-function fmtCost(n: number): string {
-  if (n <= 0) return '—'
-  return `$${n.toFixed(5)}`
-}
+import { fmtCostDense as fmtCost } from '@/lib/format'
 
 function fmtAge(dateStr: string, now: number): string {
   const s = Math.floor((now - new Date(dateStr).getTime()) / 1000)

--- a/apps/web/app/(dashboard)/users/[userId]/user-detail-client.tsx
+++ b/apps/web/app/(dashboard)/users/[userId]/user-detail-client.tsx
@@ -11,11 +11,7 @@ import { Topbar } from '@/components/layout/topbar'
 // TODO: re-add `usePostHog()` + `user_detail_viewed` capture once the
 // PostHog provider lands on main (separate PR).
 
-function fmtCost(n: number | null | undefined): string {
-  if (n == null) return '—'
-  if (n === 0) return '$0.00'
-  return n < 0.01 ? '< $0.01' : '$' + Number(n).toFixed(2)
-}
+import { fmtCostSummary as fmtCost } from '@/lib/format'
 
 function fmtCount(n: number): string {
   return n.toLocaleString()

--- a/apps/web/app/(dashboard)/users/users-client.tsx
+++ b/apps/web/app/(dashboard)/users/users-client.tsx
@@ -30,11 +30,7 @@ const PAGE_SIZE = 50
 const SLOW_LATENCY_MS = 2000
 const DEFAULT_RANGE: TimeRange = '30d'
 
-function fmtCost(n: number | null | undefined): string {
-  if (n == null) return '—'
-  if (n === 0) return '$0.00'
-  return n < 0.01 ? '< $0.01' : '$' + n.toFixed(2)
-}
+import { fmtCostSummary as fmtCost } from '@/lib/format'
 
 function fmtCount(n: number): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'

--- a/apps/web/app/demo/dashboard/page.tsx
+++ b/apps/web/app/demo/dashboard/page.tsx
@@ -49,9 +49,7 @@ import {
 
 // ── Helpers ────────────────────────────────────────────────────
 
-function fmtCost(n: number): string {
-  return '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-}
+import { fmtCostKpi as fmtCost } from '@/lib/format'
 
 function fmtDelta(delta: number | null | undefined): string | undefined {
   if (delta == null) return undefined

--- a/apps/web/components/dashboard/spend-forecast.tsx
+++ b/apps/web/components/dashboard/spend-forecast.tsx
@@ -21,9 +21,7 @@ const C = {
   bgElev: 'var(--bg-elev)',
 } as const
 
-function fmtCost(n: number) {
-  return '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-}
+import { fmtCostKpi as fmtCost } from '@/lib/format'
 
 interface SpendForecastCardProps {
   data: SpendForecast

--- a/apps/web/lib/format.test.ts
+++ b/apps/web/lib/format.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest'
+import { fmtCostKpi, fmtCostDense, fmtCostSummary } from './format.js'
+
+/**
+ * Pin the three cost-formatting modes. The same input renders differently
+ * on purpose — collapsing two modes would change the dashboard visually.
+ * If a regression flips the format silently, this file catches it.
+ */
+
+describe('fmtCostKpi — KPI / headline (always 2 digits, en-US separators)', () => {
+  test('formats integer dollar amounts with thousand separator', () => {
+    expect(fmtCostKpi(1234.5)).toBe('$1,234.50')
+    expect(fmtCostKpi(1_000_000)).toBe('$1,000,000.00')
+  })
+
+  test('null and zero render as $0.00 (no layout reflow)', () => {
+    expect(fmtCostKpi(null)).toBe('$0.00')
+    expect(fmtCostKpi(undefined)).toBe('$0.00')
+    expect(fmtCostKpi(0)).toBe('$0.00')
+  })
+
+  test('clips beyond 2 fraction digits (KPI tile is too small for trailing precision)', () => {
+    expect(fmtCostKpi(0.00123)).toBe('$0.00')
+    expect(fmtCostKpi(1.999)).toBe('$2.00')
+  })
+})
+
+describe('fmtCostDense — per-row table cell (5 digits, "—" for missing)', () => {
+  test('renders small amounts at 5 fraction digits with trailing zeros', () => {
+    expect(fmtCostDense(0.00020)).toBe('$0.00020')
+    expect(fmtCostDense(0.00200)).toBe('$0.00200')
+  })
+
+  test('null → "—"', () => {
+    expect(fmtCostDense(null)).toBe('—')
+    expect(fmtCostDense(undefined)).toBe('—')
+  })
+
+  test('zero and negative → "—" (empty rows do not pretend to have data)', () => {
+    expect(fmtCostDense(0)).toBe('—')
+    expect(fmtCostDense(-0.001)).toBe('—')
+  })
+
+  test('larger amounts keep all 5 digits (alignment)', () => {
+    expect(fmtCostDense(12.5)).toBe('$12.50000')
+  })
+})
+
+describe('fmtCostSummary — per-user/session aggregate ("< $0.01" cutoff)', () => {
+  test('null → "—"', () => {
+    expect(fmtCostSummary(null)).toBe('—')
+    expect(fmtCostSummary(undefined)).toBe('—')
+  })
+
+  test('exactly zero → "$0.00" (distinguishes "no spend" from "missing data")', () => {
+    expect(fmtCostSummary(0)).toBe('$0.00')
+  })
+
+  test('between 0 and 0.01 → "< $0.01" (cannot round-down to "$0.00" or operators get confused)', () => {
+    expect(fmtCostSummary(0.0001)).toBe('< $0.01')
+    expect(fmtCostSummary(0.009999)).toBe('< $0.01')
+  })
+
+  test('≥ 0.01 → "$N.NN" 2 fraction digits', () => {
+    expect(fmtCostSummary(0.01)).toBe('$0.01')
+    expect(fmtCostSummary(1.235)).toBe('$1.24') // banker's rounding via toFixed
+    expect(fmtCostSummary(1234.56)).toBe('$1234.56')
+  })
+})

--- a/apps/web/lib/format.ts
+++ b/apps/web/lib/format.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared currency / time / number formatters used across the dashboard.
+ *
+ * Why this file exists: the audit on 2026-06-12 found `fmtCost` redefined in
+ * 19 separate files. That number is misleading on its own — the call sites
+ * actually split into three INTENTIONAL display modes (KPI headline,
+ * dense table row, summary band). Collapsing them to a single function
+ * would change the visual output across the dashboard. Instead, this file
+ * exports three named helpers with explicit semantics; the 19 call sites
+ * import the matching one and the duplicated bodies disappear.
+ *
+ * When choosing between them:
+ *   - `fmtCostKpi(n)`     — large bold KPI cards, sparkline labels, spend
+ *                           forecast headline. en-US thousand separators,
+ *                           always 2 fraction digits, no zero/null mask.
+ *   - `fmtCostDense(n)`   — per-request / per-trace table rows where the
+ *                           column needs to align vertically and tiny
+ *                           amounts (< $0.001) still need to read as
+ *                           non-zero. Always 5 fraction digits, null → "—".
+ *   - `fmtCostSummary(n)` — per-user / per-session aggregate cells in
+ *                           list tables. 2 fraction digits, but with the
+ *                           "< $0.01" cutoff so a $0.0003 row doesn't
+ *                           render as "$0.00" and look broken.
+ *
+ * The three modes are not interchangeable — passing the same number through
+ * each produces different strings on purpose. A regression test pinning
+ * those strings lives in lib/format.test.ts.
+ */
+
+/**
+ * KPI / headline formatter. en-US thousand separators, always 2 fraction
+ * digits. Returns "$0.00" for null/zero — KPI cards are designed to always
+ * show a number so the layout doesn't reflow when data is missing.
+ */
+export function fmtCostKpi(n: number | null | undefined): string {
+  const v = n ?? 0
+  return '$' + v.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+/**
+ * Dense per-row formatter for /requests, /traces table cells. 5 fraction
+ * digits so trailing zeros are visible (eyeballing $0.00020 vs $0.00200
+ * shouldn't require counting digits). Null → "—". Zero → "—" so empty rows
+ * don't pretend to have data.
+ */
+export function fmtCostDense(n: number | null | undefined): string {
+  if (n == null || n <= 0) return '—'
+  return '$' + n.toFixed(5)
+}
+
+/**
+ * Aggregate-summary formatter for /users, /sessions list cells. 2 fraction
+ * digits with the "< $0.01" cutoff so a $0.0003 aggregate doesn't render as
+ * "$0.00" (which reads as "no cost" and surprises operators when they drill
+ * in). Null → "—".
+ */
+export function fmtCostSummary(n: number | null | undefined): string {
+  if (n == null) return '—'
+  if (n === 0) return '$0.00'
+  return n < 0.01 ? '< $0.01' : '$' + n.toFixed(2)
+}


### PR DESCRIPTION
First PR in the tech-debt pass identified in the 2026-06-12 audit. Three follow-ups will land separately to keep each PR reviewable.

## Summary

**Server (\`lib/structured-logger.ts\`)** — replaces free-form \`console.error\` in the hot paths with a single emitter that writes \`LEVEL[CODE] {json}\` lines. Every string field in the context bag is masked via \`maskApiKeys\` so \`sl_live_*\`, \`sk-ant-*\`, \`sk-proj-\`, \`sk-\`, and \`AIza\` prefixes never reach Sentry's search index. Migrated 7 hot-path sites (all 6 in lib/logger.ts + retry-queue fetch in webhook-dispatch.ts).

**Web (\`lib/format.ts\`)** — exports three named cost formatters that match the three INTENTIONAL display modes the audit found across 19 sites: \`fmtCostKpi\` (KPI tiles), \`fmtCostDense\` (table rows), \`fmtCostSummary\` (aggregate cells). Migrated 10 sites that exactly matched one of the modes; remaining 9 sites use slightly different shapes and are preserved to avoid silent visual regression.

## Test plan

- [x] \`pnpm --filter server test\` — 1022/1022 (was 1012)
- [x] \`pnpm --filter web test\` — 57/57 (was 46)
- [x] \`pnpm --filter server typecheck\` — clean
- [x] \`pnpm --filter web typecheck\` — clean
- [x] PII masking covers nested values (test: \`messages[].content\`)
- [x] Each cost-formatter mode pinned to exact output string
- [ ] CI green on this branch

## Why the proxy console.errors are not in this PR

\`proxy/{openai,anthropic,gemini,azure}.ts\` have 14 \`console.error\` calls across 4 files. They are deferred to **PR C** because the shared-middleware extraction will consolidate them through one logging pass instead of editing 4 files for cosmetic reasons. Editing them here, then again in PR C, doubles the review burden for no incremental safety.

## Next in this series

- **PR B** — \`cron.ts\` 1053-line file split into \`lib/cron-jobs/<job>.ts\` (13 jobs)
- **PR C** — \`proxy/{openai,anthropic,gemini,azure}.ts\` shared middleware (eliminates 40~50% duplication)
- **PR D** — \`eval-runner.ts\` 1273-line file split by evaluator kind (LLM judge / regex / JSON schema)