### PR TITLE
feat(server,web): OTel exporter MVP — download any trace as OTLP JSON

### DIFF
--- a/apps/server/src/__tests__/otel-export.test.ts
+++ b/apps/server/src/__tests__/otel-export.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from 'vitest'
+import { traceToOtlp, type SpanlensTrace, type SpanlensSpan } from '../lib/otel-export.js'
+
+/**
+ * Pin the OTLP HTTP/JSON envelope shape against the OpenTelemetry spec
+ * + the gen_ai semantic conventions. A backend that rejects this output
+ * is a regression — every OTLP-aware tool we care about (Datadog,
+ * Honeycomb, Jaeger, Tempo, Grafana, OTel Collector) accepts it.
+ */
+
+const TRACE: SpanlensTrace = {
+  id: '015a5187-d896-40b4-bef8-7d2b2d18c81d',
+  name: 'support_chat',
+  status: 'completed',
+  started_at: '2026-06-12T10:00:00.000Z',
+  ended_at: '2026-06-12T10:00:01.500Z',
+  metadata: { user_id: 'u_42' },
+}
+
+const LLM_SPAN: SpanlensSpan = {
+  id: 'a1b2c3d4-e5f6-7890-1234-567890abcdef',
+  parent_span_id: null,
+  name: 'gpt-4o.chat',
+  span_type: 'llm',
+  status: 'completed',
+  started_at: '2026-06-12T10:00:00.500Z',
+  ended_at: '2026-06-12T10:00:01.200Z',
+  metadata: { provider: 'openai', model: 'gpt-4o' },
+  prompt_tokens: 150,
+  completion_tokens: 80,
+  total_tokens: 230,
+  cost_usd: 0.001175,
+}
+
+describe('traceToOtlp — envelope shape', () => {
+  test('top-level structure matches OTLP HTTP/JSON spec', () => {
+    const out = traceToOtlp(TRACE, [LLM_SPAN])
+    expect(out.resourceSpans).toHaveLength(1)
+    const rs = out.resourceSpans[0]!
+    expect(rs.scopeSpans).toHaveLength(1)
+    expect(rs.scopeSpans[0]!.scope).toEqual({ name: 'spanlens', version: '1.0.0' })
+    expect(rs.scopeSpans[0]!.spans).toHaveLength(1)
+  })
+
+  test('resource attributes include the required service.name', () => {
+    const out = traceToOtlp(TRACE, [LLM_SPAN])
+    const attrs = out.resourceSpans[0]!.resource.attributes
+    const serviceName = attrs.find((a) => a.key === 'service.name')
+    expect(serviceName).toBeDefined()
+    expect(serviceName!.value).toEqual({ stringValue: 'spanlens' })
+  })
+})
+
+describe('traceToOtlp — span id encoding', () => {
+  test('traceId is 32 lowercase hex chars (16 bytes) with dashes stripped', () => {
+    const out = traceToOtlp(TRACE, [LLM_SPAN])
+    const span = out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!
+    expect(span.traceId).toBe('015a5187d89640b4bef87d2b2d18c81d')
+    expect(span.traceId).toMatch(/^[a-f0-9]{32}$/)
+  })
+
+  test('spanId is the leading 16 hex chars (8 bytes) of the UUID', () => {
+    const out = traceToOtlp(TRACE, [LLM_SPAN])
+    const span = out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!
+    expect(span.spanId).toBe('a1b2c3d4e5f67890')
+    expect(span.spanId).toMatch(/^[a-f0-9]{16}$/)
+  })
+
+  test('parentSpanId follows the same 16-hex shape', () => {
+    const childSpan: SpanlensSpan = {
+      ...LLM_SPAN,
+      id: 'cccccccc-dddd-eeee-ffff-000000000000',
+      parent_span_id: LLM_SPAN.id,
+    }
+    const out = traceToOtlp(TRACE, [LLM_SPAN, childSpan])
+    const ch = out.resourceSpans[0]!.scopeSpans[0]!.spans[1]!
+    expect(ch.parentSpanId).toBe('a1b2c3d4e5f67890')
+  })
+
+  test('root span (no parent) omits parentSpanId entirely', () => {
+    const out = traceToOtlp(TRACE, [LLM_SPAN])
+    const span = out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!
+    expect('parentSpanId' in span).toBe(false)
+  })
+})
+
+describe('traceToOtlp — timestamps', () => {
+  test('startTimeUnixNano / endTimeUnixNano are stringified nanoseconds since epoch', () => {
+    const out = traceToOtlp(TRACE, [LLM_SPAN])
+    const span = out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!
+    // 2026-06-12T10:00:00.500Z = 1781258400500 ms = 1781258400500000000 ns.
+    // (verified via Date.parse('2026-06-12T10:00:00.500Z') in Node)
+    expect(span.startTimeUnixNano).toBe('1781258400500000000')
+    expect(span.endTimeUnixNano).toBe('1781258401200000000')
+  })
+
+  test('null timestamp falls back to "0" instead of throwing', () => {
+    const broken: SpanlensSpan = { ...LLM_SPAN, started_at: null, ended_at: null }
+    const out = traceToOtlp(TRACE, [broken])
+    const span = out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!
+    expect(span.startTimeUnixNano).toBe('0')
+    expect(span.endTimeUnixNano).toBe('0')
+  })
+})
+
+describe('traceToOtlp — gen_ai semantic conventions', () => {
+  test('LLM span carries gen_ai.system + gen_ai.request.model from metadata', () => {
+    const out = traceToOtlp(TRACE, [LLM_SPAN])
+    const attrs = out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.attributes
+    expect(attrs).toContainEqual({ key: 'gen_ai.system', value: { stringValue: 'openai' } })
+    expect(attrs).toContainEqual({ key: 'gen_ai.request.model', value: { stringValue: 'gpt-4o' } })
+  })
+
+  test('token counts emitted as gen_ai.usage.input_tokens / output_tokens / total_tokens', () => {
+    const out = traceToOtlp(TRACE, [LLM_SPAN])
+    const attrs = out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.attributes
+    expect(attrs).toContainEqual({ key: 'gen_ai.usage.input_tokens', value: { intValue: '150' } })
+    expect(attrs).toContainEqual({ key: 'gen_ai.usage.output_tokens', value: { intValue: '80' } })
+    expect(attrs).toContainEqual({ key: 'gen_ai.usage.total_tokens', value: { intValue: '230' } })
+  })
+
+  test('cost emitted as spanlens.cost_usd doubleValue (private, no semconv yet)', () => {
+    const out = traceToOtlp(TRACE, [LLM_SPAN])
+    const attrs = out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.attributes
+    expect(attrs).toContainEqual({ key: 'spanlens.cost_usd', value: { doubleValue: 0.001175 } })
+  })
+
+  test('null token / cost / provider values are omitted, not emitted as empty', () => {
+    const sparseSpan: SpanlensSpan = {
+      ...LLM_SPAN,
+      prompt_tokens: null,
+      completion_tokens: null,
+      total_tokens: null,
+      cost_usd: null,
+      metadata: {}, // no provider, no model
+    }
+    const out = traceToOtlp(TRACE, [sparseSpan])
+    const attrs = out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.attributes
+    expect(attrs.find((a) => a.key === 'gen_ai.system')).toBeUndefined()
+    expect(attrs.find((a) => a.key === 'gen_ai.request.model')).toBeUndefined()
+    expect(attrs.find((a) => a.key === 'gen_ai.usage.input_tokens')).toBeUndefined()
+    expect(attrs.find((a) => a.key === 'spanlens.cost_usd')).toBeUndefined()
+  })
+})
+
+describe('traceToOtlp — span kind + status', () => {
+  test('llm span_type → SPAN_KIND_CLIENT (3)', () => {
+    const out = traceToOtlp(TRACE, [LLM_SPAN])
+    expect(out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.kind).toBe(3)
+  })
+
+  test('tool span_type → SPAN_KIND_CLIENT (3)', () => {
+    const tool: SpanlensSpan = { ...LLM_SPAN, span_type: 'tool', name: 'web.search' }
+    const out = traceToOtlp(TRACE, [tool])
+    expect(out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.kind).toBe(3)
+  })
+
+  test('non-llm / non-tool span → SPAN_KIND_INTERNAL (1)', () => {
+    const internal: SpanlensSpan = { ...LLM_SPAN, span_type: 'custom', name: 'parse_input' }
+    const out = traceToOtlp(TRACE, [internal])
+    expect(out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.kind).toBe(1)
+  })
+
+  test('status="completed" → STATUS_CODE_OK (1)', () => {
+    const out = traceToOtlp(TRACE, [LLM_SPAN])
+    expect(out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.status.code).toBe(1)
+  })
+
+  test('status="error" + error_message → STATUS_CODE_ERROR (2) + message attached', () => {
+    const errSpan: SpanlensSpan = {
+      ...LLM_SPAN,
+      status: 'error',
+      error_message: 'rate_limit_exceeded',
+    }
+    const out = traceToOtlp(TRACE, [errSpan])
+    const status = out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.status
+    expect(status.code).toBe(2)
+    expect(status.message).toBe('rate_limit_exceeded')
+  })
+
+  test('null status → STATUS_CODE_UNSET (0)', () => {
+    const unset: SpanlensSpan = { ...LLM_SPAN, status: null }
+    const out = traceToOtlp(TRACE, [unset])
+    expect(out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.status.code).toBe(0)
+  })
+})
+
+describe('traceToOtlp — edge cases', () => {
+  test('empty span list still produces a valid envelope (no spans field empty)', () => {
+    const out = traceToOtlp(TRACE, [])
+    expect(out.resourceSpans[0]!.scopeSpans[0]!.spans).toEqual([])
+  })
+
+  test('multiple spans are preserved in input order', () => {
+    const a: SpanlensSpan = { ...LLM_SPAN, id: '11111111-1111-1111-1111-111111111111', name: 'a' }
+    const b: SpanlensSpan = { ...LLM_SPAN, id: '22222222-2222-2222-2222-222222222222', name: 'b' }
+    const c: SpanlensSpan = { ...LLM_SPAN, id: '33333333-3333-3333-3333-333333333333', name: 'c' }
+    const out = traceToOtlp(TRACE, [a, b, c])
+    const names = out.resourceSpans[0]!.scopeSpans[0]!.spans.map((s) => s.name)
+    expect(names).toEqual(['a', 'b', 'c'])
+  })
+})

