### PR TITLE
feat(sdk): Python onboarding CLI (spanlens init)

### DIFF
--- a/apps/web/app/docs/cli/page.tsx
+++ b/apps/web/app/docs/cli/page.tsx
@@ -4,7 +4,7 @@ import { CodeBlock } from '../_components/code-block'
 export const metadata = {
   title: 'Spanlens CLI · Spanlens Docs',
   description:
-    'One-command setup wizard for Spanlens. Auto-detects OpenAI, Anthropic, and Gemini SDK calls in your codebase and routes them through the proxy.',
+    'One-command setup wizard for Spanlens, in both Node (npx @spanlens/cli) and Python (spanlens init). Auto-detects OpenAI, Anthropic, and Gemini SDK calls and routes them through the proxy.',
   alternates: { canonical: '/docs/cli' },
 }
 
@@ -64,6 +64,55 @@ const GEMINI_DIFF = `- import { GoogleGenerativeAI } from '@google/generative-ai
 const DRY_RUN_CMD = `npx @spanlens/cli init --dry-run`
 const SELF_HOST_CMD = `npx @spanlens/cli init --server-url https://spanlens.yourcompany.com`
 
+const PY_INSTALL_CMD = `pip install spanlens
+spanlens init`
+
+const PY_WIZARD_OUTPUT = `🔭  Spanlens setup
+
+  Detected pip project · uses openai, anthropic
+
+  Before continuing, make sure you have:
+    1. A Spanlens account at https://www.spanlens.io
+    2. A Project at https://www.spanlens.io/projects
+    3. Provider keys (OpenAI / Anthropic / Gemini) added to that project
+    4. A Spanlens key issued for that project (sl_live_...)
+
+  ? Paste your Spanlens key > sl_live_*************
+
+  Key valid · project chatbot-prod · providers: openai, anthropic
+  Created .env with SPANLENS_API_KEY
+  Installed (pip install spanlens[anthropic,openai])
+
+  Found 2 patches to apply
+    • [openai] app/agent.py
+        → import: from openai → from spanlens.integrations.openai import create_openai
+        → 1 × constructor → create_openai(...)
+    • [anthropic] app/summarize.py
+        → 1 × constructor → create_anthropic(...)
+
+  ? Apply these changes? > yes
+  Patched 2 file(s)
+
+🎉 Spanlens setup complete`
+
+const PY_OPENAI_DIFF = `- from openai import OpenAI
+- client = OpenAI(api_key=os.environ["OPENAI_API_KEY"], timeout=30)
++ from spanlens.integrations.openai import create_openai
++ client = create_openai(timeout=30)`
+
+const PY_ANTHROPIC_DIFF = `- from anthropic import Anthropic
+- client = Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
++ from spanlens.integrations.anthropic import create_anthropic
++ client = create_anthropic()`
+
+const PY_GEMINI_DIFF = `  import google.generativeai as genai
+- genai.configure(api_key=os.environ["GEMINI_API_KEY"])
++ from spanlens.integrations.gemini import configure_gemini
++ configure_gemini()`
+
+const PY_DRY_RUN_CMD = `spanlens init --dry-run`
+const PY_TEST_CMD = `spanlens test`
+
 const MANUAL_SNIPPET = `import { createOpenAI }    from '@spanlens/sdk/openai'
 import { createAnthropic } from '@spanlens/sdk/anthropic'
 import { createGemini }    from '@spanlens/sdk/gemini'
@@ -91,6 +140,15 @@ export default function CliDocs() {
           If the wizard does not fit your stack, skip it and use the{' '}
           <Link href="/docs/sdk" className="underline">@spanlens/sdk</Link>{' '}
           factories directly. Same end result, same proxy, same dashboard.
+        </p>
+      </div>
+
+      <div className="my-6 rounded-lg border-l-4 border-accent bg-accent-bg p-4 text-sm">
+        <p className="m-0 font-semibold text-accent">Working in Python?</p>
+        <p className="mt-1 mb-0 text-accent">
+          The same wizard ships with the Python SDK. Run{' '}
+          <code>pip install spanlens &amp;&amp; spanlens init</code> and jump to the{' '}
+          <Link href="#python" className="underline">Python CLI</Link> section below.
         </p>
       </div>
 
@@ -133,6 +191,51 @@ export default function CliDocs() {
       <CodeBlock language="diff">{ANTHROPIC_DIFF}</CodeBlock>
       <h3>Gemini</h3>
       <CodeBlock language="diff">{GEMINI_DIFF}</CodeBlock>
+
+      <h2 id="python">Python CLI</h2>
+      <p>
+        The Python SDK ships the same wizard as a console command. There is no
+        separate package to install: <code>pip install spanlens</code> gives you
+        both the SDK and the <code>spanlens</code> command. It uses only the
+        standard library plus <code>httpx</code>, so it adds no weight to your
+        environment.
+      </p>
+      <CodeBlock language="bash">{PY_INSTALL_CMD}</CodeBlock>
+      <p>
+        It detects your package manager (<code>poetry</code>, <code>uv</code>,{' '}
+        <code>pipenv</code>, or <code>pip</code>), reads which provider libraries
+        you already declare, validates your key, writes <code>.env</code>, and
+        rewrites your client construction. A real run looks like this:
+      </p>
+      <CodeBlock language="bash">{PY_WIZARD_OUTPUT}</CodeBlock>
+      <p>
+        Every patched file is re-parsed before it is written, so the wizard never
+        leaves you with code that will not import. Here is what each provider
+        rewrite looks like:
+      </p>
+      <h3>OpenAI (Python)</h3>
+      <CodeBlock language="diff">{PY_OPENAI_DIFF}</CodeBlock>
+      <h3>Anthropic (Python)</h3>
+      <CodeBlock language="diff">{PY_ANTHROPIC_DIFF}</CodeBlock>
+      <h3>Gemini (Python)</h3>
+      <p>
+        Gemini uses module-level configuration in Python, so the wizard rewrites
+        the <code>genai.configure(...)</code> call and keeps your{' '}
+        <code>GenerativeModel</code> usage untouched:
+      </p>
+      <CodeBlock language="diff">{PY_GEMINI_DIFF}</CodeBlock>
+      <p>
+        Preview without writing anything, or check connectivity without running
+        the full wizard:
+      </p>
+      <CodeBlock language="bash">{PY_DRY_RUN_CMD}</CodeBlock>
+      <CodeBlock language="bash">{PY_TEST_CMD}</CodeBlock>
+      <p>
+        For CI or scripted setup, pass <code>--yes</code> to accept every prompt
+        and <code>--api-key sl_live_...</code> (or set <code>SPANLENS_API_KEY</code>)
+        to skip the interactive key entry. Self-hosting works the same way with{' '}
+        <code>--server-url</code>.
+      </p>
 
       <h2 id="supported">What is supported today</h2>
       <table>

--- a/packages/sdk-python/CHANGELOG.md
+++ b/packages/sdk-python/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.7.0
+
+Onboarding CLI release. `pip install spanlens` now also installs a `spanlens` console command that connects a Python project to Spanlens in one step, the same wizard the Node `@spanlens/cli` ships. No extra dependency: it uses only the standard library plus `httpx` (already a runtime dependency).
+
+### Added
+
+- `spanlens init` interactive wizard: detects the package manager (`poetry` / `uv` / `pipenv` / `pip`) and which provider libraries are declared, validates the pasted `sl_live_*` key against `/api/v1/me/key-info`, writes `SPANLENS_API_KEY` into `.env` (idempotent, comment-preserving), installs the right `spanlens[...]` extras, and rewrites client construction to route through the proxy.
+- AST-based code patcher (`spanlens.cli.code_patcher`): rewrites `OpenAI(...)` / `AsyncOpenAI(...)` into `create_openai()` / `create_async_openai()`, `Anthropic(...)` / `AsyncAnthropic(...)` into `create_anthropic()` / `create_async_anthropic()`, and `genai.configure(...)` into `configure_gemini()`. It strips `api_key` / `base_url`, preserves every other argument, edits by byte offset so formatting and comments survive, and re-parses each file before writing so a patched file always imports.
+- `spanlens test` for a quick key + connectivity check, and `spanlens --version`.
+- Flags: `--dry-run`, `--yes` (non-interactive), `--api-key`, `--server-url` (self-hosting).
+- `[project.scripts]` entry point so the command is available immediately after install. Output forces UTF-8 so the wizard renders on legacy Windows code pages.
+
+### Verified
+
+- 48 unit tests across env writing, project detection, install-target construction, the AST patcher (including Unicode-offset safety and validity of every emitted file), the key-info client (mocked with `respx`), and the end-to-end wizard in `--dry-run` / `--yes` modes.
+- Production smoke: the full wizard ran against `www.spanlens.io`, validated a live key, and previewed then applied a real OpenAI patch.
+
+### Docs
+
+- The `/docs/cli` page now documents the Python CLI alongside the Node wizard, with install, walkthrough, before / after diffs for all three providers, and a flag reference.
+
 ## 0.6.0
 
 LlamaIndex integration release. Drop `SpanlensCallbackHandler` onto any LlamaIndex query engine, agent, or workflow and every `CBEventType` (LLM, RETRIEVE, EMBEDDING, FUNCTION_CALL, QUERY) becomes a typed Spanlens span with parent / child linkage matching the framework's per-event UUIDs.

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -26,6 +26,31 @@ pip install "spanlens[langchain]"
 pip install "spanlens[all]"
 ```
 
+## Fastest start: the `spanlens` CLI
+
+Installing the package gives you a `spanlens` command. Run the wizard from your
+project root and it detects your package manager, validates your key, writes
+`.env`, and rewrites your `OpenAI(...)` / `Anthropic(...)` / `genai.configure(...)`
+calls to route through Spanlens.
+
+```bash
+pip install spanlens
+spanlens init
+```
+
+Useful flags:
+
+```bash
+spanlens init --dry-run                 # preview every change, write nothing
+spanlens init --yes --api-key sl_live_  # non-interactive (CI / scripts)
+spanlens init --server-url https://...  # self-hosted Spanlens
+spanlens test                           # just validate the key + connectivity
+```
+
+The wizard re-parses every file it touches before saving, so it never leaves
+you with code that will not import. Prefer to wire it up by hand? The two
+manual modes below are all it does under the covers.
+
 ## Two ways to use it
 
 | Mode | Best for | Setup |

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "spanlens"
-version = "0.6.0"
+version = "0.7.0"
 description = "Spanlens SDK for Python. Agent tracing, LLM usage capture, and cost observability."
 readme = "README.md"
 license = { text = "MIT" }
