### PR TITLE
feat(server,db): track OpenAI embeddings cost (RAG observability)

### DIFF
--- a/apps/server/src/__tests__/cost.test.ts
+++ b/apps/server/src/__tests__/cost.test.ts
@@ -29,6 +29,30 @@ describe('calculateCost', () => {
     expect(result?.totalCost).toBe(18)
   })
 
+  it('calculates cost for OpenAI embeddings (input-only, completion is 0)', () => {
+    // Embeddings return prompt_tokens only; completion_tokens is always 0
+    // (the response carries vectors, not generated text). The calculator
+    // multiplies completion_tokens × completion_price so the completion side
+    // contributes 0 to the total regardless of the seed price. This test
+    // pins that RAG cost tracking lands non-zero for the prompt side.
+    const result = calculateCost('openai', 'text-embedding-3-small', {
+      promptTokens: 1_000_000,
+      completionTokens: 0,
+    })
+    expect(result).not.toBeNull()
+    expect(result?.promptCost).toBe(0.02)
+    expect(result?.completionCost).toBe(0)
+    expect(result?.totalCost).toBe(0.02)
+  })
+
+  it('calculates cost for text-embedding-3-large at $0.13 / 1M', () => {
+    const result = calculateCost('openai', 'text-embedding-3-large', {
+      promptTokens: 1_000_000,
+      completionTokens: 0,
+    })
+    expect(result?.totalCost).toBe(0.13)
+  })
+
   it('falls back to prefix match for dated model suffix (e.g. gpt-4o-mini-2024-07-18)', () => {
     const result = calculateCost('openai', 'gpt-4o-mini-2024-07-18', {
       promptTokens: 1_000_000,

--- a/apps/server/src/__tests__/parsers.test.ts
+++ b/apps/server/src/__tests__/parsers.test.ts
@@ -23,6 +23,29 @@ describe('OpenAI parser', () => {
     })
   })
 
+  it('parses embeddings response (data array, prompt_tokens only)', () => {
+    // OpenAI's /v1/embeddings returns `data: [{embedding: [...]}]` instead of
+    // `choices`, and the usage shape carries only prompt_tokens (no completion
+    // side because embedding is input-only). The parser reads `usage` blindly
+    // so embeddings work without a separate code path — this test pins that
+    // contract so a future refactor that special-cases `choices` doesn't
+    // silently regress RAG cost tracking.
+    const body = {
+      object: 'list',
+      model: 'text-embedding-3-small',
+      data: [{ object: 'embedding', index: 0, embedding: [0.01, 0.02, 0.03] }],
+      usage: { prompt_tokens: 8, total_tokens: 8 },
+    }
+    expect(parseOpenAIResponse(body)).toEqual({
+      promptTokens: 8,
+      completionTokens: 0,
+      totalTokens: 8,
+      model: 'text-embedding-3-small',
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    })
+  })
+
   it('extracts cached_tokens from prompt_tokens_details', () => {
     const body = {
       model: 'gpt-4o',

--- a/apps/server/src/__tests__/proxy-openai.test.ts
+++ b/apps/server/src/__tests__/proxy-openai.test.ts
@@ -322,6 +322,55 @@ describe('openai proxy — logging + cost calculation', () => {
   })
 })
 
+describe('openai proxy — embeddings (RAG cost tracking)', () => {
+  test('embeddings response is tracked end-to-end (tokens parsed, cost calculated)', async () => {
+    // Embeddings have a different response shape than chat completions —
+    // `data: [{embedding}]` instead of `choices`, and `usage.completion_tokens`
+    // is absent because the model returns vectors, not generated text. The
+    // proxy + parser + cost calculator must all handle this without changes
+    // beyond the model_prices seed (added in the same PR). This test pins
+    // that contract — if a future refactor special-cases `choices`, embedding
+    // cost tracking regresses to NULL and RAG customers lose ~30-50% of
+    // their LLM spend from the dashboard.
+    const embeddingsResponse = new Response(
+      JSON.stringify({
+        object: 'list',
+        model: 'text-embedding-3-small',
+        data: [
+          { object: 'embedding', index: 0, embedding: [0.01, 0.02, 0.03] },
+          { object: 'embedding', index: 1, embedding: [0.04, 0.05, 0.06] },
+        ],
+        usage: { prompt_tokens: 1_000_000, total_tokens: 1_000_000 },
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    )
+    mockUpstream(embeddingsResponse)
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/openai/v1/embeddings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'text-embedding-3-small',
+        input: ['hello', 'world'],
+      }),
+    })
+    await drainPendingTasks()
+
+    expect(res.status).toBe(200)
+    expect(proxyState.fetchCalls[0]!.url).toBe('https://api.openai.com/v1/embeddings')
+
+    expect(proxyState.loggerCalls).toHaveLength(1)
+    const row = proxyState.loggerCalls[0]!
+    expect(row['model']).toBe('text-embedding-3-small')
+    expect(row['promptTokens']).toBe(1_000_000)
+    expect(row['completionTokens']).toBe(0) // embeddings have no completion side
+    expect(row['totalTokens']).toBe(1_000_000)
+    // text-embedding-3-small priced at $0.02 / 1M (input-only).
+    expect(row['costUsd']).toBeCloseTo(0.02, 4)
+  })
+})
+
 describe('openai proxy — response passthrough', () => {
   test('response body bytes are returned verbatim to caller', async () => {
     const upstreamBody = JSON.stringify({

--- a/apps/server/src/lib/model-prices-cache.ts
+++ b/apps/server/src/lib/model-prices-cache.ts
@@ -123,6 +123,13 @@ export const FALLBACK_PRICES: Record<string, ModelPrice> = {
   'gpt-3.5-turbo-16k-0613':       { prompt: 3.0,  completion: 4.0 },
   'davinci-002':                  { prompt: 2.0,  completion: 2.0 },
   'babbage-002':                  { prompt: 0.4,  completion: 0.4 },
+  // ── OpenAI: Embeddings (input-only — completion stays 0) ──────────────────
+  // Same rows live in supabase/seeds/model_prices.sql + the
+  // 20260612120000 migration; these fallbacks let cost still land non-NULL
+  // on a cold start before the cache fetches from Supabase.
+  'text-embedding-3-small':       { prompt: 0.02, completion: 0 },
+  'text-embedding-3-large':       { prompt: 0.13, completion: 0 },
+  'text-embedding-ada-002':       { prompt: 0.10, completion: 0 },
   // ── Anthropic: Claude 4.x (aliases + dated variants) ─────────────────────
   'claude-opus-4-7':              { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 },
   'claude-opus-4-6':              { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 }, // alias only; no dated form per docs

--- a/supabase/migrations/20260612120000_seed_openai_embedding_prices.sql
+++ b/supabase/migrations/20260612120000_seed_openai_embedding_prices.sql
@@ -1,0 +1,26 @@
+-- Seed pricing rows for OpenAI's embedding model family.
+--
+-- Why this exists: proxy/openai.ts already forwards POST /v1/embeddings to
+-- OpenAI verbatim (the catch-all `.all('/*', ...)` route handles every path),
+-- and parsers/openai.ts already extracts usage from the response (because the
+-- parser only reads the `usage` field, not `choices`). The missing piece was
+-- pricing — without rows here, lib/cost.ts.calculateCost('openai',
+-- 'text-embedding-3-small', ...) returns null and the requests row lands
+-- with cost_usd = NULL. RAG customers were seeing tokens but not cost.
+--
+-- Embeddings are input-only — completion_price stays at 0 (the calculator
+-- multiplies by completion_tokens which is also 0 for embeddings). cache_read
+-- pricing isn't a thing for embeddings on OpenAI as of 2026-06.
+--
+-- Source: https://openai.com/api/pricing (2026-06 published rates).
+-- These are USD per 1M tokens, matching the rest of model_prices.
+
+INSERT INTO model_prices (
+  provider, model,
+  prompt_price_per_1m, completion_price_per_1m,
+  cache_read_price_per_1m, cache_write_price_per_1m
+) VALUES
+  ('openai', 'text-embedding-3-small', 0.020, 0.000, NULL, NULL),
+  ('openai', 'text-embedding-3-large', 0.130, 0.000, NULL, NULL),
+  ('openai', 'text-embedding-ada-002', 0.100, 0.000, NULL, NULL)
+ON CONFLICT (provider, model) DO NOTHING;

--- a/supabase/seeds/model_prices.sql
+++ b/supabase/seeds/model_prices.sql
@@ -61,6 +61,12 @@ INSERT INTO model_prices (
   ('openai', 'gpt-3.5-turbo-16k-0613',           3.00,   4.00,   NULL,   NULL),
   ('openai', 'davinci-002',                      2.00,   2.00,   NULL,   NULL),
   ('openai', 'babbage-002',                      0.40,   0.40,   NULL,   NULL),
+  -- ── OpenAI: Embeddings (input-only — completion_price stays 0) ───────────
+  -- Source: openai.com/api/pricing as of 2026-06. No cache pricing exists
+  -- for embeddings on OpenAI as of this seed.
+  ('openai', 'text-embedding-3-small',           0.020,  0.000,  NULL,   NULL),
+  ('openai', 'text-embedding-3-large',           0.130,  0.000,  NULL,   NULL),
+  ('openai', 'text-embedding-ada-002',           0.100,  0.000,  NULL,   NULL),
   -- ── Anthropic: Claude 4.x (aliases + dated variants) ────────────────────
   ('anthropic', 'claude-opus-4-7',               5.00,  25.00,   0.50,   6.25),
   ('anthropic', 'claude-opus-4-6',               5.00,  25.00,   0.50,   6.25), -- alias only; no dated form per docs


### PR DESCRIPTION
RAG customers were seeing tokens from \`/v1/embeddings\` calls but no cost on /requests. Embeddings can drive 30~50% of a RAG workload's LLM spend (retrieval queries fire roughly 10× more often than chat completions), so that whole slice was invisible on the dashboard.

## Root cause

The proxy + parser already handle \`/v1/embeddings\` correctly:
- \`proxy/openai.ts\`'s catch-all route forwards every path verbatim
- \`parsers/openai.ts\`'s \`parseOpenAIResponse\` reads \`usage\` directly without depending on \`choices\`, so the embeddings response shape (\`data: [{embedding}]\`, \`usage.prompt_tokens\` only) works as-is

The missing piece was pricing — \`model_prices\` had no rows for the embedding family, so \`calculateCost('openai', 'text-embedding-3-small', ...)\` returned \`null\` and the row landed with \`cost_usd = NULL\`.

## Changes

- **\`supabase/migrations/20260612120000_seed_openai_embedding_prices.sql\`** — idempotent INSERT for the 3 embedding models. \`completion_price\` stays 0 because embeddings are input-only and the calculator multiplies by \`completion_tokens\` (also 0), so the product contributes 0 regardless of the seed value.
- **\`supabase/seeds/model_prices.sql\`** — same rows appended so fresh local inits have them without needing the migration.
- **\`lib/model-prices-cache.ts\` \`FALLBACK_PRICES\`** — same three keys so cost still lands non-NULL during the cold-start window before the cache fetches from Supabase.

## Pricing

Source: openai.com/api/pricing (2026-06 published rates), USD per 1M tokens.

| Model | Prompt | Completion |
|---|---|---|
| text-embedding-3-small | $0.020 | 0 |
| text-embedding-3-large | $0.130 | 0 |
| text-embedding-ada-002 | $0.100 | 0 |

## Test plan

- [x] \`pnpm --filter server test\` — 1026/1026 (was 1022)
- [x] \`pnpm --filter server typecheck\` — clean
- [x] \`pnpm --filter server lint\` — clean
- 4 new tests:
  - \`parsers.test.ts\`: pins the embeddings response shape against the unified \`parseOpenAIResponse\` contract — a future refactor that special-cases \`choices\` would silently regress RAG cost tracking
  - \`cost.test.ts\`: two tests for embedding pricing at official $/1M rates
  - \`proxy-openai.test.ts\`: end-to-end test through the proxy — log row carries promptTokens=1M, completionTokens=0, costUsd ≈ $0.02
- [ ] CI green on this branch

## Notes for reviewer

- The migration uses \`ON CONFLICT (provider, model) DO NOTHING\` so it's safe to re-apply if the seed already populated the rows on a fresh init.
- No proxy code change needed — the catch-all + duck-typed parser were already covering this. The audit's "OpenAI Embeddings 프록시" item turned out to be a pricing-table gap, not a routing gap.