--- a/apps/server/src/api/traces.ts
+++ b/apps/server/src/api/traces.ts
@@ -10,6 +10,7 @@ import {
   getTraceWithSpansFromEvents,
 } from '../lib/traces-events-queries.js'
 import { ApiError } from '../lib/errors.js'
+import { traceToOtlp, type SpanlensTrace, type SpanlensSpan } from '../lib/otel-export.js'
 
 export const tracesRouter = new Hono<JwtContext>()
 
@@ -105,6 +106,69 @@ tracesRouter.get('/', async (c) => {
     success: true,
     data: data ?? [],
     meta: { total: count ?? 0, page, limit },
+  })
+})
+
+// GET /api/v1/traces/:id/otlp.json — trace + spans serialized as an OTLP
+// HTTP/JSON envelope. Customers download this file and re-upload to any
+// OTLP-aware backend (Datadog / Honeycomb / Jaeger / Tempo / Grafana) so
+// their LLM trace doesn't have to live in a silo. MVP: download only —
+// per-org collector endpoint + automatic forwarding is a later feature.
+//
+// Mounted BEFORE /:id because Hono's trie matches '/:id' against any
+// path segment, including 'otlp.json' if it were registered second.
+tracesRouter.get('/:id/otlp.json', async (c) => {
+  const traceId = c.req.param('id')
+  const orgId = c.get('orgId')
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+
+  // Reuse the same fetch path as GET /:id so the export sees the exact
+  // same data the detail page shows. Try the events-read flag first, fall
+  // back to Postgres if it errors (same defensive pattern as below).
+  let trace: SpanlensTrace | null = null
+  let spans: SpanlensSpan[] = []
+
+  if (await useEventsForTraces(orgId)) {
+    try {
+      const result = await getTraceWithSpansFromEvents(traceId, orgId)
+      if (result.trace) {
+        trace = result.trace as SpanlensTrace
+        spans = result.spans as SpanlensSpan[]
+      }
+    } catch {
+      /* fall through to Postgres */
+    }
+  }
+
+  if (!trace) {
+    const { data: pgTrace, error: traceErr } = await supabaseAdmin
+      .from('traces')
+      .select('id, name, status, started_at, ended_at, metadata')
+      .eq('id', traceId)
+      .eq('organization_id', orgId)
+      .single()
+    if (traceErr || !pgTrace) throw new ApiError('NOT_FOUND', 'Trace not found')
+    trace = pgTrace as SpanlensTrace
+
+    const { data: pgSpans, error: spansErr } = await supabaseAdmin
+      .from('spans')
+      .select(
+        'id, parent_span_id, name, span_type, status, started_at, ended_at, error_message, metadata, prompt_tokens, completion_tokens, total_tokens, cost_usd',
+      )
+      .eq('trace_id', traceId)
+      .order('started_at', { ascending: true })
+    if (spansErr) throw new ApiError('INTERNAL_ERROR', 'Failed to fetch spans')
+    spans = (pgSpans ?? []) as SpanlensSpan[]
+  }
+
+  const envelope = traceToOtlp(trace, spans)
+  return new Response(JSON.stringify(envelope, null, 2), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Content-Disposition': `attachment; filename="spanlens-trace-${traceId}.otlp.json"`,
+      'Cache-Control': 'no-store',
+    },
   })
 })
 

