### PR TITLE
feat(server,web): OpenRouter as the 6th supported provider

### DIFF
--- a/apps/server/src/__tests__/proxy-openrouter.test.ts
+++ b/apps/server/src/__tests__/proxy-openrouter.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { Context, MiddlewareHandler, Next } from 'hono'
+import { drainPendingTasks, mockUpstream, openAIChatResponse, proxyState, resetProxyMocks } from './helpers/proxy-mocks.js'
+import { installOnError } from './helpers/install-on-error.js'
+
+/**
+ * Integration tests for the OpenRouter proxy.
+ *
+ * OpenRouter is a meta-provider: one API key, 100+ models from 30+
+ * providers. The wire protocol is OpenAI-compatible, so the proxy reuses
+ * the OpenAI parser and stream logger. The two genuinely
+ * OpenRouter-specific contracts this file pins:
+ *
+ *   1. Cost preference order: when the response carries `usage.cost` (USD,
+ *      OpenRouter's own billed figure), that wins over our local price
+ *      lookup. Our calculator only runs when usage.cost is missing.
+ *
+ *   2. Model id vendor-prefix stripping for the lookup fallback:
+ *      `openai/gpt-4o` → `gpt-4o` matches our `model_prices` row;
+ *      otherwise the proxy would log a non-NULL token count but a NULL cost
+ *      for every OpenRouter call (RAG-cost-tracking regression of #325 shape).
+ */
+
+vi.mock('../middleware/authApiKey.js', async () => {
+  const actual = await vi.importActual<typeof import('../middleware/authApiKey.js')>(
+    '../middleware/authApiKey.js',
+  )
+  return {
+    ...actual,
+    authApiKey: (async (c: Context, next: Next) => {
+      c.set('apiKeyId', proxyState.apiKeyId)
+      c.set('organizationId', proxyState.organizationId)
+      c.set('projectId', proxyState.projectId)
+      c.set('apiKeyScope', proxyState.scope)
+      await next()
+    }) as MiddlewareHandler,
+  }
+})
+
+vi.mock('../middleware/requireFullScope.js', () => ({
+  requireFullScope: (async (_c: Context, next: Next) => {
+    if (proxyState.scope === 'public') {
+      const { ApiError } = await import('../lib/errors.js')
+      throw new ApiError('PUBLIC_KEY_WRITE_FORBIDDEN', 'Public API key cannot write')
+    }
+    await next()
+  }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/rateLimit.js', () => ({
+  proxyRateLimit: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/quota.js', () => ({
+  enforceQuota: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../proxy/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../proxy/utils.js')>(
+    '../proxy/utils.js',
+  )
+  return {
+    ...actual,
+    getDecryptedProviderKey: vi.fn(async () => {
+      if (proxyState.decryptedKey === '') return null
+      return {
+        plaintext: proxyState.decryptedKey,
+        id: proxyState.providerKeyId,
+        metadata: {},
+      }
+    }),
+    isBlockingEnabled: vi.fn(async () => proxyState.blockingEnabled),
+  }
+})
+
+vi.mock('../lib/logger.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/logger.js')>(
+    '../lib/logger.js',
+  )
+  return {
+    ...actual,
+    logRequestAsync: vi.fn(async (data: Record<string, unknown>) => {
+      proxyState.loggerCalls.push(data)
+    }),
+  }
+})
+
+vi.mock('../lib/resolve-prompt-version.js', () => ({
+  resolvePromptVersion: vi.fn(async () => null),
+}))
+
+vi.mock('../lib/wait-until.js', () => ({
+  fireAndForget: (_c: Context, promise: Promise<unknown>) => {
+    proxyState.pendingTasks.push(promise.catch(() => undefined))
+  },
+}))
+
+async function buildApp() {
+  const { Hono } = await import('hono')
+  const { openrouterProxy } = await import('../proxy/openrouter.js')
+  const app = new Hono()
+  app.route('/proxy/openrouter', openrouterProxy)
+  installOnError(app)
+  return app
+}
+
+/**
+ * Build an OpenRouter-shaped chat completion response. Extends the OpenAI
+ * shape with an optional `usage.cost` field — present when the caller
+ * passes `cost`. OpenRouter sometimes returns the model with the vendor
+ * prefix attached (which we then strip for the cost lookup).
+ */
+function openrouterChatResponse(opts: {
+  model: string
+  promptTokens?: number
+  completionTokens?: number
+  /** When set, attached as `usage.cost` (USD) — authoritative for billing. */
+  cost?: number
+}): Response {
+  const pt = opts.promptTokens ?? 100
+  const ct = opts.completionTokens ?? 200
+  const usage: Record<string, unknown> = {
+    prompt_tokens: pt,
+    completion_tokens: ct,
+    total_tokens: pt + ct,
+  }
+  if (opts.cost !== undefined) usage['cost'] = opts.cost
+  return new Response(
+    JSON.stringify({
+      id: 'gen-test',
+      object: 'chat.completion',
+      model: opts.model,
+      choices: [{ message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+      usage,
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  )
+}
+
+beforeEach(() => {
+  resetProxyMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('openrouter proxy — auth + URL building', () => {
+  test('upstream URL = openrouter.ai/api + path with /proxy/openrouter stripped', async () => {
+    mockUpstream(openAIChatResponse({ model: 'openai/gpt-4o' }))
+    const app = await buildApp()
+
+    await app.request('/proxy/openrouter/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'openai/gpt-4o', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(proxyState.fetchCalls[0]!.url).toBe('https://openrouter.ai/api/v1/chat/completions')
+  })
+
+  test('upstream Authorization carries decrypted OpenRouter key (not customer sl_live_*)', async () => {
+    proxyState.decryptedKey = 'sk-or-v1-real-key'
+    mockUpstream(openAIChatResponse({ model: 'openai/gpt-4o' }))
+    const app = await buildApp()
+
+    await app.request('/proxy/openrouter/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer sl_live_customer_should_not_leak',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ model: 'openai/gpt-4o', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    const sent = proxyState.fetchCalls[0]!
+    expect(sent.headers.get('authorization')).toBe('Bearer sk-or-v1-real-key')
+    sent.headers.forEach((v) => expect(v).not.toContain('sl_live_'))
+  })
+})
+
+describe('openrouter proxy — guards', () => {
+  test('NO_PROVIDER_KEY 400 with provider:"openrouter" detail', async () => {
+    proxyState.decryptedKey = ''
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/openrouter/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'openai/gpt-4o', messages: [] }),
+    })
+
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: { code: string; details: { provider: string } } }
+    expect(body.error.code).toBe('NO_PROVIDER_KEY')
+    expect(body.error.details.provider).toBe('openrouter')
+  })
+
+  test('public-scope key returns 403 PUBLIC_KEY_WRITE_FORBIDDEN', async () => {
+    proxyState.scope = 'public'
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/openrouter/v1/chat/completions', {
+      method: 'POST',
+      body: JSON.stringify({ model: 'openai/gpt-4o', messages: [] }),
+    })
+
+    expect(res.status).toBe(403)
+    expect(proxyState.fetchCalls).toHaveLength(0)
+  })
+})
+
+describe('openrouter proxy — cost preference (authoritative cost wins)', () => {
+  test('usage.cost from upstream is used verbatim, our local lookup is ignored', async () => {
+    // 1.5M prompt × $2.50 + 0.5M completion × $10 would be $8.75 by our
+    // local gpt-4o seed. OpenRouter reports $7.123 with their margin /
+    // discount — we trust their number and skip ours.
+    mockUpstream(openrouterChatResponse({
+      model: 'openai/gpt-4o',
+      promptTokens: 1_500_000,
+      completionTokens: 500_000,
+      cost: 7.123,
+    }))
+    const app = await buildApp()
+
+    await app.request('/proxy/openrouter/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'openai/gpt-4o', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(proxyState.loggerCalls).toHaveLength(1)
+    const row = proxyState.loggerCalls[0]!
+    expect(row['provider']).toBe('openrouter')
+    expect(row['model']).toBe('openai/gpt-4o') // vendor prefix preserved on the row
+    expect(row['costUsd']).toBe(7.123)
+  })
+
+  test('fallback to local lookup with vendor prefix stripped (openai/gpt-4o → gpt-4o)', async () => {
+    // No usage.cost field present — proxy strips the vendor prefix and
+    // looks the model up in our normal model_prices table. gpt-4o priced
+    // at $2.50 / 1M prompt + $10 / 1M completion. With 1M prompt + 0.5M
+    // completion: 2.50 + 5.00 = 7.50.
+    mockUpstream(openrouterChatResponse({
+      model: 'openai/gpt-4o',
+      promptTokens: 1_000_000,
+      completionTokens: 500_000,
+    }))
+    const app = await buildApp()
+
+    await app.request('/proxy/openrouter/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'openai/gpt-4o', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    const row = proxyState.loggerCalls[0]!
+    expect(row['model']).toBe('openai/gpt-4o')
+    expect(row['costUsd']).toBeCloseTo(7.5, 4)
+  })
+
+  test('unknown model and no usage.cost → cost_usd lands NULL (no fake number)', async () => {
+    mockUpstream(openrouterChatResponse({
+      model: 'someprovider/model-we-dont-know',
+      promptTokens: 100,
+      completionTokens: 50,
+    }))
+    const app = await buildApp()
+
+    await app.request('/proxy/openrouter/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'someprovider/model-we-dont-know', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    const row = proxyState.loggerCalls[0]!
+    expect(row['costUsd']).toBeNull()
+    expect(row['model']).toBe('someprovider/model-we-dont-know') // still logged
+    expect(row['promptTokens']).toBe(100)
+  })
+})
+
+describe('openrouter proxy — error passthrough', () => {
+  test('upstream non-2xx is forwarded and recorded with errorMessage', async () => {
+    mockUpstream(new Response(
+      JSON.stringify({ error: { message: 'No allowance left for this model' } }),
+      { status: 402, headers: { 'content-type': 'application/json' } },
+    ))
+    const app = await buildApp()
+
+    const res = await app.request('/proxy/openrouter/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'openai/gpt-4o', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    expect(res.status).toBe(402)
+    expect(proxyState.loggerCalls[0]!['statusCode']).toBe(402)
+    expect((proxyState.loggerCalls[0]!['errorMessage'] as string)).toContain('No allowance left')
+  })
+})

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -12,6 +12,7 @@ import { anthropicProxy }  from './proxy/anthropic.js'
 import { geminiProxy }     from './proxy/gemini.js'
 import { azureProxy }      from './proxy/azure.js'
 import { mistralProxy }    from './proxy/mistral.js'
+import { openrouterProxy } from './proxy/openrouter.js'
 
 import { organizationsRouter } from './api/organizations.js'
 import { projectsRouter }      from './api/projects.js'
@@ -141,6 +142,7 @@ app.route('/proxy/anthropic', anthropicProxy)
 app.route('/proxy/gemini',    geminiProxy)
 app.route('/proxy/azure',     azureProxy)
 app.route('/proxy/mistral',   mistralProxy)
+app.route('/proxy/openrouter', openrouterProxy)
 
 // ── SDK ingestion routes (authApiKey middleware) ──────────────
 app.route('/ingest',          ingestRouter)

--- a/apps/server/src/lib/cost.ts
+++ b/apps/server/src/lib/cost.ts
@@ -17,7 +17,7 @@ import type { ServiceTier } from '../parsers/openai.js'
 // at OpenAI prices). The proxy in proxy/azure.ts calls calculateCost('openai', ...)
 // directly, but the type is included here so type-safe call sites that pass
 // `requests.provider` through don't have to special-case it.
-export type Provider = 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral'
+export type Provider = 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
 
 export interface Usage {
   /** Total input tokens INCLUDING any cached/cache-creation portion. */

--- a/apps/server/src/proxy/openrouter.ts
+++ b/apps/server/src/proxy/openrouter.ts
@@ -1,0 +1,175 @@
+import { Hono } from 'hono'
+import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
+import { enforceQuota } from '../middleware/quota.js'
+import { proxyRateLimit } from '../middleware/rateLimit.js'
+import { calculateCost } from '../lib/cost.js'
+import { logRequestAsync } from '../lib/logger.js'
+import { fireAndForget } from '../lib/wait-until.js'
+import { parseOpenAIResponse, type ServiceTier } from '../parsers/openai.js'
+import { buildUpstreamHeaders, buildDownstreamHeaders } from './utils.js'
+import { logOpenAIStream } from './stream-logger.js'
+import { assertProviderKey } from './shared/provider-key.js'
+import { parseProxyRequestBody, chooseFetchBody } from './shared/request-body.js'
+import { runSecurityGate } from './shared/security-gate.js'
+import { fetchUpstreamWithTimeout } from './shared/upstream-fetch.js'
+import { buildLogBase } from './shared/log-base.js'
+import { runLineBufferedStreamPump } from './shared/stream-pump.js'
+
+// OpenRouter is a meta-provider — one API key, one base URL, 100+ models from
+// 30+ providers underneath (OpenAI, Anthropic, Mistral, Meta, DeepSeek,
+// Qwen, Cohere, Perplexity, ...). The wire protocol is OpenAI-compatible
+// end-to-end, so the same parser + stream logger work unchanged. The only
+// two OpenRouter-specific bits live in this file:
+//
+//   1. Model names carry a `<provider>/<model>` prefix
+//      (e.g. `anthropic/claude-3.5-sonnet`, `meta-llama/llama-3.1-70b-instruct`).
+//      For our local price lookup we strip the leading segment so the
+//      `model_prices` row keyed on the bare model name still matches.
+//
+//   2. OpenRouter optionally reports the actual billed cost on the response
+//      under `usage.cost` (USD, after their margin / discount). When present
+//      we trust that number over our own lookup — it's authoritative and
+//      already includes any per-customer discount we don't see.
+//
+// Why not seed every model price: OpenRouter ships hundreds of models that
+// rotate weekly. Maintaining a parallel price table would drift; we lean on
+// (a) our existing seeds for any model that's also reachable directly and
+// (b) OpenRouter's own cost field for the rest. When neither is available
+// `cost_usd` lands NULL, mirroring how the proxy already handles unknown
+// models (gotcha #2).
+const OPENROUTER_BASE = (
+  process.env['OPENROUTER_API_BASE'] ?? 'https://openrouter.ai/api'
+).replace(/\/v1\/?$/, '')
+
+/** Strip the leading `vendor/` prefix from a model id (no-op when absent). */
+function stripVendorPrefix(modelId: string): string {
+  const idx = modelId.indexOf('/')
+  return idx === -1 ? modelId : modelId.slice(idx + 1)
+}
+
+export const openrouterProxy = new Hono<ApiKeyContext>()
+
+openrouterProxy.use('*', authApiKey)
+openrouterProxy.use('*', requireFullScope)
+openrouterProxy.use('*', proxyRateLimit)
+openrouterProxy.use('*', enforceQuota)
+
+openrouterProxy.all('/*', async (c) => {
+  const handlerStartMs = Date.now()
+  const organizationId = c.get('organizationId')
+  const projectId = c.get('projectId') as string
+  const apiKeyId = c.get('apiKeyId')
+
+  const providerKey = await assertProviderKey(apiKeyId, 'openrouter')
+  const parsed = await parseProxyRequestBody(c)
+  const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
+
+  const upstreamUrl = `${OPENROUTER_BASE}${c.req.path.replace(/^\/proxy\/openrouter/, '')}`
+  // OpenRouter recommends sending `HTTP-Referer` and `X-Title` so the dashboard
+  // attribution shows which integration made the call; pass them through if
+  // the customer set them, otherwise OpenRouter falls back to its defaults.
+  // Their auth header is identical to OpenAI (`Authorization: Bearer ...`).
+  const headers = buildUpstreamHeaders(c.req.raw.headers, {
+    Authorization: `Bearer ${providerKey.plaintext}`,
+    'Content-Type': 'application/json',
+  })
+
+  const { upstreamRes, latencyMs, proxyOverheadMs } = await fetchUpstreamWithTimeout({
+    url: upstreamUrl,
+    method: c.req.method,
+    headers,
+    body: chooseFetchBody(c, parsed, false),
+    provider: 'openrouter',
+    handlerStartMs,
+  })
+
+  const logBase = await buildLogBase({
+    c, provider: 'openrouter',
+    organizationId, projectId, apiKeyId,
+    providerKey,
+    reqBodyJson: parsed.reqBodyJson,
+    requestFlags,
+    latencyMs, proxyOverheadMs,
+    statusCode: upstreamRes.status,
+  })
+
+  const model = (parsed.reqBodyJson?.['model'] as string | undefined) ?? ''
+
+  // ── Streaming path ────────────────────────────────────────────────────────
+  if (parsed.isStreaming && upstreamRes.body) {
+    return runLineBufferedStreamPump({
+      c, upstreamRes, handlerStartMs, provider: 'openrouter',
+      onComplete: (lines, truncated) =>
+        logOpenAIStream(lines, { ...logBase, model }, { truncated }),
+    })
+  }
+
+  // ── Non-streaming path ────────────────────────────────────────────────────
+  const downstreamHeaders = buildDownstreamHeaders(upstreamRes.headers)
+  const resBodyText = await upstreamRes.text()
+  let resBodyJson: unknown = null
+  try { resBodyJson = JSON.parse(resBodyText) } catch { /* non-JSON response */ }
+
+  let promptTokens = 0
+  let completionTokens = 0
+  let totalTokens = 0
+  let cacheReadTokens = 0
+  let cacheWriteTokens = 0
+  let resolvedModel = model
+  let serviceTier: ServiceTier | undefined
+  // OpenRouter reports actual billed USD on `usage.cost` for some models;
+  // capture it before the parser collapses the usage shape so we can prefer
+  // it over our local price lookup below.
+  let openrouterReportedCost: number | null = null
+
+  if (upstreamRes.ok && resBodyJson) {
+    try {
+      const bodyAsRecord = resBodyJson as Record<string, unknown>
+      const usage = bodyAsRecord['usage'] as Record<string, unknown> | undefined
+      const rawCost = usage?.['cost']
+      if (typeof rawCost === 'number' && Number.isFinite(rawCost)) {
+        openrouterReportedCost = rawCost
+      }
+      const p = parseOpenAIResponse(bodyAsRecord)
+      if (p) {
+        resolvedModel = p.model || model
+        promptTokens = p.promptTokens
+        completionTokens = p.completionTokens
+        totalTokens = p.totalTokens
+        cacheReadTokens = p.cacheReadTokens ?? 0
+        cacheWriteTokens = p.cacheWriteTokens ?? 0
+        serviceTier = p.serviceTier
+      }
+    } catch { /* ignore */ }
+  }
+
+  // Cost preference order:
+  //   1. OpenRouter's own usage.cost field — authoritative, includes any
+  //      per-customer discount / margin we don't see.
+  //   2. Our local calculator against the model id with the vendor prefix
+  //      stripped (`anthropic/claude-3-5-sonnet` → `claude-3-5-sonnet`).
+  //   3. NULL — unknown model, cost not surfaced by upstream.
+  let finalCostUsd: number | null = null
+  if (openrouterReportedCost !== null) {
+    finalCostUsd = openrouterReportedCost
+  } else {
+    const lookup = calculateCost('openrouter', stripVendorPrefix(resolvedModel), {
+      promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
+    })
+    finalCostUsd = lookup?.totalCost ?? null
+  }
+
+  fireAndForget(c, logRequestAsync({
+    ...logBase,
+    model: resolvedModel,
+    promptTokens, completionTokens, totalTokens,
+    cacheReadTokens, cacheWriteTokens,
+    serviceTier: serviceTier ?? null,
+    costUsd: finalCostUsd,
+    responseBody: resBodyJson,
+    errorMessage: upstreamRes.ok ? null : resBodyText.slice(0, 1000),
+  }))
+
+  return new Response(resBodyText, { status: upstreamRes.status, headers: downstreamHeaders })
+})

--- a/apps/server/src/proxy/shared/provider-key.ts
+++ b/apps/server/src/proxy/shared/provider-key.ts
@@ -16,7 +16,7 @@ import { getDecryptedProviderKey, type ResolvedProviderKey } from '../utils.js'
 
 /** Provider tag used in `NO_PROVIDER_KEY` error details and the user-visible
  * message. Matches the keys in provider_keys.provider. */
-export type ProxyProvider = 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral'
+export type ProxyProvider = 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
 
 const PROVIDER_LABEL: Record<ProxyProvider, string> = {
   openai: 'OpenAI',
@@ -24,6 +24,7 @@ const PROVIDER_LABEL: Record<ProxyProvider, string> = {
   gemini: 'Gemini',
   azure: 'Azure',
   mistral: 'Mistral',
+  openrouter: 'OpenRouter',
 }
 
 /**

--- a/apps/web/app/docs/proxy/page.tsx
+++ b/apps/web/app/docs/proxy/page.tsx
@@ -37,7 +37,8 @@ export default function ProxyDocs() {
 https://server.spanlens.io/proxy/anthropic
 https://server.spanlens.io/proxy/gemini/v1beta
 https://server.spanlens.io/proxy/azure
-https://server.spanlens.io/proxy/mistral/v1`}</CodeBlock>
+https://server.spanlens.io/proxy/mistral/v1
+https://server.spanlens.io/proxy/openrouter/v1`}</CodeBlock>
       <p>
         Send requests exactly as you would to the real provider, with two changes:
       </p>
@@ -183,6 +184,46 @@ res = client.chat.completions.create(
         (multimodal), <code>codestral-latest</code>, the <code>ministral-*</code>{' '}
         family, <code>open-mistral-nemo</code>, and <code>mistral-embed</code>{' '}
         for embeddings. Cost lands on every row.
+      </p>
+
+      <h2 id="python-openrouter">Python, OpenRouter</h2>
+      <p>
+        OpenRouter is a meta-provider: one API key, one base URL, 100+ models
+        from 30+ providers (OpenAI, Anthropic, Mistral, Meta, DeepSeek, Qwen,
+        Cohere, Perplexity, ...). The wire protocol is OpenAI-compatible, so
+        the same <code>openai</code> client works once the base URL is pointed
+        at <code>/proxy/openrouter/v1</code>. Switch models with a single
+        string change instead of swapping clients.
+      </p>
+      <CodeBlock language="python">{`from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["SPANLENS_API_KEY"],
+    base_url="https://server.spanlens.io/proxy/openrouter/v1",
+)
+
+# Model id carries a vendor prefix
+res = client.chat.completions.create(
+    model="anthropic/claude-3.5-sonnet",
+    messages=[{"role": "user", "content": "Hi"}],
+)
+
+# Same client, different model — no code changes
+res2 = client.chat.completions.create(
+    model="meta-llama/llama-3.1-70b-instruct",
+    messages=[{"role": "user", "content": "Hi"}],
+)`}</CodeBlock>
+      <p className="text-sm text-muted-foreground">
+        Cost preference: when OpenRouter reports{' '}
+        <code>usage.cost</code> on the response (authoritative, includes
+        their margin/discount) Spanlens logs that figure verbatim. When it
+        is absent, the proxy strips the vendor prefix (
+        <code>anthropic/claude-3-5-sonnet</code> →{' '}
+        <code>claude-3-5-sonnet</code>) and looks the model up in the same
+        <code> model_prices</code> table the other providers use. Unknown
+        model + no <code>usage.cost</code> → <code>cost_usd</code> lands
+        NULL (visible in <a href="/requests">/requests</a> so you know to
+        check OpenRouter&apos;s own dashboard for that row).
       </p>
 
       <h2 id="curl">curl, raw HTTP</h2>


### PR DESCRIPTION
OpenRouter is a meta-provider — one API key, one base URL, 100+ models from 30+ providers (OpenAI, Anthropic, Mistral, Meta, DeepSeek, Qwen, Cohere, Perplexity, ...). The wire protocol is OpenAI-compatible, so the proxy reuses the OpenAI parser, stream logger, and the shared \`proxy/shared/*\` middleware. PR 2 of the 3-PR series after PR 1 (#327) added Mistral.

## Two OpenRouter-specific bits

### 1. Cost preference order

| Priority | Source | When it applies |
|---|---|---|
| 1 | \`usage.cost\` from upstream | Authoritative — already includes OpenRouter's margin / discount |
| 2 | Local \`model_prices\` lookup with vendor prefix stripped | \`anthropic/claude-3-5-sonnet\` → look up \`claude-3-5-sonnet\` |
| 3 | NULL | Unknown model + no \`usage.cost\` — surface this honestly rather than guess |

### 2. Model id handling

The row keeps the full vendor-prefixed id (\`openai/gpt-4o\`) so dashboard users see which route OpenRouter chose. Only the cost calculation strips the prefix because our \`model_prices\` rows are keyed on bare model names.

## Why no per-model pricing seed

OpenRouter ships hundreds of models that rotate weekly. Maintaining a parallel table would drift and break silently. We lean on:
- Our existing seeds for any model also reachable directly (OpenAI / Anthropic / Gemini / Mistral)
- OpenRouter's own \`usage.cost\` for everything else
- Honest NULL when neither is available

## Changes

- \`proxy/openrouter.ts\` (170 lines)
- \`proxy/shared/provider-key.ts\` \`ProxyProvider\` gains \`'openrouter'\`
- \`lib/cost.ts\` \`Provider\` type gains \`'openrouter'\`
- \`app.ts\` mounts \`/proxy/openrouter\`
- \`proxy-openrouter.test.ts\` — 8 integration tests
- \`/docs/proxy\` gains a Python-OpenRouter section + base URL listed

## Test plan

- [x] \`pnpm --filter server test\` — **1041/1041** (was 1033, +8)
- [x] \`pnpm --filter server typecheck\` — clean
- [x] \`pnpm --filter web typecheck\` — clean
- [x] \`pnpm --filter server lint\` — clean
- [x] \`pnpm --filter web lint\` — clean
- [ ] CI green on this branch