### PR TITLE
fix(web): point provider-key snippets at server.spanlens.io

### DIFF
--- a/apps/web/app/(dashboard)/projects/projects-client.tsx
+++ b/apps/web/app/(dashboard)/projects/projects-client.tsx
@@ -127,7 +127,7 @@ const model = genAI.getGenerativeModel({ model: 'gemini-2.5-flash' })
 // Azure resource URL is stored on the Spanlens provider key — your client
 // just talks to /proxy/azure and Spanlens forwards to the right Azure endpoint.
 const azure = new OpenAI({
-  baseURL: 'https://api.spanlens.io/proxy/azure',
+  baseURL: 'https://server.spanlens.io/proxy/azure',
   apiKey: process.env.SPANLENS_API_KEY,
 })
 // await azure.chat.completions.create({ model: 'gpt-4o', messages: [...] })`,
@@ -136,7 +136,7 @@ const azure = new OpenAI({
 // Mistral exposes an OpenAI-compatible API — point the OpenAI SDK at the
 // Spanlens proxy and use any Mistral model id.
 const mistral = new OpenAI({
-  baseURL: 'https://api.spanlens.io/proxy/mistral/v1',
+  baseURL: 'https://server.spanlens.io/proxy/mistral/v1',
   apiKey: process.env.SPANLENS_API_KEY,
 })
 // await mistral.chat.completions.create({ model: 'mistral-large-latest', messages: [...] })`,
@@ -145,7 +145,7 @@ const mistral = new OpenAI({
 // OpenRouter is OpenAI-compatible and gives you 100+ models behind one key.
 // Use the vendor-prefixed model id (e.g. 'openai/gpt-4o', 'anthropic/claude-sonnet-4').
 const openrouter = new OpenAI({
-  baseURL: 'https://api.spanlens.io/proxy/openrouter/v1',
+  baseURL: 'https://server.spanlens.io/proxy/openrouter/v1',
   apiKey: process.env.SPANLENS_API_KEY,
 })
 // await openrouter.chat.completions.create({ model: 'anthropic/claude-sonnet-4', messages: [...] })`,

--- a/apps/web/app/demo/settings/page.tsx
+++ b/apps/web/app/demo/settings/page.tsx
@@ -516,7 +516,7 @@ function OtelTab() {
       <TabHeader title="OpenTelemetry" description="Export Spanlens traces to your existing OTel collector." />
       <Section title="OTLP endpoint">
         <FormRow label="Endpoint">
-          <DemoInput value="https://api.spanlens.io/otel/v1/traces" mono />
+          <DemoInput value="https://server.spanlens.io/v1/traces" mono />
         </FormRow>
         <FormRow label="Headers">
           <DemoInput value="Authorization: Bearer sl_live_…" mono />


### PR DESCRIPTION
## Summary
The 'Add provider key' modal showed customers a code snippet with `https://api.spanlens.io/proxy/<provider>/v1` as the baseURL. That host has no DNS record, so any customer who copy-pasted the snippet got `ERR_NAME_NOT_RESOLVED`. Live production endpoint is `server.spanlens.io`.

Caught while end-to-end testing a Mistral key after #330+#331 — `curl` against the snippet URL fails DNS, against `server.spanlens.io` returns 200 with a real Mistral response.

- Fix Azure (pre-existing bug, fixed here as a drive-by), Mistral, OpenRouter SDK snippets.
- Fix demo /settings OTel endpoint preview. Also corrects the stale path (`/otel/v1/traces` → `/v1/traces` per docs/otel and apps/server route).

The published `@spanlens/mcp-server` package has the same bug in its `DEFAULT_BASE_URL`, but that needs a version bump + npm + MCP Registry republish, so I'll ship it as a separate PR.

## Test plan
- [x] pnpm --filter web typecheck
- [x] pnpm --filter web lint
- [x] curl `server.spanlens.io/proxy/mistral/v1/chat/completions` → 200 (real Mistral response, 22+8 tokens)
- [x] curl `api.spanlens.io/proxy/mistral/v1/chat/completions` → ERR_NAME_NOT_RESOLVED (confirms the bug)