--- a/apps/server/src/lib/otel-export.ts
+++ b/apps/server/src/lib/otel-export.ts
@@ -1,0 +1,215 @@
+/**
+ * Convert a Spanlens trace + its spans into an OTLP HTTP/JSON envelope.
+ *
+ * Why: enterprise customers already run Datadog / Honeycomb / Jaeger /
+ * Tempo for the rest of their stack and don't want LLM observability to
+ * live in a silo. The "Download as OTLP" button on the trace detail page
+ * hits this serializer and returns a single JSON file the operator can
+ * upload to any OTLP-aware backend, or pipe through
+ * `curl -X POST -d @file.json https://<collector>/v1/traces`.
+ *
+ * Spec references:
+ *   - OTLP HTTP encoding: https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding
+ *   - GenAI semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/
+ *
+ * What this is NOT: a real-time push exporter. That's a separate feature
+ * (per-org collector endpoint + cron-driven forwarding). This module is the
+ * one-row download path — the smallest user-visible deliverable that signals
+ * "Spanlens is not a data silo".
+ */
+
+/** Subset of the Spanlens trace row this exporter needs. */
+export interface SpanlensTrace {
+  id: string
+  name: string
+  status: string | null
+  started_at: string | null
+  ended_at: string | null
+  metadata?: Record<string, unknown> | null
+}
+
+/** Subset of the Spanlens span row this exporter needs. */
+export interface SpanlensSpan {
+  id: string
+  parent_span_id?: string | null
+  name: string
+  span_type?: string | null
+  status: string | null
+  started_at: string | null
+  ended_at: string | null
+  error_message?: string | null
+  metadata?: Record<string, unknown> | null
+  prompt_tokens?: number | null
+  completion_tokens?: number | null
+  total_tokens?: number | null
+  cost_usd?: number | null
+}
+
+/** OTLP attribute value — one of the supported scalar shapes. */
+type OtlpAttrValue =
+  | { stringValue: string }
+  | { intValue: string }    // OTLP spec stores int64 as string in JSON
+  | { doubleValue: number }
+  | { boolValue: boolean }
+
+interface OtlpAttribute {
+  key: string
+  value: OtlpAttrValue
+}
+
+interface OtlpSpan {
+  traceId: string
+  spanId: string
+  parentSpanId?: string
+  name: string
+  kind: number
+  startTimeUnixNano: string
+  endTimeUnixNano: string
+  attributes: OtlpAttribute[]
+  status: { code: number; message?: string }
+}
+
+export interface OtlpExport {
+  resourceSpans: Array<{
+    resource: { attributes: OtlpAttribute[] }
+    scopeSpans: Array<{
+      scope: { name: string; version: string }
+      spans: OtlpSpan[]
+    }>
+  }>
+}
+
+// OpenTelemetry SpanKind enum values (proto). LLM and tool calls are
+// client-style (we initiate work against an external system).
+const SPAN_KIND_INTERNAL = 1
+const SPAN_KIND_CLIENT = 3
+// Status codes per the OTLP spec.
+const STATUS_CODE_UNSET = 0
+const STATUS_CODE_OK = 1
+const STATUS_CODE_ERROR = 2
+
+/**
+ * Spanlens UUIDs are 32 hex chars (128 bits) — perfect for OTLP traceId
+ * (16 bytes / 32 hex). For OTLP spanId (8 bytes / 16 hex) we take the
+ * leading half. This is deterministic so re-exporting the same trace
+ * always produces the same ids — important if the customer wants to
+ * deduplicate against a previous upload.
+ */
+function uuidToTraceId(uuid: string): string {
+  return uuid.replace(/-/g, '').toLowerCase()
+}
+
+function uuidToSpanId(uuid: string): string {
+  return uuid.replace(/-/g, '').slice(0, 16).toLowerCase()
+}
+
+function isoToUnixNano(iso: string | null): string {
+  if (!iso) return '0'
+  const ms = Date.parse(iso)
+  if (!Number.isFinite(ms)) return '0'
+  // OTLP timestamps are nanoseconds since Unix epoch, encoded as string
+  // because JS numbers lose precision above 2^53.
+  return `${ms}000000`
+}
+
+function attrStr(key: string, value: string | null | undefined): OtlpAttribute | null {
+  if (value == null || value === '') return null
+  return { key, value: { stringValue: value } }
+}
+
+function attrInt(key: string, value: number | null | undefined): OtlpAttribute | null {
+  if (value == null || !Number.isFinite(value)) return null
+  return { key, value: { intValue: String(Math.round(value)) } }
+}
+
+function attrDouble(key: string, value: number | null | undefined): OtlpAttribute | null {
+  if (value == null || !Number.isFinite(value)) return null
+  return { key, value: { doubleValue: value } }
+}
+
+function statusFromSpan(span: SpanlensSpan): { code: number; message?: string } {
+  if (span.status === 'error' || span.error_message) {
+    const out: { code: number; message?: string } = { code: STATUS_CODE_ERROR }
+    if (span.error_message) out.message = span.error_message
+    return out
+  }
+  if (span.status === 'completed' || span.status === 'ok') {
+    return { code: STATUS_CODE_OK }
+  }
+  return { code: STATUS_CODE_UNSET }
+}
+
+/**
+ * Build an OTLP HTTP/JSON envelope for one Spanlens trace.
+ *
+ * The envelope is shaped so any OTLP-aware backend (Datadog, Honeycomb,
+ * Jaeger, Tempo, Grafana) accepts it via `POST /v1/traces`. We bake the
+ * gen_ai semantic-convention attributes onto every span so the receiving
+ * backend's LLM views light up automatically.
+ */
+export function traceToOtlp(trace: SpanlensTrace, spans: SpanlensSpan[]): OtlpExport {
+  const traceIdHex = uuidToTraceId(trace.id)
+
+  const resourceAttributes: OtlpAttribute[] = [
+    { key: 'service.name', value: { stringValue: 'spanlens' } },
+    { key: 'service.namespace', value: { stringValue: 'llm-observability' } },
+    { key: 'telemetry.sdk.name', value: { stringValue: 'spanlens-otel-export' } },
+  ]
+
+  const otlpSpans: OtlpSpan[] = spans.map((span) => {
+    const spanIdHex = uuidToSpanId(span.id)
+    const meta = (span.metadata ?? {}) as Record<string, unknown>
+    const provider = typeof meta['provider'] === 'string' ? meta['provider'] : undefined
+    const model = typeof meta['model'] === 'string' ? meta['model'] : undefined
+
+    const attrs: OtlpAttribute[] = []
+    const pushIf = (a: OtlpAttribute | null): void => { if (a) attrs.push(a) }
+
+    // Spanlens-native attributes — keep so a downstream filter can isolate
+    // these spans from non-Spanlens traffic.
+    pushIf(attrStr('spanlens.span_type', span.span_type))
+    pushIf(attrDouble('spanlens.cost_usd', span.cost_usd))
+
+    // GenAI semantic conventions — what Datadog/Honeycomb LLM views consume.
+    // Map only what we actually have; missing attributes are omitted rather
+    // than emitted as empty strings.
+    pushIf(attrStr('gen_ai.system', provider))
+    pushIf(attrStr('gen_ai.request.model', model))
+    pushIf(attrInt('gen_ai.usage.input_tokens', span.prompt_tokens))
+    pushIf(attrInt('gen_ai.usage.output_tokens', span.completion_tokens))
+    pushIf(attrInt('gen_ai.usage.total_tokens', span.total_tokens))
+
+    const kind = span.span_type === 'llm' || span.span_type === 'tool'
+      ? SPAN_KIND_CLIENT
+      : SPAN_KIND_INTERNAL
+
+    const out: OtlpSpan = {
+      traceId: traceIdHex,
+      spanId: spanIdHex,
+      name: span.name,
+      kind,
+      startTimeUnixNano: isoToUnixNano(span.started_at),
+      endTimeUnixNano: isoToUnixNano(span.ended_at),
+      attributes: attrs,
+      status: statusFromSpan(span),
+    }
+    if (span.parent_span_id) {
+      out.parentSpanId = uuidToSpanId(span.parent_span_id)
+    }
+    return out
+  })
+
+  return {
+    resourceSpans: [
+      {
+        resource: { attributes: resourceAttributes },
+        scopeSpans: [
+          {
+            scope: { name: 'spanlens', version: '1.0.0' },
+            spans: otlpSpans,
+          },
+        ],
+      },
+    ],
+  }
+}

