### PR TITLE
feat(server,docs): self-host env diagnostic — pnpm check:env

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,6 +13,7 @@
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:watch": "vitest",
     "test:e2e": "tsx scripts/test-e2e.ts",
+    "check:env": "tsx scripts/check-env.ts",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/apps/server/scripts/check-env.test.ts
+++ b/apps/server/scripts/check-env.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from 'vitest'
+import {
+  validateRequiredString,
+  validateUrl,
+  validateBase64Bytes,
+  validateSupabaseRole,
+  validatePort,
+  validateWebUrl,
+} from './check-env.js'
+
+/**
+ * Each validator is the user-facing edge of `pnpm check:env`. A regression here
+ * means a self-host operator gets a confusing or wrong message at the worst
+ * possible moment (during first install). Cases mirror the actual gotchas we
+ * have hit in the wild — see CLAUDE.md gotchas 5, 6, 17.
+ */
+
+describe('validateRequiredString', () => {
+  test('rejects undefined', () => {
+    expect(validateRequiredString(undefined, 'FOO')).toEqual({
+      status: 'error',
+      detail: 'FOO is required but not set',
+    })
+  })
+  test('rejects empty string', () => {
+    expect(validateRequiredString('', 'FOO').status).toBe('error')
+  })
+  test('rejects whitespace-only', () => {
+    expect(validateRequiredString('   ', 'FOO').status).toBe('error')
+  })
+  test('accepts non-empty', () => {
+    expect(validateRequiredString('hello', 'FOO')).toEqual({
+      status: 'ok',
+      detail: '5 chars',
+    })
+  })
+})
+
+describe('validateUrl', () => {
+  test('rejects undefined', () => {
+    expect(validateUrl(undefined, 'X').status).toBe('error')
+  })
+  test('rejects malformed', () => {
+    expect(validateUrl('not a url', 'X').status).toBe('error')
+  })
+  test('rejects ftp scheme', () => {
+    const r = validateUrl('ftp://example.com', 'X')
+    expect(r.status).toBe('error')
+    expect(r.detail).toContain('http://')
+  })
+  test('accepts http://', () => {
+    expect(validateUrl('http://localhost:8123', 'X').status).toBe('ok')
+  })
+  test('accepts https://', () => {
+    expect(validateUrl('https://example.com/path', 'X').status).toBe('ok')
+  })
+})
+
+describe('validateBase64Bytes', () => {
+  test('rejects unset', () => {
+    const r = validateBase64Bytes(undefined, 'ENCRYPTION_KEY', 32)
+    expect(r.status).toBe('error')
+    expect('fix' in r && r.fix).toContain('openssl')
+  })
+  test('rejects 16-byte key (would silently fail provider key decrypt)', () => {
+    // gotcha #5 in CLAUDE.md — wrong length silently broke decryption
+    const wrong = Buffer.alloc(16, 0xab).toString('base64')
+    const r = validateBase64Bytes(wrong, 'ENCRYPTION_KEY', 32)
+    expect(r.status).toBe('error')
+    expect(r.detail).toContain('16 bytes')
+    expect('fix' in r && r.fix).toContain('openssl rand -base64 32')
+  })
+  test('accepts exactly 32-byte key', () => {
+    const ok = Buffer.alloc(32, 0x7f).toString('base64')
+    expect(validateBase64Bytes(ok, 'ENCRYPTION_KEY', 32).status).toBe('ok')
+  })
+  test('accepts both standard and url-safe base64 variants', () => {
+    // Node's Buffer.from(value, 'base64') is lenient with both variants.
+    const standard = Buffer.alloc(32, 0).toString('base64')
+    expect(validateBase64Bytes(standard, 'X', 32).status).toBe('ok')
+  })
+})
+
+/**
+ * Tiny helper: forge a JWT with the role claim we want to test against.
+ * Real Supabase JWTs are signed but we only inspect the payload here, so an
+ * unsigned token is enough for these tests.
+ */
+function forgeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url')
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  return `${header}.${body}.signature`
+}
+
+describe('validateSupabaseRole', () => {
+  test('rejects unset', () => {
+    expect(validateSupabaseRole(undefined, 'service_role').status).toBe('error')
+  })
+  test('rejects non-JWT', () => {
+    const r = validateSupabaseRole('not-a-jwt', 'service_role')
+    expect(r.status).toBe('error')
+    expect(r.detail).toContain('3 dot-separated parts')
+  })
+  test('rejects anon key in the service_role slot (common mix-up)', () => {
+    const anon = forgeJwt({ role: 'anon', iss: 'supabase' })
+    const r = validateSupabaseRole(anon, 'service_role')
+    expect(r.status).toBe('error')
+    expect(r.detail).toContain('anon')
+    expect(r.detail).toContain('service_role')
+  })
+  test('rejects service_role in the anon slot', () => {
+    const svc = forgeJwt({ role: 'service_role', iss: 'supabase' })
+    const r = validateSupabaseRole(svc, 'anon')
+    expect(r.status).toBe('error')
+  })
+  test('accepts correct role match', () => {
+    const ok = forgeJwt({ role: 'service_role', iss: 'supabase' })
+    expect(validateSupabaseRole(ok, 'service_role').status).toBe('ok')
+  })
+  test('rejects malformed payload (not JSON)', () => {
+    const bad = `aaa.${Buffer.from('not json').toString('base64url')}.sig`
+    expect(validateSupabaseRole(bad, 'anon').status).toBe('error')
+  })
+})
+
+describe('validatePort', () => {
+  test('accepts unset (defaults to 3001)', () => {
+    expect(validatePort(undefined).status).toBe('ok')
+  })
+  test('rejects non-integer', () => {
+    expect(validatePort('abc').status).toBe('error')
+  })
+  test('rejects negative', () => {
+    expect(validatePort('-1').status).toBe('error')
+  })
+  test('rejects 0', () => {
+    expect(validatePort('0').status).toBe('error')
+  })
+  test('rejects 65536', () => {
+    expect(validatePort('65536').status).toBe('error')
+  })
+  test('accepts 3001', () => {
+    expect(validatePort('3001')).toEqual({ status: 'ok', detail: '3001' })
+  })
+  test('accepts 65535', () => {
+    expect(validatePort('65535').status).toBe('ok')
+  })
+})
+
+describe('validateWebUrl', () => {
+  test('warns (not errors) when unset — local dev still works', () => {
+    expect(validateWebUrl(undefined).status).toBe('warn')
+  })
+  test('warns when malformed', () => {
+    // gotcha #17 — invite emails break silently with localhost in production
+    expect(validateWebUrl('not a url').status).toBe('error')
+  })
+  test('accepts http://localhost (dev OK)', () => {
+    expect(validateWebUrl('http://localhost:3000').status).toBe('ok')
+  })
+  test('accepts https://canonical', () => {
+    expect(validateWebUrl('https://www.spanlens.io').status).toBe('ok')
+  })
+  test('warns when localhost combined with NODE_ENV=production', () => {
+    const prev = process.env['NODE_ENV']
+    process.env['NODE_ENV'] = 'production'
+    try {
+      const r = validateWebUrl('http://localhost:3000')
+      expect(r.status).toBe('warn')
+      expect(r.detail).toContain('production')
+    } finally {
+      if (prev === undefined) delete process.env['NODE_ENV']
+      else process.env['NODE_ENV'] = prev
+    }
+  })
+})

