### PR TITLE
fix(sdk): point @spanlens/mcp-server default base URL at server.spanlens.io

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -101,7 +101,7 @@ This server is designed for the IDE-config use case, where the credential sits i
 | Environment variable | Default | Notes |
 |---|---|---|
 | `SPANLENS_API_KEY` | _required_ | A `sl_live_pub_*` key from the **Public Keys** card on `/projects`. The server refuses to start without one, and refuses to start with a `sl_live_*` (full) key. |
-| `SPANLENS_BASE_URL` | `https://api.spanlens.io` | Override for self-hosted Spanlens. Trailing slashes are normalised. |
+| `SPANLENS_BASE_URL` | `https://server.spanlens.io` | Override for self-hosted Spanlens. Trailing slashes are normalised. |
 
 ## Self-hosted Spanlens
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/mcp-server",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "mcpName": "io.github.spanlens/mcp-server",
   "description": "MCP server for Spanlens — query LLM cost, anomalies, traces, and per-user analytics from inside Cursor, Continue, or Claude Desktop.",
   "type": "module",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -7,12 +7,12 @@
     "source": "github",
     "subfolder": "packages/mcp-server"
   },
-  "version": "0.1.1",
+  "version": "0.1.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@spanlens/mcp-server",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "transport": {
         "type": "stdio"
       },
@@ -26,10 +26,10 @@
         },
         {
           "name": "SPANLENS_BASE_URL",
-          "description": "Override the API endpoint for self-hosted Spanlens. Default: https://api.spanlens.io",
+          "description": "Override the API endpoint for self-hosted Spanlens. Default: https://server.spanlens.io",
           "isRequired": false,
           "format": "string",
-          "default": "https://api.spanlens.io"
+          "default": "https://server.spanlens.io"
         }
       ]
     }

--- a/packages/mcp-server/src/__tests__/client.test.ts
+++ b/packages/mcp-server/src/__tests__/client.test.ts
@@ -38,7 +38,7 @@ describe('SpanlensClient', () => {
     // Verify Authorization header + URL composition.
     const url = fetchMock.mock.calls[0]?.[0] as string
     const init = fetchMock.mock.calls[0]?.[1] as RequestInit
-    expect(url).toBe('https://api.spanlens.io/api/v1/stats/overview')
+    expect(url).toBe('https://server.spanlens.io/api/v1/stats/overview')
     expect(
       (init.headers as Record<string, string>)['Authorization'],
     ).toBe('Bearer sl_live_pub_test1234567890ab')

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -13,7 +13,7 @@
  * proxy spend on the user's behalf.
  */
 
-const DEFAULT_BASE_URL = 'https://api.spanlens.io'
+const DEFAULT_BASE_URL = 'https://server.spanlens.io'
 
 export interface SpanlensClientOptions {
   apiKey: string


### PR DESCRIPTION
## Summary

- `@spanlens/mcp-server` defaults `SPANLENS_BASE_URL` to `https://api.spanlens.io`, but that hostname has no DNS record. Anyone who installed the npm package without overriding `SPANLENS_BASE_URL` gets `ERR_NAME_NOT_RESOLVED` in production.
- The live production server is `https://server.spanlens.io`. This PR repoints the default at it.
- Same dead-domain class of bug as the dashboard snippets fixed in [#332](https://github.com/spanlens/Spanlens/pull/332).

## Changes

- `packages/mcp-server/src/client.ts` — `DEFAULT_BASE_URL` constant
- `packages/mcp-server/src/__tests__/client.test.ts` — expected URL in `get()` test
- `packages/mcp-server/server.json` — MCP Registry metadata default + description + version
- `packages/mcp-server/README.md` — env var doc default
- `packages/mcp-server/package.json` — `0.1.2` → `0.1.3` (lockstep with `server.json`, which was at `0.1.1`)

## Test plan

- [x] `pnpm --filter @spanlens/mcp-server test` — 6/6 pass
- [x] `pnpm --filter @spanlens/mcp-server typecheck` — clean
- [x] `pnpm --filter @spanlens/mcp-server build` — clean
- [ ] After merge: tag `mcp-server-v0.1.3` → `.github/workflows/publish-mcp-server.yml` publishes to npm
- [ ] After npm publish: `cd packages/mcp-server && mcp-publisher login github && mcp-publisher publish` to update MCP Registry
- [ ] Verify on https://registry.modelcontextprotocol.io that `0.1.3` and `server.spanlens.io` are visible

## Notes

- Not adding a redirect from `api.spanlens.io` — the domain has no DNS+TLS, code fix is the right move.