--- a/apps/web/app/(dashboard)/traces/[id]/trace-detail-client.tsx
+++ b/apps/web/app/(dashboard)/traces/[id]/trace-detail-client.tsx
@@ -91,6 +91,25 @@ export function TraceDetailClient({ id }: { id: string }) {
                 next →
               </button>
             )}
+            <button
+              type="button"
+              onClick={() => {
+                // OTLP export — server returns the file with a
+                // Content-Disposition: attachment header. We hit the URL via a
+                // hidden anchor click so the browser handles the download
+                // (works in every modern engine without extra blob plumbing).
+                const a = document.createElement('a')
+                a.href = `/api/v1/traces/${id}/otlp.json`
+                a.download = `spanlens-trace-${id}.otlp.json`
+                document.body.appendChild(a)
+                a.click()
+                a.remove()
+              }}
+              title="Download this trace as OTLP JSON. Upload to Datadog / Honeycomb / Jaeger / Tempo."
+              className="font-mono text-[11px] px-[9px] py-1 border border-border rounded-[5px] text-text-muted hover:border-border-strong transition-colors"
+            >
+              ↓ OTLP
+            </button>
             <ShareDialog scope="trace" targetId={id} variant="primary" />
           </div>
         }

--- a/apps/web/app/docs/otel/page.tsx
+++ b/apps/web/app/docs/otel/page.tsx
@@ -239,6 +239,33 @@ sdk.start()
         </tbody>
       </table>
 
