### PR TITLE
fix(server): capture OpenRouter usage.cost on streaming path

### DIFF
--- a/apps/server/src/proxy/openrouter.ts
+++ b/apps/server/src/proxy/openrouter.ts
@@ -8,7 +8,7 @@ import { logRequestAsync } from '../lib/logger.js'
 import { fireAndForget } from '../lib/wait-until.js'
 import { parseOpenAIResponse, type ServiceTier } from '../parsers/openai.js'
 import { buildUpstreamHeaders, buildDownstreamHeaders } from './utils.js'
-import { logOpenAIStream } from './stream-logger.js'
+import { logOpenRouterStream } from './stream-logger.js'
 import { assertProviderKey } from './shared/provider-key.js'
 import { parseProxyRequestBody, chooseFetchBody } from './shared/request-body.js'
 import { runSecurityGate } from './shared/security-gate.js'
@@ -101,7 +101,7 @@ openrouterProxy.all('/*', async (c) => {
     return runLineBufferedStreamPump({
       c, upstreamRes, handlerStartMs, provider: 'openrouter',
       onComplete: (lines, truncated) =>
-        logOpenAIStream(lines, { ...logBase, model }, { truncated }),
+        logOpenRouterStream(lines, { ...logBase, model }, { truncated }),
     })
   }
 

--- a/apps/server/src/proxy/stream-logger.ts
+++ b/apps/server/src/proxy/stream-logger.ts
@@ -132,6 +132,125 @@ export async function logOpenAIStream(
   }
 }
 