@@ -80,6 +80,9 @@ dev = [
     "openai>=1.0.0",
     "anthropic>=0.18.0",
 ]
+
+[project.scripts]
+spanlens = "spanlens.cli:main"
 
 [project.urls]
 Homepage = "https://spanlens.io"

--- a/packages/sdk-python/spanlens/__init__.py
+++ b/packages/sdk-python/spanlens/__init__.py
@@ -37,7 +37,7 @@ from .parsers import parse_anthropic_usage, parse_gemini_usage, parse_openai_usa
 from .span import SpanHandle
 from .trace import TraceHandle
 
-__version__ = "0.5.0"
+__version__ = "0.7.0"
 
 __all__ = [
     "SpanHandle",

--- a/packages/sdk-python/spanlens/cli/__init__.py
+++ b/packages/sdk-python/spanlens/cli/__init__.py
@@ -1,0 +1,33 @@
+"""Spanlens onboarding CLI.
+
+Installed as the ``spanlens`` console command via ``[project.scripts]``::
+
+    pip install spanlens
+    spanlens init
+
+Walks a Python developer through connecting their app to Spanlens:
+
+    1. Detect the project type (poetry / pipenv / uv / pip) and LLM libraries
+    2. Validate the pasted Spanlens key against the API and introspect which
+       provider keys are registered
+    3. Write ``SPANLENS_API_KEY`` into ``.env`` (idempotent, comment-preserving)
+    4. Install the ``spanlens`` provider extras into the project
+    5. Patch ``OpenAI(...)`` / ``Anthropic(...)`` / ``genai.configure(...)`` to
+       route through the Spanlens proxy
+
+The CLI uses only the standard library plus ``httpx`` (already a runtime
+dependency of the SDK), so ``pip install spanlens`` makes ``spanlens init``
+work out of the box with no extra weight.
+"""
+
+from __future__ import annotations
+
+__all__ = ["main"]
+
+
+def main() -> int:
+    """Console-script entry point. Imported lazily so importing the package
+    does not pull the whole CLI graph for SDK-only users."""
+    from .main import main as _main
+
+    return _main()

--- a/packages/sdk-python/spanlens/cli/__main__.py
+++ b/packages/sdk-python/spanlens/cli/__main__.py
@@ -1,0 +1,10 @@
+"""Allow ``python -m spanlens.cli`` as an alias for the ``spanlens`` command."""
+
+from __future__ import annotations
+
+import sys
+
+from .main import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/sdk-python/spanlens/cli/code_patcher.py
+++ b/packages/sdk-python/spanlens/cli/code_patcher.py
@@ -1,0 +1,389 @@
+"""AST-based patcher that routes direct LLM SDK usage through Spanlens.
+
+Python counterpart of ``packages/cli/src/code-patcher.ts``. We detect usage
+with the standard-library :mod:`ast` (precise, no third-party parser) and then
+splice targeted edits into the original source by byte offset, so formatting,
+comments, and unrelated code are left untouched.
+
+Supported rewrites::
+
+    from openai import OpenAI                 from spanlens.integrations.openai import create_openai
+    client = OpenAI(api_key=KEY)        →     client = create_openai()
+
+    from anthropic import AsyncAnthropic      from spanlens.integrations.anthropic import create_async_anthropic
+    client = AsyncAnthropic()           →     client = create_async_anthropic()
+
+    import google.generativeai as genai       import google.generativeai as genai
+    genai.configure(api_key=KEY)        →     from spanlens.integrations.gemini import configure_gemini
+                                              configure_gemini()
+
+Scope (MVP, matching the Node CLI): top-level ``from X import Name`` /
+``import X`` plus their call sites. Dynamic imports and re-exports are not
+rewritten. The patch is always *additive-safe*. A patched file still imports
+and runs even in the rare shapes we leave for the user to finish by hand.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+# api_key / base_url are supplied by the Spanlens factory from the environment,
+# so we strip them from the original constructor call.
+_STRIP_KWARGS = frozenset({"api_key", "base_url"})
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    provider: str
+    module: str
+    classes: Dict[str, str]  # original class name → Spanlens factory name
+    spanlens_module: str
+
+
+CONSTRUCTOR_SPECS: Dict[str, ProviderSpec] = {
+    "openai": ProviderSpec(
+        provider="openai",
+        module="openai",
+        classes={"OpenAI": "create_openai", "AsyncOpenAI": "create_async_openai"},
+        spanlens_module="spanlens.integrations.openai",
+    ),
+    "anthropic": ProviderSpec(
+        provider="anthropic",
+        module="anthropic",
+        classes={
+            "Anthropic": "create_anthropic",
+            "AsyncAnthropic": "create_async_anthropic",
+        },
+        spanlens_module="spanlens.integrations.anthropic",
+    ),
+}
+
+_GEMINI_MODULE = "google.generativeai"
+_GEMINI_SPANLENS_IMPORT = "from spanlens.integrations.gemini import configure_gemini"
+
+_EXCLUDE_DIRS = frozenset(
+    {
+        ".venv",
+        "venv",
+        "env",
+        ".env",
+        ".git",
+        "__pycache__",
+        "node_modules",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        "build",
+        "dist",
+        ".tox",
+        ".eggs",
+        "site-packages",
+    }
+)
+
+
+@dataclass(frozen=True)
+class PatchPlan:
+    filepath: str
+    provider: str
+    changes: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class PatchResult:
+    filepath: str
+    provider: str
+    patched: bool
+    reason: Optional[str] = None
+
+
+# ── source-editing primitives ────────────────────────────────────────
+
+
+def _byte_line_starts(encoded: bytes) -> List[int]:
+    starts = [0]
+    for i, byte in enumerate(encoded):
+        if byte == 0x0A:  # newline
+            starts.append(i + 1)
+    return starts
+
+
+def _pos_to_byte(line_starts: List[int], lineno: int, col_offset: int) -> int:
+    # ast col_offset is a UTF-8 byte offset within the line (CPython semantics).
+    return line_starts[lineno - 1] + col_offset
+
+
+def _node_span(line_starts: List[int], node: ast.AST) -> Tuple[int, int]:
+    start = _pos_to_byte(line_starts, node.lineno, node.col_offset)  # type: ignore[attr-defined]
+    end = _pos_to_byte(line_starts, node.end_lineno, node.end_col_offset)  # type: ignore[attr-defined]
+    return start, end
+
+
+def _apply_edits(src: str, edits: List[Tuple[int, int, str]]) -> str:
+    """Apply (start_byte, end_byte, replacement) edits bottom-up on UTF-8 bytes."""
+    encoded = bytearray(src.encode("utf-8"))
+    for start, end, replacement in sorted(edits, key=lambda e: e[0], reverse=True):
+        encoded[start:end] = replacement.encode("utf-8")
+    return encoded.decode("utf-8")
+
+
+def _segment(src: str, node: ast.AST) -> str:
+    seg = ast.get_source_segment(src, node)
+    return seg if seg is not None else ""
+
+
+def _render_kept_args(src: str, call: ast.Call) -> str:
+    """Reconstruct a call's argument list minus api_key / base_url."""
+    parts: List[str] = []
+    for arg in call.args:
+        if isinstance(arg, ast.Starred):
+            parts.append(f"*{_segment(src, arg.value)}")
+        else:
+            parts.append(_segment(src, arg))
+    for kw in call.keywords:
+        if kw.arg is None:  # **kwargs
+            parts.append(f"**{_segment(src, kw.value)}")
+        elif kw.arg not in _STRIP_KWARGS:
+            parts.append(f"{kw.arg}={_segment(src, kw.value)}")
+    return ", ".join(parts)
+
+
+# ── constructor providers (OpenAI / Anthropic) ───────────────────────
+
+
+def _patch_constructor(src: str, spec: ProviderSpec) -> Tuple[Optional[str], List[str]]:
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return None, []
+
+    line_starts = _byte_line_starts(src.encode("utf-8"))
+
+    # local class name → original class name (named imports)
+    named_bindings: Dict[str, str] = {}
+    named_import_nodes: List[ast.ImportFrom] = []
+    # local module alias → True (module imports: `import openai` / `import openai as oai`)
+    module_aliases: Dict[str, bool] = {}
+    module_import_nodes: List[ast.Import] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == spec.module:
+            for alias in node.names:
+                if alias.name in spec.classes:
+                    local = alias.asname or alias.name
+                    named_bindings[local] = alias.name
+                    if node not in named_import_nodes:
+                        named_import_nodes.append(node)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == spec.module:
+                    module_aliases[alias.asname or alias.name] = True
+                    if node not in module_import_nodes:
+                        module_import_nodes.append(node)
+
+    if not named_bindings and not module_aliases:
+        return None, []
+
+    edits: List[Tuple[int, int, str]] = []
+    used_factories: List[str] = []
+    call_count = 0
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        class_name: Optional[str] = None
+        if isinstance(func, ast.Name) and func.id in named_bindings:
+            class_name = named_bindings[func.id]
+        elif (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id in module_aliases
+            and func.attr in spec.classes
+        ):
+            class_name = func.attr
+        if class_name is None:
+            continue
+
+        factory = spec.classes[class_name]
+        if factory not in used_factories:
+            used_factories.append(factory)
+        kept = _render_kept_args(src, node)
+        start, end = _node_span(line_starts, node)
+        edits.append((start, end, f"{factory}({kept})"))
+        call_count += 1
+
+    if call_count == 0:
+        return None, []
+
+    changes: List[str] = []
+    import_line = f"from {spec.spanlens_module} import {', '.join(used_factories)}"
+
+    # Prefer replacing a named import that imports ONLY provider classes,
+    # that yields the clean `from openai import OpenAI` → spanlens swap.
+    replaced_import = False
+    for node in named_import_nodes:
+        only_provider = all(a.name in spec.classes for a in node.names)
+        if only_provider and not replaced_import:
+            start, end = _node_span(line_starts, node)
+            edits.append((start, end, import_line))
+            replaced_import = True
+            changes.append(f"import: from {spec.module} → {import_line}")
+            break
+
+    if not replaced_import:
+        # Insert the Spanlens import right after the first provider import we saw.
+        anchor: Optional[ast.AST] = (
+            named_import_nodes[0]
+            if named_import_nodes
+            else (module_import_nodes[0] if module_import_nodes else None)
+        )
+        if anchor is not None:
+            _, end = _node_span(line_starts, anchor)
+            edits.append((end, end, f"\n{import_line}"))
+            changes.append(f"add import: {import_line}")
+
+    changes.append(
+        f"{call_count} × constructor → {', '.join(sorted(used_factories))}(...)"
+    )
+    return _apply_edits(src, edits), changes
+
+
+# ── gemini (configure-call style) ────────────────────────────────────
+
+
+def _patch_gemini(src: str) -> Tuple[Optional[str], List[str]]:
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return None, []
+
+    line_starts = _byte_line_starts(src.encode("utf-8"))
+
+    module_aliases: Dict[str, bool] = {}
+    import_nodes: List[ast.Import] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == _GEMINI_MODULE:
+                    module_aliases[alias.asname or alias.name.split(".")[0]] = True
+                    if node not in import_nodes:
+                        import_nodes.append(node)
+
+    if not module_aliases:
+        return None, []
+
+    edits: List[Tuple[int, int, str]] = []
+    call_count = 0
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "configure"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in module_aliases
+        ):
+            start, end = _node_span(line_starts, node)
+            edits.append((start, end, "configure_gemini()"))
+            call_count += 1
+
+    if call_count == 0:
+        return None, []
+
+    _, end = _node_span(line_starts, import_nodes[0])
+    edits.append((end, end, f"\n{_GEMINI_SPANLENS_IMPORT}"))
+
+    changes = [
+        f"add import: {_GEMINI_SPANLENS_IMPORT}",
+        f"{call_count} × genai.configure(...) → configure_gemini()",
+    ]
+    return _apply_edits(src, edits), changes
+
+
+def _patch_source(src: str, provider: str) -> Tuple[Optional[str], List[str]]:
+    if provider == "gemini":
+        return _patch_gemini(src)
+    spec = CONSTRUCTOR_SPECS.get(provider)
+    if spec is None:
+        return None, []
+    return _patch_constructor(src, spec)
+
+
+# ── filesystem scanning ──────────────────────────────────────────────
+
+
+def _candidate_files(root: str) -> List[str]:
+    out: List[str] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in _EXCLUDE_DIRS]
+        for name in filenames:
+            if name.endswith(".py"):
+                out.append(os.path.join(dirpath, name))
+    return out
+
+
+def _prefilter(text: str, provider: str) -> bool:
+    if provider == "gemini":
+        return _GEMINI_MODULE in text and "configure" in text
+    spec = CONSTRUCTOR_SPECS.get(provider)
+    if spec is None:
+        return False
+    return spec.module in text and any(cls in text for cls in spec.classes)
+
+
+def plan_patches(cwd: str, providers: List[str]) -> List[PatchPlan]:
+    plans: List[PatchPlan] = []
+    supported = [p for p in providers if p == "gemini" or p in CONSTRUCTOR_SPECS]
+    if not supported:
+        return plans
+
+    for filepath in _candidate_files(cwd):
+        try:
+            with open(filepath, encoding="utf-8") as fh:
+                src = fh.read()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for provider in supported:
+            if not _prefilter(src, provider):
+                continue
+            new_src, changes = _patch_source(src, provider)
+            if new_src is not None and changes:
+                plans.append(PatchPlan(filepath=filepath, provider=provider, changes=changes))
+    return plans
+
+
+def apply_patches(plans: List[PatchPlan], *, dry_run: bool = False) -> List[PatchResult]:
+    results: List[PatchResult] = []
+    for plan in plans:
+        try:
+            with open(plan.filepath, encoding="utf-8") as fh:
+                src = fh.read()
+        except (OSError, UnicodeDecodeError) as exc:
+            results.append(
+                PatchResult(plan.filepath, plan.provider, patched=False, reason=str(exc))
+            )
+            continue
+        new_src, _changes = _patch_source(src, plan.provider)
+        if new_src is None or new_src == src:
+            results.append(
+                PatchResult(plan.filepath, plan.provider, patched=False, reason="no change")
+            )
+            continue
+        if not dry_run:
+            with open(plan.filepath, "w", encoding="utf-8") as fh:
+                fh.write(new_src)
+        results.append(PatchResult(plan.filepath, plan.provider, patched=True))
+    return results
+
+
+__all__ = [
+    "CONSTRUCTOR_SPECS",
+    "PatchPlan",
+    "PatchResult",
+    "ProviderSpec",
+    "apply_patches",
+    "plan_patches",
+]

