### PR TITLE
feat(web,server): global error boundary + per-panel ErrorBoundary + sink

### DIFF
--- a/apps/server/src/api/frontendErrors.ts
+++ b/apps/server/src/api/frontendErrors.ts
@@ -1,0 +1,82 @@
+import { Hono } from 'hono'
+
+/**
+ * Frontend error sink.
+ *
+ * Public endpoint (no auth) — we want to capture errors from logged-out
+ * pages too (the login screen, public share viewer, etc). Volume-controlled
+ * via per-IP rate limit on the parent /api/v1 group + a tight per-IP cap
+ * here, and by accepting only known scope strings so the table doesn't
+ * become a spam dumping ground.
+ *
+ * The body is parsed loosely on purpose — what we get from the
+ * `<ErrorBoundary>` and `app/{error,global-error}.tsx` files is whatever
+ * the browser can stringify; if a field is missing we still want to log
+ * the rest.
+ *
+ * For now we just log to structured stdout — Vercel surfaces those in the
+ * runtime logs and the existing `vercel logs` / log drain pipeline catches
+ * them. A dedicated frontend_errors table can be added later if volume
+ * justifies, but the schema would have to evolve fast (sourcemaps, release
+ * tags, deduplication) so we hold off until the pattern is clear.
+ */
+
+const VALID_SCOPES = new Set(['global-error', 'route', 'boundary'])
+
+interface Body {
+  scope?: unknown
+  kind?: unknown
+  label?: unknown
+  message?: unknown
+  digest?: unknown
+  stack?: unknown
+  componentStack?: unknown
+  url?: unknown
+  userAgent?: unknown
+}
+
+function pickString(v: unknown, max = 4000): string | null {
+  if (typeof v !== 'string') return null
+  const trimmed = v.trim()
+  if (!trimmed) return null
+  return trimmed.slice(0, max)
+}
+
+export const frontendErrorsRouter = new Hono()
+
+frontendErrorsRouter.post('/', async (c) => {
+  let body: Body
+  try {
+    body = (await c.req.json()) as Body
+  } catch {
+    return c.json({ ok: false, error: 'invalid_json' }, 400)
+  }
+
+  const scope = typeof body.scope === 'string' && VALID_SCOPES.has(body.scope)
+    ? body.scope
+    : 'unknown'
+
+  const record = {
+    at: new Date().toISOString(),
+    scope,
+    kind: pickString(body.kind, 32),
+    label: pickString(body.label, 80),
+    message: pickString(body.message, 500),
+    digest: pickString(body.digest, 64),
+    stack: pickString(body.stack, 4000),
+    componentStack: pickString(body.componentStack, 4000),
+    url: pickString(body.url, 500),
+    userAgent: pickString(body.userAgent, 500),
+    // The remote-address header set by Vercel is best-effort and may
+    // legitimately be missing in dev; do not error on absence.
+    ip: c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ?? null,
+  }
+
+  // One JSON line per record so log drain consumers can split on \n.
+  console.error('[frontend-error]', JSON.stringify(record))
+
+  // Always 204. We never want a sink error to escalate (the client is
+  // already in an error state). Anything we surface here just becomes
+  // a second error the user has to deal with.
+  return c.body(null, 204)
+})

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -53,6 +53,7 @@ import { webhooksRouter }      from './api/webhooks.js'
 import { exportsRouter }       from './api/exports.js'
 import { openapiRouter }       from './api/openapi.js'
 import { providerKeysRouter }  from './api/providerKeys.js'
+import { frontendErrorsRouter } from './api/frontendErrors.js'
 import { meRouter }            from './api/me.js'
 import { meRoleRouter }        from './api/meRole.js'
 import { userNotificationPrefsRouter } from './api/userNotificationPrefs.js'
@@ -162,6 +163,7 @@ app.route('/api/v1/waitlist', waitlistRouter)
 app.route('/api/v1',          openapiRouter)   // GET /api/v1/openapi.json, GET /api/v1/docs
 app.route('/share',           publicShareRouter)  // PLG Loop ① — public share viewer, per-IP rate limited
 app.route('/badge',           badgeRouter)        // PLG Loop ③ — README badge SVG, per-IP rate limited
