### PR TITLE
fix(db): extend provider_keys CHECK to allow mistral and openrouter

### DIFF
--- a/supabase/migrations/20260613030000_provider_keys_mistral_openrouter.sql
+++ b/supabase/migrations/20260613030000_provider_keys_mistral_openrouter.sql
@@ -1,0 +1,19 @@
+-- Migration: provider_keys — extend provider CHECK to allow 'mistral' and 'openrouter'.
+--
+-- The proxy routes (PR #327 Mistral, PR #328 OpenRouter) shipped earlier this
+-- week and the app-layer validator in apps/server/src/api/providerKeys.ts now
+-- accepts both, but the DB CHECK constraint (created in
+-- 20260520100000_provider_keys_azure.sql) still rejects rows with
+-- provider != openai/anthropic/gemini/azure. Result: any UI attempt to
+-- register a Mistral or OpenRouter key 500s on check_violation.
+--
+-- Same swap-with-IF-EXISTS pattern the azure migration used. The constraint
+-- name (provider_keys_provider_check) is the PG-default for inline CHECKs in
+-- the initial schema.
+
+ALTER TABLE provider_keys
+  DROP CONSTRAINT IF EXISTS provider_keys_provider_check;
+
+ALTER TABLE provider_keys
+  ADD CONSTRAINT provider_keys_provider_check
+  CHECK (provider IN ('openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter'));


### PR DESCRIPTION
## Summary
Hot fix for PR #330. Registering a Mistral or OpenRouter provider key 500'd against the DB because the CHECK constraint from 20260520100000_provider_keys_azure.sql only permits openai/anthropic/gemini/azure. App-layer validator passed but the INSERT exploded on check_violation.

Same swap-with-IF-EXISTS pattern the azure migration used. Additive only.

## Test plan
- [x] Migration is idempotent (DROP CONSTRAINT IF EXISTS)
- [ ] After deploy: register a Mistral key from /projects, expect 201
- [ ] After deploy: register an OpenRouter key from /projects, expect 201
- [ ] Verify existing OpenAI/Anthropic/Gemini/Azure rows still accepted (CHECK widened only)