### PR TITLE
feat(web,server): add 3 breakdown charts to /dashboard

### DIFF
--- a/apps/server/src/api/stats.ts
+++ b/apps/server/src/api/stats.ts
@@ -163,9 +163,12 @@ statsRouter.get('/timeseries', async (c) => {
       requests: r.requests,
       cost: parseFloat(r.cost.toFixed(6)),
       tokens: r.tokens,
+      promptTokens: r.prompt_tokens,
+      completionTokens: r.completion_tokens,
       errors: r.errors,
       errors4xx: r.errors_4xx,
       errors5xx: r.errors_5xx,
+      errors429: r.errors_429,
       p50LatencyMs: r.p50_latency_ms,
       p95LatencyMs: r.p95_latency_ms,
     }))

--- a/apps/server/src/lib/stats-queries.ts
+++ b/apps/server/src/lib/stats-queries.ts
@@ -179,10 +179,19 @@ export interface TimeseriesRow {
   day: string
   requests: number
   cost: number
+  /** Total tokens (prompt + completion) — kept for backward compatibility. */
   tokens: number
+  /** Prompt-side tokens — input to the model. Powers the token-trends chart. */
+  prompt_tokens: number
+  /** Completion-side tokens — output from the model. Powers the token-trends chart. */
+  completion_tokens: number
   errors: number
   errors_4xx: number
   errors_5xx: number
+  /** 429 specifically — split out from 4xx so the dashboard can flag rate
+   * limiting as a distinct failure mode (an account-quota issue, not a
+   * client-error). countIf(status_code = 429). */
+  errors_429: number
   /** p50 latency in milliseconds. Null when the bucket has zero requests. */
   p50_latency_ms: number | null
   /** p95 latency in milliseconds. Null when the bucket has zero requests. */
@@ -251,9 +260,12 @@ export async function getStatsTimeseries(
       count()                                                    AS requests,
       sum(cost_usd)                                              AS cost,
       sum(total_tokens)                                          AS tokens,
+      sum(prompt_tokens)                                         AS prompt_tokens,
+      sum(completion_tokens)                                     AS completion_tokens,
       countIf(status_code >= 400)                                AS errors,
       countIf(status_code >= 400 AND status_code < 500)          AS errors_4xx,
       countIf(status_code >= 500)                                AS errors_5xx,
+      countIf(status_code = 429)                                 AS errors_429,
       quantile(0.5)(latency_ms)                                  AS p50_latency_ms,
       quantile(0.95)(latency_ms)                                 AS p95_latency_ms
     FROM ${source}
@@ -268,15 +280,18 @@ export async function getStatsTimeseries(
   })
   const rows = (await result.json()) as Array<Record<string, string | number | null>>
   return rows.map((r) => ({
-    day:            String(r['day'] ?? ''),
-    requests:       Number(r['requests'] ?? 0),
-    cost:           Number(r['cost'] ?? 0),
-    tokens:         Number(r['tokens'] ?? 0),
-    errors:         Number(r['errors'] ?? 0),
-    errors_4xx:     Number(r['errors_4xx'] ?? 0),
-    errors_5xx:     Number(r['errors_5xx'] ?? 0),
-    p50_latency_ms: r['p50_latency_ms'] == null ? null : Number(r['p50_latency_ms']),
-    p95_latency_ms: r['p95_latency_ms'] == null ? null : Number(r['p95_latency_ms']),
+    day:               String(r['day'] ?? ''),
+    requests:          Number(r['requests'] ?? 0),
+    cost:              Number(r['cost'] ?? 0),
+    tokens:            Number(r['tokens'] ?? 0),
+    prompt_tokens:     Number(r['prompt_tokens'] ?? 0),
+    completion_tokens: Number(r['completion_tokens'] ?? 0),
+    errors:            Number(r['errors'] ?? 0),
+    errors_4xx:        Number(r['errors_4xx'] ?? 0),
+    errors_5xx:        Number(r['errors_5xx'] ?? 0),
+    errors_429:        Number(r['errors_429'] ?? 0),
+    p50_latency_ms:    r['p50_latency_ms'] == null ? null : Number(r['p50_latency_ms']),
+    p95_latency_ms:    r['p95_latency_ms'] == null ? null : Number(r['p95_latency_ms']),
   }))
 }
 