--- a/packages/sdk-python/spanlens/cli/colors.py
+++ b/packages/sdk-python/spanlens/cli/colors.py
@@ -1,0 +1,65 @@
+"""Tiny ANSI color helpers, a stdlib-only stand-in for picocolors.
+
+Colors are disabled automatically when:
+
+  * ``NO_COLOR`` is set (https://no-color.org/), or
+  * ``stdout`` is not a TTY (piped / redirected / CI without a terminal).
+
+Keeping this dependency-free matters: ``pip install spanlens`` should not pull
+a color library just so the SDK is importable.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_RESET = "\033[0m"
+
+
+def _enabled() -> bool:
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    if os.environ.get("FORCE_COLOR") is not None:
+        return True
+    try:
+        return sys.stdout.isatty()
+    except Exception:
+        return False
+
+
+def _wrap(code: str, text: str) -> str:
+    if not _enabled():
+        return text
+    return f"\033[{code}m{text}{_RESET}"
+
+
+def bold(text: str) -> str:
+    return _wrap("1", text)
+
+
+def dim(text: str) -> str:
+    return _wrap("2", text)
+
+
+def underline(text: str) -> str:
+    return _wrap("4", text)
+
+
+def red(text: str) -> str:
+    return _wrap("31", text)
+
+
+def green(text: str) -> str:
+    return _wrap("32", text)
+
+
+def yellow(text: str) -> str:
+    return _wrap("33", text)
+
+
+def cyan(text: str) -> str:
+    return _wrap("36", text)
+
+
+__all__ = ["bold", "cyan", "dim", "green", "red", "underline", "yellow"]

--- a/packages/sdk-python/spanlens/cli/env_writer.py
+++ b/packages/sdk-python/spanlens/cli/env_writer.py
@@ -1,0 +1,87 @@
+"""Idempotently add or update a ``KEY=VALUE`` line in a ``.env`` file.
+
+Mirrors ``packages/cli/src/env-writer.ts`` so the Python and Node wizards
+behave identically:
+
+  * Existing lines and comments are preserved.
+  * If ``KEY`` already exists, its value is replaced in place.
+  * If the file does not exist, it is created.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class UpsertResult:
+    changed: bool
+    created: bool
+    existed: bool
+
+
+def read_env_var(cwd: str, filename: str, key: str) -> Optional[str]:
+    """Return the current value of ``key`` in the env file, or ``None``."""
+    path = os.path.join(cwd, filename)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, encoding="utf-8") as fh:
+            text = fh.read()
+    except OSError:
+        return None
+    match = re.search(rf"^{re.escape(key)}\s*=\s*(.+)$", text, re.MULTILINE)
+    return match.group(1).strip() if match else None
+
+
+def upsert_env_var(cwd: str, filename: str, key: str, value: str) -> UpsertResult:
+    path = os.path.join(cwd, filename)
+    existed = os.path.isfile(path)
+    existing = ""
+    if existed:
+        try:
+            with open(path, encoding="utf-8") as fh:
+                existing = fh.read()
+        except OSError:
+            existing = ""
+
+    lines = existing.split("\n") if existing else []
+    pattern = re.compile(rf"^{re.escape(key)}\s*=")
+    found = False
+    value_changed = False
+    new_line = f"{key}={value}"
+
+    updated = []
+    for line in lines:
+        if pattern.match(line):
+            found = True
+            if line != new_line:
+                value_changed = True
+            updated.append(new_line)
+        else:
+            updated.append(line)
+
+    if not found:
+        if updated and updated[-1] != "":
+            updated.append("")
+        updated.append(new_line)
+        updated.append("")  # trailing newline
+
+    next_text = "\n".join(updated)
+    if next_text == existing:
+        return UpsertResult(changed=False, created=False, existed=existed)
+
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(next_text)
+
+    return UpsertResult(
+        changed=value_changed if found else True,
+        created=not existed,
+        existed=existed,
+    )
+
+
+__all__ = ["UpsertResult", "read_env_var", "upsert_env_var"]

