### PR TITLE
refactor(server): extract proxy shared middleware, 999→589 lines (PR 3/4 tech-debt)

### DIFF
--- a/apps/server/src/proxy/anthropic.ts
+++ b/apps/server/src/proxy/anthropic.ts
@@ -1,22 +1,23 @@
 import { Hono } from 'hono'
-import { stream } from 'hono/streaming'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
 import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
 import { calculateCost } from '../lib/cost.js'
-import { logRequestAsync, parseLogBodyMode } from '../lib/logger.js'
-import { resolvePromptVersion } from '../lib/resolve-prompt-version.js'
+import { logRequestAsync } from '../lib/logger.js'
 import { fireAndForget } from '../lib/wait-until.js'
 import { parseAnthropicResponse } from '../parsers/anthropic.js'
-import { scanAll } from '../lib/security-scan.js'
-import { getDecryptedProviderKey, buildUpstreamHeaders, buildDownstreamHeaders, isBlockingEnabled } from './utils.js'
+import type { ServiceTier } from '../parsers/openai.js'
+import { buildUpstreamHeaders, buildDownstreamHeaders } from './utils.js'
 import { logAnthropicStream } from './stream-logger.js'
-import { cancelReaderSilently, makeStreamDeadline, readWithDeadline } from './stream-deadline.js'
-import { ApiError } from '../lib/errors.js'
+import { assertProviderKey } from './shared/provider-key.js'
+import { parseProxyRequestBody, chooseFetchBody } from './shared/request-body.js'
+import { runSecurityGate } from './shared/security-gate.js'
+import { fetchUpstreamWithTimeout } from './shared/upstream-fetch.js'
+import { buildLogBase } from './shared/log-base.js'
+import { runLineBufferedStreamPump } from './shared/stream-pump.js'
 
 const ANTHROPIC_BASE = 'https://api.anthropic.com'
-const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '35000', 10)
 
 export const anthropicProxy = new Hono<ApiKeyContext>()
 
