### PR TITLE
chore(server): clean up lint fallout from PR D (eval-runner split)

### DIFF
--- a/apps/server/src/lib/cron-jobs/aggregate-usage.ts
+++ b/apps/server/src/lib/cron-jobs/aggregate-usage.ts
@@ -17,7 +17,10 @@
  * bypass via service-role is correct here.
  */
 
-// eslint-disable-next-line no-restricted-imports
+// no-restricted-imports rule is scoped to api/ handlers (the worry is
+// tenant-blind reads from request handlers). lib/cron-jobs/ is operator-
+// internal cron territory, so the lint rule doesn't fire here and the
+// inline disable was redundant.
 import { unscopedClickhouse } from '../clickhouse.js'
 import { supabaseAdmin } from '../db.js'
 

--- a/apps/server/src/lib/cron-jobs/detect-missing-model-prices.ts
+++ b/apps/server/src/lib/cron-jobs/detect-missing-model-prices.ts
@@ -8,7 +8,9 @@
  * already in internal_alerts deduplicates.
  */
 
-// eslint-disable-next-line no-restricted-imports
+// Cross-tenant scan by design — operator-internal cron. The
+// no-restricted-imports rule is scoped to api/ handlers and does not
+// fire here, so the inline disable was a no-op.
 import { unscopedClickhouse } from '../clickhouse.js'
 import { supabaseAdmin } from '../db.js'
 

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -30,7 +30,7 @@ import { buildOpenAIBody } from './playground-runner.js'
 import { startInternalTrace } from './internal-tracing.js'
 // Extracted sub-modules. Re-exported below so existing import sites
 // (`from '../lib/eval-runner.js'`) keep working unchanged.
-import { MAX_RESPONSE_CHARS, extractResponseText } from './eval-runners/shared.js'
+import { extractResponseText } from './eval-runners/shared.js'
 import {
   buildJudgePrompt,
   parseJudgeReply,

--- a/apps/server/src/lib/structured-logger.ts
+++ b/apps/server/src/lib/structured-logger.ts
@@ -105,11 +105,13 @@ function emit(level: 'ERROR' | 'WARN', code: LogCode, context: LogContext, err?:
   }
   // Single line, prefixed for grep-ability.
   const line = `${level}[${code}] ${JSON.stringify(payload)}`
+  // The no-console rule is not active in this codebase (the lint config
+  // permits console.error/warn — only console.log is discouraged), so the
+  // earlier `// eslint-disable-next-line no-console` lines were no-ops
+  // and warned as unused directives.
   if (level === 'ERROR') {
-    // eslint-disable-next-line no-console
     console.error(line)
   } else {
-    // eslint-disable-next-line no-console
     console.warn(line)
   }
 }


### PR DESCRIPTION
Hotfix for the lint failures introduced when PR D (#321) merged. Four warnings + 1 error reported by the post-merge CI run.

## Fixes

- \`eval-runner.ts:33\` — \`MAX_RESPONSE_CHARS\` was in the import list but unused (the constant is only consumed by the extracted sub-modules now)
- \`cron-jobs/aggregate-usage.ts:20\` + \`detect-missing-model-prices.ts:11\` — unused \`eslint-disable-next-line no-restricted-imports\` directives (the rule is scoped to \`api/\` request handlers, doesn't fire in \`lib/cron-jobs/\`)
- \`structured-logger.ts:109,112\` — unused \`eslint-disable-next-line no-console\` directives (the lint config permits \`console.error\`/\`warn\`)

Each disable directive was replaced with a one-line comment explaining why the call is allowed, so a future contributor doesn't re-add a redundant disable.

## Verification

- \`pnpm --filter server lint\` — clean (was: 1 error, 4 warnings)
- \`pnpm --filter server typecheck\` — clean
- \`pnpm --filter server test\` — 1022/1022 (unchanged)