--- a/packages/sdk-python/spanlens/cli/framework_detect.py
+++ b/packages/sdk-python/spanlens/cli/framework_detect.py
@@ -1,0 +1,183 @@
+"""Detect the Python project layout and which LLM libraries it already uses.
+
+Unlike the Node CLI (Next.js-centric), Python projects vary widely in their
+package manager and manifest. We sniff the common ones and, crucially, figure
+out which provider SDKs (``openai`` / ``anthropic`` / ``google-generativeai``)
+are declared so the wizard can suggest the right integrations even before the
+Spanlens key tells us which provider keys are registered.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+try:  # Python 3.11+ ships tomllib; older versions degrade to a regex sniff.
+    import tomllib  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - exercised on <3.11 only
+    tomllib = None
+
+
+# Maps the Spanlens provider name to the PyPI distribution names that imply it.
+PROVIDER_LIBRARIES = {
+    "openai": ("openai",),
+    "anthropic": ("anthropic",),
+    "gemini": ("google-generativeai", "google-genai"),
+}
+
+
+@dataclass(frozen=True)
+class ProjectInfo:
+    """Everything the wizard learned by looking at the filesystem."""
+
+    package_manager: str  # 'poetry' | 'uv' | 'pipenv' | 'pip' | 'unknown'
+    manifest: Optional[str]  # the file we read deps from, if any
+    env_file: str  # preferred env file to write to (always '.env' for Python)
+    detected_providers: List[str] = field(default_factory=list)
+
+
+def detect_project(cwd: Optional[str] = None) -> ProjectInfo:
+    root = cwd or os.getcwd()
+
+    pm, manifest = _detect_package_manager(root)
+    providers = _detect_providers(root)
+
+    return ProjectInfo(
+        package_manager=pm,
+        manifest=manifest,
+        env_file=".env",
+        detected_providers=providers,
+    )
+
+
+def _exists(root: str, name: str) -> bool:
+    return os.path.isfile(os.path.join(root, name))
+
+
+def _detect_package_manager(root: str) -> tuple[str, Optional[str]]:
+    """Lockfiles are the most reliable signal; fall back to manifests."""
+    if _exists(root, "poetry.lock"):
+        return "poetry", "pyproject.toml"
+    if _exists(root, "uv.lock"):
+        return "uv", "pyproject.toml"
+    if _exists(root, "Pipfile.lock") or _exists(root, "Pipfile"):
+        return "pipenv", "Pipfile"
+
+    if _exists(root, "pyproject.toml"):
+        # A pyproject with [tool.poetry] means poetry even without a lockfile.
+        text = _read(os.path.join(root, "pyproject.toml"))
+        if text and "[tool.poetry]" in text:
+            return "poetry", "pyproject.toml"
+        return "pip", "pyproject.toml"
+
+    if _exists(root, "requirements.txt"):
+        return "pip", "requirements.txt"
+
+    return "unknown", None
+
+
+def _read(path: str) -> Optional[str]:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return fh.read()
+    except OSError:
+        return None
+
+
+def _detect_providers(root: str) -> List[str]:
+    """Collect declared dependencies across every manifest we can find, then
+    map distribution names back to Spanlens provider names."""
+    declared = set()
+
+    declared |= _deps_from_pyproject(os.path.join(root, "pyproject.toml"))
+    declared |= _deps_from_requirements(os.path.join(root, "requirements.txt"))
+    declared |= _deps_from_pipfile(os.path.join(root, "Pipfile"))
+
+    found: List[str] = []
+    for provider, dists in PROVIDER_LIBRARIES.items():
+        if any(_normalize(d) in declared for d in dists):
+            found.append(provider)
+    return found
+
+
+def _normalize(name: str) -> str:
+    # PEP 503 normalization so 'Google-GenerativeAI' == 'google-generativeai'.
+    return re.sub(r"[-_.]+", "-", name).strip().lower()
+
+
+def _deps_from_pyproject(path: str) -> set[str]:
+    text = _read(path)
+    if text is None:
+        return set()
+
+    names: set[str] = set()
+    if tomllib is not None:
+        try:
+            data = tomllib.loads(text)
+        except Exception:
+            data = {}
+        # PEP 621 [project].dependencies + optional-dependencies
+        project = data.get("project", {}) if isinstance(data, dict) else {}
+        for spec in project.get("dependencies", []) or []:
+            names.add(_dist_from_spec(spec))
+        for group in (project.get("optional-dependencies", {}) or {}).values():
+            for spec in group or []:
+                names.add(_dist_from_spec(spec))
+        # Poetry [tool.poetry.dependencies] is a table keyed by dist name.
+        poetry = (
+            data.get("tool", {}).get("poetry", {}) if isinstance(data, dict) else {}
+        )
+        for key in (poetry.get("dependencies", {}) or {}):
+            names.add(_normalize(key))
+        for group in (poetry.get("group", {}) or {}).values():
+            for key in (group.get("dependencies", {}) or {}):
+                names.add(_normalize(key))
+    else:  # pragma: no cover - <3.11 fallback
+        for spec in re.findall(r'"([A-Za-z0-9._-]+(?:\[[^\]]*\])?[^"]*)"', text):
+            names.add(_dist_from_spec(spec))
+
+    names.discard("")
+    return names
+
+
+def _deps_from_requirements(path: str) -> set[str]:
+    text = _read(path)
+    if text is None:
+        return set()
+    names: set[str] = set()
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("-"):
+            continue
+        names.add(_dist_from_spec(line))
+    names.discard("")
+    return names
+
+
+def _deps_from_pipfile(path: str) -> set[str]:
+    text = _read(path)
+    if text is None:
+        return set()
+    # Pipfile is TOML but commonly read loosely; grab the bare package names
+    # under [packages] / [dev-packages] via a simple key sniff.
+    names: set[str] = set()
+    for match in re.finditer(r'^\s*"?([A-Za-z0-9._-]+)"?\s*=', text, re.MULTILINE):
+        names.add(_normalize(match.group(1)))
+    names.discard("")
+    return names
+
+
+def _dist_from_spec(spec: str) -> str:
+    """Extract the distribution name from a PEP 508 requirement string.
+
+    ``openai>=1.0.0`` → ``openai``; ``spanlens[openai]`` → ``spanlens``.
+    """
+    spec = spec.strip()
+    # Cut at the first version / marker / extras delimiter.
+    name = re.split(r"[\s<>=!~\[;@(]", spec, maxsplit=1)[0]
+    return _normalize(name)
+
+
+__all__ = ["PROVIDER_LIBRARIES", "ProjectInfo", "detect_project"]

--- a/packages/sdk-python/spanlens/cli/installer.py
+++ b/packages/sdk-python/spanlens/cli/installer.py
@@ -1,0 +1,122 @@
+"""Install the ``spanlens`` provider extras into the user's project.
+
+The ``spanlens`` distribution is the SDK *and* this CLI, so the user already
+has it on their machine to run ``spanlens init``. What this step does is make
+it a declared dependency of their project and pull the right provider extras
+(``spanlens[openai]`` etc.) using whichever package manager they use.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess  # noqa: S404 - we build argv lists ourselves, never shell strings
+import sys
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+# Spanlens provider name → extras key in pyproject [project.optional-dependencies].
+PROVIDER_EXTRAS = {
+    "openai": "openai",
+    "anthropic": "anthropic",
+    "gemini": "gemini",
+}
+
+
+@dataclass(frozen=True)
+class InstallResult:
+    ok: bool
+    command: str
+    error: Optional[str] = None
+
+
+def install_target(providers: Sequence[str]) -> str:
+    """Build the pip-style requirement, e.g. ``spanlens[openai,anthropic]``."""
+    extras = sorted(
+        {PROVIDER_EXTRAS[p] for p in providers if p in PROVIDER_EXTRAS}
+    )
+    if not extras:
+        return "spanlens"
+    return f"spanlens[{','.join(extras)}]"
+
+
+def _install_argv(package_manager: str, target: str) -> List[str]:
+    if package_manager == "poetry":
+        return ["poetry", "add", target]
+    if package_manager == "uv":
+        return ["uv", "add", target]
+    if package_manager == "pipenv":
+        return ["pipenv", "install", target]
+    # pip (and 'unknown') uses the active interpreter so we install into the
+    # same environment the CLI is running from.
+    return [sys.executable, "-m", "pip", "install", target]
+
+
+def install_spanlens(
+    cwd: str,
+    package_manager: str,
+    providers: Sequence[str],
+    *,
+    dry_run: bool = False,
+    timeout: int = 300,
+) -> InstallResult:
+    target = install_target(providers)
+    argv = _install_argv(package_manager, target)
+    command = " ".join(argv if argv[0] != sys.executable else ["python", "-m", "pip", "install", target])
+
+    if dry_run:
+        return InstallResult(ok=True, command=command)
+
+    try:
+        proc = subprocess.run(  # noqa: S603 - argv is a fixed list, no shell
+            argv,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        return InstallResult(
+            ok=False,
+            command=command,
+            error=f"{package_manager} not found on PATH",
+        )
+    except subprocess.TimeoutExpired:
+        return InstallResult(ok=False, command=command, error="install timed out")
+
+    if proc.returncode == 0:
+        return InstallResult(ok=True, command=command)
+
+    detail = (proc.stderr or proc.stdout or "").strip()
+    return InstallResult(
+        ok=False,
+        command=command,
+        error=f"exited with code {proc.returncode}{f': {detail[:200]}' if detail else ''}",
+    )
+
+
+def is_spanlens_declared(cwd: str) -> bool:
+    """Best-effort check for an existing ``spanlens`` dependency in a manifest."""
+    for manifest in ("pyproject.toml", "requirements.txt", "Pipfile"):
+        path = os.path.join(cwd, manifest)
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path, encoding="utf-8") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        # Match the package name as a token, not a substring of another word.
+        if re.search(r"(?<![\w-])spanlens(?![\w-])", text):
+            return True
+    return False
+
+
+__all__ = [
+    "PROVIDER_EXTRAS",
+    "InstallResult",
+    "install_spanlens",
+    "install_target",
+    "is_spanlens_declared",
+]