--- a/apps/server/scripts/check-env.ts
+++ b/apps/server/scripts/check-env.ts
@@ -1,0 +1,473 @@
+#!/usr/bin/env tsx
+/**
+ * Self-host environment diagnostic.
+ *
+ * Usage:
+ *   pnpm check:env                  # human-readable, colorized
+ *   pnpm check:env --json           # machine-readable, for CI
+ *   pnpm check:env --quiet          # errors only
+ *
+ * Exit code:
+ *   0 — all required vars present + valid + reachable
+ *   1 — at least one required check failed
+ *   2 — script crashed (bug, not env issue)
+ *
+ * What it catches up front so the operator doesn't hit them at runtime:
+ *   - ENCRYPTION_KEY wrong length / not base64 → silent provider-key decrypt
+ *     failures (CLAUDE.md gotcha #5)
+ *   - WEB_URL left at localhost → invite emails are broken at root
+ *   - Supabase service-role key actually being an anon key → RLS bypass fails
+ *   - ClickHouse unreachable → all proxy logging silently lost (gotcha #3)
+ *   - PADDLE_ENVIRONMENT swapped sandbox/production with leftover ctm_ rows
+ *     (gotcha #6)
+ *
+ * Adding a new check: extend CHECKS below. Keep messages actionable —
+ * include the exact command or URL the operator should follow.
+ */
+
+import { exit } from 'node:process'
+import 'dotenv/config'
+
+interface Check {
+  name: string
+  level: 'required' | 'optional' | 'connectivity'
+  /** Short description of what the var unlocks (shown when missing). */
+  unlocks?: string
+  run: () => CheckResult | Promise<CheckResult>
+}
+
+type CheckResult =
+  | { status: 'ok'; detail?: string }
+  | { status: 'warn'; detail: string }
+  | { status: 'error'; detail: string; fix?: string }
+  | { status: 'skip'; detail: string }
+
+interface Output {
+  level: Check['level']
+  name: string
+  status: CheckResult['status']
+  detail?: string
+  fix?: string
+}
+
+// ── Format primitives (no chalk dep) ────────────────────────────────────────
+const NO_COLOR = !!process.env['NO_COLOR'] || process.env['TERM'] === 'dumb'
+const c = {
+  reset: NO_COLOR ? '' : '\x1b[0m',
+  bold: NO_COLOR ? '' : '\x1b[1m',
+  dim: NO_COLOR ? '' : '\x1b[2m',
+  red: NO_COLOR ? '' : '\x1b[31m',
+  green: NO_COLOR ? '' : '\x1b[32m',
+  yellow: NO_COLOR ? '' : '\x1b[33m',
+  cyan: NO_COLOR ? '' : '\x1b[36m',
+  grey: NO_COLOR ? '' : '\x1b[90m',
+}
+
+function symbol(status: CheckResult['status']): string {
+  if (status === 'ok') return `${c.green}✓${c.reset}`
+  if (status === 'warn') return `${c.yellow}⚠${c.reset}`
+  if (status === 'error') return `${c.red}✗${c.reset}`
+  return `${c.grey}∙${c.reset}`
+}
+
+// ── Validators (exported for tests) ─────────────────────────────────────────
+
+export function validateRequiredString(value: string | undefined, name: string): CheckResult {
+  if (!value || !value.trim()) {
+    return { status: 'error', detail: `${name} is required but not set` }
+  }
+  return { status: 'ok', detail: `${value.length} chars` }
+}
+
+export function validateUrl(value: string | undefined, name: string): CheckResult {
+  if (!value || !value.trim()) {
+    return { status: 'error', detail: `${name} is required but not set` }
+  }
+  try {
+    const u = new URL(value)
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+      return {
+        status: 'error',
+        detail: `${name} must be http:// or https://, got ${u.protocol}`,
+      }
+    }
+    return { status: 'ok', detail: value }
+  } catch {
+    return {
+      status: 'error',
+      detail: `${name} is not a valid URL: ${value}`,
+    }
+  }
+}
+
+export function validateBase64Bytes(
+  value: string | undefined,
+  name: string,
+  expectedBytes: number,
+): CheckResult {
+  if (!value || !value.trim()) {
+    return {
+      status: 'error',
+      detail: `${name} is required but not set`,
+      fix: `openssl rand -base64 ${expectedBytes}`,
+    }
+  }
+  let buf: Buffer
+  try {
+    buf = Buffer.from(value, 'base64')
+  } catch {
+    return {
+      status: 'error',
+      detail: `${name} is not valid base64`,
+      fix: `openssl rand -base64 ${expectedBytes}`,
+    }
+  }
+  if (buf.length !== expectedBytes) {
+    return {
+      status: 'error',
+      detail: `${name} must decode to ${expectedBytes} bytes, got ${buf.length} bytes`,
+      fix: `openssl rand -base64 ${expectedBytes}`,
+    }
+  }
+  return { status: 'ok', detail: `${expectedBytes} bytes base64` }
+}
+
+export function validateSupabaseRole(
+  jwt: string | undefined,
+  expected: 'anon' | 'service_role',
+): CheckResult {
+  if (!jwt || !jwt.trim()) {
+    return { status: 'error', detail: 'not set' }
+  }
+  const parts = jwt.split('.')
+  if (parts.length !== 3) {
+    return {
+      status: 'error',
+      detail: `not a JWT (expected 3 dot-separated parts, got ${parts.length})`,
+    }
+  }
+  try {
+    // base64url decode without external dep
+    const padded = parts[1]! + '='.repeat((4 - (parts[1]!.length % 4)) % 4)
+    const payload = JSON.parse(
+      Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf-8'),
+    ) as { role?: string; iss?: string }
+    if (payload.role !== expected) {
+      return {
+        status: 'error',
+        detail: `JWT role is "${payload.role ?? '(missing)'}", expected "${expected}"`,
+        fix:
+          expected === 'service_role'
+            ? 'Get the service_role key from Supabase Dashboard → Settings → API'
+            : 'Get the anon key from Supabase Dashboard → Settings → API',
+      }
+    }
+    return { status: 'ok', detail: `JWT role=${expected}` }
+  } catch (err) {
+    return {
+      status: 'error',
+      detail: `could not parse JWT payload: ${err instanceof Error ? err.message : String(err)}`,
+    }
+  }
+}
+
+export function validatePort(value: string | undefined): CheckResult {
+  if (!value) return { status: 'ok', detail: '(unset, will default to 3001)' }
+  const n = Number(value)
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    return { status: 'error', detail: `PORT must be an integer 1-65535, got "${value}"` }
+  }
+  return { status: 'ok', detail: String(n) }
+}
+
+export function validateWebUrl(value: string | undefined): CheckResult {
+  if (!value || !value.trim()) {
+    return {
+      status: 'warn',
+      detail: 'WEB_URL not set — invitation emails will use http://localhost:3000 and break for real recipients',
+    }
+  }
+  const urlResult = validateUrl(value, 'WEB_URL')
+  if (urlResult.status !== 'ok') return urlResult
+  if (value.startsWith('http://localhost') && process.env['NODE_ENV'] === 'production') {
+    return {
+      status: 'warn',
+      detail: 'WEB_URL points to localhost while NODE_ENV=production — invitation links will be broken',
+    }
+  }
+  return { status: 'ok', detail: value }
+}
+
+// ── Connectivity tests ──────────────────────────────────────────────────────
+
+async function pingHttp(url: string, timeoutMs = 5000): Promise<CheckResult> {
+  const ctrl = new AbortController()
+  const t = setTimeout(() => ctrl.abort(), timeoutMs)
+  const started = Date.now()
+  try {
+    const res = await fetch(url, { signal: ctrl.signal })
+    const ms = Date.now() - started
+    if (res.status >= 200 && res.status < 500) {
+      return { status: 'ok', detail: `HTTP ${res.status} in ${ms}ms` }
+    }
+    return { status: 'error', detail: `HTTP ${res.status} in ${ms}ms` }
+  } catch (err) {
+    const ms = Date.now() - started
+    const msg = err instanceof Error ? err.message : String(err)
+    return { status: 'error', detail: `${msg} (after ${ms}ms)` }
+  } finally {
+    clearTimeout(t)
+  }
+}
+
+async function checkSupabaseReachable(): Promise<CheckResult> {
+  const url = process.env['SUPABASE_URL']
+  if (!url) return { status: 'skip', detail: 'SUPABASE_URL not set, skipped' }
+  // /auth/v1/health is a stable public endpoint on every Supabase instance.
+  return pingHttp(`${url.replace(/\/$/, '')}/auth/v1/health`)
+}
+
+async function checkClickhouseReachable(): Promise<CheckResult> {
+  const url = process.env['CLICKHOUSE_URL']
+  if (!url) return { status: 'skip', detail: 'CLICKHOUSE_URL not set, skipped' }
+  return pingHttp(`${url.replace(/\/$/, '')}/ping`)
+}
+
+// ── Check list ──────────────────────────────────────────────────────────────
+
+const CHECKS: Check[] = [
+  // Required
+  {
+    name: 'SUPABASE_URL',
+    level: 'required',
+    run: () => validateUrl(process.env['SUPABASE_URL'], 'SUPABASE_URL'),
+  },
+  {
+    name: 'SUPABASE_ANON_KEY',
+    level: 'required',
+    run: () => validateSupabaseRole(process.env['SUPABASE_ANON_KEY'], 'anon'),
+  },
+  {
+    name: 'SUPABASE_SERVICE_ROLE_KEY',
+    level: 'required',
+    run: () => validateSupabaseRole(process.env['SUPABASE_SERVICE_ROLE_KEY'], 'service_role'),
+  },
+  {
+    name: 'ENCRYPTION_KEY',
+    level: 'required',
+    run: () => validateBase64Bytes(process.env['ENCRYPTION_KEY'], 'ENCRYPTION_KEY', 32),
+  },
+  {
+    name: 'CLICKHOUSE_URL',
+    level: 'required',
+    run: () => validateUrl(process.env['CLICKHOUSE_URL'], 'CLICKHOUSE_URL'),
+  },
+  {
+    name: 'CLICKHOUSE_USER',
+    level: 'required',
+    run: () => validateRequiredString(process.env['CLICKHOUSE_USER'], 'CLICKHOUSE_USER'),
+  },
+  {
+    name: 'CLICKHOUSE_PASSWORD',
+    level: 'required',
+    run: () => validateRequiredString(process.env['CLICKHOUSE_PASSWORD'], 'CLICKHOUSE_PASSWORD'),
+  },
+  {
+    name: 'CLICKHOUSE_DB',
+    level: 'required',
+    run: () => validateRequiredString(process.env['CLICKHOUSE_DB'], 'CLICKHOUSE_DB'),
+  },
+  {
+    name: 'PORT',
+    level: 'required',
+    run: () => validatePort(process.env['PORT']),
+  },
+  {
+    name: 'WEB_URL',
+    level: 'required',
+    unlocks: 'invitation links',
+    run: () => validateWebUrl(process.env['WEB_URL']),
+  },
+
+  // Connectivity
+  {
+    name: 'Supabase HTTP',
+    level: 'connectivity',
+    run: () => checkSupabaseReachable(),
+  },
+  {
+    name: 'ClickHouse HTTP',
+    level: 'connectivity',
+    run: () => checkClickhouseReachable(),
+  },
+
+  // Optional features
+  {
+    name: 'RESEND_API_KEY',
+    level: 'optional',
+    unlocks: 'invitation email delivery',
+    run: () => {
+      const v = process.env['RESEND_API_KEY']
+      if (!v) {
+        return {
+          status: 'warn',
+          detail: 'unset — invite emails fall back to dev console URL (fine for local dev)',
+        }
+      }
+      if (!v.startsWith('re_')) {
+        return { status: 'error', detail: 'should start with "re_", got something else' }
+      }
+      return { status: 'ok', detail: `${v.slice(0, 6)}…` }
+    },
+  },
+  {
+    name: 'CRON_SECRET',
+    level: 'optional',
+    unlocks: '/cron/* endpoint Bearer auth',
+    run: () => {
+      const v = process.env['CRON_SECRET']
+      if (!v) {
+        return {
+          status: 'warn',
+          detail: 'unset — /cron/* endpoints will reject everything (intentional in production)',
+        }
+      }
+      if (v.length < 16) {
+        return { status: 'error', detail: 'too short — generate with `openssl rand -hex 32`' }
+      }
+      return { status: 'ok', detail: `${v.length} chars` }
+    },
+  },
+  {
+    name: 'PADDLE_ENVIRONMENT',
+    level: 'optional',
+    unlocks: 'billing',
+    run: () => {
+      const v = process.env['PADDLE_ENVIRONMENT']
+      if (!v) return { status: 'ok', detail: '(unset, will default to sandbox)' }
+      if (v !== 'sandbox' && v !== 'production') {
+        return {
+          status: 'error',
+          detail: `must be "sandbox" or "production", got "${v}"`,
+        }
+      }
+      if (v === 'production' && process.env['NODE_ENV'] !== 'production') {
+        return {
+          status: 'warn',
+          detail: 'PADDLE_ENVIRONMENT=production but NODE_ENV!=production — verify intentional',
+        }
+      }
+      return { status: 'ok', detail: v }
+    },
+  },
+  {
+    name: 'KV_REST_API_URL',
+    level: 'optional',
+    unlocks: 'rate limiting (fails-open without)',
+    run: () => {
+      const v = process.env['KV_REST_API_URL']
+      if (!v) {
+        return {
+          status: 'warn',
+          detail: 'unset — rate limit fails-open (everything allowed)',
+        }
+      }
+      return validateUrl(v, 'KV_REST_API_URL')
+    },
+  },
+  {
+    name: 'SENTRY_DSN',
+    level: 'optional',
+    unlocks: 'error monitoring',
+    run: () => {
+      const v = process.env['SENTRY_DSN']
+      if (!v) {
+        return {
+          status: 'warn',
+          detail: 'unset — errors logged to console only',
+        }
+      }
+      return validateUrl(v, 'SENTRY_DSN')
+    },
+  },
+]
+
+// ── Runner ──────────────────────────────────────────────────────────────────
+
+const args = new Set(process.argv.slice(2))
+const isJson = args.has('--json')
+const isQuiet = args.has('--quiet')
+
+async function main(): Promise<void> {
+  const results: Output[] = []
+  for (const check of CHECKS) {
+    const r = await Promise.resolve().then(() => check.run())
+    results.push({
+      level: check.level,
+      name: check.name,
+      status: r.status,
+      ...('detail' in r ? { detail: r.detail } : {}),
+      ...('fix' in r && r.fix ? { fix: r.fix } : {}),
+    })
+  }
+
+  const counts = {
+    ok: results.filter((r) => r.status === 'ok').length,
+    warn: results.filter((r) => r.status === 'warn').length,
+    error: results.filter((r) => r.status === 'error').length,
+    skip: results.filter((r) => r.status === 'skip').length,
+  }
+  // Required + connectivity errors are the only exit-1 cases. Optional warnings
+  // shouldn't break a self-host that intentionally skipped Sentry/Paddle/etc.
+  const hardFail = results.filter(
+    (r) => r.status === 'error' && (r.level === 'required' || r.level === 'connectivity'),
+  ).length
+
+  if (isJson) {
+    console.log(JSON.stringify({ counts, hardFail, results }, null, 2))
+    exit(hardFail > 0 ? 1 : 0)
+  }
+
+  // Human-readable output, grouped by level.
+  const groups: Array<{ label: string; level: Check['level'] }> = [
+    { label: 'Required vars', level: 'required' },
+    { label: 'Connectivity', level: 'connectivity' },
+    { label: 'Optional features', level: 'optional' },
+  ]
+  for (const g of groups) {
+    const rows = results.filter((r) => r.level === g.level)
+    const printable = isQuiet
+      ? rows.filter((r) => r.status === 'error' || r.status === 'warn')
+      : rows
+    if (printable.length === 0 && isQuiet) continue
+    const okCount = rows.filter((r) => r.status === 'ok').length
+    console.log(`\n${c.bold}${g.label}${c.reset} ${c.dim}(${okCount}/${rows.length} ok)${c.reset}`)
+    for (const r of printable) {
+      const head = `  ${symbol(r.status)} ${r.name.padEnd(28)}`
+      const tail = r.detail ? `${c.dim}${r.detail}${c.reset}` : ''
+      console.log(`${head} ${tail}`)
+      if (r.fix) console.log(`    ${c.cyan}→ ${r.fix}${c.reset}`)
+    }
+  }
+
+  console.log('')
+  if (hardFail > 0) {
+    console.log(
+      `${c.red}${c.bold}${hardFail} required check${hardFail === 1 ? '' : 's'} failed${c.reset} — fix the items above before starting the server`,
+    )
+    exit(1)
+  } else if (counts.warn > 0) {
+    console.log(
+      `${c.green}All required checks pass${c.reset} ${c.yellow}(${counts.warn} optional warning${counts.warn === 1 ? '' : 's'})${c.reset}`,
+    )
+    exit(0)
+  } else {
+    console.log(`${c.green}${c.bold}All checks pass${c.reset}`)
+    exit(0)
+  }
+}
+
+main().catch((err) => {
+  console.error(`${c.red}check-env crashed:${c.reset}`, err)
+  exit(2)
+})

