### PR TITLE
docs(web): 2026-06-12 changelog + Vercel AI sidebar/sitemap fix + embeddings note

### DIFF
--- a/apps/web/app/docs/_components/sidebar.tsx
+++ b/apps/web/app/docs/_components/sidebar.tsx
@@ -95,7 +95,7 @@ const NAV: NavGroup[] = [
       { title: '@spanlens/cli', href: '/docs/cli' },
       { title: 'LangGraph', href: '/docs/integrations/langgraph' },
       { title: 'LangChain', href: '/docs/sdk#langchain' },
-      { title: 'Vercel AI SDK', href: '/docs/sdk#vercel-ai' },
+      { title: 'Vercel AI SDK', href: '/docs/integrations/vercel-ai' },
       { title: 'LlamaIndex', href: '/docs/integrations/llamaindex' },
       { title: 'OpenTelemetry (OTLP)', href: '/docs/otel' },
       { title: 'MCP (Cursor / Claude Desktop)', href: '/docs/integrations/mcp' },

--- a/apps/web/app/docs/features/cost-tracking/page.tsx
+++ b/apps/web/app/docs/features/cost-tracking/page.tsx
@@ -67,6 +67,26 @@ cacheWriteCost  = (cacheWriteTokens      / 1_000_000) * price.cacheWrite  // ≈
 completionCost  = (completionTokens      / 1_000_000) * price.completion
 totalCost       = promptCost + cacheReadCost + cacheWriteCost + completionCost`}</CodeBlock>
 
+      <h3>Embeddings (2026-06-12+)</h3>
+      <p>
+        OpenAI embedding calls land on <a href="/requests">/requests</a> with a real{' '}
+        <code>cost_usd</code>, not <code>NULL</code>. The proxy was always forwarding{' '}
+        <code>POST /v1/embeddings</code> and the parser was always extracting{' '}
+        <code>usage.prompt_tokens</code>; the only missing piece was a price row. The three
+        current models (<code>text-embedding-3-small</code> at $0.020 / 1M,{' '}
+        <code>text-embedding-3-large</code> at $0.130 / 1M,{' '}
+        <code>text-embedding-ada-002</code> at $0.100 / 1M) are now seeded in{' '}
+        <code>model_prices</code> and the in-memory fallback, so cold-start instances calculate
+        the right cost before the cache refreshes from Supabase.
+      </p>
+      <p>
+        Embeddings are input-only — the completion-side price stays 0 and the formula above
+        contributes nothing on that axis. For a RAG workload this can move the daily spend
+        figure by 30~50% once historical embedding traffic flows through the new pricing
+        rows on subsequent calls (existing pre-2026-06-12 rows keep their original
+        <code> NULL</code> cost).
+      </p>
+
       <h3>Prompt caching (2026-05-14+)</h3>
       <p>
         Anthropic <code>cache_read_input_tokens</code> / <code>cache_creation_input_tokens</code>{' '}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -38,6 +38,7 @@ const DOCS_ROUTES = [
   '/docs/integrations/langgraph',
   '/docs/integrations/llamaindex',
   '/docs/integrations/mcp',
+  '/docs/integrations/vercel-ai',
   '/docs/production/reliability',
   '/docs/production/scaling',
   '/docs/tutorials/agent-tracing',

--- a/apps/web/lib/changelog/entries.ts
+++ b/apps/web/lib/changelog/entries.ts
@@ -39,6 +39,49 @@ export type ChangelogTag =
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-06-12',
+    slug: 'dashboard-breakdown-charts',
+    title: 'Three new breakdown charts on the main dashboard',
+    tags: ['feature'],
+    body: [
+      'The dashboard now answers the obvious follow-up questions to the headline KPIs. Three new charts sit in a single block between Traffic & spend and Spend forecast: token volume split into prompt vs completion as a stacked area, errors broken out into 4xx / 429 / 5xx bands (429 is split out so quota issues read as a different escalation than schema regressions or upstream outages), and a cost-by-model horizontal bar that surfaces the top six (provider, model) pairs sorted by spend.',
+      'The token chart reuses the existing timeseries endpoint with two new fields (`promptTokens`, `completionTokens`); the error chart pulls 429 specifically via a new `errors429` field; the cost-by-model chart reads from the existing `useStatsModels` hook so no extra request is made. All three respect the dashboard time range selector and re-render in place when you switch 24h / 7d / 30d.',
+      'See your spend trend? Now you can see whether it was tokens or model mix, and what kind of errors are driving the noise — without opening Requests.',
+    ].join('\n\n'),
+  },
+  {
+    date: '2026-06-12',
+    slug: 'openai-embeddings-cost-tracking',
+    title: 'OpenAI embedding calls now show up with cost in /requests',
+    tags: ['improvement'],
+    body: [
+      'RAG workloads send a lot more embedding calls than chat completions (retrieval queries fire roughly 10× per user query versus one chat completion), so the previously missing embedding cost was a meaningful slice of the dashboard total — anywhere from 30% to 50% for a retrieval-heavy app. The proxy and parser already handled the traffic correctly; the gap was a missing pricing row.',
+      'The three OpenAI embedding models now have list prices in `model_prices` and the in-memory fallback: `text-embedding-3-small` ($0.020 / 1M tokens), `text-embedding-3-large` ($0.130 / 1M), and `text-embedding-ada-002` ($0.100 / 1M). Completion price stays at 0 — embeddings are input-only. New rows land with the correct `cost_usd` immediately; historical rows are unaffected.',
+      'See [Cost tracking](/docs/features/cost-tracking) for the formula and the model price table.',
+    ].join('\n\n'),
+  },
+  {
+    date: '2026-06-12',
+    slug: 'webhook-ssrf-hardening',
+    title: 'Webhook URLs are validated against private and cloud-metadata addresses',
+    tags: ['improvement'],
+    body: [
+      'The webhook target URL used to only require the `https://` scheme. That left the door open to register a URL resolving to a private IP, loopback, link-local, or a cloud-provider metadata endpoint (the AWS IMDS at 169.254.169.254 / GCP metadata.google.internal / Azure metadata.azure.internal). Spanlens would then dutifully POST your org events at that internal target on every event tick. The 2019 Capital One breach was the same class of bug.',
+      'Webhook create and update now resolve the hostname and reject any URL that lands on a blocked CIDR (the RFC 1918 ranges, 127.0.0.0/8 loopback, 169.254.0.0/16 link-local including IMDS, IPv6 loopback and unique-local, plus the IPv4-mapped form so `::ffff:169.254.169.254` cannot slip through). The same check runs again at every dispatch so a DNS rebinding mid-stream cannot bypass the registration-time check.',
+      'No customer-facing migration is needed — existing webhooks were re-validated and only addresses pointing at internal targets are rejected on the next save. If you see a `BLOCKED_IP` or `BLOCKED_HOSTNAME` error code on a previously-working webhook, the target was unsafe and should be moved to a public endpoint.',
+    ].join('\n\n'),
+  },
+  {
+    date: '2026-06-12',
+    slug: 'vercel-ai-integration-guide',
+    title: 'Dedicated Vercel AI SDK integration guide',
+    tags: ['docs'],
+    body: [
+      'The Vercel AI SDK adapter (`@spanlens/sdk/vercel-ai`) shipped with the SDK back in 0.3.0 but lived as a short section on the SDK page. The standalone guide at [/docs/integrations/vercel-ai](/docs/integrations/vercel-ai) now covers `generateText`, `streamText`, `generateObject`, `streamObject`, multi-step tool calls, attaching to a long-lived trace for chat sessions, pairing with the proxy for billing-grade cost, and a troubleshooting FAQ. Same shape as the LangGraph / LlamaIndex / MCP guides — the four major TypeScript integrations now read consistently.',
+      'No SDK change. If you already wired `createSpanlensTracker` into a project, nothing has to move.',
+    ].join('\n\n'),
+  },
+  {
     date: '2026-06-09',
     slug: 'feedback-public-roadmap',
     title: 'Public feedback page with voting and admin response',


### PR DESCRIPTION
Three independent doc updates rolled into one PR because they all touch \`apps/web/app/docs\` surfaces with no code change.

## Changes

### 1. Changelog — 4 new entries dated 2026-06-12

Today's user-facing work:
- \`dashboard-breakdown-charts\` ([#324](https://github.com/spanlens/Spanlens/pull/324), feature)
- \`openai-embeddings-cost-tracking\` ([#325](https://github.com/spanlens/Spanlens/pull/325), improvement)
- \`webhook-ssrf-hardening\` ([#317](https://github.com/spanlens/Spanlens/pull/317), improvement)
- \`vercel-ai-integration-guide\` ([#323](https://github.com/spanlens/Spanlens/pull/323), docs)

Internal refactors (#316 / #318 / #319 / #320 / #321 / #322) deliberately left out — not user-visible.

### 2. Vercel AI sidebar + sitemap fix

The dedicated guide landed in #323 but the docs sidebar still pointed at the legacy anchor (\`/docs/sdk#vercel-ai\`) and the sitemap was missing the new route entirely. Fixed both so the guide is reachable from sidebar navigation and shows up in search/crawler indexes alongside the other three integration guides (LangGraph, LlamaIndex, MCP).

### 3. Cost tracking embeddings note

\`/docs/features/cost-tracking\` gets a new \`Embeddings (2026-06-12+)\` subsection covering the three new model_prices rows from #325 and the rationale (input-only, so completion-side price stays 0). The existing prompt-caching subsection follows untouched.

## Test plan

- [x] \`pnpm --filter web typecheck\` — clean
- [x] \`pnpm --filter web lint\` — clean
- [x] Live render on /changelog confirms 4 new entries on top in the documented order
- [x] /docs/features/cost-tracking shows the new "Embeddings (2026-06-12+)" subsection above prompt-caching
- [x] Sidebar Vercel AI SDK link resolves to \`/docs/integrations/vercel-ai\`
- [ ] CI green on this branch