--- a/packages/sdk-python/spanlens/cli/key_info.py
+++ b/packages/sdk-python/spanlens/cli/key_info.py
@@ -1,0 +1,72 @@
+"""Validate a Spanlens key against the API and introspect its providers.
+
+Hits ``GET /api/v1/me/key-info`` exactly like ``packages/cli`` does. The
+endpoint authenticates with the ``sl_live_*`` key in the ``Authorization``
+header (no Supabase session) and returns which provider keys are registered
+under that Spanlens key, so the wizard knows which integrations to patch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import httpx
+
+
+class KeyInfoError(Exception):
+    """A user-actionable failure validating the key (network or API)."""
+
+
+@dataclass(frozen=True)
+class KeyInfo:
+    project_id: Optional[str]
+    project_name: Optional[str]
+    providers: List[str] = field(default_factory=list)
+    scope: str = "full"
+
+
+def fetch_key_info(api_key: str, api_base: str, *, timeout: float = 15.0) -> KeyInfo:
+    url = f"{api_base.rstrip('/')}/api/v1/me/key-info"
+    try:
+        response = httpx.get(
+            url,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=timeout,
+        )
+    except httpx.HTTPError as exc:
+        raise KeyInfoError(
+            f"Network error contacting {api_base}. Check your connection. ({exc})"
+        ) from exc
+
+    if response.status_code == 401:
+        raise KeyInfoError(
+            "Spanlens rejected this key (401). Re-copy it from the dashboard."
+        )
+    if response.status_code >= 400:
+        raise KeyInfoError(
+            f"Spanlens returned {response.status_code} from /me/key-info. Try again in a moment."
+        )
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise KeyInfoError("Unexpected (non-JSON) response from /me/key-info.") from exc
+
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, dict):
+        raise KeyInfoError("Unexpected response shape from /me/key-info.")
+
+    providers = data.get("providers") or []
+    if not isinstance(providers, list):
+        providers = []
+
+    return KeyInfo(
+        project_id=data.get("projectId"),
+        project_name=data.get("projectName"),
+        providers=[str(p) for p in providers],
+        scope=str(data.get("scope") or "full"),
+    )
+
+
+__all__ = ["KeyInfo", "KeyInfoError", "fetch_key_info"]

--- a/packages/sdk-python/spanlens/cli/main.py
+++ b/packages/sdk-python/spanlens/cli/main.py
@@ -1,0 +1,349 @@
+"""``spanlens`` command entry point. The onboarding wizard.
+
+Usage::
+
+    spanlens init [--dry-run] [--yes] [--api-key KEY] [--server-url URL]
+    spanlens test [--api-key KEY] [--server-url URL]
+    spanlens --version
+
+``init`` is the default subcommand, so a bare ``spanlens`` runs the wizard.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import List, Optional
+
+from . import colors as c
+from . import prompts as p
+from .code_patcher import apply_patches, plan_patches
+from .env_writer import read_env_var, upsert_env_var
+from .framework_detect import detect_project
+from .installer import install_spanlens, is_spanlens_declared
+from .key_info import KeyInfo, KeyInfoError, fetch_key_info
+
+DEFAULT_DASHBOARD_URL = "https://www.spanlens.io"
+# Providers the wizard can auto-patch (those with a dedicated SDK integration).
+PATCHABLE_PROVIDERS = ("openai", "anthropic", "gemini")
+
+
+def _force_utf8_output() -> None:
+    """Make stdout/stderr accept UTF-8 so the box-drawing glyphs and emoji in
+    the wizard do not crash on legacy Windows code pages (e.g. cp949). Falls
+    back to ``errors='replace'`` so output degrades to '?' rather than raising.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError):  # pragma: no cover - platform dependent
+            pass
+
+
+def _version() -> str:
+    try:
+        from spanlens import __version__
+
+        return __version__
+    except Exception:
+        return "unknown"
+
+
+def _resolve_bases(server_url: Optional[str]) -> tuple[str, str]:
+    """Return (dashboard_url, api_base). ``--server-url`` overrides both."""
+    if server_url:
+        clean = server_url.rstrip("/")
+        return clean, clean
+    api_base = os.environ.get("SPANLENS_API_BASE", DEFAULT_DASHBOARD_URL).rstrip("/")
+    return DEFAULT_DASHBOARD_URL, api_base
+
+
+def _validate_key_format(value: str) -> Optional[str]:
+    if not value or len(value) < 20:
+        return "Looks too short. Copy the whole key."
+    if not value.startswith("sl_live_") and not value.startswith("sl_test_"):
+        return "Spanlens keys start with sl_live_ or sl_test_"
+    return None
+
+
+def _collect_key(args: argparse.Namespace) -> str:
+    """Resolve the Spanlens key from --api-key, env, or an interactive prompt."""
+    candidate = args.api_key or os.environ.get("SPANLENS_API_KEY")
+    if candidate:
+        problem = _validate_key_format(candidate)
+        if problem:
+            raise SystemExit(f"[spanlens] {problem}")
+        return candidate
+    return p.password(
+        "Paste your Spanlens key (starts with sl_live_)",
+        validate=_validate_key_format,
+    )
+
+
+def _print_key_summary(dashboard_url: str, info: KeyInfo) -> None:
+    provider_text = ", ".join(info.providers) if info.providers else c.dim("(none registered)")
+    project = info.project_name or c.dim("(workspace key)")
+    p.success(f"Key valid · project {c.bold(project)} · providers: {provider_text}")
+
+    if info.scope == "public":
+        p.warn(
+            "This is a public (read-only) key, so proxy calls return 403. "
+            "Issue a full key (sl_live_, not sl_live_pub_) to log requests."
+        )
+    if not info.providers:
+        p.warn("No active provider keys on this Spanlens key, so calls return 400 until you add one.")
+        p.message(
+            f"  Add one at {c.underline(dashboard_url + '/projects')} → your project → "
+            '"Add provider key"'
+        )
+
+
+# ── subcommand: init ─────────────────────────────────────────────────
+
+
+def _cmd_init(args: argparse.Namespace) -> int:
+    dashboard_url, api_base = _resolve_bases(args.server_url)
+    cwd = os.getcwd()
+
+    p.intro(c.cyan("🔭  Spanlens setup"))
+
+    # 1. project detection
+    project = detect_project(cwd)
+    if project.package_manager == "unknown":
+        p.warn(f"No Python project manifest found in {c.dim(cwd)}")
+        p.message("  Run this from your project root (where pyproject.toml / requirements.txt lives).")
+        if not p.confirm("Continue anyway?", default=False, assume_yes=args.yes):
+            p.cancel("Aborted.")
+            return 0
+    else:
+        detected = (
+            f" · uses {', '.join(project.detected_providers)}"
+            if project.detected_providers
+            else ""
+        )
+        p.success(f"Detected {c.bold(project.package_manager)} project{detected}")
+
+    # 2. prerequisites
+    p.message("")
+    p.step(c.bold("Before continuing, make sure you have:"))
+    p.message(f"  1. A Spanlens account at {c.underline(dashboard_url)}")
+    p.message(f"  2. A Project at {c.underline(dashboard_url + '/projects')}")
+    p.message("  3. Provider keys (OpenAI / Anthropic / Gemini) added to that project")
+    p.message("  4. A Spanlens key issued for that project (sl_live_…)")
+    p.message("")
+    if not p.confirm("Ready?", default=True, assume_yes=args.yes):
+        p.cancel("Aborted. Come back after setting up the dashboard.")
+        return 0
+
+    # 3. collect + validate key
+    try:
+        api_key = _collect_key(args)
+    except p.NonInteractiveError as exc:
+        p.error(str(exc))
+        return 1
+
+    s = p.spinner()
+    s.start("Validating key with Spanlens")
+    try:
+        info = fetch_key_info(api_key, api_base)
+    except KeyInfoError as exc:
+        s.stop(c.red("Key validation failed"))
+        p.error(str(exc))
+        return 1
+    s.stop("Key validated")
+    _print_key_summary(dashboard_url, info)
+
+    # 4. write .env (overwrite confirm)
+    existing = read_env_var(cwd, project.env_file, "SPANLENS_API_KEY")
+    if existing and existing != api_key:
+        masked = f"{existing[:12]}…{existing[-4:]}" if len(existing) > 16 else "••••"
+        if not p.confirm(
+            f"{project.env_file} already has SPANLENS_API_KEY={masked}. Replace it?",
+            default=False,
+            assume_yes=args.yes,
+        ):
+            p.cancel("Kept existing key. Re-run when ready.")
+            return 0
+
+    s = p.spinner()
+    s.start(f"Updating {project.env_file}")
+    if args.dry_run:
+        s.stop(f"[dry-run] would write SPANLENS_API_KEY to {project.env_file}")
+    else:
+        result = upsert_env_var(cwd, project.env_file, "SPANLENS_API_KEY", api_key)
+        if args.server_url:
+            upsert_env_var(cwd, project.env_file, "SPANLENS_BASE_URL", args.server_url.rstrip("/"))
+        if result.created:
+            s.stop(f"Created {project.env_file} with SPANLENS_API_KEY")
+        elif result.changed:
+            s.stop(f"Updated SPANLENS_API_KEY in {project.env_file}")
+        else:
+            s.stop(f"SPANLENS_API_KEY already up to date in {project.env_file}")
+
+    # 5. install spanlens extras
+    install_providers = info.providers or list(project.detected_providers)
+    if is_spanlens_declared(cwd):
+        p.success("spanlens already in project dependencies")
+    elif p.confirm(
+        f"Install spanlens via {c.cyan(project.package_manager)} now?",
+        default=True,
+        assume_yes=args.yes,
+    ):
+        s = p.spinner()
+        s.start(f"Installing spanlens with {project.package_manager}")
+        res = install_spanlens(
+            cwd, project.package_manager, install_providers, dry_run=args.dry_run
+        )
+        if res.ok:
+            s.stop(
+                f"[dry-run] would run: {c.cyan(res.command)}"
+                if args.dry_run
+                else f"Installed ({res.command})"
+            )
+        else:
+            s.stop(c.yellow("Could not auto-install. Run this manually:"))
+            p.message(f"  {c.cyan(res.command)}")
+            if res.error:
+                p.message(c.dim(f"  ({res.error})"))
+    else:
+        p.warn("Skipped install. Run it manually before deploying.")
+
+    # 6. scan + patch
+    patch_targets = [pr for pr in install_providers if pr in PATCHABLE_PROVIDERS]
+    s = p.spinner()
+    s.start("Scanning your code for provider usage")
+    plans = plan_patches(cwd, patch_targets)
+    s.stop(f"Found {len(plans)} patch{'' if len(plans) == 1 else 'es'} to apply")
+
+    if not plans:
+        rel = c.dim("from spanlens.integrations.openai import create_openai")
+        p.message(c.dim(f"No matching client construction found. Add manually, e.g.:\n  {rel}"))
+    else:
+        for plan in plans:
+            p.message(f"  {c.cyan('•')} [{plan.provider}] {c.dim(os.path.relpath(plan.filepath, cwd))}")
+            for change in plan.changes:
+                p.message(f"      {c.dim('→')} {change}")
+        verb = "Show patch preview?" if args.dry_run else "Apply these changes?"
+        if p.confirm(verb, default=True, assume_yes=args.yes):
+            s = p.spinner()
+            s.start("Dry-run patch" if args.dry_run else "Patching files")
+            results = apply_patches(plans, dry_run=args.dry_run)
+            patched = sum(1 for r in results if r.patched)
+            s.stop(
+                f"[dry-run] would patch {patched} file(s)"
+                if args.dry_run
+                else f"Patched {patched} file(s)"
+            )
+        else:
+            p.warn("Code patch skipped. You can re-run the wizard anytime.")
+
+    # 7. next steps
+    p.note(
+        "\n".join(
+            [
+                f"{c.bold('1.')} Add {c.cyan('SPANLENS_API_KEY')} to your deployment environment",
+                f"     {c.dim('(your host → Settings → Environment Variables)')}",
+                "",
+                f"{c.bold('2.')} Redeploy your app",
+                "",
+                f"{c.bold('3.')} Your requests will show up at:",
+                f"     {c.underline(dashboard_url + '/requests')}",
+            ]
+        ),
+        "Next steps",
+    )
+
+    p.message("")
+    p.message(
+        f"{c.yellow('★')}  Star Spanlens on GitHub:  "
+        f"{c.underline('https://github.com/spanlens/Spanlens?utm_source=cli_init')}"
+    )
+    p.message(c.dim("   Read the docs:           https://spanlens.io/docs"))
+    p.outro(c.green("🎉 Spanlens setup complete"))
+    return 0
+
+
+# ── subcommand: test ─────────────────────────────────────────────────
+
+
+def _cmd_test(args: argparse.Namespace) -> int:
+    dashboard_url, api_base = _resolve_bases(args.server_url)
+    p.intro(c.cyan("🔭  Spanlens connection test"))
+    try:
+        api_key = _collect_key(args)
+    except p.NonInteractiveError as exc:
+        p.error(str(exc))
+        return 1
+
+    s = p.spinner()
+    s.start(f"Contacting {api_base}")
+    try:
+        info = fetch_key_info(api_key, api_base)
+    except KeyInfoError as exc:
+        s.stop(c.red("Connection failed"))
+        p.error(str(exc))
+        return 1
+    s.stop("Connected")
+    _print_key_summary(dashboard_url, info)
+    p.outro(c.green("✓ Spanlens is reachable and your key is valid"))
+    return 0
+
+
+# ── arg parsing ──────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="spanlens",
+        description="Spanlens onboarding wizard. Connect your app in two minutes.",
+    )
+    parser.add_argument("--version", action="version", version=f"spanlens {_version()}")
+
+    sub = parser.add_subparsers(dest="command")
+
+    def _add_common(sp: argparse.ArgumentParser) -> None:
+        sp.add_argument("--api-key", default=None, help="Spanlens key (else prompt / SPANLENS_API_KEY).")
+        sp.add_argument("--server-url", default=None, help="Self-hosted Spanlens base URL.")
+
+    init = sub.add_parser("init", help="Run the onboarding wizard (default).")
+    _add_common(init)
+    init.add_argument("--dry-run", action="store_true", help="Preview without writing files.")
+    init.add_argument("-y", "--yes", action="store_true", help="Accept all prompts (non-interactive).")
+
+    test = sub.add_parser("test", help="Validate your key and connectivity.")
+    _add_common(test)
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    _force_utf8_output()
+    raw = list(sys.argv[1:] if argv is None else argv)
+
+    # `init` is the default subcommand: inject it when the first token is not a
+    # known command or a top-level flag, so `spanlens` and `spanlens --dry-run`
+    # both run the wizard while `spanlens test` / `spanlens --version` still work.
+    passthrough = {"init", "test", "-h", "--help", "--version"}
+    if not raw or raw[0] not in passthrough:
+        raw = ["init", *raw]
+
+    parser = _build_parser()
+    args = parser.parse_args(raw)
+    command = args.command or "init"
+
+    try:
+        if command == "test":
+            return _cmd_test(args)
+        return _cmd_init(args)
+    except p.PromptCancelledError:
+        print()
+        p.cancel("Aborted.")
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/sdk-python/spanlens/cli/prompts.py
+++ b/packages/sdk-python/spanlens/cli/prompts.py
@@ -1,0 +1,146 @@
+"""Interactive prompt helpers, a stdlib-only stand-in for @clack/prompts.
+
+Everything degrades gracefully when stdin is not a TTY (CI, piped input):
+``confirm`` returns its default and ``password`` raises ``NonInteractive`` so
+the caller can fall back to a flag / env var instead of hanging on ``input()``.
+"""
+
+from __future__ import annotations
+
+import getpass
+import sys
+from typing import Callable, Optional
+
+from . import colors as c
+
+_BAR = c.dim("│")
+
+
+class PromptCancelledError(Exception):
+    """Raised when the user aborts a prompt (Ctrl-C / Ctrl-D)."""
+
+
+class NonInteractiveError(Exception):
+    """Raised when a value is required but no TTY is available to ask for it."""
+
+
+def stdin_is_tty() -> bool:
+    try:
+        return sys.stdin.isatty()
+    except Exception:
+        return False
+
+
+def intro(title: str) -> None:
+    print()
+    print(f"{c.dim('┌')}  {title}")
+
+
+def outro(message: str) -> None:
+    print(f"{c.dim('└')}  {message}")
+    print()
+
+
+def step(message: str) -> None:
+    print(f"{c.cyan('◇')}  {message}")
+
+
+def success(message: str) -> None:
+    print(f"{c.green('✓')}  {message}")
+
+
+def warn(message: str) -> None:
+    print(f"{c.yellow('▲')}  {message}")
+
+
+def error(message: str) -> None:
+    print(f"{c.red('■')}  {message}")
+
+
+def message(text: str = "") -> None:
+    if text == "":
+        print(_BAR)
+    else:
+        print(f"{_BAR}  {text}")
+
+
+def note(body: str, title: str = "") -> None:
+    print(_BAR)
+    if title:
+        print(f"{c.dim('├')}  {c.bold(title)}")
+    for line in body.split("\n"):
+        print(f"{_BAR}  {line}")
+    print(_BAR)
+
+
+def cancel(message_text: str) -> None:
+    print(f"{c.red('■')}  {message_text}")
+
+
+def confirm(prompt: str, *, default: bool = True, assume_yes: bool = False) -> bool:
+    """Yes/No prompt. Returns ``default`` for non-interactive / ``assume_yes``."""
+    if assume_yes:
+        return True
+    if not stdin_is_tty():
+        return default
+    suffix = c.dim("(Y/n)") if default else c.dim("(y/N)")
+    try:
+        raw = input(f"{c.cyan('◆')}  {prompt} {suffix} ").strip().lower()
+    except (EOFError, KeyboardInterrupt) as exc:
+        raise PromptCancelledError() from exc
+    if raw == "":
+        return default
+    return raw in ("y", "yes")
+
+
+def password(prompt: str, *, validate: Optional[Callable[[str], Optional[str]]] = None) -> str:
+    """Masked input. Raises ``NonInteractive`` when there is no TTY."""
+    if not stdin_is_tty():
+        raise NonInteractiveError(
+            "No interactive terminal. Pass --api-key or set SPANLENS_API_KEY."
+        )
+    while True:
+        try:
+            value = getpass.getpass(f"{c.cyan('◆')}  {prompt}: ").strip()
+        except (EOFError, KeyboardInterrupt) as exc:
+            raise PromptCancelledError() from exc
+        if validate is not None:
+            problem = validate(value)
+            if problem is not None:
+                error(problem)
+                continue
+        return value
+
+
+class Spinner:
+    """Minimal start/stop status line. No animation, CI-log friendly."""
+
+    def start(self, label: str) -> None:
+        print(f"{c.cyan('○')}  {label}{c.dim(' …')}")
+
+    def stop(self, label: str) -> None:
+        print(f"{c.green('●')}  {label}")
+
+
+def spinner() -> Spinner:
+    return Spinner()
+
+
+__all__ = [
+    "PromptCancelledError",
+    "NonInteractiveError",
+    "Spinner",
+    "cancel",
+    "confirm",
+    "error",
+    "intro",
+    "message",
+    "note",
+    "outro",
+    "password",
+    "spinner",
+    "stdin_is_tty",
+    "step",
+    "success",
+    "warn",
+]

--- a/packages/sdk-python/tests/cli/test_code_patcher.py
+++ b/packages/sdk-python/tests/cli/test_code_patcher.py
@@ -1,0 +1,171 @@
+"""AST patcher — the riskiest module, so it gets the deepest coverage.
+
+Every patched output is re-parsed to guarantee we never emit broken Python.
+"""
+
+import ast
+from pathlib import Path
+
+from spanlens.cli.code_patcher import _patch_source, apply_patches, plan_patches
+
+
+def _patch(src: str, provider: str) -> str:
+    new_src, changes = _patch_source(src, provider)
+    assert new_src is not None, "expected a patch"
+    assert changes, "expected human-readable changes"
+    ast.parse(new_src)  # must stay valid Python
+    return new_src
+
+
+def test_openai_single_import_clean_swap() -> None:
+    src = (
+        "import os\n"
+        "from openai import OpenAI\n"
+        'client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])\n'
+    )
+    out = _patch(src, "openai")
+    assert "from spanlens.integrations.openai import create_openai" in out
+    assert "from openai import OpenAI" not in out  # only-name import replaced
+    assert "client = create_openai()" in out
+    assert "api_key" not in out
+
+
+def test_openai_preserves_other_kwargs() -> None:
+    src = (
+        "from openai import OpenAI\n"
+        'client = OpenAI(api_key="k", base_url="x", timeout=30, max_retries=2)\n'
+    )
+    out = _patch(src, "openai")
+    assert "timeout=30" in out
+    assert "max_retries=2" in out
+    assert "base_url" not in out
+    assert "api_key" not in out
+
+
+def test_async_openai() -> None:
+    src = "from openai import AsyncOpenAI\nc = AsyncOpenAI()\n"
+    out = _patch(src, "openai")
+    assert "from spanlens.integrations.openai import create_async_openai" in out
+    assert "c = create_async_openai()" in out
+
+
+def test_openai_module_import_style() -> None:
+    src = "import openai\nc = openai.OpenAI(api_key='k')\n"
+    out = _patch(src, "openai")
+    # module import is kept (it may be used elsewhere); spanlens import added.
+    assert "import openai" in out
+    assert "from spanlens.integrations.openai import create_openai" in out
+    assert "c = create_openai()" in out
+
+
+def test_aliased_named_import() -> None:
+    src = "from openai import OpenAI as Client\nc = Client(api_key='k')\n"
+    out = _patch(src, "openai")
+    assert "c = create_openai()" in out
+
+
+def test_multi_name_import_keeps_original_and_adds() -> None:
+    src = (
+        "from openai import OpenAI, OpenAIError\n"
+        "c = OpenAI()\n"
+        "err = OpenAIError\n"
+    )
+    out = _patch(src, "openai")
+    # OpenAIError still needed → original import stays, spanlens import appended.
+    assert "from openai import OpenAI, OpenAIError" in out
+    assert "from spanlens.integrations.openai import create_openai" in out
+    assert "c = create_openai()" in out
+
+
+def test_anthropic_sync_and_async() -> None:
+    src = (
+        "from anthropic import Anthropic, AsyncAnthropic\n"
+        "a = Anthropic(api_key='k')\n"
+        "b = AsyncAnthropic()\n"
+    )
+    out = _patch(src, "anthropic")
+    assert "create_anthropic" in out
+    assert "create_async_anthropic" in out
+    assert "a = create_anthropic()" in out
+    assert "b = create_async_anthropic()" in out
+
+
+def test_gemini_configure_rewrite() -> None:
+    src = (
+        "import google.generativeai as genai\n"
+        'genai.configure(api_key="k")\n'
+        'model = genai.GenerativeModel("gemini-1.5-flash")\n'
+    )
+    out = _patch(src, "gemini")
+    assert "from spanlens.integrations.gemini import configure_gemini" in out
+    assert "configure_gemini()" in out
+    # GenerativeModel usage and the original import are preserved.
+    assert "import google.generativeai as genai" in out
+    assert "genai.GenerativeModel" in out
+
+
+def test_no_op_when_provider_unused() -> None:
+    src = "import os\nprint(os.getcwd())\n"
+    new_src, changes = _patch_source(src, "openai")
+    assert new_src is None
+    assert changes == []
+
+
+def test_no_op_on_syntax_error() -> None:
+    new_src, _ = _patch_source("def (:\n", "openai")
+    assert new_src is None
+
+
+def test_unicode_before_node_is_safe() -> None:
+    # A non-ASCII comment shifts byte offsets vs char offsets — patcher must
+    # use byte offsets so the splice lands correctly.
+    src = (
+        "# 한국어 주석 comment\n"
+        "from openai import OpenAI\n"
+        "c = OpenAI(api_key='k')  # 키\n"
+    )
+    out = _patch(src, "openai")
+    assert "# 한국어 주석 comment" in out
+    assert "c = create_openai()" in out
+    assert "# 키" in out
+
+
+def test_multiple_calls_same_file() -> None:
+    src = (
+        "from openai import OpenAI\n"
+        "a = OpenAI(api_key='1')\n"
+        "b = OpenAI(api_key='2', timeout=5)\n"
+    )
+    out = _patch(src, "openai")
+    assert "a = create_openai()" in out
+    assert "b = create_openai(timeout=5)" in out
+
+
+def test_plan_and_apply_end_to_end(tmp_path: Path) -> None:
+    f = tmp_path / "agent.py"
+    f.write_text("from openai import OpenAI\nc = OpenAI(api_key='k')\n", encoding="utf-8")
+    # exclude dirs should be skipped
+    (tmp_path / ".venv").mkdir()
+    (tmp_path / ".venv" / "junk.py").write_text("from openai import OpenAI\nOpenAI()\n", encoding="utf-8")
+
+    plans = plan_patches(str(tmp_path), ["openai"])
+    assert len(plans) == 1
+    assert plans[0].filepath == str(f)
+
+    # dry run leaves the file untouched
+    apply_patches(plans, dry_run=True)
+    assert "OpenAI(api_key='k')" in f.read_text(encoding="utf-8")
+
+    # real apply rewrites it
+    results = apply_patches(plans)
+    assert results[0].patched is True
+    out = f.read_text(encoding="utf-8")
+    assert "c = create_openai()" in out
+    ast.parse(out)
+
+
+def test_plan_skips_unsupported_providers(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text("from openai import OpenAI\nOpenAI()\n", encoding="utf-8")
+    # mistral/openrouter/azure are not auto-patchable
+    assert plan_patches(str(tmp_path), ["mistral", "azure"]) == []

--- a/packages/sdk-python/tests/cli/test_env_writer.py
+++ b/packages/sdk-python/tests/cli/test_env_writer.py
@@ -1,0 +1,51 @@
+"""Env-file upsert mirrors packages/cli/src/env-writer.ts behavior."""
+
+from pathlib import Path
+
+from spanlens.cli.env_writer import read_env_var, upsert_env_var
+
+
+def test_creates_file_when_missing(tmp_path: Path) -> None:
+    result = upsert_env_var(str(tmp_path), ".env", "SPANLENS_API_KEY", "sl_live_abc")
+    assert result.created is True
+    assert result.changed is True
+    assert (tmp_path / ".env").read_text(encoding="utf-8") == "SPANLENS_API_KEY=sl_live_abc\n"
+
+
+def test_appends_preserving_existing_lines(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text("# my config\nOPENAI_API_KEY=sk-123\n", encoding="utf-8")
+    result = upsert_env_var(str(tmp_path), ".env", "SPANLENS_API_KEY", "sl_live_abc")
+    assert result.created is False
+    assert result.changed is True
+    text = env.read_text(encoding="utf-8")
+    assert "# my config" in text
+    assert "OPENAI_API_KEY=sk-123" in text
+    assert "SPANLENS_API_KEY=sl_live_abc" in text
+
+
+def test_replaces_existing_key_in_place(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text("SPANLENS_API_KEY=old\nFOO=bar\n", encoding="utf-8")
+    result = upsert_env_var(str(tmp_path), ".env", "SPANLENS_API_KEY", "new")
+    assert result.changed is True
+    text = env.read_text(encoding="utf-8")
+    assert "SPANLENS_API_KEY=new" in text
+    assert "SPANLENS_API_KEY=old" not in text
+    assert "FOO=bar" in text
+
+
+def test_idempotent_when_value_unchanged(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text("SPANLENS_API_KEY=same\n", encoding="utf-8")
+    result = upsert_env_var(str(tmp_path), ".env", "SPANLENS_API_KEY", "same")
+    assert result.changed is False
+    assert result.created is False
+
+
+def test_read_env_var(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text("SPANLENS_API_KEY= sl_live_xyz \nA=1\n", encoding="utf-8")
+    assert read_env_var(str(tmp_path), ".env", "SPANLENS_API_KEY") == "sl_live_xyz"
+    assert read_env_var(str(tmp_path), ".env", "MISSING") is None
+    assert read_env_var(str(tmp_path), "nope.env", "SPANLENS_API_KEY") is None

--- a/packages/sdk-python/tests/cli/test_framework_detect.py
+++ b/packages/sdk-python/tests/cli/test_framework_detect.py
@@ -1,0 +1,80 @@
+"""Project + provider detection across the common Python manifests."""
+
+from pathlib import Path
+
+from spanlens.cli.framework_detect import detect_project
+
+
+def test_unknown_when_empty(tmp_path: Path) -> None:
+    info = detect_project(str(tmp_path))
+    assert info.package_manager == "unknown"
+    assert info.manifest is None
+    assert info.env_file == ".env"
+    assert info.detected_providers == []
+
+
+def test_poetry_via_lockfile(tmp_path: Path) -> None:
+    (tmp_path / "poetry.lock").write_text("", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text("[tool.poetry]\nname='x'\n", encoding="utf-8")
+    assert detect_project(str(tmp_path)).package_manager == "poetry"
+
+
+def test_uv_via_lockfile(tmp_path: Path) -> None:
+    (tmp_path / "uv.lock").write_text("", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    assert detect_project(str(tmp_path)).package_manager == "uv"
+
+
+def test_pipenv_via_pipfile(tmp_path: Path) -> None:
+    (tmp_path / "Pipfile").write_text("[packages]\nopenai = '*'\n", encoding="utf-8")
+    info = detect_project(str(tmp_path))
+    assert info.package_manager == "pipenv"
+    assert "openai" in info.detected_providers
+
+
+def test_pip_via_requirements(tmp_path: Path) -> None:
+    (tmp_path / "requirements.txt").write_text(
+        "openai>=1.0.0\nanthropic==0.30.0\n# comment\n-r other.txt\n", encoding="utf-8"
+    )
+    info = detect_project(str(tmp_path))
+    assert info.package_manager == "pip"
+    assert set(info.detected_providers) == {"openai", "anthropic"}
+
+
+def test_pep621_dependencies_and_extras(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "demo"
+dependencies = ["openai>=1.0.0", "httpx"]
+
+[project.optional-dependencies]
+ai = ["google-generativeai>=0.5.0"]
+""",
+        encoding="utf-8",
+    )
+    info = detect_project(str(tmp_path))
+    assert set(info.detected_providers) == {"openai", "gemini"}
+
+
+def test_poetry_table_dependencies(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[tool.poetry]
+name = "demo"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+anthropic = "^0.30"
+""",
+        encoding="utf-8",
+    )
+    info = detect_project(str(tmp_path))
+    assert info.package_manager == "poetry"
+    assert "anthropic" in info.detected_providers
+
+
+def test_gemini_normalization(tmp_path: Path) -> None:
+    # PEP 503 normalization: Google_Generativeai == google-generativeai
+    (tmp_path / "requirements.txt").write_text("Google_Generativeai==0.8\n", encoding="utf-8")
+    assert "gemini" in detect_project(str(tmp_path)).detected_providers

--- a/packages/sdk-python/tests/cli/test_installer.py
+++ b/packages/sdk-python/tests/cli/test_installer.py
@@ -1,0 +1,58 @@
+"""Install-target construction + package-manager command selection."""
+
+import sys
+from pathlib import Path
+
+from spanlens.cli import installer
+from spanlens.cli.installer import (
+    install_spanlens,
+    install_target,
+    is_spanlens_declared,
+)
+
+
+def test_install_target_no_providers() -> None:
+    assert install_target([]) == "spanlens"
+
+
+def test_install_target_sorted_extras() -> None:
+    assert install_target(["anthropic", "openai"]) == "spanlens[anthropic,openai]"
+
+
+def test_install_target_ignores_unknown_provider() -> None:
+    # azure / mistral / openrouter have no SDK extra — they fall back to bare.
+    assert install_target(["mistral"]) == "spanlens"
+    assert install_target(["openai", "mistral"]) == "spanlens[openai]"
+
+
+def test_argv_per_manager() -> None:
+    assert installer._install_argv("poetry", "spanlens")[:2] == ["poetry", "add"]
+    assert installer._install_argv("uv", "spanlens")[:2] == ["uv", "add"]
+    assert installer._install_argv("pipenv", "spanlens")[:2] == ["pipenv", "install"]
+    pip = installer._install_argv("pip", "spanlens")
+    assert pip[0] == sys.executable and pip[1:4] == ["-m", "pip", "install"]
+
+
+def test_dry_run_returns_command_without_spawning(tmp_path: Path) -> None:
+    res = install_spanlens(str(tmp_path), "poetry", ["openai"], dry_run=True)
+    assert res.ok is True
+    assert res.command == "poetry add spanlens[openai]"
+
+
+def test_missing_manager_reports_error(tmp_path: Path) -> None:
+    res = install_spanlens(str(tmp_path), "poetry", ["openai"])
+    # poetry is almost certainly not on PATH in CI for this monorepo job.
+    if not res.ok:
+        assert "not found" in (res.error or "") or "exited" in (res.error or "")
+
+
+def test_is_spanlens_declared(tmp_path: Path) -> None:
+    assert is_spanlens_declared(str(tmp_path)) is False
+    (tmp_path / "requirements.txt").write_text("openai\nspanlens[openai]>=0.6\n", encoding="utf-8")
+    assert is_spanlens_declared(str(tmp_path)) is True
+
+
+def test_is_spanlens_declared_word_boundary(tmp_path: Path) -> None:
+    # "spanlens-extra" should not be mistaken for the spanlens package.
+    (tmp_path / "requirements.txt").write_text("spanlens-extra\n", encoding="utf-8")
+    assert is_spanlens_declared(str(tmp_path)) is False

--- a/packages/sdk-python/tests/cli/test_key_info.py
+++ b/packages/sdk-python/tests/cli/test_key_info.py
@@ -1,0 +1,94 @@
+"""Key-info client — mocks the /api/v1/me/key-info endpoint with respx."""
+
+import httpx
+import pytest
+import respx
+
+from spanlens.cli.key_info import KeyInfoError, fetch_key_info
+
+BASE = "https://www.spanlens.io"
+URL = f"{BASE}/api/v1/me/key-info"
+
+
+@respx.mock
+def test_valid_full_key_with_providers() -> None:
+    respx.get(URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "success": True,
+                "data": {
+                    "projectId": "p_1",
+                    "projectName": "My Project",
+                    "providers": ["openai", "anthropic"],
+                    "scope": "full",
+                },
+            },
+        )
+    )
+    info = fetch_key_info("sl_live_abc", BASE)
+    assert info.project_name == "My Project"
+    assert info.providers == ["openai", "anthropic"]
+    assert info.scope == "full"
+
+
+@respx.mock
+def test_public_workspace_key() -> None:
+    respx.get(URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "success": True,
+                "data": {
+                    "projectId": None,
+                    "projectName": None,
+                    "providers": [],
+                    "scope": "public",
+                },
+            },
+        )
+    )
+    info = fetch_key_info("sl_live_pub_abc", BASE)
+    assert info.project_id is None
+    assert info.scope == "public"
+    assert info.providers == []
+
+
+@respx.mock
+def test_401_raises_actionable_error() -> None:
+    respx.get(URL).mock(return_value=httpx.Response(401, json={"error": "nope"}))
+    with pytest.raises(KeyInfoError, match="rejected this key"):
+        fetch_key_info("sl_live_bad", BASE)
+
+
+@respx.mock
+def test_500_raises() -> None:
+    respx.get(URL).mock(return_value=httpx.Response(500, text="boom"))
+    with pytest.raises(KeyInfoError, match="500"):
+        fetch_key_info("sl_live_abc", BASE)
+
+
+@respx.mock
+def test_network_error_raises() -> None:
+    respx.get(URL).mock(side_effect=httpx.ConnectError("refused"))
+    with pytest.raises(KeyInfoError, match="Network error"):
+        fetch_key_info("sl_live_abc", BASE)
+
+
+@respx.mock
+def test_unexpected_shape_raises() -> None:
+    respx.get(URL).mock(return_value=httpx.Response(200, json={"success": True}))
+    with pytest.raises(KeyInfoError, match="Unexpected response shape"):
+        fetch_key_info("sl_live_abc", BASE)
+
+
+@respx.mock
+def test_trailing_slash_base_is_normalized() -> None:
+    route = respx.get(URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"success": True, "data": {"projectId": "p", "projectName": "n", "providers": [], "scope": "full"}},
+        )
+    )
+    fetch_key_info("sl_live_abc", BASE + "/")
+    assert route.called

--- a/packages/sdk-python/tests/cli/test_main.py
+++ b/packages/sdk-python/tests/cli/test_main.py
@@ -1,0 +1,81 @@
+"""End-to-end wizard smoke tests in non-interactive (--yes --dry-run) mode."""
+
+from pathlib import Path
+
+import pytest
+
+import spanlens.cli.main as cli_main
+from spanlens.cli.key_info import KeyInfo
+
+
+@pytest.fixture
+def fake_key_info(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake(api_key: str, api_base: str, **_kw: object) -> KeyInfo:
+        return KeyInfo(
+            project_id="p_1",
+            project_name="Demo",
+            providers=["openai"],
+            scope="full",
+        )
+
+    monkeypatch.setattr(cli_main, "fetch_key_info", _fake)
+
+
+def test_init_dry_run_writes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_key_info: None
+) -> None:
+    (tmp_path / "requirements.txt").write_text("openai>=1.0\n", encoding="utf-8")
+    (tmp_path / "agent.py").write_text(
+        "from openai import OpenAI\nc = OpenAI(api_key='k')\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    code = cli_main.main(["init", "--yes", "--dry-run", "--api-key", "sl_live_" + "a" * 20])
+    assert code == 0
+    # dry run: no .env created, source untouched
+    assert not (tmp_path / ".env").exists()
+    assert "OpenAI(api_key='k')" in (tmp_path / "agent.py").read_text(encoding="utf-8")
+
+
+def test_init_real_run_writes_env_and_patches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_key_info: None
+) -> None:
+    (tmp_path / "requirements.txt").write_text("openai>=1.0\nspanlens\n", encoding="utf-8")
+    (tmp_path / "agent.py").write_text(
+        "from openai import OpenAI\nc = OpenAI(api_key='k')\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    # spanlens already declared → install step is skipped (no subprocess).
+    code = cli_main.main(["init", "--yes", "--api-key", "sl_live_" + "b" * 20])
+    assert code == 0
+    assert (tmp_path / ".env").read_text(encoding="utf-8").count("SPANLENS_API_KEY=") == 1
+    assert "c = create_openai()" in (tmp_path / "agent.py").read_text(encoding="utf-8")
+
+
+def test_bad_key_format_exits(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(SystemExit):
+        cli_main.main(["init", "--yes", "--api-key", "not-a-key"])
+
+
+def test_test_subcommand(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_key_info: None) -> None:
+    monkeypatch.chdir(tmp_path)
+    code = cli_main.main(["test", "--api-key", "sl_live_" + "c" * 20])
+    assert code == 0
+
+
+def test_bare_invocation_defaults_to_init(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_key_info: None
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    # No subcommand, just flags → should run init.
+    code = cli_main.main(["--yes", "--dry-run", "--api-key", "sl_live_" + "d" * 20])
+    assert code == 0
+
+
+def test_version_flag_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc:
+        cli_main.main(["--version"])
+    assert exc.value.code == 0
+    assert "spanlens" in capsys.readouterr().out


### PR DESCRIPTION
## What

Adds an interactive onboarding wizard to the **Python SDK**, the Python counterpart of the Node `@spanlens/cli`. After `pip install spanlens`, a `spanlens` console command connects a Python project to Spanlens in one step. No new dependency: it uses only the standard library plus `httpx` (already a runtime dep), so it adds zero weight to plain SDK installs.

This closes the biggest onboarding gap for the Python market (70%+ of LLM work). Langfuse / Phoenix / Helicone / LangSmith all ship a `pip install` first run; Spanlens now matches.

## Commands

```bash
spanlens init                       # interactive wizard (default)
spanlens init --dry-run             # preview, write nothing
spanlens init --yes --api-key sl_   # non-interactive (CI / scripts)
spanlens init --server-url https... # self-hosted Spanlens
spanlens test                       # validate key + connectivity
spanlens --version
```

## What the wizard does

1. Detects the package manager (`poetry` / `uv` / `pipenv` / `pip`) and which provider libraries are already declared.
2. Validates the pasted `sl_live_*` key against `/api/v1/me/key-info` and introspects registered providers.
3. Writes `SPANLENS_API_KEY` into `.env` (idempotent, comment-preserving).
4. Installs the right `spanlens[...]` extras.
5. Rewrites client construction to route through the proxy.

## Code patcher (the risky bit)

AST-based (`spanlens.cli.code_patcher`): detects usage with stdlib `ast`, then splices edits by **byte offset** so formatting, comments, and unrelated code survive. Rewrites:

- `OpenAI(...)` / `AsyncOpenAI(...)` → `create_openai()` / `create_async_openai()`
- `Anthropic(...)` / `AsyncAnthropic(...)` → `create_anthropic()` / `create_async_anthropic()`
- `genai.configure(...)` → `configure_gemini()` (keeps `GenerativeModel` usage)

It strips `api_key` / `base_url`, preserves every other argument, and **re-parses each file before writing** so a patched file always imports.

## Files

- `packages/sdk-python/spanlens/cli/` — `main` (argparse), `prompts` (stdlib + ANSI), `colors`, `framework_detect`, `env_writer`, `installer`, `key_info`, `code_patcher`.
- `[project.scripts] spanlens = "spanlens.cli:main"`. Forces UTF-8 stdout so the wizard renders on legacy Windows code pages (cp949).
- `/docs/cli` page gains a full Python CLI section (install, walkthrough, before/after diffs for all three providers, flags).
- Version 0.7.0, aligned `__version__`, CHANGELOG.

## Test plan

- [x] 48 new unit tests (env / detect / install / patcher / key-info / wizard). Every patched output is re-parsed to guarantee valid Python; includes a Unicode-offset-safety case.
- [x] Full Python suite: 153 passed, 1 skipped.
- [x] `ruff check` clean, `mypy` strict clean.
- [x] `spanlens --help` / `--version` work on a cp949 Windows console (UTF-8 fix verified).
- [x] **Production smoke**: ran the full wizard against `www.spanlens.io` with a live key — validated (project + 3 providers), computed the correct `pip install spanlens[...]`, previewed and applied a real OpenAI patch producing valid Python.
- [x] Web `typecheck` + `lint` clean; `/docs/cli` renders 200 with no console errors (verified in preview).