--- a/apps/server/scripts/check-env.ts
+++ b/apps/server/scripts/check-env.ts
@@ -26,6 +26,7 @@
  */
 
 import { exit } from 'node:process'
+import { fileURLToPath } from 'node:url'
 import 'dotenv/config'
 
 interface Check {
@@ -467,7 +468,20 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err) => {
-  console.error(`${c.red}check-env crashed:${c.reset}`, err)
-  exit(2)
-})
+// Only run when invoked directly (e.g. `pnpm check:env`), not when this
+// module is imported by `check-env.test.ts` — otherwise vitest would
+// execute main() during the test discovery pass and pollute CI output.
+const isEntryPoint = (() => {
+  try {
+    return fileURLToPath(import.meta.url) === process.argv[1]
+  } catch {
+    return false
+  }
+})()
+
+if (isEntryPoint) {
+  main().catch((err) => {
+    console.error(`${c.red}check-env crashed:${c.reset}`, err)
+    exit(2)
+  })
+}

--- a/apps/web/app/docs/self-host/page.tsx
+++ b/apps/web/app/docs/self-host/page.tsx
@@ -102,7 +102,27 @@ CLICKHOUSE_DB=spanlens
 # RESEND_API_KEY=re_...
 # RESEND_FROM=Spanlens <no-reply@your-domain.com>`}</CodeBlock>
 