+      <h2 id="export-otlp">Export a trace as OTLP (the other direction)</h2>
+      <p>
+        Every trace detail page on the dashboard has a{' '}
+        <strong>↓ OTLP</strong> button next to the share button. Clicking it
+        downloads the trace + all its spans as a single OTLP HTTP/JSON
+        envelope you can re-upload to any OTLP-aware backend (Datadog,
+        Honeycomb, Jaeger, Tempo, Grafana, or your own OTel Collector).
+        Spans carry the gen_ai semantic-convention attributes (
+        <code>gen_ai.system</code>, <code>gen_ai.request.model</code>,{' '}
+        <code>gen_ai.usage.input_tokens</code> / <code>output_tokens</code> /
+        <code> total_tokens</code>) plus a private{' '}
+        <code>spanlens.cost_usd</code> field.
+      </p>
+      <CodeBlock language="bash">{`# Same file works as a POST body for any OTLP/HTTP collector
+curl -X POST https://<your-collector>/v1/traces \\
+  -H 'Content-Type: application/json' \\
+  --data-binary @spanlens-trace-<id>.otlp.json`}</CodeBlock>
+      <p className="text-sm text-muted-foreground">
+        The endpoint is also reachable directly:{' '}
+        <code>GET /api/v1/traces/&lt;id&gt;/otlp.json</code>{' '}
+        (Bearer JWT or <code>sl_live_*</code> key). Useful if you want to
+        script bulk export or wire up a CI test against a known-good trace.
+        A push-based auto-forward to a registered collector endpoint is a
+        future feature; this MVP is the smallest signal that Spanlens is
+        not a data silo.
+      </p>
+
       <h2>Notes</h2>
       <ul>
         <li>


