### PR TITLE
feat(web,server): expose Mistral and OpenRouter in provider-key dialog

### DIFF
--- a/apps/server/src/api/providerKeys.ts
+++ b/apps/server/src/api/providerKeys.ts
@@ -22,7 +22,7 @@ providerKeysRouter.use('*', authJwt)
 
 const requireEdit = requireRole('admin', 'editor')
 
-const VALID_PROVIDERS = new Set(['openai', 'anthropic', 'gemini', 'azure'])
+const VALID_PROVIDERS = new Set(['openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter'])
 
 const SELECT_COLUMNS =
   'id, provider, name, is_active, api_key_id, provider_metadata, created_at, updated_at'
@@ -187,7 +187,7 @@ providerKeysRouter.post('/', requireEdit, async (c) => {
   }
 
   if (typeof body.provider !== 'string' || !VALID_PROVIDERS.has(body.provider)) {
-    throw new ApiError('VALIDATION_FAILED', 'provider must be one of: openai, anthropic, gemini, azure')
+    throw new ApiError('VALIDATION_FAILED', 'provider must be one of: openai, anthropic, gemini, azure, mistral, openrouter')
   }
   if (typeof body.key !== 'string' || body.key.trim().length === 0) {
     throw new ApiError('VALIDATION_FAILED', 'key is required')

--- a/apps/web/app/(dashboard)/projects/projects-client.tsx
+++ b/apps/web/app/(dashboard)/projects/projects-client.tsx
@@ -74,7 +74,7 @@ function CopyIdButton({ value, label = 'Copy ID' }: { value: string; label?: str
   )
 }
 
-const PROVIDERS = ['openai', 'anthropic', 'gemini', 'azure'] as const
+const PROVIDERS = ['openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter'] as const
 type ProviderName = typeof PROVIDERS[number]
 
 const PROVIDER_LABELS: Record<ProviderName, string> = {
@@ -82,6 +82,8 @@ const PROVIDER_LABELS: Record<ProviderName, string> = {
   anthropic: 'Anthropic',
   gemini: 'Gemini',
   azure: 'Azure OpenAI',
+  mistral: 'Mistral',
+  openrouter: 'OpenRouter',
 }
 
 const PROVIDER_PLACEHOLDERS: Record<ProviderName, string> = {
@@ -91,6 +93,8 @@ const PROVIDER_PLACEHOLDERS: Record<ProviderName, string> = {
   // Azure keys are 32-char hex strings with no prefix — show two groups so users
   // recognize the format.
   azure: '0123456789abcdef0123456789abcdef',
+  mistral: 'mistral-…',
+  openrouter: 'sk-or-v1-…',
 }
 
 /**
@@ -127,6 +131,24 @@ const azure = new OpenAI({
   apiKey: process.env.SPANLENS_API_KEY,
 })
 // await azure.chat.completions.create({ model: 'gpt-4o', messages: [...] })`,
+  mistral: `import OpenAI from 'openai'
+
+// Mistral exposes an OpenAI-compatible API — point the OpenAI SDK at the
+// Spanlens proxy and use any Mistral model id.
+const mistral = new OpenAI({
+  baseURL: 'https://api.spanlens.io/proxy/mistral/v1',
+  apiKey: process.env.SPANLENS_API_KEY,
+})
+// await mistral.chat.completions.create({ model: 'mistral-large-latest', messages: [...] })`,
+  openrouter: `import OpenAI from 'openai'
+
+// OpenRouter is OpenAI-compatible and gives you 100+ models behind one key.
+// Use the vendor-prefixed model id (e.g. 'openai/gpt-4o', 'anthropic/claude-sonnet-4').
+const openrouter = new OpenAI({
+  baseURL: 'https://api.spanlens.io/proxy/openrouter/v1',
+  apiKey: process.env.SPANLENS_API_KEY,
+})
+// await openrouter.chat.completions.create({ model: 'anthropic/claude-sonnet-4', messages: [...] })`,
 }
 
 export function ProjectsClient() {

--- a/apps/web/lib/queries/use-provider-keys.ts
+++ b/apps/web/lib/queries/use-provider-keys.ts
@@ -33,7 +33,7 @@ export function useAddProviderKey() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: async (input: {
-      provider: 'openai' | 'anthropic' | 'gemini' | 'azure'
+      provider: 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
       key: string
       name: string
       api_key_id: string


### PR DESCRIPTION
## Summary
- Surface Mistral and OpenRouter in the "Add provider key" modal (dropdown, placeholder, SDK snippet).
- Lift the server-side validator to accept both providers — it was rejecting them with VALIDATION_FAILED even though the proxy routes ship.

Backend support for Mistral and OpenRouter landed in #327 and #328, but the dashboard UI still listed only OpenAI / Anthropic / Gemini / Azure, so customers couldn't actually register a key. Spotted while validating the 3-PR series on production: the proxy returned the expected NO_PROVIDER_KEY error, but the only way to add a key was via direct API.

## Test plan
- [x] pnpm --filter web typecheck
- [x] pnpm --filter server typecheck
- [x] pnpm --filter web lint
- [x] pnpm --filter server lint
- [x] pnpm --filter server test (1061 passed)
- [x] pnpm --filter web build
- [ ] After deploy: open /projects, "Add provider key" → confirm Mistral and OpenRouter appear in dropdown, register a real Mistral key, call /proxy/mistral/v1/chat/completions, see request logged