--- a/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
@@ -859,7 +859,10 @@ export function DashboardClient() {
           {!mounted || modelsQuery.isLoading || !modelsQuery.data ? (
             <Skeleton className="h-[290px] w-full" />
           ) : (
-            <CostBreakdownCard models={modelsQuery.data} />
+            <CostBreakdownCard
+              models={modelsQuery.data}
+              rangeLabel={shortRangeLabel(timeRange, customRange)}
+            />
           )}
         </div>
 

--- a/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
@@ -30,6 +30,21 @@ const SpendForecastCard = dynamic(
   () => import('@/components/dashboard/spend-forecast').then((m) => m.SpendForecastCard),
   { ssr: false, loading: () => <Skeleton className="h-[320px] w-full" /> },
 )
+// New breakdown cards. Same SSR-off treatment as the existing charts —
+// recharts measures its own width via ResizeObserver, which isn't available
+// on the server (CLAUDE.md gotcha #22 D).
+const CostBreakdownCard = dynamic(
+  () => import('@/components/dashboard/cost-breakdown').then((m) => m.CostBreakdownCard),
+  { ssr: false, loading: () => <Skeleton className="h-[290px] w-full" /> },
+)
+const TokenTrendsCard = dynamic(
+  () => import('@/components/dashboard/token-trends').then((m) => m.TokenTrendsCard),
+  { ssr: false, loading: () => <Skeleton className="h-[260px] w-full" /> },
+)
+const ErrorDistributionCard = dynamic(
+  () => import('@/components/dashboard/error-distribution').then((m) => m.ErrorDistributionCard),
+  { ssr: false, loading: () => <Skeleton className="h-[260px] w-full" /> },
+)
 
 // ── Helpers ────────────────────────────────────────────────────
 
@@ -812,6 +827,39 @@ export function DashboardClient() {
             <Skeleton className="h-[220px] w-full" />
           ) : (
             <RequestChart data={timeseries.data} firedAt={alertFiredAt} isHourly={hours <= 48} />
+          )}
+        </div>
+
+        {/* Token volume + Error distribution row — answers the obvious
+            follow-up questions to the spend chart above ("was it tokens or
+            model mix?" and "what kind of errors?"). */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3 px-[22px] py-5 border-b border-border">
+          {!mounted || isLoading || !timeseries.data ? (
+            <>
+              <Skeleton className="h-[260px] w-full" />
+              <Skeleton className="h-[260px] w-full" />
+            </>
+          ) : (
+            <>
+              <TokenTrendsCard
+                series={timeseries.data}
+                rangeLabel={shortRangeLabel(timeRange, customRange)}
+              />
+              <ErrorDistributionCard
+                series={timeseries.data}
+                rangeLabel={shortRangeLabel(timeRange, customRange)}
+              />
+            </>
+          )}
+        </div>
+
+        {/* Cost-by-model breakdown — full width so long provider/model labels
+            (anthropic / claude-sonnet-4-6) read comfortably. */}
+        <div className="px-[22px] py-5 border-b border-border">
+          {!mounted || modelsQuery.isLoading || !modelsQuery.data ? (
+            <Skeleton className="h-[290px] w-full" />
+          ) : (
+            <CostBreakdownCard models={modelsQuery.data} />
           )}
         </div>
 

--- a/apps/web/components/dashboard/cost-breakdown.tsx
+++ b/apps/web/components/dashboard/cost-breakdown.tsx
@@ -29,6 +29,9 @@ interface CostBreakdownProps {
   /** Limit to the top-N highest-cost rows. Default 6 — beyond that the
    * vertical density gets uncomfortable on the standard tile width. */
   topN?: number
+  /** Range label shown in the card header (e.g. "24h", "7d") so this
+   * card matches the Token volume / Errors by class siblings. */
+  rangeLabel?: string
 }
 
 /**
@@ -42,7 +45,7 @@ interface CostBreakdownProps {
  * Tooltip carries the absolute USD; the bar length itself encodes the
  * share visually so we don't need to render percent text alongside.
  */
-export function CostBreakdownCard({ models, topN = 6 }: CostBreakdownProps) {
+export function CostBreakdownCard({ models, topN = 6, rangeLabel }: CostBreakdownProps) {
   const sorted = [...models]
     .filter((m) => m.totalCostUsd > 0)
     .sort((a, b) => b.totalCostUsd - a.totalCostUsd)
@@ -55,11 +58,13 @@ export function CostBreakdownCard({ models, topN = 6 }: CostBreakdownProps) {
       requests: m.requests,
     }))
 
+  const headerTitle = rangeLabel ? `Cost by model · ${rangeLabel}` : 'Cost by model'
+
   if (sorted.length === 0) {
     return (
       <div className="rounded-md border border-border bg-bg-elev p-4">
         <div className="flex items-center justify-between mb-2">
-          <h3 className="text-[14px] font-medium text-text">Cost by model</h3>
+          <h3 className="text-[14px] font-medium text-text">{headerTitle}</h3>
         </div>
         <p className="text-[13px] text-text-faint py-6">No spend recorded in this window.</p>
       </div>
@@ -69,7 +74,7 @@ export function CostBreakdownCard({ models, topN = 6 }: CostBreakdownProps) {
   return (
     <div className="rounded-md border border-border bg-bg-elev p-4">
       <div className="flex items-center justify-between mb-3">
-        <h3 className="text-[14px] font-medium text-text">Cost by model</h3>
+        <h3 className="text-[14px] font-medium text-text">{headerTitle}</h3>
         <span className="text-[11px] text-text-faint font-mono">top {sorted.length}</span>
       </div>
       <div className="h-[260px]">

--- a/apps/web/components/dashboard/cost-breakdown.tsx
+++ b/apps/web/components/dashboard/cost-breakdown.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts'
+import { fmtCostKpi } from '@/lib/format'
+import type { ModelStat } from '@/lib/queries/use-stats'
+
+const C = {
+  text:   'var(--text)',
+  faint:  'var(--text-faint)',
+  border: 'var(--border)',
+  bgElev: 'var(--bg-elev)',
+  accent: 'var(--accent)',
+} as const
+
+// A small repeatable palette for the model bars. Drawn from the warm
+// monochrome dashboard palette so the chart blends with the existing
+// KPI tiles instead of fighting them for attention.
+const BAR_PALETTE = [
+  'var(--accent)',
+  'var(--accent-2)',
+  'var(--good)',
+  'var(--warn)',
+  'var(--text-muted)',
+  'var(--text-faint)',
+]
+
+interface CostBreakdownProps {
+  models: ModelStat[]
+  /** Limit to the top-N highest-cost rows. Default 6 — beyond that the
+   * vertical density gets uncomfortable on the standard tile width. */
+  topN?: number
+}
+
+/**
+ * Cost-by-model horizontal bar chart for the main dashboard.
+ *
+ * Why horizontal: model labels (`anthropic / claude-sonnet-4-6`) are long
+ * and don't fit on a vertical bar's X axis without truncation. Horizontal
+ * orientation reads naturally as "biggest cost first" and the label has
+ * room to breathe on the left side.
+ *
+ * Tooltip carries the absolute USD; the bar length itself encodes the
+ * share visually so we don't need to render percent text alongside.
+ */
+export function CostBreakdownCard({ models, topN = 6 }: CostBreakdownProps) {
+  const sorted = [...models]
+    .filter((m) => m.totalCostUsd > 0)
+    .sort((a, b) => b.totalCostUsd - a.totalCostUsd)
+    .slice(0, topN)
+    .map((m) => ({
+      // Provider/model collapsed to one label — the slash separates the two
+      // dimensions naturally and keeps the recharts payload simple.
+      label: `${m.provider} / ${m.model}`,
+      cost: m.totalCostUsd,
+      requests: m.requests,
+    }))
+
+  if (sorted.length === 0) {
+    return (
+      <div className="rounded-md border border-border bg-bg-elev p-4">
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="text-[14px] font-medium text-text">Cost by model</h3>
+        </div>
+        <p className="text-[13px] text-text-faint py-6">No spend recorded in this window.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-md border border-border bg-bg-elev p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-[14px] font-medium text-text">Cost by model</h3>
+        <span className="text-[11px] text-text-faint font-mono">top {sorted.length}</span>
+      </div>
+      <div className="h-[260px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={sorted}
+            layout="vertical"
+            margin={{ top: 4, right: 16, left: 0, bottom: 4 }}
+            barCategoryGap={6}
+          >
+            <CartesianGrid stroke={C.border} strokeDasharray="2 4" horizontal={false} />
+            <XAxis
+              type="number"
+              tick={{ fill: C.faint, fontSize: 10 }}
+              tickFormatter={(v: number) => fmtCostKpi(v)}
+              stroke={C.border}
+            />
+            <YAxis
+              dataKey="label"
+              type="category"
+              tick={{ fill: C.text, fontSize: 11 }}
+              width={170}
+              stroke={C.border}
+            />
+            <Tooltip
+              contentStyle={{ background: C.bgElev, border: `1px solid ${C.border}`, fontSize: 12 }}
+              labelStyle={{ color: C.text }}
+              formatter={((value: number, _key: unknown, payload: { payload?: { requests?: number } }) => {
+                const requests = payload?.payload?.requests
+                return [
+                  `${fmtCostKpi(value)}${requests ? ` · ${requests.toLocaleString('en-US')} req` : ''}`,
+                  'Cost',
+                ] as [string, string]
+              }) as never}
+            />
+            <Bar dataKey="cost" radius={[0, 3, 3, 0]}>
+              {sorted.map((_, i) => (
+                <Cell key={i} fill={BAR_PALETTE[i % BAR_PALETTE.length] ?? 'var(--accent)'} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/dashboard/error-distribution.tsx
+++ b/apps/web/components/dashboard/error-distribution.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import type { TimeseriesPoint } from '@/lib/queries/types'
+
+const C = {
+  text:   'var(--text)',
+  faint:  'var(--text-faint)',
+  border: 'var(--border)',
+  bgElev: 'var(--bg-elev)',
+} as const
+
+// Three semantic colours: 429 is its own band so quota issues read as a
+// different failure mode from "user typed a bad request" or "upstream is
+// melting". Order matters in the stack — 5xx on top because it usually
+// matters most operationally.
+const CLR_429 = 'var(--warn)'
+const CLR_4XX = 'var(--text-muted)'
+const CLR_5XX = 'var(--accent)'
+
+interface ErrorDistributionProps {
+  series: TimeseriesPoint[]
+  rangeLabel?: string
+}
+
+function fmtTimeLabel(iso: string): string {
+  const d = new Date(iso)
+  const ageHours = (Date.now() - d.getTime()) / 3_600_000
+  if (ageHours <= 36) {
+    return d.toLocaleTimeString('en-US', { hour: 'numeric', hour12: true })
+  }
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+/**
+ * Error count per bucket, stacked by status-code class.
+ *
+ * Why three bands instead of just `errors`: the Error Rate KPI tile already
+ * shows the headline percentage; this chart's job is the next question —
+ * "what kind of errors". A 429 spike means the customer is over quota
+ * upstream, a 5xx spike means a provider outage, and 4xx-other usually
+ * means an SDK or schema regression on the customer's side. Each calls
+ * for a different escalation.
+ *
+ * Backward-compat: when the API returns the older shape without
+ * `errors4xx`/`errors5xx`/`errors429`, we fold everything into a single
+ * `Other` bar so we don't drop the bucket.
+ */
+export function ErrorDistributionCard({ series, rangeLabel = '24h' }: ErrorDistributionProps) {
+  const data = series.map((p) => {
+    const e429 = p.errors429 ?? 0
+    const e5xx = p.errors5xx ?? 0
+    const e4xxAll = p.errors4xx ?? 0
+    const e4xxOther = Math.max(0, e4xxAll - e429)
+    // Fall back to bundled `errors` if none of the split fields are present.
+    const haveSplit = p.errors4xx != null || p.errors5xx != null
+    const otherBucket = haveSplit ? e4xxOther : Math.max(0, (p.errors ?? 0) - e5xx - e429)
+    return {
+      date: p.date,
+      e4xx: otherBucket,
+      e5xx,
+      e429,
+    }
+  })
+
+  const totalAcross = data.reduce((acc, p) => acc + p.e4xx + p.e5xx + p.e429, 0)
+  if (totalAcross === 0) {
+    return (
+      <div className="rounded-md border border-border bg-bg-elev p-4">
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="text-[14px] font-medium text-text">Errors by class</h3>
+          <span className="text-[11px] text-text-faint font-mono">{rangeLabel}</span>
+        </div>
+        <p className="text-[13px] text-text-faint py-6">No errors recorded in this window.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-md border border-border bg-bg-elev p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-[14px] font-medium text-text">Errors by class · {rangeLabel}</h3>
+        <div className="flex items-center gap-3 text-[11px] text-text-faint font-mono">
+          <span className="flex items-center gap-1">
+            <span className="inline-block w-2 h-2 rounded-sm" style={{ background: CLR_4XX }} />4xx
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block w-2 h-2 rounded-sm" style={{ background: CLR_429 }} />429
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block w-2 h-2 rounded-sm" style={{ background: CLR_5XX }} />5xx
+          </span>
+        </div>
+      </div>
+      <div className="h-[220px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} margin={{ top: 4, right: 16, left: 0, bottom: 4 }} barCategoryGap={2}>
+            <CartesianGrid stroke={C.border} strokeDasharray="2 4" vertical={false} />
+            <XAxis
+              dataKey="date"
+              tickFormatter={fmtTimeLabel}
+              tick={{ fill: C.faint, fontSize: 10 }}
+              stroke={C.border}
+            />
+            <YAxis
+              tick={{ fill: C.faint, fontSize: 10 }}
+              stroke={C.border}
+              width={32}
+              allowDecimals={false}
+            />
+            <Tooltip
+              contentStyle={{ background: C.bgElev, border: `1px solid ${C.border}`, fontSize: 12 }}
+              labelStyle={{ color: C.text }}
+              labelFormatter={((label: string) => fmtTimeLabel(label)) as never}
+              formatter={((value: number, key: string) => {
+                const labels: Record<string, string> = { e4xx: '4xx', e429: '429', e5xx: '5xx' }
+                return [value.toLocaleString('en-US'), labels[key] ?? key] as [string, string]
+              }) as never}
+            />
+            <Bar dataKey="e4xx" stackId="e" fill={CLR_4XX} />
+            <Bar dataKey="e429" stackId="e" fill={CLR_429} />
+            <Bar dataKey="e5xx" stackId="e" fill={CLR_5XX} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/dashboard/token-trends.tsx
+++ b/apps/web/components/dashboard/token-trends.tsx
@@ -8,8 +8,13 @@ const C = {
   faint:  'var(--text-faint)',
   border: 'var(--border)',
   bgElev: 'var(--bg-elev)',
-  accent: 'var(--accent)',
-  accent2: 'var(--accent-2)',
+  // Prompt = accent (orange). Completion = good (green) — chosen because
+  // it contrasts cleanly with the prompt band in both themes and isn't
+  // already used by the Errors-by-class card sitting next to this one.
+  // An earlier draft used `var(--accent-2)` which doesn't exist in the
+  // current theme, so the completion band rendered near-invisible.
+  prompt:     'var(--accent)',
+  completion: 'var(--good)',
 } as const
 
 interface TokenTrendsProps {
@@ -81,11 +86,11 @@ export function TokenTrendsCard({ series, rangeLabel = '24h' }: TokenTrendsProps
         <h3 className="text-[14px] font-medium text-text">Token volume · {rangeLabel}</h3>
         <div className="flex items-center gap-3 text-[11px] text-text-faint font-mono">
           <span className="flex items-center gap-1">
-            <span className="inline-block w-2 h-2 rounded-sm" style={{ background: C.accent }} />
+            <span className="inline-block w-2 h-2 rounded-sm" style={{ background: C.prompt }} />
             prompt
           </span>
           <span className="flex items-center gap-1">
-            <span className="inline-block w-2 h-2 rounded-sm" style={{ background: C.accent2 }} />
+            <span className="inline-block w-2 h-2 rounded-sm" style={{ background: C.completion }} />
             completion
           </span>
         </div>
@@ -95,12 +100,12 @@ export function TokenTrendsCard({ series, rangeLabel = '24h' }: TokenTrendsProps
           <AreaChart data={data} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
             <defs>
               <linearGradient id="gradPrompt" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stopColor={C.accent} stopOpacity={0.55} />
-                <stop offset="100%" stopColor={C.accent} stopOpacity={0.05} />
+                <stop offset="0%" stopColor={C.prompt} stopOpacity={0.55} />
+                <stop offset="100%" stopColor={C.prompt} stopOpacity={0.05} />
               </linearGradient>
               <linearGradient id="gradCompletion" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stopColor={C.accent2} stopOpacity={0.55} />
-                <stop offset="100%" stopColor={C.accent2} stopOpacity={0.05} />
+                <stop offset="0%" stopColor={C.completion} stopOpacity={0.55} />
+                <stop offset="100%" stopColor={C.completion} stopOpacity={0.05} />
               </linearGradient>
             </defs>
             <CartesianGrid stroke={C.border} strokeDasharray="2 4" vertical={false} />
@@ -130,7 +135,7 @@ export function TokenTrendsCard({ series, rangeLabel = '24h' }: TokenTrendsProps
               type="monotone"
               dataKey="promptTokens"
               stackId="t"
-              stroke={C.accent}
+              stroke={C.prompt}
               strokeWidth={1.5}
               fill="url(#gradPrompt)"
             />
@@ -138,7 +143,7 @@ export function TokenTrendsCard({ series, rangeLabel = '24h' }: TokenTrendsProps
               type="monotone"
               dataKey="completionTokens"
               stackId="t"
-              stroke={C.accent2}
+              stroke={C.completion}
               strokeWidth={1.5}
               fill="url(#gradCompletion)"
             />

--- a/apps/web/components/dashboard/token-trends.tsx
+++ b/apps/web/components/dashboard/token-trends.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from 'recharts'
+import type { TimeseriesPoint } from '@/lib/queries/types'
+
+const C = {
+  text:   'var(--text)',
+  faint:  'var(--text-faint)',
+  border: 'var(--border)',
+  bgElev: 'var(--bg-elev)',
+  accent: 'var(--accent)',
+  accent2: 'var(--accent-2)',
+} as const
+
+interface TokenTrendsProps {
+  series: TimeseriesPoint[]
+  /** Range label shown in the card header (e.g. "24h", "7d"). */
+  rangeLabel?: string
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`
+  return n.toLocaleString('en-US')
+}
+
+function fmtTimeLabel(iso: string): string {
+  // Match the convention used on /dashboard's Traffic & spend chart — short
+  // hour-of-day for sub-day ranges, MMM D for multi-day.
+  const d = new Date(iso)
+  const now = Date.now()
+  const ageHours = (now - d.getTime()) / 3_600_000
+  if (ageHours <= 36) {
+    return d.toLocaleTimeString('en-US', { hour: 'numeric', hour12: true })
+  }
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+/**
+ * Input + output token volume over time as a stacked area chart.
+ *
+ * Why stacked area: the spend chart sits above and answers "how much did
+ * we pay". This chart answers the obvious follow-up — "was it because we
+ * sent more tokens, or because the output got longer?". Prompt tokens
+ * on the bottom (cheaper, larger volume usually) + completion tokens on
+ * top (pricier, smaller volume) makes the cost split visually intuitive
+ * even before users learn the per-token rates.
+ *
+ * Falls back gracefully when the API didn't return the new prompt/completion
+ * fields (older response shape, the demo fixture, etc.) by reusing the
+ * legacy `tokens` field on the bottom area only.
+ */
+export function TokenTrendsCard({ series, rangeLabel = '24h' }: TokenTrendsProps) {
+  const data = series.map((p) => ({
+    date: p.date,
+    promptTokens: p.promptTokens ?? Math.max(0, (p.tokens ?? 0) - (p.completionTokens ?? 0)),
+    completionTokens: p.completionTokens ?? 0,
+  }))
+
+  // Empty buckets — recharts still renders a frame but the user sees nothing
+  // useful, so show an explicit empty state instead.
+  const totalAcross = data.reduce(
+    (acc, p) => acc + p.promptTokens + p.completionTokens,
+    0,
+  )
+  if (totalAcross === 0) {
+    return (
+      <div className="rounded-md border border-border bg-bg-elev p-4">
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="text-[14px] font-medium text-text">Token volume</h3>
+          <span className="text-[11px] text-text-faint font-mono">{rangeLabel}</span>
+        </div>
+        <p className="text-[13px] text-text-faint py-6">No token usage recorded in this window.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-md border border-border bg-bg-elev p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-[14px] font-medium text-text">Token volume · {rangeLabel}</h3>
+        <div className="flex items-center gap-3 text-[11px] text-text-faint font-mono">
+          <span className="flex items-center gap-1">
+            <span className="inline-block w-2 h-2 rounded-sm" style={{ background: C.accent }} />
+            prompt
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block w-2 h-2 rounded-sm" style={{ background: C.accent2 }} />
+            completion
+          </span>
+        </div>
+      </div>
+      <div className="h-[220px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={data} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
+            <defs>
+              <linearGradient id="gradPrompt" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={C.accent} stopOpacity={0.55} />
+                <stop offset="100%" stopColor={C.accent} stopOpacity={0.05} />
+              </linearGradient>
+              <linearGradient id="gradCompletion" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={C.accent2} stopOpacity={0.55} />
+                <stop offset="100%" stopColor={C.accent2} stopOpacity={0.05} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid stroke={C.border} strokeDasharray="2 4" vertical={false} />
+            <XAxis
+              dataKey="date"
+              tickFormatter={fmtTimeLabel}
+              tick={{ fill: C.faint, fontSize: 10 }}
+              stroke={C.border}
+            />
+            <YAxis
+              tickFormatter={fmtTokens}
+              tick={{ fill: C.faint, fontSize: 10 }}
+              stroke={C.border}
+              width={42}
+            />
+            <Tooltip
+              contentStyle={{ background: C.bgElev, border: `1px solid ${C.border}`, fontSize: 12 }}
+              labelStyle={{ color: C.text }}
+              labelFormatter={((label: string) => fmtTimeLabel(label)) as never}
+              formatter={((value: number, key: string) => [
+                fmtTokens(value),
+                key === 'promptTokens' ? 'Prompt' : 'Completion',
+              ] as [string, string]) as never}
+            />
+            <Legend wrapperStyle={{ display: 'none' }} />
+            <Area
+              type="monotone"
+              dataKey="promptTokens"
+              stackId="t"
+              stroke={C.accent}
+              strokeWidth={1.5}
+              fill="url(#gradPrompt)"
+            />
+            <Area
+              type="monotone"
+              dataKey="completionTokens"
+              stackId="t"
+              stroke={C.accent2}
+              strokeWidth={1.5}
+              fill="url(#gradCompletion)"
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/lib/queries/types.ts
+++ b/apps/web/lib/queries/types.ts
@@ -153,12 +153,19 @@ export interface TimeseriesPoint {
   date: string
   requests: number
   cost: number
+  /** Total tokens (prompt + completion). Kept for backward compat. */
   tokens: number
+  /** Prompt-side tokens. Optional so demo / older API responses still type-check. */
+  promptTokens?: number
+  /** Completion-side tokens. Optional for the same reason. */
+  completionTokens?: number
   errors: number
   /** 4xx error count (subset of `errors`). Optional for backward compat with the demo data shim. */
   errors4xx?: number
   /** 5xx error count (subset of `errors`). Optional for backward compat with the demo data shim. */
   errors5xx?: number
+  /** 429 rate-limit count (subset of `errors4xx`). Optional for backward compat. */
+  errors429?: number
   /** Median latency in ms for this bucket. Null when bucket is empty. */
   p50LatencyMs?: number | null
   /** 95th percentile latency in ms for this bucket. Null when bucket is empty. */


### PR DESCRIPTION
The dashboard had KPI tiles + a Traffic & spend chart but no answers to the obvious follow-up questions. This adds three charts that sit in a new row between Traffic & spend and the Spend forecast card.

## What lands

| Chart | Layout | Data source | Question it answers |
|---|---|---|---|
| **Token volume** | stacked area, half row | `useStatsTimeseries` (new `promptTokens`/`completionTokens`) | "Was the spend bump more tokens or longer outputs?" |
| **Errors by class** | stacked bar over time, half row | `useStatsTimeseries` (new `errors429` + existing `errors4xx`/`errors5xx`) | "What kind of errors — quota, schema, or upstream?" |
| **Cost by model** | horizontal bar, full row | `useStatsModels` (existing — no new request) | "Which model drove the biggest share of spend?" |

## Server changes

- `lib/stats-queries.ts` + `api/stats.ts`: \`TimeseriesRow\` and the \`/api/v1/stats/timeseries\` response gain \`prompt_tokens\`, \`completion_tokens\`, and \`errors_429\` (\`countIf(status_code = 429)\`). The existing \`tokens\` field stays for backward compat.

## Web changes

- New optional fields in \`lib/queries/types.ts\` (kept optional so demo / older API responses still type-check).
- Three new dynamic-imported chart components under \`components/dashboard/\`. All use \`ssr: false\` + \`<Skeleton>\` loading shim, matching the existing recharts cards (CLAUDE.md gotcha #22 D — \`ResizeObserver\` is not available during SSR).

## Test plan

- [x] \`pnpm --filter server typecheck\` — clean
- [x] \`pnpm --filter web typecheck\` — clean
- [x] \`pnpm --filter server test\` — 1022/1022 (unchanged)
- [x] \`pnpm --filter web test\` — 57/57 (unchanged)
- [x] \`pnpm --filter web lint\` — clean
- [x] Local dev /dashboard render check confirms all 3 new section headers land in the DOM in the documented order
- [ ] Vercel preview screenshot to confirm chart visuals (dev-server screenshot timed out, expected in production build)
- [ ] CI green

## Notes for reviewer

- The trio sits in a single new section block between Traffic & spend and Spend forecast. The 2-up row (Token + Error) handles the time-series follow-ups; the full-width row below (Cost by model) handles the categorical breakdown.
- All three components have empty-state copy when the window has no spend / tokens / errors, so the dashboard never shows an empty chart frame.