+/**
+ * OpenRouter streams use the OpenAI SSE shape, but the final usage chunk
+ * also carries an authoritative `usage.cost` field (USD), which our local
+ * price table can't replicate because OpenRouter applies per-customer
+ * discounts and routes some traffic through cheaper inference providers
+ * we don't see. We pre-extract that value here and prefer it over the
+ * model-table lookup — same preference order as the non-streaming path
+ * in proxy/openrouter.ts. Without this, /requests rows for streamed
+ * OpenRouter calls show cost_usd = null.
+ */
+export async function logOpenRouterStream(
+  lines: string[],
+  base: StreamLogBase,
+  ctx: StreamLogContext = {},
+): Promise<void> {
+  let model = base.model
+  let promptTokens = 0
+  let completionTokens = 0
+  let totalTokens = 0
+  let cacheReadTokens = 0
+  let cacheWriteTokens = 0
+  let serviceTier: ServiceTier | undefined
+  let openrouterReportedCost: number | null = null
+
+  for (const line of lines) {
+    // Capture usage.cost before delegating to parseOpenAIStreamChunk, which
+    // collapses the chunk into a typed shape that drops unrecognized fields.
+    const dataMatch = line.match(/^data:\s*(.+)$/)
+    if (dataMatch && dataMatch[1] && dataMatch[1] !== '[DONE]') {
+      try {
+        const chunk = JSON.parse(dataMatch[1]) as Record<string, unknown>
+        const usage = chunk['usage'] as Record<string, unknown> | undefined
+        const rawCost = usage?.['cost']
+        if (typeof rawCost === 'number' && Number.isFinite(rawCost)) {
+          openrouterReportedCost = rawCost
+        }
+      } catch {
+        /* non-JSON line, ignore */
+      }
+    }
+    const parsed = parseOpenAIStreamChunk(line)
+    if (!parsed) continue
+    if (parsed.model) model = parsed.model
+    if (parsed.promptTokens) promptTokens = parsed.promptTokens
+    if (parsed.completionTokens) completionTokens = parsed.completionTokens
+    if (parsed.totalTokens) totalTokens = parsed.totalTokens
+    if (parsed.cacheReadTokens) cacheReadTokens = parsed.cacheReadTokens
+    if (parsed.cacheWriteTokens) cacheWriteTokens = parsed.cacheWriteTokens
+    if (parsed.serviceTier) serviceTier = parsed.serviceTier
+  }
+
+  // Cost preference order matches the non-streaming path in proxy/openrouter.ts:
+  //   1. usage.cost from the final SSE chunk (authoritative).
+  //   2. local calculator against the vendor-stripped model id.
+  //   3. NULL.
+  const strippedModel = (() => {
+    const idx = model.indexOf('/')
+    return idx === -1 ? model : model.slice(idx + 1)
+  })()
+  let finalCostUsd: number | null = null
+  if (openrouterReportedCost !== null) {
+    finalCostUsd = openrouterReportedCost
+  } else {
+    const lookup = calculateCost('openrouter' as Provider, strippedModel, {
+      promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
+    })
+    finalCostUsd = lookup?.totalCost ?? null
+  }
+
+  const text = extractOpenAIStreamText(lines)
+  if (lines.length > 0 && text.length === 0) {
+    console.warn(
+      '[openrouter-stream] capture-empty: %d SSE lines, 0 chars extracted (parser drift?)',
+      lines.length,
+    )
+  }
+  const responseBody = text ? {
+    object: 'chat.completion',
+    model,
+    choices: [{ message: { role: 'assistant', content: text }, finish_reason: 'stop' }],
+    usage: {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: totalTokens,
+      ...(cacheReadTokens > 0 ? { prompt_tokens_details: { cached_tokens: cacheReadTokens } } : {}),
+      ...(openrouterReportedCost !== null ? { cost: openrouterReportedCost } : {}),
+    },
+  } : null
+
+  await logRequestAsync({
+    ...base,
+    model,
+    promptTokens,
+    completionTokens,
+    totalTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    serviceTier: serviceTier ?? null,
+    costUsd: finalCostUsd,
+    responseBody,
+    truncated: ctx.truncated ?? false,
+  })
+
+  if (base.spanId) {
+    const reqBody = base.requestBody as Record<string, unknown> | null
+    const messages = reqBody?.messages
+    if (messages) {
+      await injectSpanInput(base.spanId, base.organizationId, { messages }).catch((err) => {
+        console.error('[span-input-inject:openrouter]', err)
+      })
+    }
+    if (text) {
+      await injectSpanOutput(base.spanId, base.organizationId, text).catch((err) => {
+        console.error('[span-output-inject:openrouter]', err)
+      })
+    }
+  }
+}
+
 export async function logAnthropicStream(
   lines: string[],
   base: StreamLogBase,


### PR DESCRIPTION
## Summary
Streaming OpenRouter calls logged \`cost_usd = NULL\` because \`logOpenAIStream\` (1) drops the \`usage.cost\` field while parsing the final chunk, and (2) calls \`calculateCost('openai', ...)\` against the vendor-prefixed model id (e.g. \`anthropic/claude-3.5-haiku\`), which never matches our price table.

Non-streaming OpenRouter calls were unaffected — #328 already had the cost-preference logic there.

Caught while end-to-end testing the chain #330/#331/#332 after the user registered a real OpenRouter key.

## Approach
- New \`logOpenRouterStream\` in stream-logger.ts. Mirror of \`logOpenAIStream\` but:
  - Pre-extracts \`usage.cost\` from each SSE chunk before the typed parser collapses it.
  - Applies same cost preference order as the non-streaming path: upstream cost → \`calculateCost('openrouter', stripVendorPrefix(model), ...)\` → NULL.
  - Preserves span input/output injection.
- openrouter.ts streaming \`onComplete\` now uses the new helper.

## Test plan
- [x] pnpm --filter server typecheck
- [x] pnpm --filter server lint
- [x] pnpm --filter server test — 1061 passed
- [x] Repro confirmed pre-fix: streaming \`anthropic/claude-3.5-haiku\` via OpenRouter → 16+27 tokens, cost_usd = NULL (real /requests row, ID at top of dashboard)
- [ ] After deploy: same streaming call → cost_usd populated with upstream-reported value (~\$0.0001)
- [ ] After deploy: streaming \`openai/gpt-4o-mini\` via OpenRouter → cost_usd populated
- [ ] Non-streaming path remains correct