### PR TITLE
docs(changelog): add 2026-06-13 entry for Mistral + OpenRouter proxies

### DIFF
--- a/apps/web/lib/changelog/entries.ts
+++ b/apps/web/lib/changelog/entries.ts
@@ -39,6 +39,17 @@ export type ChangelogTag =
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-06-13',
+    slug: 'mistral-and-openrouter-providers',
+    title: 'Mistral and OpenRouter are now first-class providers',
+    tags: ['feature'],
+    body: [
+      'Two new proxies join OpenAI, Anthropic, Gemini, and Azure. Point the OpenAI SDK at `https://server.spanlens.io/proxy/mistral/v1` or `/proxy/openrouter/v1` with your Spanlens key and Mistral chat completions or any of OpenRouter\'s 100+ models route through Spanlens with cost, latency, and token counts on every row in /requests. Both APIs are OpenAI-compatible, so existing client code only needs a baseURL swap.',
+      'OpenRouter is a meta-provider that fronts models from 30+ vendors behind one key — `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`, `meta-llama/llama-3.3-70b-instruct`, `deepseek/deepseek-r1`, and so on. For these calls Spanlens prefers the `usage.cost` field on OpenRouter\'s response (the authoritative billed amount, which captures any volume discount or upstream-provider margin we don\'t see) over our local price-table lookup. Streaming responses get the same treatment via the final SSE chunk.',
+      'Register a provider key from /projects and the dropdown now lists both. Evaluators and experiments can also use Mistral or OpenRouter as the judge or run model — the New Evaluator dialog reads the live model catalog, so any new model in `model_prices` shows up automatically. See [the proxy guide](/docs/proxy) for code samples in TypeScript, Python, and curl.',
+    ].join('\n\n'),
+  },
+  {
     date: '2026-06-12',
     slug: 'dashboard-breakdown-charts',
     title: 'Three new breakdown charts on the main dashboard',


### PR DESCRIPTION
## Summary
Single changelog entry tagged \`feature\` covering both Mistral and OpenRouter proxies, which shipped earlier today as PR #327 and PR #328. The entry highlights:

1. Both APIs are OpenAI-compatible — baseURL swap on the OpenAI SDK is the only client change.
2. OpenRouter is the meta-provider behind 100+ vendor-prefixed models (\`openai/gpt-4o-mini\`, \`anthropic/claude-sonnet-4-5\`, etc).
3. Spanlens prefers OpenRouter's authoritative \`usage.cost\` field over our local price-table lookup, including on streaming responses.
4. Both providers show up in /projects key registration, /evals judge dropdown, and /experiments run dropdown via the live model catalog.

Skips the smaller fix-class PRs (snippet domain, MCP server rebuild, streaming cost capture, price-table reseeds, eval dropdown plumbing) — they're internal to the same delivery.

## Test plan
- [x] pnpm --filter web typecheck
- [ ] After deploy: /changelog renders the new entry at the top with correct date, slug, single 'feature' chip, and 3 paragraphs
- [ ] /changelog/feed.xml includes a corresponding \`<item>\` with publish date 2026-06-13
- [ ] Both inline links (\`/docs/proxy\`) resolve