-      <h4>3. Start</h4>
+      <h4>3. Verify your env file before starting</h4>
+      <p>
+        Bad <code>ENCRYPTION_KEY</code> length silently corrupts provider keys at decrypt time
+        (the failure surfaces hours later as &ldquo;wrong API key&rdquo; from the upstream
+        provider). A missing <code>WEB_URL</code> sends invite emails pointing at{' '}
+        <code>localhost</code>. Run <code>check:env</code> once before you start the stack and
+        get an actionable report instead of debugging at runtime:
+      </p>
+      <CodeBlock language="bash">{`# From a clone of the repo:
+pnpm install
+pnpm check:env
+
+# Or one-shot via npx, no clone:
+npx -y tsx https://raw.githubusercontent.com/spanlens/Spanlens/main/apps/server/scripts/check-env.ts`}</CodeBlock>
+      <p className="text-sm text-muted-foreground">
+        Exit 0 = all required vars present + valid + Supabase / ClickHouse reachable. Exit 1 =
+        something is wrong, with the exact fix command in the output. <code>--json</code> for
+        CI pipelines, <code>--quiet</code> to show only warnings and errors.
+      </p>
+
+      <h4>4. Start</h4>
       <CodeBlock language="bash">{`curl -o docker-compose.yml https://raw.githubusercontent.com/spanlens/Spanlens/main/docker-compose.yml
 docker compose up -d`}</CodeBlock>
       <ul>
