### PR TITLE
feat(server,db,web): Mistral as the 5th supported provider

### DIFF
--- a/apps/server/src/__tests__/proxy-mistral.test.ts
+++ b/apps/server/src/__tests__/proxy-mistral.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { Context, MiddlewareHandler, Next } from 'hono'
+import { drainPendingTasks, mockUpstream, openAIChatResponse, proxyState, resetProxyMocks } from './helpers/proxy-mocks.js'
+import { installOnError } from './helpers/install-on-error.js'
+
+/**
+ * Integration tests for the Mistral proxy. The Mistral API is
+ * OpenAI-compatible end-to-end, so the proxy reuses the OpenAI parser
+ * and stream logger — these tests pin the Mistral-specific contract:
+ *   1. Upstream URL is built from MISTRAL_API_BASE (default api.mistral.ai)
+ *      and forwards `/proxy/mistral/...` after stripping the prefix.
+ *   2. Authorization header carries the decrypted Mistral key, not the
+ *      customer Spanlens key.
+ *   3. The log row carries provider='mistral' so the dashboard can
+ *      group by it, and cost is calculated via the new pricing seed.
+ *   4. Public-scope key + NO_PROVIDER_KEY paths return the same 403/400
+ *      codes as the other proxy handlers (consistency).
+ */
+
+vi.mock('../middleware/authApiKey.js', async () => {
+  const actual = await vi.importActual<typeof import('../middleware/authApiKey.js')>(
+    '../middleware/authApiKey.js',
+  )
+  return {
+    ...actual,
+    authApiKey: (async (c: Context, next: Next) => {
+      c.set('apiKeyId', proxyState.apiKeyId)
+      c.set('organizationId', proxyState.organizationId)
+      c.set('projectId', proxyState.projectId)
+      c.set('apiKeyScope', proxyState.scope)
+      await next()
+    }) as MiddlewareHandler,
+  }
+})
+
+vi.mock('../middleware/requireFullScope.js', () => ({
+  requireFullScope: (async (_c: Context, next: Next) => {
+    if (proxyState.scope === 'public') {
+      const { ApiError } = await import('../lib/errors.js')
+      throw new ApiError('PUBLIC_KEY_WRITE_FORBIDDEN', 'Public API key cannot write')
+    }
+    await next()
+  }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/rateLimit.js', () => ({
+  proxyRateLimit: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/quota.js', () => ({
+  enforceQuota: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../proxy/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../proxy/utils.js')>(
+    '../proxy/utils.js',
+  )
+  return {
+    ...actual,
+    getDecryptedProviderKey: vi.fn(async () => {
+      if (proxyState.decryptedKey === '') return null
+      return {
+        plaintext: proxyState.decryptedKey,
+        id: proxyState.providerKeyId,
+        metadata: {},
+      }
+    }),
+    isBlockingEnabled: vi.fn(async () => proxyState.blockingEnabled),
+  }
+})
+
+vi.mock('../lib/logger.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/logger.js')>(
+    '../lib/logger.js',
+  )
+  return {
+    ...actual,
+    logRequestAsync: vi.fn(async (data: Record<string, unknown>) => {
+      proxyState.loggerCalls.push(data)
+    }),
+  }
+})
+
+vi.mock('../lib/resolve-prompt-version.js', () => ({
+  resolvePromptVersion: vi.fn(async () => null),
+}))
+
+vi.mock('../lib/wait-until.js', () => ({
+  fireAndForget: (_c: Context, promise: Promise<unknown>) => {
+    proxyState.pendingTasks.push(promise.catch(() => undefined))
+  },
+}))
+
+async function buildApp() {
+  const { Hono } = await import('hono')
+  const { mistralProxy } = await import('../proxy/mistral.js')
+  const app = new Hono()
+  app.route('/proxy/mistral', mistralProxy)
+  installOnError(app)
+  return app
+}
+
+beforeEach(() => {
+  resetProxyMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('mistral proxy — auth + URL building', () => {
+  test('upstream URL = api.mistral.ai + path with /proxy/mistral stripped', async () => {
+    mockUpstream(openAIChatResponse({ model: 'mistral-small-latest' }))
+    const app = await buildApp()
+
+    await app.request('/proxy/mistral/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'mistral-small-latest', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(proxyState.fetchCalls[0]!.url).toBe('https://api.mistral.ai/v1/chat/completions')
+  })
+
+  test('upstream Authorization carries decrypted Mistral key (not customer sl_live_*)', async () => {
+    proxyState.decryptedKey = 'mistral-real-key-abc'
+    mockUpstream(openAIChatResponse({ model: 'mistral-large-latest' }))
+    const app = await buildApp()
+
+    await app.request('/proxy/mistral/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer sl_live_customer_must_not_leak',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ model: 'mistral-large-latest', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    const sent = proxyState.fetchCalls[0]!
+    expect(sent.headers.get('authorization')).toBe('Bearer mistral-real-key-abc')
+    sent.headers.forEach((v) => expect(v).not.toContain('sl_live_'))
+  })
+
+  test('x-spanlens-* headers stripped before reaching upstream', async () => {
+    mockUpstream(openAIChatResponse({ model: 'mistral-small-latest' }))
+    const app = await buildApp()
+
+    await app.request('/proxy/mistral/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-spanlens-user': 'usr_internal',
+        'x-spanlens-session': 'sess_internal',
+      },
+      body: JSON.stringify({ model: 'mistral-small-latest', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    proxyState.fetchCalls[0]!.headers.forEach((_v, k) => {
+      expect(k.toLowerCase().startsWith('x-spanlens-')).toBe(false)
+    })
+  })
+})
+
+describe('mistral proxy — guards', () => {
+  test('NO_PROVIDER_KEY 400 with provider:"mistral" detail', async () => {
+    proxyState.decryptedKey = ''
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/mistral/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'mistral-small-latest', messages: [] }),
+    })
+
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: { code: string; details: { provider: string } } }
+    expect(body.error.code).toBe('NO_PROVIDER_KEY')
+    expect(body.error.details.provider).toBe('mistral')
+    expect(proxyState.fetchCalls).toHaveLength(0)
+  })
+
+  test('public-scope key returns 403 PUBLIC_KEY_WRITE_FORBIDDEN', async () => {
+    proxyState.scope = 'public'
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/mistral/v1/chat/completions', {
+      method: 'POST',
+      body: JSON.stringify({ model: 'mistral-small-latest', messages: [] }),
+    })
+
+    expect(res.status).toBe(403)
+    expect(proxyState.fetchCalls).toHaveLength(0)
+  })
+})
+
+describe('mistral proxy — logging + cost', () => {
+  test('parsed tokens + Mistral cost forwarded to logRequestAsync', async () => {
+    mockUpstream(openAIChatResponse({
+      model: 'mistral-large-latest',
+      promptTokens: 1_000_000,
+      completionTokens: 500_000,
+    }))
+    const app = await buildApp()
+
+    await app.request('/proxy/mistral/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'mistral-large-latest', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(proxyState.loggerCalls).toHaveLength(1)
+    const row = proxyState.loggerCalls[0]!
+    expect(row['provider']).toBe('mistral')
+    expect(row['model']).toBe('mistral-large-latest')
+    expect(row['promptTokens']).toBe(1_000_000)
+    expect(row['completionTokens']).toBe(500_000)
+    // mistral-large-latest: $2.00 / 1M prompt + $6.00 / 1M completion
+    // 1M * 2.00 + 0.5M * 6.00 = 2 + 3 = 5
+    expect(row['costUsd']).toBeCloseTo(5.0, 4)
+  })
+
+  test('upstream non-2xx is passed through and recorded with errorMessage', async () => {
+    mockUpstream(new Response(
+      JSON.stringify({ message: 'Invalid model id' }),
+      { status: 400, headers: { 'content-type': 'application/json' } },
+    ))
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/mistral/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'unknown-model', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(res.status).toBe(400)
+    expect(proxyState.loggerCalls[0]!['statusCode']).toBe(400)
+    expect((proxyState.loggerCalls[0]!['errorMessage'] as string)).toContain('Invalid model id')
+  })
+})

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -11,6 +11,7 @@ import { openaiProxy }     from './proxy/openai.js'
 import { anthropicProxy }  from './proxy/anthropic.js'
 import { geminiProxy }     from './proxy/gemini.js'
 import { azureProxy }      from './proxy/azure.js'
+import { mistralProxy }    from './proxy/mistral.js'
 
 import { organizationsRouter } from './api/organizations.js'
 import { projectsRouter }      from './api/projects.js'
@@ -139,6 +140,7 @@ app.route('/proxy/openai',    openaiProxy)
 app.route('/proxy/anthropic', anthropicProxy)
 app.route('/proxy/gemini',    geminiProxy)
 app.route('/proxy/azure',     azureProxy)
+app.route('/proxy/mistral',   mistralProxy)
 
 // ── SDK ingestion routes (authApiKey middleware) ──────────────
 app.route('/ingest',          ingestRouter)

--- a/apps/server/src/lib/cost.ts
+++ b/apps/server/src/lib/cost.ts
@@ -17,7 +17,7 @@ import type { ServiceTier } from '../parsers/openai.js'
 // at OpenAI prices). The proxy in proxy/azure.ts calls calculateCost('openai', ...)
 // directly, but the type is included here so type-safe call sites that pass
 // `requests.provider` through don't have to special-case it.
-export type Provider = 'openai' | 'anthropic' | 'gemini' | 'azure'
+export type Provider = 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral'
 
 export interface Usage {
   /** Total input tokens INCLUDING any cached/cache-creation portion. */

--- a/apps/server/src/lib/model-prices-cache.ts
+++ b/apps/server/src/lib/model-prices-cache.ts
@@ -130,6 +130,20 @@ export const FALLBACK_PRICES: Record<string, ModelPrice> = {
   'text-embedding-3-small':       { prompt: 0.02, completion: 0 },
   'text-embedding-3-large':       { prompt: 0.13, completion: 0 },
   'text-embedding-ada-002':       { prompt: 0.10, completion: 0 },
+  // ── Mistral: chat completion + embeddings (OpenAI-compatible API) ────────
+  // Same rows live in supabase/seeds/model_prices.sql + the 20260612150000
+  // migration. cache pricing not published by Mistral.
+  'mistral-large-latest':         { prompt: 2.00, completion: 6.00 },
+  'mistral-medium-latest':        { prompt: 0.40, completion: 2.00 },
+  'mistral-small-latest':         { prompt: 0.20, completion: 0.60 },
+  'pixtral-large-latest':         { prompt: 2.00, completion: 6.00 },
+  'pixtral-12b':                  { prompt: 0.15, completion: 0.15 },
+  'codestral-latest':             { prompt: 0.20, completion: 0.60 },
+  'ministral-3b-latest':          { prompt: 0.04, completion: 0.04 },
+  'ministral-8b-latest':          { prompt: 0.10, completion: 0.10 },
+  'open-mistral-nemo':            { prompt: 0.15, completion: 0.15 },
+  'mixtral-8x22b':                { prompt: 2.00, completion: 6.00 },
+  'mistral-embed':                { prompt: 0.10, completion: 0 },
   // ── Anthropic: Claude 4.x (aliases + dated variants) ─────────────────────
   'claude-opus-4-7':              { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 },
   'claude-opus-4-6':              { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 }, // alias only; no dated form per docs

--- a/apps/server/src/proxy/mistral.ts
+++ b/apps/server/src/proxy/mistral.ts
@@ -1,0 +1,134 @@
+import { Hono } from 'hono'
+import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
+import { enforceQuota } from '../middleware/quota.js'
+import { proxyRateLimit } from '../middleware/rateLimit.js'
+import { calculateCost } from '../lib/cost.js'
+import { logRequestAsync } from '../lib/logger.js'
+import { fireAndForget } from '../lib/wait-until.js'
+import { parseOpenAIResponse, type ServiceTier } from '../parsers/openai.js'
+import { buildUpstreamHeaders, buildDownstreamHeaders } from './utils.js'
+import { logOpenAIStream } from './stream-logger.js'
+import { assertProviderKey } from './shared/provider-key.js'
+import { parseProxyRequestBody, chooseFetchBody } from './shared/request-body.js'
+import { runSecurityGate } from './shared/security-gate.js'
+import { fetchUpstreamWithTimeout } from './shared/upstream-fetch.js'
+import { buildLogBase } from './shared/log-base.js'
+import { runLineBufferedStreamPump } from './shared/stream-pump.js'
+
+// Mistral's public API. Their chat completion endpoint is OpenAI-compatible
+// down to the request and response shape, the SSE chunk format, and the
+// usage field — so the OpenAI parser, OpenAI stream logger, and OpenAI cost
+// calculator path all apply unchanged. Only the upstream host + provider tag
+// for log rows differ.
+//
+// The official EU-data-residency endpoint is `api.mistral.ai`; an alternate
+// `codestral.mistral.ai` exists for the code-completion model family but
+// is API-compatible — operators who need that path can override via env.
+const MISTRAL_BASE = (
+  process.env['MISTRAL_API_BASE'] ?? 'https://api.mistral.ai'
+).replace(/\/v1\/?$/, '')
+
+export const mistralProxy = new Hono<ApiKeyContext>()
+
+mistralProxy.use('*', authApiKey)
+mistralProxy.use('*', requireFullScope)
+mistralProxy.use('*', proxyRateLimit)
+mistralProxy.use('*', enforceQuota)
+
+mistralProxy.all('/*', async (c) => {
+  const handlerStartMs = Date.now()
+  const organizationId = c.get('organizationId')
+  // requireFullScope rejects 'public' keys and the DB CHECK constraint forces
+  // 'full' keys to carry a project_id, so this narrowing is safe.
+  const projectId = c.get('projectId') as string
+  const apiKeyId = c.get('apiKeyId')
+
+  const providerKey = await assertProviderKey(apiKeyId, 'mistral')
+  // stream_options.include_usage is OpenAI-only — Mistral always emits usage
+  // in the final SSE chunk regardless of any flag, so no injection needed.
+  const parsed = await parseProxyRequestBody(c)
+  const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
+
+  const upstreamUrl = `${MISTRAL_BASE}${c.req.path.replace(/^\/proxy\/mistral/, '')}`
+  const headers = buildUpstreamHeaders(c.req.raw.headers, {
+    Authorization: `Bearer ${providerKey.plaintext}`,
+    'Content-Type': 'application/json',
+  })
+
+  const { upstreamRes, latencyMs, proxyOverheadMs } = await fetchUpstreamWithTimeout({
+    url: upstreamUrl,
+    method: c.req.method,
+    headers,
+    body: chooseFetchBody(c, parsed, false),
+    provider: 'mistral',
+    handlerStartMs,
+  })
+
+  const logBase = await buildLogBase({
+    c, provider: 'mistral',
+    organizationId, projectId, apiKeyId,
+    providerKey,
+    reqBodyJson: parsed.reqBodyJson,
+    requestFlags,
+    latencyMs, proxyOverheadMs,
+    statusCode: upstreamRes.status,
+  })
+
+  const model = (parsed.reqBodyJson?.['model'] as string | undefined) ?? ''
+
+  // ── Streaming path ────────────────────────────────────────────────────────
+  if (parsed.isStreaming && upstreamRes.body) {
+    return runLineBufferedStreamPump({
+      c, upstreamRes, handlerStartMs, provider: 'mistral',
+      onComplete: (lines, truncated) =>
+        logOpenAIStream(lines, { ...logBase, model }, { truncated }),
+    })
+  }
+
+  // ── Non-streaming path ────────────────────────────────────────────────────
+  const downstreamHeaders = buildDownstreamHeaders(upstreamRes.headers)
+  const resBodyText = await upstreamRes.text()
+  let resBodyJson: unknown = null
+  try { resBodyJson = JSON.parse(resBodyText) } catch { /* non-JSON response */ }
+
+  let promptTokens = 0
+  let completionTokens = 0
+  let totalTokens = 0
+  let cacheReadTokens = 0
+  let cacheWriteTokens = 0
+  let resolvedModel = model
+  let serviceTier: ServiceTier | undefined
+
+  if (upstreamRes.ok && resBodyJson) {
+    try {
+      const p = parseOpenAIResponse(resBodyJson as Record<string, unknown>)
+      if (p) {
+        resolvedModel = p.model || model
+        promptTokens = p.promptTokens
+        completionTokens = p.completionTokens
+        totalTokens = p.totalTokens
+        cacheReadTokens = p.cacheReadTokens ?? 0
+        cacheWriteTokens = p.cacheWriteTokens ?? 0
+        serviceTier = p.serviceTier
+      }
+    } catch { /* ignore */ }
+  }
+
+  const cost = calculateCost('mistral', resolvedModel, {
+    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
+  })
+
+  fireAndForget(c, logRequestAsync({
+    ...logBase,
+    model: resolvedModel,
+    promptTokens, completionTokens, totalTokens,
+    cacheReadTokens, cacheWriteTokens,
+    serviceTier: serviceTier ?? null,
+    costUsd: cost?.totalCost ?? null,
+    responseBody: resBodyJson,
+    errorMessage: upstreamRes.ok ? null : resBodyText.slice(0, 1000),
+  }))
+
+  return new Response(resBodyText, { status: upstreamRes.status, headers: downstreamHeaders })
+})

--- a/apps/server/src/proxy/shared/provider-key.ts
+++ b/apps/server/src/proxy/shared/provider-key.ts
@@ -16,13 +16,14 @@ import { getDecryptedProviderKey, type ResolvedProviderKey } from '../utils.js'
 
 /** Provider tag used in `NO_PROVIDER_KEY` error details and the user-visible
  * message. Matches the keys in provider_keys.provider. */
-export type ProxyProvider = 'openai' | 'anthropic' | 'gemini' | 'azure'
+export type ProxyProvider = 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral'
 
 const PROVIDER_LABEL: Record<ProxyProvider, string> = {
   openai: 'OpenAI',
   anthropic: 'Anthropic',
   gemini: 'Gemini',
   azure: 'Azure',
+  mistral: 'Mistral',
 }
 
 /**

--- a/apps/web/app/docs/proxy/page.tsx
+++ b/apps/web/app/docs/proxy/page.tsx
@@ -36,7 +36,8 @@ export default function ProxyDocs() {
       <CodeBlock>{`https://server.spanlens.io/proxy/openai/v1
 https://server.spanlens.io/proxy/anthropic
 https://server.spanlens.io/proxy/gemini/v1beta
-https://server.spanlens.io/proxy/azure`}</CodeBlock>
+https://server.spanlens.io/proxy/azure
+https://server.spanlens.io/proxy/mistral/v1`}</CodeBlock>
       <p>
         Send requests exactly as you would to the real provider, with two changes:
       </p>
@@ -153,6 +154,35 @@ res = client.chat.completions.create(
         <code>https://&lt;your-resource&gt;.openai.azure.com</code> + API key 1 from Azure
         portal. The proxy stores the URL on the key row and injects the right{' '}
         <code>api-key</code> header on every request.
+      </p>
+
+      <h2 id="python-mistral">Python, Mistral</h2>
+      <p>
+        Mistral&apos;s API is OpenAI-compatible end-to-end (request shape, SSE
+        chunk format, <code>usage</code> field), so the same{' '}
+        <code>openai</code> Python package works with the base URL pointed at{' '}
+        <code>/proxy/mistral/v1</code>. Useful when EU data residency matters
+        (Mistral hosts in France) or when you want to A/B against OpenAI without
+        rewriting your client.
+      </p>
+      <CodeBlock language="python">{`from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["SPANLENS_API_KEY"],
+    base_url="https://server.spanlens.io/proxy/mistral/v1",
+)
+
+res = client.chat.completions.create(
+    model="mistral-small-latest",
+    messages=[{"role": "user", "content": "Hi"}],
+)`}</CodeBlock>
+      <p className="text-sm text-muted-foreground">
+        Supported models include <code>mistral-large-latest</code>,{' '}
+        <code>mistral-medium-latest</code>, <code>mistral-small-latest</code>,{' '}
+        <code>pixtral-large-latest</code> / <code>pixtral-12b</code>{' '}
+        (multimodal), <code>codestral-latest</code>, the <code>ministral-*</code>{' '}
+        family, <code>open-mistral-nemo</code>, and <code>mistral-embed</code>{' '}
+        for embeddings. Cost lands on every row.
       </p>
 
       <h2 id="curl">curl, raw HTTP</h2>

--- a/supabase/migrations/20260612150000_seed_mistral_model_prices.sql
+++ b/supabase/migrations/20260612150000_seed_mistral_model_prices.sql
@@ -1,0 +1,31 @@
+-- Seed pricing rows for Mistral's chat completion models.
+--
+-- Mistral's chat completion API is OpenAI-compatible (same request shape,
+-- same SSE chunk format, same usage field), so the proxy reuses the OpenAI
+-- parser and stream logger. The only piece that needs Mistral-specific data
+-- is the pricing — provider tag `'mistral'` flows into requests.provider
+-- so the dashboard can group by it.
+--
+-- Source: https://mistral.ai/technology/#pricing (2026-06 published rates),
+-- USD per 1M tokens. cache pricing isn't published for Mistral; left NULL
+-- so calculateCost falls back to the regular prompt price for any cached
+-- portion (defensive — Mistral doesn't surface cache_read_tokens today).
+
+INSERT INTO model_prices (
+  provider, model,
+  prompt_price_per_1m, completion_price_per_1m,
+  cache_read_price_per_1m, cache_write_price_per_1m
+) VALUES
+  ('mistral', 'mistral-large-latest',  2.00, 6.00, NULL, NULL),
+  ('mistral', 'mistral-medium-latest', 0.40, 2.00, NULL, NULL),
+  ('mistral', 'mistral-small-latest',  0.20, 0.60, NULL, NULL),
+  ('mistral', 'pixtral-large-latest',  2.00, 6.00, NULL, NULL),
+  ('mistral', 'pixtral-12b',           0.15, 0.15, NULL, NULL),
+  ('mistral', 'codestral-latest',      0.20, 0.60, NULL, NULL),
+  ('mistral', 'ministral-3b-latest',   0.04, 0.04, NULL, NULL),
+  ('mistral', 'ministral-8b-latest',   0.10, 0.10, NULL, NULL),
+  ('mistral', 'open-mistral-nemo',     0.15, 0.15, NULL, NULL),
+  ('mistral', 'mixtral-8x22b',         2.00, 6.00, NULL, NULL),
+  -- Embedding (input-only — completion price stays 0)
+  ('mistral', 'mistral-embed',         0.10, 0.000, NULL, NULL)
+ON CONFLICT (provider, model) DO NOTHING;

--- a/supabase/seeds/model_prices.sql
+++ b/supabase/seeds/model_prices.sql
@@ -67,6 +67,20 @@ INSERT INTO model_prices (
   ('openai', 'text-embedding-3-small',           0.020,  0.000,  NULL,   NULL),
   ('openai', 'text-embedding-3-large',           0.130,  0.000,  NULL,   NULL),
   ('openai', 'text-embedding-ada-002',           0.100,  0.000,  NULL,   NULL),
+  -- ── Mistral: chat completion + multimodal + embeddings ───────────────────
+  -- Source: mistral.ai/technology pricing page, 2026-06. Cache pricing not
+  -- published (Mistral doesn't surface cache tokens in usage today).
+  ('mistral', 'mistral-large-latest',            2.00,   6.00,   NULL,   NULL),
+  ('mistral', 'mistral-medium-latest',           0.40,   2.00,   NULL,   NULL),
+  ('mistral', 'mistral-small-latest',            0.20,   0.60,   NULL,   NULL),
+  ('mistral', 'pixtral-large-latest',            2.00,   6.00,   NULL,   NULL),
+  ('mistral', 'pixtral-12b',                     0.15,   0.15,   NULL,   NULL),
+  ('mistral', 'codestral-latest',                0.20,   0.60,   NULL,   NULL),
+  ('mistral', 'ministral-3b-latest',             0.04,   0.04,   NULL,   NULL),
+  ('mistral', 'ministral-8b-latest',             0.10,   0.10,   NULL,   NULL),
+  ('mistral', 'open-mistral-nemo',               0.15,   0.15,   NULL,   NULL),
+  ('mistral', 'mixtral-8x22b',                   2.00,   6.00,   NULL,   NULL),
+  ('mistral', 'mistral-embed',                   0.10,   0.000,  NULL,   NULL),
   -- ── Anthropic: Claude 4.x (aliases + dated variants) ────────────────────
   ('anthropic', 'claude-opus-4-7',               5.00,  25.00,   0.50,   6.25),
   ('anthropic', 'claude-opus-4-6',               5.00,  25.00,   0.50,   6.25), -- alias only; no dated form per docs


### PR DESCRIPTION
Mistral's chat completion API is OpenAI-compatible end-to-end (request shape, SSE chunk format, \`usage\` field), so the new proxy reuses the OpenAI parser, OpenAI stream logger, and the shared \`proxy/shared/*\` middleware extracted in PR C (#320). The only genuinely new code is the handler scaffolding, the pricing seed, and the docs section.

## Use cases

- **EU data residency** — Mistral hosts in France, drop-in OpenAI replacement for GDPR-conscious customers
- **A/B against OpenAI / Anthropic** without rewriting client code (\`openai\` Python package works as-is)
- **Multimodal**: \`pixtral-large-latest\`, \`pixtral-12b\`
- **Code-focused**: \`codestral-latest\`
- **Embeddings**: \`mistral-embed\` (input-only, completion price = 0, same shape as #325 did for OpenAI embeddings)

## Changes

- \`proxy/mistral.ts\` (130 lines) — mirrors \`proxy/openai.ts\` shape, only the base URL and \`provider: 'mistral'\` tag differ
- \`proxy/shared/provider-key.ts\` \`ProxyProvider\` gains \`'mistral'\`
- \`lib/cost.ts\` \`Provider\` type gains \`'mistral'\`
- \`app.ts\` mounts \`/proxy/mistral\`
- \`supabase/migrations/20260612150000_seed_mistral_model_prices.sql\` + seed + \`FALLBACK_PRICES\` — 11 rows covering the current Mistral lineup
- \`proxy-mistral.test.ts\` — 7 integration tests
- \`/docs/proxy\` page gains a Python-Mistral section + new base URL listed

## Pricing (USD per 1M tokens)

| Model | Prompt | Completion |
|---|---|---|
| mistral-large-latest | $2.00 | $6.00 |
| mistral-medium-latest | $0.40 | $2.00 |
| mistral-small-latest | $0.20 | $0.60 |
| pixtral-large-latest | $2.00 | $6.00 |
| pixtral-12b | $0.15 | $0.15 |
| codestral-latest | $0.20 | $0.60 |
| ministral-3b-latest | $0.04 | $0.04 |
| ministral-8b-latest | $0.10 | $0.10 |
| open-mistral-nemo | $0.15 | $0.15 |
| mixtral-8x22b | $2.00 | $6.00 |
| mistral-embed | $0.10 | 0 |

Cache pricing is \`NULL\` — Mistral does not surface \`cache_read_tokens\` in the response today.

## Test plan

- [x] \`pnpm --filter server test\` — **1033/1033** (was 1026, +7 from proxy-mistral.test.ts)
- [x] \`pnpm --filter server typecheck\` — clean
- [x] \`pnpm --filter web typecheck\` — clean
- [x] \`pnpm --filter server lint\` — clean
- [x] \`pnpm --filter web lint\` — clean
- [ ] CI green on this branch

## Series

This is PR 1 of 3 covering the remaining "more providers + interoperability" audit items:
- **PR 1 (this)** — Mistral
- **PR 2** — OpenRouter
- **PR 3** — OTel exporter MVP