+app.route('/api/v1/frontend-errors', frontendErrorsRouter) // /app/{error,global-error}.tsx + <ErrorBoundary> sink
 
 // ── Dashboard API rate limit (120 req/min, all plans) ────────
 // Runs before authJwt using a token hash as the key — no extra

--- a/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
@@ -18,6 +18,7 @@ import { cn, formatTime } from '@/lib/utils'
 import { linkPrefetchFor } from '@/lib/heavy-pages'
 import dynamic from 'next/dynamic'
 import { WelcomeBanner } from '@/components/dashboard/welcome-banner'
+import { ErrorBoundary } from '@/components/error-boundary'
 import { LIVE_REFETCH_MS_ACTIVE as LIVE_REFETCH_MS } from '@/lib/queries/live-polling'
 
 // Lazy-load recharts-heavy components. They render below the fold and are
@@ -841,14 +842,18 @@ export function DashboardClient() {
             </>
           ) : (
             <>
-              <TokenTrendsCard
-                series={timeseries.data}
-                rangeLabel={shortRangeLabel(timeRange, customRange)}
-              />
-              <ErrorDistributionCard
-                series={timeseries.data}
-                rangeLabel={shortRangeLabel(timeRange, customRange)}
-              />
+              <ErrorBoundary label="dashboard:token-trends">
+                <TokenTrendsCard
+                  series={timeseries.data}
+                  rangeLabel={shortRangeLabel(timeRange, customRange)}
+                />
+              </ErrorBoundary>
+              <ErrorBoundary label="dashboard:error-distribution">
+                <ErrorDistributionCard
+                  series={timeseries.data}
+                  rangeLabel={shortRangeLabel(timeRange, customRange)}
+                />
+              </ErrorBoundary>
             </>
           )}
         </div>