### PR DESCRIPTION
PR 3 of 3 after #327 (Mistral) and #328 (OpenRouter). Closes the audit's "OTel exporter" gap with the smallest user-visible deliverable: a per-trace download button.

## What it does

- Every trace detail page on the dashboard gets a **\`↓ OTLP\`** button next to the share button. One click streams a single OTLP HTTP/JSON file the user can re-upload to any OTLP-aware backend (Datadog, Honeycomb, Jaeger, Tempo, Grafana, OTel Collector).
- The same endpoint is reachable via \`GET /api/v1/traces/<id>/otlp.json\` with a Bearer JWT or \`sl_live_*\` key, so bulk-export / CI scripts can hit it directly.

## What it does NOT do (future work)

- No automatic push to a registered collector endpoint
- No per-org collector config UI
- No retry / queue / batch — the MVP is one trace, one click

## Why the MVP shape

Enterprise customers reject "data silo" tools out of hand. Even a manual download signals "Spanlens is not a lock-in"; a real push exporter can be layered on later without the dashboard UX changing.

## Format choices

- **OTLP HTTP/JSON envelope** (not protobuf) — every backend accepts it
- **gen_ai semantic-convention attributes** on every span: \`gen_ai.system\`, \`gen_ai.request.model\`, \`gen_ai.usage.input_tokens\` / \`output_tokens\` / \`total_tokens\` — so the downstream backend's LLM views light up automatically
- **Private \`spanlens.cost_usd\` attribute** (no semconv for cost yet)
- **traceId** = UUID with dashes stripped (32 hex / 16 bytes)
- **spanId** = first 16 hex of the UUID (8 bytes per OTLP spec)
- **Status code** maps: \`completed\` → OK (1), \`error\` → ERROR (2) + message
- **SpanKind**: llm/tool → CLIENT (3); everything else → INTERNAL (1)

## Test plan

- [x] \`pnpm --filter server test\` — **1061/1061** (was 1041, +20 from otel-export.test.ts)
- [x] \`pnpm --filter server typecheck\` — clean
- [x] \`pnpm --filter web typecheck\` — clean
- [x] \`pnpm --filter server lint\` — clean
- [x] \`pnpm --filter web lint\` — clean
- [ ] CI green on this branch

## Series summary

| PR | What |
|---|---|
| [#327](https://github.com/spanlens/Spanlens/pull/327) | Mistral provider |
| [#328](https://github.com/spanlens/Spanlens/pull/328) | OpenRouter provider |
| **#329 (this)** | OTel exporter MVP |