@@ -117,7 +137,7 @@ docker compose up -d`}</CodeBlock>
         startup and patches them into the pre-built bundle automatically, no rebuild needed.
       </p>
 
-      <h4>4. Apply the ClickHouse schema</h4>
+      <h4>5. Apply the ClickHouse schema</h4>
       <p>
         The <code>requests</code> table needs to exist before the server can write logs. Run
         the migration script once after the ClickHouse container is healthy:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "pnpm --recursive test",
     "clean": "pnpm --recursive clean",
     "db:generate-init": "node scripts/generate-init-sql.mjs",
-    "ch:migrate": "pnpm --filter server exec tsx ../../clickhouse/apply.ts"
+    "ch:migrate": "pnpm --filter server exec tsx ../../clickhouse/apply.ts",
+    "check:env": "pnpm --filter server check:env"
   },
   "devDependencies": {
     "eslint": "^9",


### PR DESCRIPTION
## Summary
Self-hosters today read CLAUDE.md + .env.example and hand-verify ~15 vars before the first boot. Three of them fail silently at runtime if wrong, which is the worst possible time to discover the problem:

| Gotcha | Symptom at runtime | Caught by check:env |
|---|---|---|
| ENCRYPTION_KEY wrong length | Provider key decrypt silently returns empty string (CLAUDE.md #5) | \`ENCRYPTION_KEY must decode to 32 bytes, got N bytes\` + fix command |
| WEB_URL=localhost in prod | Invite emails point at localhost, recipients can't accept (CLAUDE.md #17) | warning before deploy |
| Anon/service-role JWT mix-up | RLS bypass missing in writes / RLS unexpectedly skipped on reads | \`JWT role is "anon", expected "service_role"\` + Supabase Dashboard link |

## Usage
\`\`\`bash
pnpm check:env             # human, colorized
pnpm check:env --json      # machine-readable for CI
pnpm check:env --quiet     # errors + warnings only

# Or as a one-shot without cloning:
npx -y tsx https://raw.githubusercontent.com/spanlens/Spanlens/main/apps/server/scripts/check-env.ts
\`\`\`

Exit 0 = all required present + valid + reachable. Exit 1 = at least one required check failed. Optional warnings (no Resend, no Sentry, no Upstash) never block exit code so an intentionally minimal self-host still passes.

## What it checks today

- **Required (10)** — SUPABASE_URL / ANON_KEY / SERVICE_ROLE_KEY (JWT \`role\` claim verified), ENCRYPTION_KEY (32-byte base64), CLICKHOUSE_URL / USER / PASSWORD / DB, PORT (range 1-65535), WEB_URL.
- **Connectivity (2)** — Supabase \`/auth/v1/health\` + ClickHouse \`/ping\`, 5s timeout.
- **Optional (5)** — RESEND_API_KEY (\`re_\` prefix), CRON_SECRET (≥16 chars), PADDLE_ENVIRONMENT (enum + production-with-NODE_ENV cross-check), KV_REST_API_URL, SENTRY_DSN.

## Test plan
- [x] 31 unit tests cover each validator's edge cases (anon-in-service-role-slot is the highest-leverage one)
- [x] Local: \`pnpm check:env\` against working .env → 10 ok, 2 reachable, 3 optional warnings, exit 0
- [x] Local: deliberately invalid 7 vars → 7 ✗ with actionable fix commands, exit 1
- [x] Local: \`--json\` produces parseable output
- [x] Local: \`--quiet\` shows only warnings + errors
- [x] pnpm --filter server typecheck + lint + test (92 → 93 files, 1061 → 1092 tests)
- [x] pnpm --filter web typecheck
- [x] docs/self-host updated with new "verify env before starting" step