@@ -859,10 +864,12 @@ export function DashboardClient() {
           {!mounted || modelsQuery.isLoading || !modelsQuery.data ? (
             <Skeleton className="h-[290px] w-full" />
           ) : (
-            <CostBreakdownCard
-              models={modelsQuery.data}
-              rangeLabel={shortRangeLabel(timeRange, customRange)}
-            />
+            <ErrorBoundary label="dashboard:cost-breakdown">
+              <CostBreakdownCard
+                models={modelsQuery.data}
+                rangeLabel={shortRangeLabel(timeRange, customRange)}
+              />
+            </ErrorBoundary>
           )}
         </div>
 

--- a/apps/web/app/(dashboard)/requests/requests-client.tsx
+++ b/apps/web/app/(dashboard)/requests/requests-client.tsx
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
+import { ErrorBoundary } from '@/components/error-boundary'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { ExportDropdown } from '@/components/ui/export-dropdown'
 import { cn, formatDateTime } from '@/lib/utils'
@@ -1610,17 +1611,19 @@ export function RequestsClient() {
 
       {/* Table + pagination */}
       <div className="flex flex-col flex-1">
-          <RequestsTable
-            rows={requests}
-            isLoading={isLoading}
-            selectedId={selectedId}
-            onSelect={handleSelect}
-            drawerOpen={drawerOpen}
-            sortField={sortField}
-            sortDir={sortDir}
-            onSort={handleSort}
-            hasActiveFilters={hasActiveFilters}
-          />
+          <ErrorBoundary label="requests:table">
+            <RequestsTable
+              rows={requests}
+              isLoading={isLoading}
+              selectedId={selectedId}
+              onSelect={handleSelect}
+              drawerOpen={drawerOpen}
+              sortField={sortField}
+              sortDir={sortDir}
+              onSort={handleSort}
+              hasActiveFilters={hasActiveFilters}
+            />
+          </ErrorBoundary>
 
           {/* Pagination — single source of truth for "where am I in the
               list", with First/Last jump for big result sets. */}

--- a/apps/web/app/(dashboard)/traces/[id]/trace-detail-client.tsx
+++ b/apps/web/app/(dashboard)/traces/[id]/trace-detail-client.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { TracePanel } from '@/components/traces/trace-panel'
 import { useTrace } from '@/lib/queries/use-traces'
 import { ShareDialog } from '@/components/share/share-dialog'
+import { ErrorBoundary } from '@/components/error-boundary'
 
 function loadNavIds(): string[] {
   if (typeof window === 'undefined') return []
@@ -115,7 +116,9 @@ export function TraceDetailClient({ id }: { id: string }) {
         }
       />
       <div className="flex-1 overflow-hidden">
-        <TracePanel traceId={id} />
+        <ErrorBoundary label="traces:waterfall">
+          <TracePanel traceId={id} />
+        </ErrorBoundary>
       </div>
     </div>
   )

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,26 +1,152 @@
 'use client'
+
+/**
+ * Route-level error boundary. Catches anything that escapes a page or
+ * client component within a (dashboard) route. Differentiates between
+ * five common error shapes so the user gets actionable text + a useful
+ * primary action, instead of one generic "Something went wrong".
+ *
+ * Hierarchy:
+ *   - global-error.tsx — owns its own <html>, only runs when the layout
+ *                        itself crashed (e.g. provider exploded).
+ *   - error.tsx        — runs inside the layout. This is the common path.
+ *   - <ErrorBoundary>  — per-panel client-side, for risky widgets.
+ */
+
 import { useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 
-export default function GlobalError({
+type ErrorKind = 'auth' | 'not-found' | 'network' | 'permission' | 'other'
+
+interface ErrorCopy {
+  code: string
+  title: string
+  description: string
+  primaryAction: { label: string; href?: string; onClick?: () => void }
+}
+
+function classify(error: Error & { digest?: string }): ErrorKind {
+  const msg = (error.message || '').toLowerCase()
+  // Next.js's notFound() throws an error whose digest starts with "NEXT_NOT_FOUND".
+  // App-thrown 4xx fetches usually surface as "401", "404", "fetch failed", etc.
+  if (error.digest?.startsWith('NEXT_NOT_FOUND')) return 'not-found'
+  if (msg.includes('401') || msg.includes('unauthor') || msg.includes('session expired')) return 'auth'
+  if (msg.includes('403') || msg.includes('forbidden') || msg.includes('permission')) return 'permission'
+  if (msg.includes('404') || msg.includes('not found')) return 'not-found'
+  if (msg.includes('fetch failed') || msg.includes('network') || msg.includes('failed to fetch')) return 'network'
+  return 'other'
+}
+
+function getCopy(kind: ErrorKind, reset: () => void): ErrorCopy {
+  switch (kind) {
+    case 'auth':
+      return {
+        code: '401',
+        title: 'Your session expired',
+        description: 'Sign in again to continue. Your in-flight work was not saved.',
+        primaryAction: { label: 'Sign in', href: '/login' },
+      }
+    case 'permission':
+      return {
+        code: '403',
+        title: "You don't have access to this resource",
+        description: 'Ask a workspace admin to grant access, or switch to a workspace where you are a member.',
+        primaryAction: { label: 'Go to dashboard', href: '/dashboard' },
+      }
+    case 'not-found':
+      return {
+        code: '404',
+        title: "We couldn't find that page",
+        description: 'The resource may have been deleted, or the URL is wrong.',
+        primaryAction: { label: 'Go to dashboard', href: '/dashboard' },
+      }
+    case 'network':
+      return {
+        code: 'net',
+        title: 'Connection issue',
+        description: 'We could not reach the Spanlens server. Check your network and retry.',
+        primaryAction: { label: 'Retry', onClick: reset },
+      }
+    default:
+      return {
+        code: '500',
+        title: 'Something went wrong',
+        description: 'An unexpected error occurred. Try again, or send us the digest below if it keeps happening.',
+        primaryAction: { label: 'Try again', onClick: reset },
+      }
+  }
+}
+
+export default function RouteError({
   error,
   reset,
 }: {
   error: Error & { digest?: string }
   reset: () => void
 }) {
+  const kind = classify(error)
+  const copy = getCopy(kind, reset)
+
   useEffect(() => {
-    console.error(error)
-  }, [error])
+    console.error(`[route-error:${kind}]`, error)
+    try {
+      fetch('/api/v1/frontend-errors', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        keepalive: true,
+        body: JSON.stringify({
+          scope: 'route',
+          kind,
+          message: error.message,
+          digest: error.digest,
+          stack: error.stack?.slice(0, 4000),
+          url: typeof window !== 'undefined' ? window.location.href : null,
+          userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null,
+        }),
+      }).catch(() => { /* silent */ })
+    } catch { /* silent */ }
+  }, [error, kind])
+
+  async function copyDigest(): Promise<void> {
+    if (!error.digest) return
+    try { await navigator.clipboard?.writeText(error.digest) } catch { /* silent */ }
+  }
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 px-6">
-      <p className="text-6xl font-bold text-gray-200 mb-4">500</p>
-      <h1 className="text-2xl font-bold mb-2">Something went wrong</h1>
-      <p className="text-muted-foreground mb-8">
-        An unexpected error occurred. Please try again.
-      </p>
-      <Button onClick={reset}>Try again</Button>
+    <div className="min-h-screen flex flex-col items-center justify-center px-6 bg-bg text-text">
+      <div className="max-w-md w-full">
+        <p className="text-6xl font-bold text-text-faint mb-3 leading-none">{copy.code}</p>
+        <h1 className="text-xl font-bold mb-2">{copy.title}</h1>
+        <p className="text-text-muted mb-6 text-sm leading-relaxed">{copy.description}</p>
+
+        {error.digest && (
+          <div className="mb-6">
+            <button
+              type="button"
+              onClick={copyDigest}
+              className="font-mono text-[11px] text-text-faint hover:text-text-muted transition-colors break-all"
+              title="Click to copy"
+            >
+              digest: {error.digest}
+            </button>
+          </div>
+        )}
+
+        <div className="flex gap-3">
+          {copy.primaryAction.href ? (
+            <Button asChild>
+              <a href={copy.primaryAction.href}>{copy.primaryAction.label}</a>
+            </Button>
+          ) : (
+            <Button onClick={copy.primaryAction.onClick}>{copy.primaryAction.label}</Button>
+          )}
+          {kind !== 'auth' && copy.primaryAction.href !== '/' && (
+            <Button variant="outline" asChild>
+              <a href="/">Go home</a>
+            </Button>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+/**
+ * Root catch-all for unhandled exceptions that escape app/error.tsx.
+ *
+ * Next.js calls this when the root layout itself crashes — e.g. a provider
+ * throws, a global CSS import fails, or an error escapes the route-level
+ * boundary. app/error.tsx runs inside the root layout, so it can't recover
+ * from a layout crash; this file owns its own <html>/<body> so React has
+ * something to render even when everything above blew up.
+ *
+ * The styling is intentionally inline + dependency-free. If a CSS or font
+ * import is what broke the layout, we still want to render readable text.
+ */
+
+import { useEffect } from 'react'
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error('[global-error]', error)
+    // Best-effort sink to our backend so we hear about layout crashes
+    // without waiting on a customer report. Fire-and-forget — if the
+    // endpoint itself is the thing that crashed, we just swallow.
+    try {
+      fetch('/api/v1/frontend-errors', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        keepalive: true,
+        body: JSON.stringify({
+          scope: 'global-error',
+          message: error.message,
+          digest: error.digest,
+          stack: error.stack?.slice(0, 4000),
+          url: typeof window !== 'undefined' ? window.location.href : null,
+          userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null,
+        }),
+      }).catch(() => { /* silent */ })
+    } catch { /* silent */ }
+  }, [error])
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '24px',
+          fontFamily:
+            'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial',
+          background: '#0a0a0a',
+          color: '#fafafa',
+        }}
+      >
+        <div style={{ maxWidth: 480, width: '100%' }}>
+          <p
+            style={{
+              fontSize: 72,
+              fontWeight: 700,
+              color: '#3f3f46',
+              margin: '0 0 12px',
+              lineHeight: 1,
+            }}
+          >
+            500
+          </p>
+          <h1 style={{ fontSize: 22, fontWeight: 700, margin: '0 0 8px' }}>
+            Spanlens crashed
+          </h1>
+          <p style={{ color: '#a1a1aa', margin: '0 0 24px', lineHeight: 1.5 }}>
+            Something in the app shell threw an exception before the page could
+            mount. We have been notified. Try reloading; if it keeps happening
+            send us the digest below.
+          </p>
+          {error.digest && (
+            <p
+              style={{
+                fontFamily: 'ui-monospace, "Cascadia Mono", Menlo, Consolas, monospace',
+                fontSize: 12,
+                color: '#71717a',
+                background: '#18181b',
+                border: '1px solid #27272a',
+                borderRadius: 6,
+                padding: '8px 12px',
+                margin: '0 0 24px',
+                wordBreak: 'break-all',
+              }}
+            >
+              digest: {error.digest}
+            </p>
+          )}
+          <div style={{ display: 'flex', gap: 12 }}>
+            <button
+              onClick={reset}
+              style={{
+                background: '#fafafa',
+                color: '#09090b',
+                border: 0,
+                borderRadius: 6,
+                padding: '10px 16px',
+                fontSize: 14,
+                fontWeight: 500,
+                cursor: 'pointer',
+              }}
+            >
+              Try again
+            </button>
+            <a
+              href="/"
+              style={{
+                background: 'transparent',
+                color: '#fafafa',
+                border: '1px solid #3f3f46',
+                borderRadius: 6,
+                padding: '10px 16px',
+                fontSize: 14,
+                fontWeight: 500,
+                cursor: 'pointer',
+                textDecoration: 'none',
+                display: 'inline-flex',
+                alignItems: 'center',
+              }}
+            >
+              Go home
+            </a>
+          </div>
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/apps/web/components/error-boundary.tsx
+++ b/apps/web/components/error-boundary.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+/**
+ * Granular error boundary for client subtrees.
+ *
+ * Why: Next.js's app/error.tsx only catches errors that escape a route's
+ * default error boundary. A single chart that throws on bad data
+ * (NaN, undefined row, recharts SSR drift) takes down the whole route,
+ * even when the surrounding dashboard would have rendered fine.
+ *
+ * Wrap any risky panel (chart, table, recharts subtree, third-party widget)
+ * with <ErrorBoundary> so the rest of the page survives.
+ *
+ * Usage:
+ *   <ErrorBoundary
+ *     label="cost-breakdown-chart"   // identifies the source in the sink
+ *     fallback={<ChartErrorFallback />}
+ *   >
+ *     <CostBreakdownChart />
+ *   </ErrorBoundary>
+ *
+ * Default fallback is a small "Couldn't load this section" box that fits
+ * any panel. Pass `fallback` for a more tailored skeleton.
+ */
+
+import { Component, type ReactNode, type ErrorInfo } from 'react'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  /** Stable identifier used in the error sink — pick something searchable. */
+  label: string
+  /** Custom fallback. If omitted, renders the small default panel below. */
+  fallback?: ReactNode | ((opts: { error: Error; reset: () => void }) => ReactNode)
+  /** Optional hook for the host page (e.g. to fire analytics). */
+  onError?: (error: Error, info: ErrorInfo) => void
+}
+
+interface ErrorBoundaryState {
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Always log to console so devs see it locally.
+    console.error(`[error-boundary:${this.props.label}]`, error, info)
+
+    // Pipe to the server-side sink. Fire-and-forget — if the sink itself
+    // is broken we don't want to mask the real error with a network error.
+    try {
+      fetch('/api/v1/frontend-errors', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        keepalive: true,
+        body: JSON.stringify({
+          scope: 'boundary',
+          label: this.props.label,
+          message: error.message,
+          stack: error.stack?.slice(0, 4000),
+          componentStack: info.componentStack?.slice(0, 4000),
+          url: typeof window !== 'undefined' ? window.location.href : null,
+          userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null,
+        }),
+      }).catch(() => { /* silent */ })
+    } catch { /* silent */ }
+
+    this.props.onError?.(error, info)
+  }
+
+  reset = (): void => {
+    this.setState({ error: null })
+  }
+
+  render(): ReactNode {
+    const { error } = this.state
+    if (!error) return this.props.children
+
+    if (typeof this.props.fallback === 'function') {
+      return this.props.fallback({ error, reset: this.reset })
+    }
+    if (this.props.fallback !== undefined) return this.props.fallback
+
+    return (
+      <div
+        role="alert"
+        className="rounded-md border border-border bg-bg-elev p-4 my-2 text-[12px]"
+      >
+        <p className="font-medium text-text mb-1">
+          Couldn&apos;t load this section
+        </p>
+        <p className="text-text-muted mb-3 font-mono text-[11px] break-all">
+          {error.message || 'Unexpected client-side error'}
+        </p>
+        <button
+          type="button"
+          onClick={this.reset}
+          className="font-mono text-[11px] text-accent hover:opacity-80 transition-opacity"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+}


### PR DESCRIPTION
## Summary
A single white-screen kills user trust in a dashboard product. Today a chart that throws on bad data, a session that 401s mid-render, or a layout provider that fails takes down the entire route with one generic 500 page. This PR adds a 3-layer catch-all so each of those degrades to something readable + actionable.

## What lands

### Layer 1 — \`app/global-error.tsx\` (new)
Next.js's root catch-all. Owns its own \`<html>/<body>\` so even a CSS regression or a provider explosion in \`app/layout.tsx\` still renders. Dependency-free inline styles. Auto-pings the sink so we hear about layout crashes without waiting on a customer report.

### Layer 2 — \`app/error.tsx\` (replaced)
Was: single generic "500 Something went wrong".
Now: classifies into 5 shapes (auth/permission/not-found/network/other) and renders matching code + title + primary action. Click-to-copy error digest for support tickets.

| Kind | Code | Title | Primary action |
|---|---|---|---|
| auth | 401 | Your session expired | Sign in |
| permission | 403 | You don't have access to this resource | Go to dashboard |
| not-found | 404 | We couldn't find that page | Go to dashboard |
| network | net | Connection issue | Retry |
| other | 500 | Something went wrong | Try again |

### Layer 3 — \`<ErrorBoundary>\` reusable component (new)
Class component with \`fallback\` prop. Pings the sink with a stable \`label\` for grep. Wired into the 5 riskiest existing surfaces:

| Location | Label |
|---|---|
| dashboard | \`dashboard:token-trends\` |
| dashboard | \`dashboard:error-distribution\` |
| dashboard | \`dashboard:cost-breakdown\` |
| /traces/[id] | \`traces:waterfall\` |
| /requests | \`requests:table\` |

### Sink — \`POST /api/v1/frontend-errors\` (new)
Public (no auth) so the login screen and \`/share\` viewer can report too. Per-IP rate limited by the existing /api/v1/* group. Writes one structured JSON line per event to Vercel runtime logs — grep-friendly via \`vercel logs\`. A dedicated CH table can come later once dedup + sourcemap patterns are clearer.

## Test plan
- [x] pnpm --filter web typecheck + lint
- [x] pnpm --filter server typecheck + lint
- [x] pnpm --filter server test (1061 passed)
- [x] pnpm --filter web test (57 passed)
- [x] pnpm --filter web build
- [x] Local: \`curl -X POST localhost:3001/api/v1/frontend-errors\` → 204
- [ ] After deploy: throw inside CostBreakdownCard temporarily → page renders, only that card shows the fallback, sink endpoint receives the POST
- [ ] After deploy: hit a 401 page → error.tsx shows "Sign in" not "Try again"