### PR TITLE
feat(evals,experiments): expose all 6 providers in judge + run dropdowns

### DIFF
--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -60,8 +60,9 @@ evalsRouter.post('/evaluators', async (c) => {
     const scaleMax = typeof config.scale_max === 'number' ? config.scale_max : 1
 
     if (!criterion) throw new ApiError('VALIDATION_FAILED', 'config.criterion is required')
-    if (judgeProvider !== 'openai' && judgeProvider !== 'anthropic' && judgeProvider !== 'gemini') {
-      throw new ApiError('VALIDATION_FAILED', 'config.judge_provider must be "openai", "anthropic", or "gemini"')
+    const VALID_JUDGE_PROVIDERS = ['openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter']
+    if (!VALID_JUDGE_PROVIDERS.includes(judgeProvider)) {
+      throw new ApiError('VALIDATION_FAILED', `config.judge_provider must be one of: ${VALID_JUDGE_PROVIDERS.join(', ')}`)
     }
     if (!judgeModel) throw new ApiError('VALIDATION_FAILED', 'config.judge_model is required')
     if (!(scaleMax > scaleMin)) {
@@ -241,10 +242,11 @@ evalsRouter.post('/eval-runs', async (c) => {
   }
 
   // Dataset evals run the prompt against each item's input before judging.
-  // The picker can only emit our three supported provider strings.
-  const runProvider: 'openai' | 'anthropic' | 'gemini' | null =
-    body.runProvider === 'openai' || body.runProvider === 'anthropic' || body.runProvider === 'gemini'
-      ? body.runProvider
+  const RUN_PROVIDERS = ['openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter'] as const
+  type RunProvider = typeof RUN_PROVIDERS[number]
+  const runProvider: RunProvider | null =
+    typeof body.runProvider === 'string' && (RUN_PROVIDERS as readonly string[]).includes(body.runProvider)
+      ? (body.runProvider as RunProvider)
       : null
   const runModel = typeof body.runModel === 'string' ? body.runModel.trim() : null
   if (source === 'dataset') {

--- a/apps/server/src/api/experiments.ts
+++ b/apps/server/src/api/experiments.ts
@@ -38,9 +38,10 @@ experimentsRouter.post('/', async (c) => {
   const datasetId = typeof body.datasetId === 'string' ? body.datasetId.trim() : ''
   const evaluatorId = typeof body.evaluatorId === 'string' && body.evaluatorId.trim()
     ? body.evaluatorId.trim() : null
-  const runProvider: 'openai' | 'anthropic' | 'gemini' =
-    body.runProvider === 'anthropic' ? 'anthropic'
-    : body.runProvider === 'gemini' ? 'gemini'
+  const RUN_PROVIDERS = ['openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter'] as const
+  type RunProvider = typeof RUN_PROVIDERS[number]
+  const runProvider: RunProvider = (RUN_PROVIDERS as readonly string[]).includes(body.runProvider as string)
+    ? (body.runProvider as RunProvider)
     : 'openai'
   const runModel = typeof body.runModel === 'string' ? body.runModel.trim() : ''
 

--- a/apps/server/src/api/models.ts
+++ b/apps/server/src/api/models.ts
@@ -40,7 +40,16 @@ interface ModelsResponse {
   openai: ModelEntry[]
   anthropic: ModelEntry[]
   gemini: ModelEntry[]
+  azure: ModelEntry[]
+  mistral: ModelEntry[]
+  openrouter: ModelEntry[]
 }
+
+type ModelProvider = keyof ModelsResponse
+
+const KNOWN_PROVIDERS: ReadonlySet<ModelProvider> = new Set([
+  'openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter',
+])
 
 const DATED_SUFFIX = /-\d{8}$|-\d{4}-\d{2}-\d{2}$/
 
@@ -63,12 +72,14 @@ modelsRouter.get('/', async (c) => {
     throw new ApiError('INTERNAL_ERROR', 'Failed to load models', { detail: error.message })
   }
 
-  const groups: ModelsResponse = { openai: [], anthropic: [], gemini: [] }
+  const groups: ModelsResponse = {
+    openai: [], anthropic: [], gemini: [], azure: [], mistral: [], openrouter: [],
+  }
 
   for (const row of data ?? []) {
     const r = row as unknown as Record<string, unknown>
-    const provider = r['provider'] as 'openai' | 'anthropic' | 'gemini'
-    if (!groups[provider]) continue
+    const provider = r['provider'] as ModelProvider
+    if (!KNOWN_PROVIDERS.has(provider)) continue
     const model = r['model'] as string
     // Skip dated variants when an alias already exists — keeps the picker
     // readable while the row stays billable for direct API calls.

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -83,10 +83,12 @@ interface JudgeOutcome {
  * Returns the assistant text on success, null on any failure (network,
  * 4xx/5xx, empty output). Callers should filter nulls.
  */
+type EvalProvider = 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
+
 async function generateForItem(
   promptContent: string,
   itemInput: Record<string, unknown>,
-  provider: 'openai' | 'anthropic' | 'gemini',
+  provider: EvalProvider,
   model: string,
   apiKey: string,
 ): Promise<string | null> {
@@ -112,6 +114,24 @@ async function generateForItem(
   try {
     if (provider === 'openai') {
       const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
+        body: JSON.stringify(buildOpenAIBody(
+          model,
+          [{ role: 'system', content: promptContent }, { role: 'user', content: userContent }],
+          { temperature: 0.7, maxTokens: 1024 },
+        )),
+      })
+      if (!res.ok) return null
+      const json = await res.json() as { choices: Array<{ message: { content: string } }> }
+      return json.choices?.[0]?.message?.content ?? null
+    }
+
+    if (provider === 'mistral' || provider === 'openrouter') {
+      const url = provider === 'mistral'
+        ? 'https://api.mistral.ai/v1/chat/completions'
+        : 'https://openrouter.ai/api/v1/chat/completions'
+      const res = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
         body: JSON.stringify(buildOpenAIBody(
@@ -261,6 +281,53 @@ async function callJudge(
       promptTokens: json.usage?.prompt_tokens ?? 0,
       completionTokens: json.usage?.completion_tokens ?? 0,
     })?.totalCost ?? 0
+    return buildOutcome(parsed, cost, tokens)
+  }
+
+  // Mistral + OpenRouter are both OpenAI-compatible chat completion APIs,
+  // so the request shape is identical to the openai branch above. Only the
+  // base URL + cost provider tag differ.
+  if (config.judge_provider === 'mistral' || config.judge_provider === 'openrouter') {
+    const url = config.judge_provider === 'mistral'
+      ? 'https://api.mistral.ai/v1/chat/completions'
+      : 'https://openrouter.ai/api/v1/chat/completions'
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(buildOpenAIBody(
+        config.judge_model,
+        [{ role: 'user', content: prompt }],
+        { temperature: 0, maxTokens: 200, responseFormat: { type: 'json_object' } },
+      )),
+    })
+    if (!res.ok) return null
+    const json = await res.json() as {
+      choices: Array<{ message: { content: string } }>
+      usage: { prompt_tokens: number; completion_tokens: number; cost?: number }
+      model: string
+    }
+    const text = json.choices?.[0]?.message?.content ?? ''
+    const parsed = parseJudgeReply(text, {
+      scale_min: config.scale_min,
+      scale_max: config.scale_max,
+      score_config: config.score_config ?? null,
+    })
+    if (!parsed) return null
+    const tokens = (json.usage?.prompt_tokens ?? 0) + (json.usage?.completion_tokens ?? 0)
+    // OpenRouter publishes the authoritative billed cost on usage.cost — prefer
+    // it over the local table lookup (same pattern as proxy/openrouter.ts).
+    let cost = 0
+    if (config.judge_provider === 'openrouter' && typeof json.usage?.cost === 'number') {
+      cost = json.usage.cost
+    } else {
+      cost = calculateCost(config.judge_provider, json.model ?? config.judge_model, {
+        promptTokens: json.usage?.prompt_tokens ?? 0,
+        completionTokens: json.usage?.completion_tokens ?? 0,
+      })?.totalCost ?? 0
+    }
     return buildOutcome(parsed, cost, tokens)
   }
 
@@ -418,7 +485,7 @@ interface RunInput {
    *  curated golden answer, not whatever the prompt actually generates.)
    * These fields are required for dataset runs; ignored for production.
    */
-  runProvider?: 'openai' | 'anthropic' | 'gemini' | null
+  runProvider?: EvalProvider | null
   runModel?: string | null
 }
 

--- a/apps/server/src/lib/eval-runners/judge-prompt.ts
+++ b/apps/server/src/lib/eval-runners/judge-prompt.ts
@@ -31,7 +31,7 @@ export interface TypedScoreConfig {
 
 export interface JudgeConfig {
   criterion: string
-  judge_provider: 'openai' | 'anthropic' | 'gemini'
+  judge_provider: 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
   judge_model: string
   scale_min: number
   scale_max: number

--- a/apps/server/src/lib/experiment-runner.ts
+++ b/apps/server/src/lib/experiment-runner.ts
@@ -22,9 +22,11 @@ const MAX_TOKENS = 1024
 const TEMPERATURE = 0.7
 
 // JudgeConfig kept in sync with eval-runner.ts. Inlined to avoid circular imports.
+type EvalProvider = 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
+
 interface JudgeConfig {
   criterion: string
-  judge_provider: 'openai' | 'anthropic' | 'gemini'
+  judge_provider: EvalProvider
   judge_model: string
   scale_min: number
   scale_max: number
@@ -59,7 +61,7 @@ interface PromptVersionRow {
 async function runPrompt(
   content: string,
   item: DatasetItemRow,
-  provider: 'openai' | 'anthropic' | 'gemini',
+  provider: EvalProvider,
   model: string,
   apiKey: string,
 ): Promise<RunResult | { error: string }> {
@@ -107,6 +109,46 @@ async function runPrompt(
       const promptTokens = json.usage?.prompt_tokens ?? 0
       const completionTokens = json.usage?.completion_tokens ?? 0
       const cost = calculateCost('openai', json.model ?? model, { promptTokens, completionTokens })?.totalCost ?? 0
+      return { output, cost, latencyMs, tokens: promptTokens + completionTokens }
+    }
+
+    // Mistral + OpenRouter — OpenAI-compatible chat completion shape.
+    if (provider === 'mistral' || provider === 'openrouter') {
+      const url = provider === 'mistral'
+        ? 'https://api.mistral.ai/v1/chat/completions'
+        : 'https://openrouter.ai/api/v1/chat/completions'
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(buildOpenAIBody(
+          model,
+          [{ role: 'system', content }, { role: 'user', content: userContent }],
+          { temperature: TEMPERATURE, maxTokens: MAX_TOKENS },
+        )),
+      })
+      const latencyMs = Date.now() - startMs
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        return { error: `${provider} error (${res.status}): ${text.slice(0, 200)}` }
+      }
+      const json = await res.json() as {
+        choices: Array<{ message: { content: string } }>
+        usage: { prompt_tokens: number; completion_tokens: number; cost?: number }
+        model: string
+      }
+      const output = json.choices?.[0]?.message?.content ?? ''
+      const promptTokens = json.usage?.prompt_tokens ?? 0
+      const completionTokens = json.usage?.completion_tokens ?? 0
+      // OpenRouter: prefer upstream usage.cost (authoritative billed amount).
+      let cost = 0
+      if (provider === 'openrouter' && typeof json.usage?.cost === 'number') {
+        cost = json.usage.cost
+      } else {
+        cost = calculateCost(provider, json.model ?? model, { promptTokens, completionTokens })?.totalCost ?? 0
+      }
       return { output, cost, latencyMs, tokens: promptTokens + completionTokens }
     }
 
@@ -257,6 +299,48 @@ async function callJudge(
       tokens,
     }
   }
+  // Mistral + OpenRouter — OpenAI-compatible.
+  if (config.judge_provider === 'mistral' || config.judge_provider === 'openrouter') {
+    const url = config.judge_provider === 'mistral'
+      ? 'https://api.mistral.ai/v1/chat/completions'
+      : 'https://openrouter.ai/api/v1/chat/completions'
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
+      body: JSON.stringify(buildOpenAIBody(
+        config.judge_model,
+        [{ role: 'user', content: prompt }],
+        { temperature: 0, maxTokens: 200, responseFormat: { type: 'json_object' } },
+      )),
+    })
+    if (!res.ok) return null
+    const json = await res.json() as {
+      choices: Array<{ message: { content: string } }>
+      usage: { prompt_tokens: number; completion_tokens: number; cost?: number }
+      model: string
+    }
+    const text = json.choices?.[0]?.message?.content ?? ''
+    const parsed = parseJudgeReply(text, config.scale_min, config.scale_max)
+    if (!parsed) return null
+    const tokens = (json.usage?.prompt_tokens ?? 0) + (json.usage?.completion_tokens ?? 0)
+    let cost = 0
+    if (config.judge_provider === 'openrouter' && typeof json.usage?.cost === 'number') {
+      cost = json.usage.cost
+    } else {
+      cost = calculateCost(config.judge_provider, json.model ?? config.judge_model, {
+        promptTokens: json.usage?.prompt_tokens ?? 0,
+        completionTokens: json.usage?.completion_tokens ?? 0,
+      })?.totalCost ?? 0
+    }
+    const range = config.scale_max - config.scale_min || 1
+    return {
+      score: (parsed.score - config.scale_min) / range,
+      reasoning: parsed.reasoning,
+      cost,
+      tokens,
+    }
+  }
+
   if (config.judge_provider === 'anthropic') {
     const res = await fetch('https://api.anthropic.com/v1/messages', {
       method: 'POST',
@@ -375,7 +459,7 @@ interface RunInput {
   versionBId: string
   datasetId: string
   evaluatorId: string | null
-  runProvider: 'openai' | 'anthropic' | 'gemini'
+  runProvider: EvalProvider
   runModel: string
 }
 

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -44,7 +44,21 @@ const JUDGE_MODELS_FALLBACK = {
   openai: ['gpt-4o-mini'],
   anthropic: ['claude-haiku-4-5'],
   gemini: ['gemini-2.5-flash-lite'],
+  azure: ['gpt-4o-mini'],
+  mistral: ['mistral-small-latest'],
+  openrouter: ['openai/gpt-4o-mini'],
 } as const
+
+type EvalProvider = 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
+
+const PROVIDER_OPTIONS: Array<{ value: EvalProvider; label: string }> = [
+  { value: 'openai',     label: 'OpenAI' },
+  { value: 'anthropic',  label: 'Anthropic' },
+  { value: 'gemini',     label: 'Gemini' },
+  { value: 'azure',      label: 'Azure OpenAI' },
+  { value: 'mistral',    label: 'Mistral' },
+  { value: 'openrouter', label: 'OpenRouter' },
+]
 
 // Hydration-safe mounted gate, same pattern as the other overhauled pages.
 const subscribeNoop = () => () => {}
@@ -97,7 +111,7 @@ function StatusBadge({ status }: { status: EvalRunStatus }) {
 interface EvaluatorTemplate {
   name: string
   criterion: string
-  judgeProvider: 'openai' | 'anthropic' | 'gemini'
+  judgeProvider: EvalProvider
   judgeModel: string
 }
 
@@ -147,15 +161,18 @@ function NewEvaluatorDialog({
   //
   // Memoised so dependent effects (template sync below) don't re-run on
   // every render and cause loops.
-  const judgeModels = useMemo<{ openai: string[]; anthropic: string[]; gemini: string[] }>(() => {
-    const next = {
-      openai: (modelsCatalog?.openai ?? []).map((m) => m.model),
-      anthropic: (modelsCatalog?.anthropic ?? []).map((m) => m.model),
-      gemini: (modelsCatalog?.gemini ?? []).map((m) => m.model),
+  const judgeModels = useMemo<Record<EvalProvider, string[]>>(() => {
+    const next: Record<EvalProvider, string[]> = {
+      openai:     (modelsCatalog?.openai ?? []).map((m) => m.model),
+      anthropic:  (modelsCatalog?.anthropic ?? []).map((m) => m.model),
+      gemini:     (modelsCatalog?.gemini ?? []).map((m) => m.model),
+      azure:      (modelsCatalog?.azure ?? []).map((m) => m.model),
+      mistral:    (modelsCatalog?.mistral ?? []).map((m) => m.model),
+      openrouter: (modelsCatalog?.openrouter ?? []).map((m) => m.model),
     }
-    if (next.openai.length === 0) next.openai = [...JUDGE_MODELS_FALLBACK.openai]
-    if (next.anthropic.length === 0) next.anthropic = [...JUDGE_MODELS_FALLBACK.anthropic]
-    if (next.gemini.length === 0) next.gemini = [...JUDGE_MODELS_FALLBACK.gemini]
+    for (const p of Object.keys(JUDGE_MODELS_FALLBACK) as EvalProvider[]) {
+      if (next[p].length === 0) next[p] = [...JUDGE_MODELS_FALLBACK[p]]
+    }
     return next
   }, [modelsCatalog])
 
@@ -163,7 +180,7 @@ function NewEvaluatorDialog({
   // only have dated variants ('gpt-4o-mini-2024-07-18'). Resolve to the
   // first available dated variant under the same family, or fall back to
   // the catalog's first model for the provider.
-  function resolveJudgeModel(provider: 'openai' | 'anthropic' | 'gemini', preferred: string): string {
+  function resolveJudgeModel(provider: EvalProvider, preferred: string): string {
     const list = judgeModels[provider]
     if (list.includes(preferred)) return preferred
     const datedMatch = list.find((m) => m.startsWith(preferred + '-'))
@@ -178,7 +195,7 @@ function NewEvaluatorDialog({
   const [promptName, setPromptName] = useState('')
   const [name, setName] = useState(initialTemplate?.name ?? '')
   const [criterion, setCriterion] = useState(initialTemplate?.criterion ?? '')
-  const [judgeProvider, setJudgeProvider] = useState<'openai' | 'anthropic' | 'gemini'>(
+  const [judgeProvider, setJudgeProvider] = useState<EvalProvider>(
     initialTemplate?.judgeProvider ?? 'openai',
   )
   const [judgeModel, setJudgeModel] = useState(() =>
@@ -368,15 +385,15 @@ function NewEvaluatorDialog({
                     Judge provider
                   </label>
                   <Select value={judgeProvider || undefined} onValueChange={(v) => {
-                      const p = v as 'openai' | 'anthropic' | 'gemini'
+                      const p = v as EvalProvider
                       setJudgeProvider(p)
                       setJudgeModel(judgeModels[p][0] ?? '')
                     }}>
                     <SelectTrigger><SelectValue placeholder="Select provider…" /></SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="openai">OpenAI</SelectItem>
-                      <SelectItem value="anthropic">Anthropic</SelectItem>
-                      <SelectItem value="gemini">Gemini</SelectItem>
+                      {PROVIDER_OPTIONS.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </div>
@@ -528,7 +545,7 @@ function RunEvaluatorDialog({
   const [error, setError] = useState('')
   // For dataset mode: which provider+model runs the prompt before judging.
   // Production mode doesn't need these — responses are already in CH.
-  const [runProvider, setRunProvider] = useState<'openai' | 'anthropic' | 'gemini'>('openai')
+  const [runProvider, setRunProvider] = useState<EvalProvider>('openai')
   const [runModel, setRunModel] = useState('gpt-4o-mini')
   const modelsCatalog = useModels()
   const runModelOptions = (modelsCatalog.data?.[runProvider] ?? []).map((m) => m.model)
@@ -711,16 +728,16 @@ function RunEvaluatorDialog({
                     Run provider
                   </label>
                   <Select value={runProvider || undefined} onValueChange={(v) => {
-                      const p = v as 'openai' | 'anthropic' | 'gemini'
+                      const p = v as EvalProvider
                       setRunProvider(p)
                       const opts = (modelsCatalog.data?.[p] ?? []).map((m) => m.model)
                       setRunModel(opts[0] ?? '')
                     }}>
                     <SelectTrigger><SelectValue placeholder="Select provider…" /></SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="openai">OpenAI</SelectItem>
-                      <SelectItem value="anthropic">Anthropic</SelectItem>
-                      <SelectItem value="gemini">Gemini</SelectItem>
+                      {PROVIDER_OPTIONS.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </div>

--- a/apps/web/app/(dashboard)/experiments/experiments-client.tsx
+++ b/apps/web/app/(dashboard)/experiments/experiments-client.tsx
@@ -27,12 +27,26 @@ function useMounted(): boolean {
   return useSyncExternalStore(subscribeNoop, getTrue, getFalse)
 }
 
+type ExpProvider = 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
+
 // Fallback for the first paint before useModels() resolves.
 const RUN_MODELS_FALLBACK = {
   openai: ['gpt-4o-mini'],
   anthropic: ['claude-haiku-4-5'],
   gemini: ['gemini-2.5-flash-lite'],
+  azure: ['gpt-4o-mini'],
+  mistral: ['mistral-small-latest'],
+  openrouter: ['openai/gpt-4o-mini'],
 } as const
+
+const PROVIDER_OPTIONS: Array<{ value: ExpProvider; label: string }> = [
+  { value: 'openai',     label: 'OpenAI' },
+  { value: 'anthropic',  label: 'Anthropic' },
+  { value: 'gemini',     label: 'Gemini' },
+  { value: 'azure',      label: 'Azure OpenAI' },
+  { value: 'mistral',    label: 'Mistral' },
+  { value: 'openrouter', label: 'OpenRouter' },
+]
 
 function fmtUsd(n: number | null | undefined): string {
   if (n == null) return '—'
@@ -85,14 +99,17 @@ function NewExperimentDialog({ open, onClose }: { open: boolean; onClose: () => 
   const datasets = useDatasets()
   const create = useCreateExperiment()
   const { data: modelsCatalog } = useModels()
-  const runModels: { openai: string[]; anthropic: string[]; gemini: string[] } = {
-    openai: (modelsCatalog?.openai ?? []).map((m) => m.model),
-    anthropic: (modelsCatalog?.anthropic ?? []).map((m) => m.model),
-    gemini: (modelsCatalog?.gemini ?? []).map((m) => m.model),
+  const runModels: Record<ExpProvider, string[]> = {
+    openai:     (modelsCatalog?.openai ?? []).map((m) => m.model),
+    anthropic:  (modelsCatalog?.anthropic ?? []).map((m) => m.model),
+    gemini:     (modelsCatalog?.gemini ?? []).map((m) => m.model),
+    azure:      (modelsCatalog?.azure ?? []).map((m) => m.model),
+    mistral:    (modelsCatalog?.mistral ?? []).map((m) => m.model),
+    openrouter: (modelsCatalog?.openrouter ?? []).map((m) => m.model),
   }
-  if (runModels.openai.length === 0) runModels.openai = [...RUN_MODELS_FALLBACK.openai]
-  if (runModels.anthropic.length === 0) runModels.anthropic = [...RUN_MODELS_FALLBACK.anthropic]
-  if (runModels.gemini.length === 0) runModels.gemini = [...RUN_MODELS_FALLBACK.gemini]
+  for (const p of Object.keys(RUN_MODELS_FALLBACK) as ExpProvider[]) {
+    if (runModels[p].length === 0) runModels[p] = [...RUN_MODELS_FALLBACK[p]]
+  }
 
   const [name, setName] = useState('')
   const [promptName, setPromptName] = useState('')
@@ -102,7 +119,7 @@ function NewExperimentDialog({ open, onClose }: { open: boolean; onClose: () => 
   const [versionBId, setVersionBId] = useState('')
   const [datasetId, setDatasetId] = useState('')
   const [evaluatorId, setEvaluatorId] = useState('__none__')
-  const [runProvider, setRunProvider] = useState<'openai' | 'anthropic' | 'gemini'>('openai')
+  const [runProvider, setRunProvider] = useState<ExpProvider>('openai')
   const [runModel, setRunModel] = useState<string>('gpt-4o-mini')
   const [error, setError] = useState('')
 
@@ -241,12 +258,12 @@ function NewExperimentDialog({ open, onClose }: { open: boolean; onClose: () => 
               <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
                 Run provider
               </label>
-              <Select value={runProvider} onValueChange={(v) => { const p = v as 'openai' | 'anthropic' | 'gemini'; setRunProvider(p); setRunModel(runModels[p][0] ?? '') }}>
+              <Select value={runProvider} onValueChange={(v) => { const p = v as ExpProvider; setRunProvider(p); setRunModel(runModels[p][0] ?? '') }}>
                 <SelectTrigger><SelectValue /></SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="openai">OpenAI</SelectItem>
-                  <SelectItem value="anthropic">Anthropic</SelectItem>
-                  <SelectItem value="gemini">Gemini</SelectItem>
+                  {PROVIDER_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>

--- a/apps/web/lib/queries/use-evals.ts
+++ b/apps/web/lib/queries/use-evals.ts
@@ -8,7 +8,7 @@ import type { ApiEnvelope } from './types'
 
 export interface JudgeConfig {
   criterion: string
-  judge_provider: 'openai' | 'anthropic' | 'gemini'
+  judge_provider: 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
   judge_model: string
   scale_min: number
   scale_max: number
@@ -216,7 +216,7 @@ export interface CreateEvalRunInput {
   sampleTo?: string
   /** Required when source = 'dataset' — used to generate the response that
    *  then gets scored by the judge. */
-  runProvider?: 'openai' | 'anthropic' | 'gemini'
+  runProvider?: 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
   runModel?: string
 }
 

--- a/apps/web/lib/queries/use-evaluator-templates.ts
+++ b/apps/web/lib/queries/use-evaluator-templates.ts
@@ -24,7 +24,7 @@ export interface EvaluatorTemplate {
   description: string
   category: EvaluatorTemplateCategory
   criterion: string
-  recommended_judge_provider: 'openai' | 'anthropic' | 'gemini'
+  recommended_judge_provider: 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
   recommended_judge_model: string
   display_order: number
 }

--- a/apps/web/lib/queries/use-experiments.ts
+++ b/apps/web/lib/queries/use-experiments.ts
@@ -107,7 +107,7 @@ export interface CreateExperimentInput {
   versionBId: string
   datasetId: string
   evaluatorId?: string
-  runProvider: 'openai' | 'anthropic' | 'gemini'
+  runProvider: 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
   runModel: string
 }
 

--- a/apps/web/lib/queries/use-models.ts
+++ b/apps/web/lib/queries/use-models.ts
@@ -24,13 +24,26 @@ export interface ModelEntry {
   longContextThresholdTokens: number | null
 }
 
-export interface ModelsByProvider {
-  openai: ModelEntry[]
-  anthropic: ModelEntry[]
-  gemini: ModelEntry[]
+export const MODEL_PROVIDERS = [
+  'openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter',
+] as const
+
+export type ModelProvider = typeof MODEL_PROVIDERS[number]
+
+export type ModelsByProvider = Record<ModelProvider, ModelEntry[]>
+
+const EMPTY: ModelsByProvider = {
+  openai: [], anthropic: [], gemini: [], azure: [], mistral: [], openrouter: [],
 }
 
-const EMPTY: ModelsByProvider = { openai: [], anthropic: [], gemini: [] }
+export const PROVIDER_LABEL: Record<ModelProvider, string> = {
+  openai: 'OpenAI',
+  anthropic: 'Anthropic',
+  gemini: 'Gemini',
+  azure: 'Azure OpenAI',
+  mistral: 'Mistral',
+  openrouter: 'OpenRouter',
+}
 
 export function useModels() {
   return useQuery({

--- a/supabase/migrations/20260613080000_expand_judge_run_provider_checks.sql
+++ b/supabase/migrations/20260613080000_expand_judge_run_provider_checks.sql
@@ -1,0 +1,36 @@
+-- Expand the CHECK constraints that gate evaluator + experiment provider
+-- choices so Mistral, OpenRouter (and Azure / Gemini for experiments) become
+-- selectable from the Evals / Experiments UI.
+--
+-- Today the dashboard only offers OpenAI / Anthropic / Gemini in the "Judge
+-- provider" and "Run provider" dropdowns, even though model_prices has 19
+-- Mistral and 170 OpenRouter rows. The UI is hardcoded because the DB
+-- CHECK would reject anything else on INSERT.
+--
+-- Constraint we're widening:
+--   evaluator_templates.recommended_judge_provider:
+--     'openai' | 'anthropic' | 'gemini'
+--     → + 'azure' | 'mistral' | 'openrouter'
+--   experiments.run_provider:
+--     'openai' | 'anthropic'
+--     → + 'gemini' | 'azure' | 'mistral' | 'openrouter'
+--
+-- The server endpoint + judge runner switch are widened in the same PR.
+
+ALTER TABLE evaluator_templates
+  DROP CONSTRAINT IF EXISTS evaluator_templates_recommended_judge_provider_check;
+
+ALTER TABLE evaluator_templates
+  ADD CONSTRAINT evaluator_templates_recommended_judge_provider_check
+  CHECK (recommended_judge_provider IN (
+    'openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter'
+  ));
+
+ALTER TABLE experiments
+  DROP CONSTRAINT IF EXISTS experiments_run_provider_check;
+
+ALTER TABLE experiments
+  ADD CONSTRAINT experiments_run_provider_check
+  CHECK (run_provider IN (
+    'openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter'
+  ));


### PR DESCRIPTION
## Summary
Evals + Experiments dialogs only let users pick OpenAI / Anthropic / Gemini even though \`model_prices\` now has 19 Mistral and 170 OpenRouter rows. The 3-provider limit was hardcoded at every layer:

| Layer | Was | Now |
|---|---|---|
| **DB CHECK** | evaluator_templates + experiments → 3 providers | 6 providers |
| **Server /api/v1/models** | groups: { openai, anthropic, gemini } | + azure, mistral, openrouter |
| **Server judge runners** | switch on 3 providers | + Mistral + OpenRouter branches (OpenAI-compatible) |
| **Server API validators** | hardcoded 3-string check | array-based 6-provider check |
| **Web TypeScript unions** | 6 files with 'openai' \| 'anthropic' \| 'gemini' | extended union |
| **Web dropdowns** | 2 pages with 3 \`<SelectItem>\` | data-driven from PROVIDER_OPTIONS |

## Why
Customer registered Mistral / OpenRouter provider keys today (PR #330–#332). They appear in /projects but not in /evals or /experiments. UI should auto-track \`model_prices\` like the model picker does.

## Server-side judge calls
Mistral and OpenRouter both speak the OpenAI chat completion format, so the new branches just reuse \`buildOpenAIBody\` with a different base URL and cost-calc provider tag. OpenRouter prefers \`usage.cost\` from the response (authoritative billed amount) over the local price-table lookup — same rule as the proxy.

## Test plan
- [x] pnpm --filter server typecheck + lint
- [x] pnpm --filter web typecheck + lint
- [x] pnpm --filter server test (1061 passed)
- [x] pnpm --filter web build
- [ ] After deploy: open /evals \"New evaluator\" dialog → Judge provider dropdown shows 6 options
- [ ] After deploy: select Mistral → Judge model dropdown shows the 19 Mistral rows
- [ ] After deploy: create an llm_judge evaluator with Mistral, run it, verify cost_usd is non-NULL
- [ ] After deploy: same for OpenRouter (with vendor-prefix models like \`openai/gpt-4o-mini\`)