@@ -27,148 +28,52 @@ anthropicProxy.use('*', enforceQuota)
 
 anthropicProxy.all('/*', async (c) => {
   const handlerStartMs = Date.now()
-
   const organizationId = c.get('organizationId')
-  // Narrowing: requireFullScope + DB CHECK constraint guarantee non-null. See openai.ts.
   const projectId = c.get('projectId') as string
   const apiKeyId = c.get('apiKeyId')
 
-  const providerKey = await getDecryptedProviderKey(apiKeyId, 'anthropic')
-  if (!providerKey) {
-    throw new ApiError(
-      'NO_PROVIDER_KEY',
-      'No active Anthropic provider key registered for this Spanlens key',
-      { provider: 'anthropic' },
-    )
-  }
-  const decryptedKey = providerKey.plaintext
+  const providerKey = await assertProviderKey(apiKeyId, 'anthropic')
+  // Anthropic stream usage is in message_delta — no stream_options injection needed.
+  const parsed = await parseProxyRequestBody(c)
+  const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
 
-  const reqBodyText = await c.req.text()
-  let reqBodyJson: Record<string, unknown> | null = null
-  let isStreaming = false
-
-  try {
-    reqBodyJson = JSON.parse(reqBodyText) as Record<string, unknown>
-    isStreaming = reqBodyJson.stream === true
-  } catch { /* non-JSON — pass through */ }
-
-  // ── Security scan + blocking ───────────────────────────────────────────────
-  const requestFlags = scanAll(reqBodyJson)
-  const hasInjection = requestFlags.some((f) => f.type === 'injection')
-  if (hasInjection && await isBlockingEnabled(projectId)) {
-    throw new ApiError(
-      'INJECTION_BLOCKED',
-      'Request blocked by Spanlens security policy: prompt injection detected.',
-    )
-  }
-
-  const path = c.req.path.replace(/^\/proxy\/anthropic/, '')
-  const upstreamUrl = `${ANTHROPIC_BASE}${path}`
-
-  // Anthropic uses x-api-key (not Authorization Bearer) + anthropic-version
+  const upstreamUrl = `${ANTHROPIC_BASE}${c.req.path.replace(/^\/proxy\/anthropic/, '')}`
+  // Anthropic uses `x-api-key` (NOT Authorization Bearer) + anthropic-version.
+  // Authorization is deleted explicitly in case a client lib retransmits one.
   const headers = buildUpstreamHeaders(c.req.raw.headers, {
-    'x-api-key': decryptedKey,
+    'x-api-key': providerKey.plaintext,
     'anthropic-version': c.req.header('anthropic-version') ?? '2023-06-01',
     'Content-Type': 'application/json',
   })
   headers.delete('authorization')
 
-  const startMs = Date.now()
-  const fetchBody = c.req.method !== 'GET' && c.req.method !== 'HEAD' ? reqBodyText : null
-
-  const upstreamAbort = new AbortController()
-  const upstreamTimer = setTimeout(() => upstreamAbort.abort(), UPSTREAM_TIMEOUT_MS)
-  let upstreamRes: Response
-  try {
-    upstreamRes = await fetch(upstreamUrl, { method: c.req.method, headers, body: fetchBody, signal: upstreamAbort.signal })
-  } catch (err) {
-    clearTimeout(upstreamTimer)
-    const msg = err instanceof Error ? err.message : 'Unknown error'
-    if (err instanceof Error && err.name === 'AbortError') {
-      throw new ApiError(
-        'UPSTREAM_TIMEOUT',
-        `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms`,
-        { provider: 'anthropic', timeoutMs: UPSTREAM_TIMEOUT_MS },
-      )
-    }
-    console.error('[anthropic-proxy] upstream fetch error:', msg)
-    throw new ApiError('UPSTREAM_FAILED', `Upstream request failed: ${msg}`, {
-      provider: 'anthropic',
-    })
-  }
-  clearTimeout(upstreamTimer)
-  const latencyMs = Date.now() - startMs
-  const proxyOverheadMs = startMs - handlerStartMs
-
-  const model = (reqBodyJson?.model as string | undefined) ?? ''
-  const traceId = c.req.header('x-trace-id') ?? null
-  const resolved = await resolvePromptVersion(
-    organizationId,
-    c.req.header('x-spanlens-prompt-version') ?? null,
-    traceId,
-  )
-  const promptVersionId = resolved?.versionId ?? null
-  const logBase = {
-    organizationId, projectId, apiKeyId,
+  const { upstreamRes, latencyMs, proxyOverheadMs } = await fetchUpstreamWithTimeout({
+    url: upstreamUrl,
+    method: c.req.method,
+    headers,
+    body: chooseFetchBody(c, parsed, false),
     provider: 'anthropic',
-    latencyMs, proxyOverheadMs, statusCode: upstreamRes.status,
-    requestBody: reqBodyJson,
-    responseBody: null,
-    errorMessage: null,
-    traceId,
-    spanId: c.req.header('x-span-id') ?? null,
-    promptVersionId,
-    providerKeyId: providerKey.id,
-    userId: c.req.header('x-spanlens-user') ?? null,
-    sessionId: c.req.header('x-spanlens-session') ?? null,
-    logBodyMode: parseLogBodyMode(c.req.header('x-spanlens-log-body')),
-    preComputedRequestFlags: requestFlags,
-  }
+    handlerStartMs,
+  })
 
-  // ── Streaming path (Hono stream helper — required for Vercel Node.js runtime) ─
-  if (isStreaming && upstreamRes.body) {
-    const downstreamHeaders = buildDownstreamHeaders(upstreamRes.headers)
-    downstreamHeaders.forEach((value, key) => c.header(key, value))
-    c.status(upstreamRes.status as 200)
+  const logBase = await buildLogBase({
+    c, provider: 'anthropic',
+    organizationId, projectId, apiKeyId,
+    providerKey,
+    reqBodyJson: parsed.reqBodyJson,
+    requestFlags,
+    latencyMs, proxyOverheadMs,
+    statusCode: upstreamRes.status,
+  })
 
-    const upstreamBody = upstreamRes.body
+  const model = (parsed.reqBodyJson?.model as string | undefined) ?? ''
 
-    return stream(c, async (honoStream) => {
-      const reader = upstreamBody.getReader()
-      const decoder = new TextDecoder()
-      const deadline = makeStreamDeadline(handlerStartMs)
-      let buffer = ''
-      const lines: string[] = []
-      let truncated = false
-
-      pump: for (;;) {
-        const outcome = await readWithDeadline(reader, deadline)
-        switch (outcome.kind) {
-          case 'done':
-            break pump
-          case 'timeout':
-            truncated = true
-            console.warn('[anthropic-stream] deadline reached, closing gracefully')
-            await cancelReaderSilently(reader)
-            break pump
-          case 'error':
-            console.error('[anthropic-stream] reader error:', outcome.error)
-            break pump
-          case 'chunk': {
-            await honoStream.write(outcome.value)
-            buffer += decoder.decode(outcome.value, { stream: true })
-            const parts = buffer.split('\n')
-            buffer = parts.pop() ?? ''
-            lines.push(...parts)
-            break
-          }
-        }
-      }
-      if (buffer.length > 0) lines.push(buffer)
-
-      await logAnthropicStream(lines, { ...logBase, model }, { truncated }).catch((err) => {
-        console.error('[anthropic-stream] log error:', err)
-      })
+  // ── Streaming path ────────────────────────────────────────────────────────
+  if (parsed.isStreaming && upstreamRes.body) {
+    return runLineBufferedStreamPump({
+      c, upstreamRes, handlerStartMs, provider: 'anthropic',
+      onComplete: (lines, truncated) =>
+        logAnthropicStream(lines, { ...logBase, model }, { truncated }),
     })
   }
 
@@ -184,19 +89,19 @@ anthropicProxy.all('/*', async (c) => {
   let cacheReadTokens = 0
   let cacheWriteTokens = 0
   let resolvedModel = model
-  let serviceTier: import('../parsers/openai.js').ServiceTier | undefined
+  let serviceTier: ServiceTier | undefined
 
   if (upstreamRes.ok && resBodyJson) {
     try {
-      const parsed = parseAnthropicResponse(resBodyJson as Record<string, unknown>)
-      if (parsed) {
-        resolvedModel = parsed.model || model
-        promptTokens = parsed.promptTokens
-        completionTokens = parsed.completionTokens
-        totalTokens = parsed.totalTokens
-        cacheReadTokens = parsed.cacheReadTokens ?? 0
-        cacheWriteTokens = parsed.cacheWriteTokens ?? 0
-        serviceTier = parsed.serviceTier
+      const p = parseAnthropicResponse(resBodyJson as Record<string, unknown>)
+      if (p) {
+        resolvedModel = p.model || model
+        promptTokens = p.promptTokens
+        completionTokens = p.completionTokens
+        totalTokens = p.totalTokens
+        cacheReadTokens = p.cacheReadTokens ?? 0
+        cacheWriteTokens = p.cacheWriteTokens ?? 0
+        serviceTier = p.serviceTier
       }
     } catch { /* ignore */ }
   }

--- a/apps/server/src/proxy/azure.ts
+++ b/apps/server/src/proxy/azure.ts
@@ -1,35 +1,34 @@
 import { Hono } from 'hono'
-import { stream } from 'hono/streaming'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
 import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
 import { calculateCost } from '../lib/cost.js'
-import { logRequestAsync, parseLogBodyMode } from '../lib/logger.js'
-import { resolvePromptVersion } from '../lib/resolve-prompt-version.js'
+import { logRequestAsync } from '../lib/logger.js'
 import { fireAndForget } from '../lib/wait-until.js'
-import { parseOpenAIResponse } from '../parsers/openai.js'
-import { scanAll } from '../lib/security-scan.js'
-import { getDecryptedProviderKey, buildUpstreamHeaders, buildDownstreamHeaders, isBlockingEnabled } from './utils.js'
+import { parseOpenAIResponse, type ServiceTier } from '../parsers/openai.js'
+import { buildUpstreamHeaders, buildDownstreamHeaders } from './utils.js'
 import { logOpenAIStream } from './stream-logger.js'
-import { cancelReaderSilently, makeStreamDeadline, readWithDeadline } from './stream-deadline.js'
 import { ApiError } from '../lib/errors.js'
+import { logError } from '../lib/structured-logger.js'
+import { assertProviderKey } from './shared/provider-key.js'
+import { parseProxyRequestBody, chooseFetchBody } from './shared/request-body.js'
+import { runSecurityGate } from './shared/security-gate.js'
+import { fetchUpstreamWithTimeout } from './shared/upstream-fetch.js'
+import { buildLogBase } from './shared/log-base.js'
+import { runLineBufferedStreamPump } from './shared/stream-pump.js'
 
 // Azure OpenAI v1 endpoint (Microsoft, Aug 2025+). Drop-in compatible with
 // OpenAI request/response shape — no api-version query, no per-deployment
-// URL fragments. Customer's resource origin lives on provider_keys.provider_metadata.resource_url.
-//
-// Request flow:
-//   client → POST /proxy/azure/chat/completions
-//          → upstream POST {resource_url}/openai/v1/chat/completions
+// URL fragments. Customer's resource origin lives on
+// provider_keys.provider_metadata.resource_url.
 //
 // Differences vs. /proxy/openai:
 //   - Base URL is per-key (Azure resource), not a constant
 //   - Auth header: api-key (not Authorization: Bearer)
-//   - Response includes Azure-only fields (prompt_filter_results, content_filter_results,
-//     system_fingerprint) — OpenAI parser ignores unknown fields, so passthrough works
-const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '35000', 10)
-
+//   - Response includes Azure-only fields (prompt_filter_results,
+//     content_filter_results, system_fingerprint) — OpenAI parser ignores
+//     unknown fields, so passthrough works
 export const azureProxy = new Hono<ApiKeyContext>()
 
 azureProxy.use('*', authApiKey)
@@ -39,17 +38,11 @@ azureProxy.use('*', enforceQuota)
 
 azureProxy.all('/*', async (c) => {
   const handlerStartMs = Date.now()
-
   const organizationId = c.get('organizationId')
-  // Narrowing: requireFullScope + DB CHECK constraint guarantee non-null. See openai.ts.
   const projectId = c.get('projectId') as string
   const apiKeyId = c.get('apiKeyId')
 
-  const providerKey = await getDecryptedProviderKey(apiKeyId, 'azure')
-  if (!providerKey) {
-    throw new ApiError('NO_PROVIDER_KEY', 'No active Azure provider key registered for this Spanlens key')
-  }
-  const decryptedKey = providerKey.plaintext
+  const providerKey = await assertProviderKey(apiKeyId, 'azure')
 
   // resource_url is enforced NOT NULL at the DB layer for 'azure' rows
   // (provider_keys_azure_requires_resource_url CHECK constraint).
@@ -58,143 +51,51 @@ azureProxy.all('/*', async (c) => {
   // malformed upstream URL.
   const resourceUrl = (providerKey.metadata['resource_url'] as string | undefined) ?? ''
   if (resourceUrl.length === 0) {
-    console.error('[azure-proxy] provider_key missing resource_url:', providerKey.id)
+    logError('UNCATEGORIZED', { provider: 'azure', providerKeyId: providerKey.id, kind: 'missing_resource_url' })
     throw new ApiError('INTERNAL_ERROR', 'Azure provider key is missing resource_url — re-register it')
   }
 
-  const reqBodyText = await c.req.text()
-  let reqBodyJson: Record<string, unknown> | null = null
-  let isStreaming = false
+  const parsed = await parseProxyRequestBody(c, { injectOpenAIStreamOptions: true })
+  const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
 
-  try {
-    reqBodyJson = JSON.parse(reqBodyText) as Record<string, unknown>
-    isStreaming = reqBodyJson.stream === true
-
-    if (isStreaming) {
-      reqBodyJson = {
-        ...reqBodyJson,
-        stream_options: { include_usage: true },
-      }
-    }
-  } catch { /* non-JSON body — pass through */ }
-
-  // ── Security scan + blocking ───────────────────────────────────────────────
-  const requestFlags = scanAll(reqBodyJson)
-  const hasInjection = requestFlags.some((f) => f.type === 'injection')
-  if (hasInjection && await isBlockingEnabled(projectId)) {
-    throw new ApiError(
-      'INJECTION_BLOCKED',
-      'Request blocked by Spanlens security policy: prompt injection detected.',
-    )
-  }
-
-  const path = c.req.path.replace(/^\/proxy\/azure/, '')
-  const upstreamUrl = `${resourceUrl}/openai/v1${path}`
-
+  const upstreamUrl = `${resourceUrl}/openai/v1${c.req.path.replace(/^\/proxy\/azure/, '')}`
   // Azure uses `api-key` (not Authorization Bearer). Strip authorization
   // explicitly in case some client lib retransmits one.
   const headers = buildUpstreamHeaders(c.req.raw.headers, {
-    'api-key': decryptedKey,
+    'api-key': providerKey.plaintext,
     'Content-Type': 'application/json',
   })
   headers.delete('authorization')
 
-  const startMs = Date.now()
-  const fetchBody =
-    c.req.method !== 'GET' && c.req.method !== 'HEAD'
-      ? isStreaming && reqBodyJson ? JSON.stringify(reqBodyJson) : reqBodyText
-      : null
-
-  const upstreamAbort = new AbortController()
-  const upstreamTimer = setTimeout(() => upstreamAbort.abort(), UPSTREAM_TIMEOUT_MS)
-  let upstreamRes: Response
-  try {
-    upstreamRes = await fetch(upstreamUrl, { method: c.req.method, headers, body: fetchBody, signal: upstreamAbort.signal })
-  } catch (err) {
-    clearTimeout(upstreamTimer)
-    const msg = err instanceof Error ? err.message : 'Unknown error'
-    if (err instanceof Error && err.name === 'AbortError') {
-      throw new ApiError('UPSTREAM_TIMEOUT', `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms`)
-    }
-    console.error('[azure-proxy] upstream fetch error:', msg)
-    throw new ApiError('UPSTREAM_FAILED', `Upstream request failed: ${msg}`)
-  }
-  clearTimeout(upstreamTimer)
-  const latencyMs = Date.now() - startMs
-  const proxyOverheadMs = startMs - handlerStartMs
-
-  const model = (reqBodyJson?.model as string | undefined) ?? ''
-  const traceId = c.req.header('x-trace-id') ?? null
-  const resolved = await resolvePromptVersion(
-    organizationId,
-    c.req.header('x-spanlens-prompt-version') ?? null,
-    traceId,
-  )
-  const promptVersionId = resolved?.versionId ?? null
-  const logBase = {
-    organizationId, projectId, apiKeyId,
+  const { upstreamRes, latencyMs, proxyOverheadMs } = await fetchUpstreamWithTimeout({
+    url: upstreamUrl,
+    method: c.req.method,
+    headers,
+    body: chooseFetchBody(c, parsed, true),
     provider: 'azure',
-    latencyMs, proxyOverheadMs, statusCode: upstreamRes.status,
-    requestBody: reqBodyJson,
-    responseBody: null,
-    errorMessage: null,
-    traceId,
-    spanId: c.req.header('x-span-id') ?? null,
-    promptVersionId,
-    providerKeyId: providerKey.id,
-    userId: c.req.header('x-spanlens-user') ?? null,
-    sessionId: c.req.header('x-spanlens-session') ?? null,
-    logBodyMode: parseLogBodyMode(c.req.header('x-spanlens-log-body')),
-    preComputedRequestFlags: requestFlags,
-  }
+    handlerStartMs,
+  })
+
+  const logBase = await buildLogBase({
+    c, provider: 'azure',
+    organizationId, projectId, apiKeyId,
+    providerKey,
+    reqBodyJson: parsed.reqBodyJson,
+    requestFlags,
+    latencyMs, proxyOverheadMs,
+    statusCode: upstreamRes.status,
+  })
+
+  const model = (parsed.reqBodyJson?.model as string | undefined) ?? ''
 
   // ── Streaming path ────────────────────────────────────────────────────────
-  if (isStreaming && upstreamRes.body) {
-    const downstreamHeaders = buildDownstreamHeaders(upstreamRes.headers)
-    downstreamHeaders.forEach((value, key) => c.header(key, value))
-    c.status(upstreamRes.status as 200)
-
-    const upstreamBody = upstreamRes.body
-
-    return stream(c, async (honoStream) => {
-      const reader = upstreamBody.getReader()
-      const decoder = new TextDecoder()
-      const deadline = makeStreamDeadline(handlerStartMs)
-      let buffer = ''
-      const lines: string[] = []
-      let truncated = false
-
-      pump: for (;;) {
-        const outcome = await readWithDeadline(reader, deadline)
-        switch (outcome.kind) {
-          case 'done':
-            break pump
-          case 'timeout':
-            truncated = true
-            console.warn('[azure-stream] deadline reached, closing gracefully')
-            await cancelReaderSilently(reader)
-            break pump
-          case 'error':
-            console.error('[azure-stream] reader error:', outcome.error)
-            break pump
-          case 'chunk': {
-            await honoStream.write(outcome.value)
-            buffer += decoder.decode(outcome.value, { stream: true })
-            const parts = buffer.split('\n')
-            buffer = parts.pop() ?? ''
-            lines.push(...parts)
-            break
-          }
-        }
-      }
-      if (buffer.length > 0) lines.push(buffer)
-
-      // Azure SSE chunk shape is OpenAI-compatible — same parser works.
-      // The 'azure' provider tag on logBase is what flows into ClickHouse,
-      // not what the parser cares about.
-      await logOpenAIStream(lines, { ...logBase, model }, { truncated }).catch((err) => {
-        console.error('[azure-stream] log error:', err)
-      })
+  if (parsed.isStreaming && upstreamRes.body) {
+    // Azure SSE chunk shape is OpenAI-compatible — same parser works. The
+    // 'azure' provider tag on logBase is what flows into ClickHouse.
+    return runLineBufferedStreamPump({
+      c, upstreamRes, handlerStartMs, provider: 'azure',
+      onComplete: (lines, truncated) =>
+        logOpenAIStream(lines, { ...logBase, model }, { truncated }),
     })
   }
 
@@ -210,28 +111,25 @@ azureProxy.all('/*', async (c) => {
   let cacheReadTokens = 0
   let cacheWriteTokens = 0
   let resolvedModel = model
-  let serviceTier: import('../parsers/openai.js').ServiceTier | undefined
+  let serviceTier: ServiceTier | undefined
 
   if (upstreamRes.ok && resBodyJson) {
     try {
-      const parsed = parseOpenAIResponse(resBodyJson as Record<string, unknown>)
-      if (parsed) {
-        resolvedModel = parsed.model || model
-        promptTokens = parsed.promptTokens
-        completionTokens = parsed.completionTokens
-        totalTokens = parsed.totalTokens
-        cacheReadTokens = parsed.cacheReadTokens ?? 0
-        cacheWriteTokens = parsed.cacheWriteTokens ?? 0
-        serviceTier = parsed.serviceTier
+      const p = parseOpenAIResponse(resBodyJson as Record<string, unknown>)
+      if (p) {
+        resolvedModel = p.model || model
+        promptTokens = p.promptTokens
+        completionTokens = p.completionTokens
+        totalTokens = p.totalTokens
+        cacheReadTokens = p.cacheReadTokens ?? 0
+        cacheWriteTokens = p.cacheWriteTokens ?? 0
+        serviceTier = p.serviceTier
       }
     } catch { /* ignore */ }
   }
 
   // Azure exposes OpenAI models at OpenAI prices — reuse the OpenAI price
-  // table rather than maintaining a parallel one. If a customer deploys a
-  // model under a custom deployment name that doesn't match a known model
-  // key, lookupPrice() returns null and cost_usd ends up NULL (existing
-  // behavior, no regression).
+  // table rather than maintaining a parallel one.
   const cost = calculateCost('openai', resolvedModel, {
     promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
   })

--- a/apps/server/src/proxy/gemini.ts
+++ b/apps/server/src/proxy/gemini.ts
@@ -1,21 +1,23 @@
 import { Hono } from 'hono'
-import { stream } from 'hono/streaming'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
 import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
 import { calculateCost } from '../lib/cost.js'
-import { logRequestAsync, parseLogBodyMode } from '../lib/logger.js'
-import { resolvePromptVersion } from '../lib/resolve-prompt-version.js'
+import { logRequestAsync } from '../lib/logger.js'
 import { fireAndForget } from '../lib/wait-until.js'
 import { parseGeminiResponse, extractGeminiStreamText } from '../parsers/gemini.js'
-import { scanAll } from '../lib/security-scan.js'
-import { getDecryptedProviderKey, buildUpstreamHeaders, buildDownstreamHeaders, isBlockingEnabled } from './utils.js'
-import { cancelReaderSilently, makeStreamDeadline, readWithDeadline } from './stream-deadline.js'
-import { ApiError } from '../lib/errors.js'
+import type { ServiceTier } from '../parsers/openai.js'
+import { buildUpstreamHeaders, buildDownstreamHeaders } from './utils.js'
+import { logWarn } from '../lib/structured-logger.js'
+import { assertProviderKey } from './shared/provider-key.js'
+import { parseProxyRequestBody, chooseFetchBody } from './shared/request-body.js'
+import { runSecurityGate } from './shared/security-gate.js'
+import { fetchUpstreamWithTimeout } from './shared/upstream-fetch.js'
+import { buildLogBase } from './shared/log-base.js'
+import { runChunkAccumulatedStreamPump } from './shared/stream-pump.js'
 
 const GEMINI_BASE = 'https://generativelanguage.googleapis.com'
-const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '35000', 10)
 
 export const geminiProxy = new Hono<ApiKeyContext>()
 
@@ -26,215 +28,118 @@ geminiProxy.use('*', enforceQuota)
 
 geminiProxy.all('/*', async (c) => {
   const handlerStartMs = Date.now()
-
   const organizationId = c.get('organizationId')
-  // Narrowing: requireFullScope + DB CHECK constraint guarantee non-null. See openai.ts.
   const projectId = c.get('projectId') as string
   const apiKeyId = c.get('apiKeyId')
 
-  const providerKey = await getDecryptedProviderKey(apiKeyId, 'gemini')
-  if (!providerKey) {
-    throw new ApiError(
-      'NO_PROVIDER_KEY',
-      'No active Gemini provider key registered for this Spanlens key',
-      { provider: 'gemini' },
-    )
-  }
-  const decryptedKey = providerKey.plaintext
+  const providerKey = await assertProviderKey(apiKeyId, 'gemini')
+  // Gemini's body stays untransformed; isStreaming is decided by the URL
+  // path (`:streamGenerateContent`), not the body's `stream` flag.
+  const parsed = await parseProxyRequestBody(c)
 
-  const reqBodyText = await c.req.text()
-  let reqBodyJson: Record<string, unknown> | null = null
-  try {
-    reqBodyJson = JSON.parse(reqBodyText) as Record<string, unknown>
-  } catch { /* non-JSON — pass through */ }
-
-  // Gemini uses ?key= query param, not Authorization header
+  // Build the upstream URL with our decrypted key in `?key=` (the caller's
+  // ?key= is OVERWRITTEN — a customer can't smuggle their own credential).
   const originalPath = c.req.path.replace(/^\/proxy\/gemini/, '')
-  const originalUrl = new URL(`${GEMINI_BASE}${originalPath}`)
-
-  // Forward existing query params from client (except 'key'), then add our key
+  const upstreamUrlObj = new URL(`${GEMINI_BASE}${originalPath}`)
   const clientUrl = new URL(c.req.raw.url)
   clientUrl.searchParams.forEach((v, k) => {
-    if (k !== 'key') originalUrl.searchParams.set(k, v)
+    if (k !== 'key') upstreamUrlObj.searchParams.set(k, v)
   })
-  originalUrl.searchParams.set('key', decryptedKey)
+  upstreamUrlObj.searchParams.set('key', providerKey.plaintext)
 
+  // Gemini doesn't use Authorization. Strip explicitly so any client-supplied
+  // bearer never reaches the upstream URL or fetch headers.
   const headers = buildUpstreamHeaders(c.req.raw.headers, {
     'Content-Type': 'application/json',
   })
   headers.delete('authorization')
 
-  // ── Security scan + blocking ───────────────────────────────────────────────
-  const requestFlags = scanAll(reqBodyJson)
-  const hasInjection = requestFlags.some((f) => f.type === 'injection')
-  if (hasInjection && await isBlockingEnabled(projectId)) {
-    throw new ApiError(
-      'INJECTION_BLOCKED',
-      'Request blocked by Spanlens security policy: prompt injection detected.',
-    )
-  }
+  const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
 
-  const startMs = Date.now()
-  const fetchBody = c.req.method !== 'GET' && c.req.method !== 'HEAD' ? reqBodyText : null
-  const upstreamAbort = new AbortController()
-  const upstreamTimer = setTimeout(() => upstreamAbort.abort(), UPSTREAM_TIMEOUT_MS)
-  let upstreamRes: Response
-  try {
-    upstreamRes = await fetch(originalUrl.toString(), {
-      method: c.req.method,
-      headers,
-      body: fetchBody,
-      signal: upstreamAbort.signal,
-    })
-  } catch (err) {
-    clearTimeout(upstreamTimer)
-    const msg = err instanceof Error ? err.message : 'Unknown error'
-    if (err instanceof Error && err.name === 'AbortError') {
-      throw new ApiError(
-        'UPSTREAM_TIMEOUT',
-        `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms`,
-        { provider: 'gemini', timeoutMs: UPSTREAM_TIMEOUT_MS },
-      )
-    }
-    console.error('[gemini-proxy] upstream fetch error:', msg)
-    throw new ApiError('UPSTREAM_FAILED', `Upstream request failed: ${msg}`, {
-      provider: 'gemini',
-    })
-  }
-  clearTimeout(upstreamTimer)
-  const latencyMs = Date.now() - startMs
-  const proxyOverheadMs = startMs - handlerStartMs
+  const { upstreamRes, latencyMs, proxyOverheadMs } = await fetchUpstreamWithTimeout({
+    url: upstreamUrlObj.toString(),
+    method: c.req.method,
+    headers,
+    body: chooseFetchBody(c, parsed, false),
+    provider: 'gemini',
+    handlerStartMs,
+  })
 
-  // Extract model name from the path (e.g. /v1/models/gemini-1.5-pro:streamGenerateContent)
+  // Extract model name from the URL path (e.g.
+  // /v1/models/gemini-1.5-pro:streamGenerateContent).
   const modelMatch = /\/models\/([^/:]+)/.exec(originalPath)
   const isStreaming = /:streamGenerateContent/.test(originalPath)
 
-  const traceId = c.req.header('x-trace-id') ?? null
-  const resolved = await resolvePromptVersion(
-    organizationId,
-    c.req.header('x-spanlens-prompt-version') ?? null,
-    traceId,
-  )
-  const promptVersionId = resolved?.versionId ?? null
-
-  const logBase = {
-    organizationId,
-    projectId,
-    apiKeyId,
-    provider: 'gemini',
-    latencyMs,
-    proxyOverheadMs,
+  const logBase = await buildLogBase({
+    c, provider: 'gemini',
+    organizationId, projectId, apiKeyId,
+    providerKey,
+    reqBodyJson: parsed.reqBodyJson,
+    requestFlags,
+    latencyMs, proxyOverheadMs,
     statusCode: upstreamRes.status,
-    requestBody: reqBodyJson,
-    errorMessage: null as string | null,
-    traceId,
-    spanId: c.req.header('x-span-id') ?? null,
-    promptVersionId,
-    providerKeyId: providerKey.id,
-    userId: c.req.header('x-spanlens-user') ?? null,
-    sessionId: c.req.header('x-spanlens-session') ?? null,
-    logBodyMode: parseLogBodyMode(c.req.header('x-spanlens-log-body')),
-    preComputedRequestFlags: requestFlags,
-  }
+  })
 
-  // ── Streaming path (:streamGenerateContent) ───────────────────────────────
-  // Pass chunks straight to the client AND buffer for token/text extraction.
-  // Without this, the previous code did `await upstreamRes.text()` and blocked
-  // the entire stream — the client never got streaming, just one big payload.
+  // ── Streaming path ────────────────────────────────────────────────────────
+  // Gemini sends a JSON array (not line-delimited SSE), so the pump
+  // accumulates raw chunks and the parser walks the full buffer.
   if (isStreaming && upstreamRes.body) {
-    const downstreamHeaders = buildDownstreamHeaders(upstreamRes.headers)
-    downstreamHeaders.forEach((value, key) => c.header(key, value))
-    c.status(upstreamRes.status as 200)
+    return runChunkAccumulatedStreamPump({
+      c, upstreamRes, handlerStartMs, provider: 'gemini',
+      onComplete: async (buffer, truncated) => {
+        const text = extractGeminiStreamText(buffer.split('\n'))
 
-    const upstreamBody = upstreamRes.body
-
-    return stream(c, async (honoStream) => {
-      const reader = upstreamBody.getReader()
-      const decoder = new TextDecoder()
-      const deadline = makeStreamDeadline(handlerStartMs)
-      const chunks: string[] = []
-      let truncated = false
-
-      pump: for (;;) {
-        const outcome = await readWithDeadline(reader, deadline)
-        switch (outcome.kind) {
-          case 'done':
-            break pump
-          case 'timeout':
-            truncated = true
-            console.warn('[gemini-stream] deadline reached, closing gracefully')
-            await cancelReaderSilently(reader)
-            break pump
-          case 'error':
-            console.error('[gemini-stream] reader error:', outcome.error)
-            break pump
-          case 'chunk':
-            await honoStream.write(outcome.value)
-            chunks.push(decoder.decode(outcome.value, { stream: true }))
-            break
-        }
-      }
-
-      const buffer = chunks.join('')
-      const text = extractGeminiStreamText(buffer.split('\n'))
-
-      // Best-effort: try to recover usage + model from the last full JSON chunk.
-      let model = modelMatch?.[1] ?? ''
-      let promptTokens = 0
-      let completionTokens = 0
-      let totalTokens = 0
-      let serviceTier: import('../parsers/openai.js').ServiceTier | undefined
-      try {
-        // Try parsing the joined buffer as a JSON array of partial responses
-        const lastChunkText = buffer.trim().replace(/^\[/, '').replace(/\]$/, '')
-        const candidates = lastChunkText.split(/(?<=})\s*,\s*(?=\{)/g)
-        const last = candidates[candidates.length - 1]
-        if (last) {
-          const parsed = parseGeminiResponse(JSON.parse(last) as Record<string, unknown>)
-          if (parsed) {
-            model = parsed.model || model
-            promptTokens = parsed.promptTokens
-            completionTokens = parsed.completionTokens
-            totalTokens = parsed.totalTokens
-            serviceTier = parsed.serviceTier
+        // Best-effort: recover usage + model from the last full JSON object
+        // in the array. usage may be missing on aborted streams — acceptable.
+        let model = modelMatch?.[1] ?? ''
+        let promptTokens = 0
+        let completionTokens = 0
+        let totalTokens = 0
+        let serviceTier: ServiceTier | undefined
+        try {
+          const lastChunkText = buffer.trim().replace(/^\[/, '').replace(/\]$/, '')
+          const candidates = lastChunkText.split(/(?<=})\s*,\s*(?=\{)/g)
+          const last = candidates[candidates.length - 1]
+          if (last) {
+            const p = parseGeminiResponse(JSON.parse(last) as Record<string, unknown>)
+            if (p) {
+              model = p.model || model
+              promptTokens = p.promptTokens
+              completionTokens = p.completionTokens
+              totalTokens = p.totalTokens
+              serviceTier = p.serviceTier
+            }
           }
+        } catch { /* parser drift on aborted streams — acceptable */ }
+
+        // Capture-rate signal: stream produced output bytes but yielded no
+        // extractable text means the parser drifted from Gemini's wire
+        // format. Surface as warn for log monitoring.
+        if (buffer.length > 0 && text.length === 0) {
+          logWarn('UNCATEGORIZED', { provider: 'gemini', kind: 'capture_empty', bytes: buffer.length })
         }
-      } catch { /* usage may be missing on aborted streams — acceptable */ }
 
-      // Capture-rate signal: a stream that produced output bytes but yielded no
-      // extractable text usually means the parser drifted from Gemini's wire
-      // format. Surface it as a warn for log monitoring.
-      if (buffer.length > 0 && text.length === 0) {
-        console.warn(
-          '[gemini-stream] capture-empty: %d bytes received, 0 chars extracted (parser drift?)',
-          buffer.length,
-        )
-      }
+        const cost = calculateCost('gemini', model, { promptTokens, completionTokens, serviceTier })
+        const responseBody = text ? {
+          candidates: [{ content: { parts: [{ text }] } }],
+          modelVersion: model,
+          usageMetadata: {
+            promptTokenCount: promptTokens,
+            candidatesTokenCount: completionTokens,
+            totalTokenCount: totalTokens,
+          },
+        } : null
 
-      const cost = calculateCost('gemini', model, { promptTokens, completionTokens, serviceTier })
-      const responseBody = text ? {
-        candidates: [{ content: { parts: [{ text }] } }],
-        modelVersion: model,
-        usageMetadata: {
-          promptTokenCount: promptTokens,
-          candidatesTokenCount: completionTokens,
-          totalTokenCount: totalTokens,
-        },
-      } : null
-
-      await logRequestAsync({
-        ...logBase,
-        model,
-        promptTokens,
-        completionTokens,
-        totalTokens,
-        serviceTier: serviceTier ?? null,
-        costUsd: cost?.totalCost ?? null,
-        responseBody,
-        truncated,
-      }).catch((err) => {
-        console.error('[gemini-stream] log error:', err)
-      })
+        return logRequestAsync({
+          ...logBase,
+          model,
+          promptTokens, completionTokens, totalTokens,
+          serviceTier: serviceTier ?? null,
+          costUsd: cost?.totalCost ?? null,
+          responseBody,
+          truncated,
+        })
+      },
     })
   }
 
@@ -247,17 +152,17 @@ geminiProxy.all('/*', async (c) => {
   let promptTokens = 0
   let completionTokens = 0
   let totalTokens = 0
-  let serviceTier: import('../parsers/openai.js').ServiceTier | undefined
+  let serviceTier: ServiceTier | undefined
 
   if (upstreamRes.ok && resBodyJson) {
     try {
-      const parsed = parseGeminiResponse(resBodyJson as Record<string, unknown>)
-      if (parsed) {
-        model = parsed.model || model
-        promptTokens = parsed.promptTokens
-        completionTokens = parsed.completionTokens
-        totalTokens = parsed.totalTokens
-        serviceTier = parsed.serviceTier
+      const p = parseGeminiResponse(resBodyJson as Record<string, unknown>)
+      if (p) {
+        model = p.model || model
+        promptTokens = p.promptTokens
+        completionTokens = p.completionTokens
+        totalTokens = p.totalTokens
+        serviceTier = p.serviceTier
       }
     } catch { /* ignore */ }
   }
@@ -267,9 +172,7 @@ geminiProxy.all('/*', async (c) => {
   fireAndForget(c, logRequestAsync({
     ...logBase,
     model,
-    promptTokens,
-    completionTokens,
-    totalTokens,
+    promptTokens, completionTokens, totalTokens,
     serviceTier: serviceTier ?? null,
     costUsd: cost?.totalCost ?? null,
     responseBody: resBodyJson,

--- a/apps/server/src/proxy/openai.ts
+++ b/apps/server/src/proxy/openai.ts
@@ -1,19 +1,20 @@
 import { Hono } from 'hono'
-import { stream } from 'hono/streaming'
 import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
 import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
 import { calculateCost } from '../lib/cost.js'
-import { logRequestAsync, parseLogBodyMode } from '../lib/logger.js'
-import { resolvePromptVersion } from '../lib/resolve-prompt-version.js'
+import { logRequestAsync } from '../lib/logger.js'
 import { fireAndForget } from '../lib/wait-until.js'
-import { parseOpenAIResponse } from '../parsers/openai.js'
-import { scanAll } from '../lib/security-scan.js'
-import { getDecryptedProviderKey, buildUpstreamHeaders, buildDownstreamHeaders, isBlockingEnabled } from './utils.js'
+import { parseOpenAIResponse, type ServiceTier } from '../parsers/openai.js'
+import { buildUpstreamHeaders, buildDownstreamHeaders } from './utils.js'
 import { logOpenAIStream } from './stream-logger.js'
-import { cancelReaderSilently, makeStreamDeadline, readWithDeadline } from './stream-deadline.js'
-import { ApiError } from '../lib/errors.js'
+import { assertProviderKey } from './shared/provider-key.js'
+import { parseProxyRequestBody, chooseFetchBody } from './shared/request-body.js'
+import { runSecurityGate } from './shared/security-gate.js'
+import { fetchUpstreamWithTimeout } from './shared/upstream-fetch.js'
+import { buildLogBase } from './shared/log-base.js'
+import { runLineBufferedStreamPump } from './shared/stream-pump.js'
 
 // Overridable so E2E (apps/web/__e2e__/smoke.spec.ts via docker-compose
 // dev mock-openai) can point this at http://localhost:4000 without hitting
@@ -24,7 +25,6 @@ import { ApiError } from '../lib/errors.js'
 const OPENAI_BASE = (
   process.env['OPENAI_API_BASE'] ?? 'https://api.openai.com'
 ).replace(/\/v1\/?$/, '')
-const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '35000', 10)
 
 export const openaiProxy = new Hono<ApiKeyContext>()
 
@@ -35,165 +35,49 @@ openaiProxy.use('*', enforceQuota)
 
 openaiProxy.all('/*', async (c) => {
   const handlerStartMs = Date.now()
-
   const organizationId = c.get('organizationId')
-  // projectId is guaranteed non-null on this path: requireFullScope rejects
-  // 'public' keys and the api_keys_scope_owner_consistency CHECK constraint
-  // forces 'full' keys to carry a project_id. Narrowing here is purely a
-  // TS aid since the dual-owner model made ApiKeyContext.projectId nullable.
+  // requireFullScope rejects 'public' keys and the DB CHECK constraint forces
+  // 'full' keys to carry a project_id, so this narrowing is safe.
   const projectId = c.get('projectId') as string
   const apiKeyId = c.get('apiKeyId')
 
-  // Nested-keys model: provider key pool is owned by this Spanlens key.
-  // Path = "/proxy/openai/..." → resolve OpenAI key under apiKeyId.
-  const providerKey = await getDecryptedProviderKey(apiKeyId, 'openai')
-  if (!providerKey) {
-    throw new ApiError(
-      'NO_PROVIDER_KEY',
-      'No active OpenAI provider key registered for this Spanlens key',
-      { provider: 'openai' },
-    )
-  }
-  const decryptedKey = providerKey.plaintext
+  const providerKey = await assertProviderKey(apiKeyId, 'openai')
+  const parsed = await parseProxyRequestBody(c, { injectOpenAIStreamOptions: true })
+  const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
 
-  const reqBodyText = await c.req.text()
-  let reqBodyJson: Record<string, unknown> | null = null
-  let isStreaming = false
-
-  try {
-    reqBodyJson = JSON.parse(reqBodyText) as Record<string, unknown>
-    isStreaming = reqBodyJson.stream === true
-
-    // Inject stream_options so the last chunk includes usage
-    if (isStreaming) {
-      reqBodyJson = {
-        ...reqBodyJson,
-        stream_options: { include_usage: true },
-      }
-    }
-  } catch { /* non-JSON body — pass through */ }
-
-  // ── Security scan + blocking ───────────────────────────────────────────────
-  // Scan request body BEFORE forwarding upstream. If injection is detected and
-  // blocking is enabled for this project, reject immediately (422).
-  // PII-only flags are never blocked — they may be legitimate user data.
-  const requestFlags = scanAll(reqBodyJson)
-  const hasInjection = requestFlags.some((f) => f.type === 'injection')
-  if (hasInjection && await isBlockingEnabled(projectId)) {
-    throw new ApiError(
-      'INJECTION_BLOCKED',
-      'Request blocked by Spanlens security policy: prompt injection detected.',
-    )
-  }
-
-  const path = c.req.path.replace(/^\/proxy\/openai/, '')
-  const upstreamUrl = `${OPENAI_BASE}${path}`
-
+  const upstreamUrl = `${OPENAI_BASE}${c.req.path.replace(/^\/proxy\/openai/, '')}`
   const headers = buildUpstreamHeaders(c.req.raw.headers, {
-    Authorization: `Bearer ${decryptedKey}`,
+    Authorization: `Bearer ${providerKey.plaintext}`,
     'Content-Type': 'application/json',
   })
 
-  const startMs = Date.now()
-  const fetchBody =
-    c.req.method !== 'GET' && c.req.method !== 'HEAD'
-      ? isStreaming && reqBodyJson ? JSON.stringify(reqBodyJson) : reqBodyText
-      : null
-
-  const upstreamAbort = new AbortController()
-  const upstreamTimer = setTimeout(() => upstreamAbort.abort(), UPSTREAM_TIMEOUT_MS)
-  let upstreamRes: Response
-  try {
-    upstreamRes = await fetch(upstreamUrl, { method: c.req.method, headers, body: fetchBody, signal: upstreamAbort.signal })
-  } catch (err) {
-    clearTimeout(upstreamTimer)
-    const msg = err instanceof Error ? err.message : 'Unknown error'
-    if (err instanceof Error && err.name === 'AbortError') {
-      throw new ApiError(
-        'UPSTREAM_TIMEOUT',
-        `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms`,
-        { provider: 'openai', timeoutMs: UPSTREAM_TIMEOUT_MS },
-      )
-    }
-    console.error('[openai-proxy] upstream fetch error:', msg)
-    throw new ApiError('UPSTREAM_FAILED', `Upstream request failed: ${msg}`, {
-      provider: 'openai',
-    })
-  }
-  clearTimeout(upstreamTimer)
-  const latencyMs = Date.now() - startMs
-  // Pre-fetch overhead: auth + key decryption + body parsing (our cost, not provider's)
-  const proxyOverheadMs = startMs - handlerStartMs
-
-  const model = (reqBodyJson?.model as string | undefined) ?? ''
-  const traceId = c.req.header('x-trace-id') ?? null
-  const resolved = await resolvePromptVersion(
-    organizationId,
-    c.req.header('x-spanlens-prompt-version') ?? null,
-    traceId,
-  )
-  const promptVersionId = resolved?.versionId ?? null
-  const logBase = {
-    organizationId, projectId, apiKeyId,
+  const { upstreamRes, latencyMs, proxyOverheadMs } = await fetchUpstreamWithTimeout({
+    url: upstreamUrl,
+    method: c.req.method,
+    headers,
+    body: chooseFetchBody(c, parsed, true),
     provider: 'openai',
-    latencyMs, proxyOverheadMs, statusCode: upstreamRes.status,
-    requestBody: reqBodyJson,
-    responseBody: null,
-    errorMessage: null,
-    traceId,
-    spanId: c.req.header('x-span-id') ?? null,
-    promptVersionId,
-    providerKeyId: providerKey.id,
-    userId: c.req.header('x-spanlens-user') ?? null,
-    sessionId: c.req.header('x-spanlens-session') ?? null,
-    logBodyMode: parseLogBodyMode(c.req.header('x-spanlens-log-body')),
-    preComputedRequestFlags: requestFlags,
-  }
+    handlerStartMs,
+  })
 
-  // ── Streaming path (Hono stream helper) ──────────────────────────────────
-  if (isStreaming && upstreamRes.body) {
-    const downstreamHeaders = buildDownstreamHeaders(upstreamRes.headers)
-    downstreamHeaders.forEach((value, key) => c.header(key, value))
-    c.status(upstreamRes.status as 200)
+  const logBase = await buildLogBase({
+    c, provider: 'openai',
+    organizationId, projectId, apiKeyId,
+    providerKey,
+    reqBodyJson: parsed.reqBodyJson,
+    requestFlags,
+    latencyMs, proxyOverheadMs,
+    statusCode: upstreamRes.status,
+  })
 
-    const upstreamBody = upstreamRes.body
+  const model = (parsed.reqBodyJson?.model as string | undefined) ?? ''
 
-    return stream(c, async (honoStream) => {
-      const reader = upstreamBody.getReader()
-      const decoder = new TextDecoder()
-      const deadline = makeStreamDeadline(handlerStartMs)
-      let buffer = ''
-      const lines: string[] = []
-      let truncated = false
-
-      pump: for (;;) {
-        const outcome = await readWithDeadline(reader, deadline)
-        switch (outcome.kind) {
-          case 'done':
-            break pump
-          case 'timeout':
-            truncated = true
-            console.warn('[openai-stream] deadline reached, closing gracefully')
-            await cancelReaderSilently(reader)
-            break pump
-          case 'error':
-            console.error('[openai-stream] reader error:', outcome.error)
-            break pump
-          case 'chunk': {
-            await honoStream.write(outcome.value)
-            buffer += decoder.decode(outcome.value, { stream: true })
-            const parts = buffer.split('\n')
-            buffer = parts.pop() ?? ''
-            lines.push(...parts)
-            break
-          }
-        }
-      }
-      if (buffer.length > 0) lines.push(buffer)
-
-      await logOpenAIStream(lines, { ...logBase, model }, { truncated }).catch((err) => {
-        console.error('[openai-stream] log error:', err)
-      })
+  // ── Streaming path ────────────────────────────────────────────────────────
+  if (parsed.isStreaming && upstreamRes.body) {
+    return runLineBufferedStreamPump({
+      c, upstreamRes, handlerStartMs, provider: 'openai',
+      onComplete: (lines, truncated) =>
+        logOpenAIStream(lines, { ...logBase, model }, { truncated }),
     })
   }
 
@@ -209,19 +93,19 @@ openaiProxy.all('/*', async (c) => {
   let cacheReadTokens = 0
   let cacheWriteTokens = 0
   let resolvedModel = model
-  let serviceTier: import('../parsers/openai.js').ServiceTier | undefined
+  let serviceTier: ServiceTier | undefined
 
   if (upstreamRes.ok && resBodyJson) {
     try {
-      const parsed = parseOpenAIResponse(resBodyJson as Record<string, unknown>)
-      if (parsed) {
-        resolvedModel = parsed.model || model
-        promptTokens = parsed.promptTokens
-        completionTokens = parsed.completionTokens
-        totalTokens = parsed.totalTokens
-        cacheReadTokens = parsed.cacheReadTokens ?? 0
-        cacheWriteTokens = parsed.cacheWriteTokens ?? 0
-        serviceTier = parsed.serviceTier
+      const p = parseOpenAIResponse(resBodyJson as Record<string, unknown>)
+      if (p) {
+        resolvedModel = p.model || model
+        promptTokens = p.promptTokens
+        completionTokens = p.completionTokens
+        totalTokens = p.totalTokens
+        cacheReadTokens = p.cacheReadTokens ?? 0
+        cacheWriteTokens = p.cacheWriteTokens ?? 0
+        serviceTier = p.serviceTier
       }
     } catch { /* ignore */ }
   }

--- a/apps/server/src/proxy/shared/log-base.ts
+++ b/apps/server/src/proxy/shared/log-base.ts
@@ -1,0 +1,79 @@
+/**
+ * Construct the `logBase` object passed to logRequestAsync / log*Stream.
+ *
+ * Each proxy previously duplicated the same 18-field literal. Centralising
+ * means new log fields (e.g. additional X-Spanlens-* identifiers) land in
+ * one file instead of four, and a future schema change (rename, add
+ * required field) cannot drift between providers.
+ */
+
+import type { Context } from 'hono'
+import { parseLogBodyMode } from '../../lib/logger.js'
+import { resolvePromptVersion } from '../../lib/resolve-prompt-version.js'
+import type { SecurityFlag } from '../../lib/security-scan.js'
+import type { ResolvedProviderKey } from '../utils.js'
+import type { ProxyProvider } from './provider-key.js'
+
+export interface ProxyLogBase {
+  organizationId: string
+  projectId: string
+  apiKeyId: string
+  provider: ProxyProvider
+  latencyMs: number
+  proxyOverheadMs: number
+  statusCode: number
+  requestBody: Record<string, unknown> | null
+  responseBody: null
+  errorMessage: null
+  traceId: string | null
+  spanId: string | null
+  promptVersionId: string | null
+  providerKeyId: string
+  userId: string | null
+  sessionId: string | null
+  logBodyMode: ReturnType<typeof parseLogBodyMode>
+  preComputedRequestFlags: SecurityFlag[]
+}
+
+export interface BuildLogBaseInput {
+  c: Context
+  provider: ProxyProvider
+  organizationId: string
+  projectId: string
+  apiKeyId: string
+  providerKey: ResolvedProviderKey
+  reqBodyJson: Record<string, unknown> | null
+  requestFlags: SecurityFlag[]
+  latencyMs: number
+  proxyOverheadMs: number
+  statusCode: number
+}
+
+export async function buildLogBase(input: BuildLogBaseInput): Promise<ProxyLogBase> {
+  const traceId = input.c.req.header('x-trace-id') ?? null
+  const resolved = await resolvePromptVersion(
+    input.organizationId,
+    input.c.req.header('x-spanlens-prompt-version') ?? null,
+    traceId,
+  )
+  return {
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    apiKeyId: input.apiKeyId,
+    provider: input.provider,
+    latencyMs: input.latencyMs,
+    proxyOverheadMs: input.proxyOverheadMs,
+    statusCode: input.statusCode,
+    requestBody: input.reqBodyJson,
+    responseBody: null,
+    errorMessage: null,
+    traceId,
+    spanId: input.c.req.header('x-span-id') ?? null,
+    promptVersionId: resolved?.versionId ?? null,
+    providerKeyId: input.providerKey.id,
+    userId: input.c.req.header('x-spanlens-user') ?? null,
+    sessionId: input.c.req.header('x-spanlens-session') ?? null,
+    logBodyMode: parseLogBodyMode(input.c.req.header('x-spanlens-log-body')),
+    preComputedRequestFlags: input.requestFlags,
+  }
+}

--- a/apps/server/src/proxy/shared/provider-key.ts
+++ b/apps/server/src/proxy/shared/provider-key.ts
@@ -1,0 +1,47 @@
+/**
+ * Provider-key resolution gate shared by all 4 proxy handlers
+ * (openai / anthropic / gemini / azure).
+ *
+ * Before this helper, each proxy duplicated the same 7-line block:
+ *   const providerKey = await getDecryptedProviderKey(apiKeyId, '<p>')
+ *   if (!providerKey) throw new ApiError('NO_PROVIDER_KEY', '...', {provider:'<p>'})
+ *
+ * Centralising it means a future change to the error message, code, or
+ * details shape propagates to every provider in one edit, instead of
+ * needing 4 (the failure mode the PR C audit flagged).
+ */
+
+import { ApiError } from '../../lib/errors.js'
+import { getDecryptedProviderKey, type ResolvedProviderKey } from '../utils.js'
+
+/** Provider tag used in `NO_PROVIDER_KEY` error details and the user-visible
+ * message. Matches the keys in provider_keys.provider. */
+export type ProxyProvider = 'openai' | 'anthropic' | 'gemini' | 'azure'
+
+const PROVIDER_LABEL: Record<ProxyProvider, string> = {
+  openai: 'OpenAI',
+  anthropic: 'Anthropic',
+  gemini: 'Gemini',
+  azure: 'Azure',
+}
+
+/**
+ * Resolve and decrypt the active provider key for a Spanlens key id, or
+ * throw a typed ApiError ready for the global onError serialiser. Returns
+ * the decrypted key + metadata bag verbatim so callers can read
+ * provider-specific fields (e.g. Azure's `resource_url`).
+ */
+export async function assertProviderKey(
+  apiKeyId: string,
+  provider: ProxyProvider,
+): Promise<ResolvedProviderKey> {
+  const providerKey = await getDecryptedProviderKey(apiKeyId, provider)
+  if (!providerKey) {
+    throw new ApiError(
+      'NO_PROVIDER_KEY',
+      `No active ${PROVIDER_LABEL[provider]} provider key registered for this Spanlens key`,
+      { provider },
+    )
+  }
+  return providerKey
+}

--- a/apps/server/src/proxy/shared/request-body.ts
+++ b/apps/server/src/proxy/shared/request-body.ts
@@ -1,0 +1,68 @@
+/**
+ * Request-body intake shared by all 4 proxy handlers.
+ *
+ * Each provider parses the incoming body the same way: read text, attempt
+ * JSON parse (non-JSON bodies pass through verbatim), detect streaming.
+ * OpenAI + Azure also inject `stream_options: { include_usage: true }` so
+ * the last SSE chunk carries token usage — without it the stream parser
+ * sees nothing and the log row records zero tokens.
+ */
+
+import type { Context } from 'hono'
+
+export interface ParsedProxyBody {
+  /** Raw text — forwarded upstream when JSON parse fails or no transform applies. */
+  reqBodyText: string
+  /** Parsed JSON, or null if the body wasn't valid JSON. */
+  reqBodyJson: Record<string, unknown> | null
+  /** True when the parsed body has `stream: true`. */
+  isStreaming: boolean
+}
+
+export interface ParseOptions {
+  /** When true, inject `stream_options.include_usage = true` on streaming
+   * requests so the last chunk includes usage. OpenAI + Azure require this;
+   * Anthropic + Gemini have native usage in their stream protocols. */
+  injectOpenAIStreamOptions?: boolean
+}
+
+export async function parseProxyRequestBody(
+  c: Context,
+  opts: ParseOptions = {},
+): Promise<ParsedProxyBody> {
+  const reqBodyText = await c.req.text()
+  let reqBodyJson: Record<string, unknown> | null = null
+  let isStreaming = false
+
+  try {
+    reqBodyJson = JSON.parse(reqBodyText) as Record<string, unknown>
+    isStreaming = reqBodyJson.stream === true
+    if (isStreaming && opts.injectOpenAIStreamOptions) {
+      reqBodyJson = {
+        ...reqBodyJson,
+        stream_options: { include_usage: true },
+      }
+    }
+  } catch {
+    /* non-JSON body — pass through verbatim */
+  }
+
+  return { reqBodyText, reqBodyJson, isStreaming }
+}
+
+/**
+ * Choose the body string to send upstream. GET/HEAD are body-less.
+ * Streaming OpenAI/Azure paths re-serialize the modified JSON (because
+ * `stream_options` was injected); other paths forward the original text.
+ */
+export function chooseFetchBody(
+  c: Context,
+  parsed: ParsedProxyBody,
+  reSerializeOnStream: boolean,
+): string | null {
+  if (c.req.method === 'GET' || c.req.method === 'HEAD') return null
+  if (reSerializeOnStream && parsed.isStreaming && parsed.reqBodyJson) {
+    return JSON.stringify(parsed.reqBodyJson)
+  }
+  return parsed.reqBodyText
+}

--- a/apps/server/src/proxy/shared/security-gate.ts
+++ b/apps/server/src/proxy/shared/security-gate.ts
@@ -1,0 +1,32 @@
+/**
+ * Pre-flight security scan shared by all 4 proxy handlers.
+ *
+ * `scanAll` returns every flag (injection + PII); only injection flags
+ * trigger the 422 block, and only when the project has opted in via
+ * `isBlockingEnabled`. PII-only flags never block — they may be legitimate
+ * customer data and the customer's own `withLogBody('none')` policy
+ * controls whether they get logged at all.
+ *
+ * Returns the full flag set so the caller can pass it through to
+ * logRequestAsync as `preComputedRequestFlags` and avoid a second scan
+ * in the logger.
+ */
+
+import { ApiError } from '../../lib/errors.js'
+import { scanAll, type SecurityFlag } from '../../lib/security-scan.js'
+import { isBlockingEnabled } from '../utils.js'
+
+export async function runSecurityGate(
+  reqBodyJson: Record<string, unknown> | null,
+  projectId: string,
+): Promise<SecurityFlag[]> {
+  const requestFlags = scanAll(reqBodyJson)
+  const hasInjection = requestFlags.some((f) => f.type === 'injection')
+  if (hasInjection && (await isBlockingEnabled(projectId))) {
+    throw new ApiError(
+      'INJECTION_BLOCKED',
+      'Request blocked by Spanlens security policy: prompt injection detected.',
+    )
+  }
+  return requestFlags
+}

--- a/apps/server/src/proxy/shared/stream-pump.ts
+++ b/apps/server/src/proxy/shared/stream-pump.ts
@@ -1,0 +1,147 @@
+/**
+ * SSE stream pump shared by 3 of the 4 proxy handlers (openai / anthropic /
+ * azure). Reads the upstream stream chunk-by-chunk, writes each chunk to
+ * the client, accumulates a line-buffered copy for token extraction, and
+ * surfaces "truncated by deadline" so the log row can flag the row.
+ *
+ * Gemini's protocol returns a JSON array (not line-delimited SSE) and is
+ * handled separately in proxy/gemini.ts.
+ *
+ * The pump never throws — a reader error or deadline gracefully ends the
+ * loop and the accumulated lines are still passed to the logger so partial
+ * traces are visible in the dashboard.
+ */
+
+import type { Context } from 'hono'
+import { stream } from 'hono/streaming'
+import { logError } from '../../lib/structured-logger.js'
+import {
+  cancelReaderSilently,
+  makeStreamDeadline,
+  readWithDeadline,
+} from '../stream-deadline.js'
+import { buildDownstreamHeaders } from '../utils.js'
+import type { ProxyProvider } from './provider-key.js'
+
+export interface StreamPumpInput {
+  c: Context
+  upstreamRes: Response
+  handlerStartMs: number
+  provider: ProxyProvider
+  /**
+   * Called after the stream completes with the captured line buffer and
+   * the truncated flag. Typically calls logOpenAIStream / logAnthropicStream.
+   */
+  onComplete: (lines: string[], truncated: boolean) => Promise<unknown>
+}
+
+export function runLineBufferedStreamPump(input: StreamPumpInput): Response {
+  const upstreamBody = input.upstreamRes.body
+  if (!upstreamBody) {
+    // Should never happen — callers gate on `isStreaming && upstreamRes.body`.
+    // Return the response verbatim if it does.
+    return new Response(null, {
+      status: input.upstreamRes.status,
+      headers: buildDownstreamHeaders(input.upstreamRes.headers),
+    })
+  }
+
+  const downstreamHeaders = buildDownstreamHeaders(input.upstreamRes.headers)
+  downstreamHeaders.forEach((value, key) => input.c.header(key, value))
+  input.c.status(input.upstreamRes.status as 200)
+
+  return stream(input.c, async (honoStream) => {
+    const reader = upstreamBody.getReader()
+    const decoder = new TextDecoder()
+    const deadline = makeStreamDeadline(input.handlerStartMs)
+    let buffer = ''
+    const lines: string[] = []
+    let truncated = false
+
+    pump: for (;;) {
+      const outcome = await readWithDeadline(reader, deadline)
+      switch (outcome.kind) {
+        case 'done':
+          break pump
+        case 'timeout':
+          truncated = true
+          await cancelReaderSilently(reader)
+          break pump
+        case 'error':
+          logError('UPSTREAM_FETCH_FAILED', { provider: input.provider, phase: 'stream' }, outcome.error)
+          break pump
+        case 'chunk': {
+          await honoStream.write(outcome.value)
+          buffer += decoder.decode(outcome.value, { stream: true })
+          const parts = buffer.split('\n')
+          buffer = parts.pop() ?? ''
+          lines.push(...parts)
+          break
+        }
+      }
+    }
+    if (buffer.length > 0) lines.push(buffer)
+
+    await input.onComplete(lines, truncated).catch((err) => {
+      logError('CH_INSERT_FAILED', { provider: input.provider, phase: 'stream_log' }, err)
+    })
+  })
+}
+
+/**
+ * Chunk-accumulating pump for Gemini's JSON-array stream protocol.
+ * Same pump skeleton but writes the raw buffer (not line splits) to the
+ * onComplete callback, because Gemini's parser walks the full JSON array.
+ */
+export interface ChunkAccumulatedStreamPumpInput {
+  c: Context
+  upstreamRes: Response
+  handlerStartMs: number
+  provider: ProxyProvider
+  onComplete: (buffer: string, truncated: boolean) => Promise<unknown>
+}
+
+export function runChunkAccumulatedStreamPump(input: ChunkAccumulatedStreamPumpInput): Response {
+  const upstreamBody = input.upstreamRes.body
+  if (!upstreamBody) {
+    return new Response(null, {
+      status: input.upstreamRes.status,
+      headers: buildDownstreamHeaders(input.upstreamRes.headers),
+    })
+  }
+
+  const downstreamHeaders = buildDownstreamHeaders(input.upstreamRes.headers)
+  downstreamHeaders.forEach((value, key) => input.c.header(key, value))
+  input.c.status(input.upstreamRes.status as 200)
+
+  return stream(input.c, async (honoStream) => {
+    const reader = upstreamBody.getReader()
+    const decoder = new TextDecoder()
+    const deadline = makeStreamDeadline(input.handlerStartMs)
+    const chunks: string[] = []
+    let truncated = false
+
+    pump: for (;;) {
+      const outcome = await readWithDeadline(reader, deadline)
+      switch (outcome.kind) {
+        case 'done':
+          break pump
+        case 'timeout':
+          truncated = true
+          await cancelReaderSilently(reader)
+          break pump
+        case 'error':
+          logError('UPSTREAM_FETCH_FAILED', { provider: input.provider, phase: 'stream' }, outcome.error)
+          break pump
+        case 'chunk':
+          await honoStream.write(outcome.value)
+          chunks.push(decoder.decode(outcome.value, { stream: true }))
+          break
+      }
+    }
+
+    await input.onComplete(chunks.join(''), truncated).catch((err) => {
+      logError('CH_INSERT_FAILED', { provider: input.provider, phase: 'stream_log' }, err)
+    })
+  })
+}

--- a/apps/server/src/proxy/shared/upstream-fetch.ts
+++ b/apps/server/src/proxy/shared/upstream-fetch.ts
@@ -1,0 +1,76 @@
+/**
+ * Upstream fetch + abort timer shared by all 4 proxy handlers.
+ *
+ * Each provider previously duplicated the same 20-line block:
+ *   - AbortController + setTimeout(abort, UPSTREAM_TIMEOUT_MS)
+ *   - try/catch around fetch
+ *   - clearTimeout on success AND failure paths
+ *   - throw UPSTREAM_TIMEOUT or UPSTREAM_FAILED with provider details
+ *   - measure latencyMs from startMs to fetch-return
+ *
+ * Centralising means a future change (e.g. swapping in a retrying fetch
+ * for 5xx upstream errors) edits one file instead of four.
+ */
+
+import { ApiError } from '../../lib/errors.js'
+import { logError } from '../../lib/structured-logger.js'
+import type { ProxyProvider } from './provider-key.js'
+
+const UPSTREAM_TIMEOUT_MS = parseInt(process.env['UPSTREAM_TIMEOUT_MS'] ?? '35000', 10)
+
+export interface UpstreamFetchResult {
+  upstreamRes: Response
+  /** Wall-clock from initiating fetch to receiving response headers. */
+  latencyMs: number
+  /** Pre-fetch overhead inside our handler: auth, key decrypt, body parse. */
+  proxyOverheadMs: number
+}
+
+export interface UpstreamFetchOptions {
+  url: string
+  method: string
+  headers: Headers
+  body: string | null
+  provider: ProxyProvider
+  /** Set to Date.now() at the very start of the request handler. */
+  handlerStartMs: number
+}
+
+export async function fetchUpstreamWithTimeout(
+  opts: UpstreamFetchOptions,
+): Promise<UpstreamFetchResult> {
+  const startMs = Date.now()
+  const upstreamAbort = new AbortController()
+  const upstreamTimer = setTimeout(() => upstreamAbort.abort(), UPSTREAM_TIMEOUT_MS)
+
+  let upstreamRes: Response
+  try {
+    upstreamRes = await fetch(opts.url, {
+      method: opts.method,
+      headers: opts.headers,
+      body: opts.body,
+      signal: upstreamAbort.signal,
+    })
+  } catch (err) {
+    clearTimeout(upstreamTimer)
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new ApiError(
+        'UPSTREAM_TIMEOUT',
+        `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms`,
+        { provider: opts.provider, timeoutMs: UPSTREAM_TIMEOUT_MS },
+      )
+    }
+    const msg = err instanceof Error ? err.message : 'Unknown error'
+    logError('UPSTREAM_FETCH_FAILED', { provider: opts.provider }, err)
+    throw new ApiError('UPSTREAM_FAILED', `Upstream request failed: ${msg}`, {
+      provider: opts.provider,
+    })
+  }
+
+  clearTimeout(upstreamTimer)
+  return {
+    upstreamRes,
+    latencyMs: Date.now() - startMs,
+    proxyOverheadMs: startMs - opts.handlerStartMs,
+  }
+}


### PR DESCRIPTION
PR 3 of 4 in the 2026-06-12 tech-debt pass. PR A (#318) + PR B (#319) already landed.

## Summary

The 4 proxy handlers had 40~50% copy-paste duplication: provider key resolution, request body intake, security scan, upstream fetch with timeout, logBase construction, and stream pump loop were all repeated verbatim across openai/anthropic/gemini/azure. A bug fix in one had to be applied 4 times by hand; skipping one was an easy review miss.

Extracted 6 helpers to \`proxy/shared/\`. Each handler is now ~100~190 lines, mostly provider-specific URL/header/parser glue, with the duplicated infrastructure delegated to the shared modules.

## Line counts (before → after)

| File | Before | After | Delta |
|---|---|---|---|
| \`openai.ts\` | 245 | 129 | -116 |
| \`anthropic.ts\` | 220 | 125 | -95 |
| \`gemini.ts\` | 283 | 186 | -97 |
| \`azure.ts\` | 251 | 149 | -102 |
| **Total** | **999** | **589** | **-410 (-41%)** |

Plus 449 lines of shared infrastructure (proxy/shared/) — net code unchanged, but the 9 duplications collapsed to single declarations.

## Shared modules

| File | Purpose |
|---|---|
| \`provider-key.ts\` | \`assertProviderKey\` — throws \`NO_PROVIDER_KEY\` |
| \`request-body.ts\` | \`parseProxyRequestBody\` + \`chooseFetchBody\` |
| \`security-gate.ts\` | \`runSecurityGate\` — throws \`INJECTION_BLOCKED\` |
| \`upstream-fetch.ts\` | \`fetchUpstreamWithTimeout\` — throws \`UPSTREAM_TIMEOUT\`/\`UPSTREAM_FAILED\` |
| \`log-base.ts\` | \`buildLogBase\` — all 18 fields in one place |
| \`stream-pump.ts\` | Line-buffered pump (openai/anthropic/azure) + chunk-accumulated pump (gemini) |

PR A's structured logger replaces the inline \`console.error\` calls in the proxy files (upstream fetch error → \`logError\`, stream reader error → \`logError\`, gemini capture-empty → \`logWarn\`). All log lines now carry provider tag, phase, and orgId-shape context.

## Test plan

- [x] \`pnpm --filter server test\` — 1022/1022 (unchanged from PR B)
- [x] \`pnpm --filter server typecheck\` — clean
- [x] 39 proxy integration tests still pass (proxy-{openai,anthropic,gemini,azure}.test.ts)
- [ ] CI green on this branch

The 39 integration tests were intentionally written in [#316](https://github.com/spanlens/Spanlens/pull/316) to be the safety net for exactly this kind of refactor.

## Next in this series

- **PR D** — eval-runner.ts 1273-line file split (LLM judge / regex / JSON schema)