### PR TITLE
fix(sdk): route configure_gemini through proxy via REST transport

### DIFF
--- a/packages/sdk-python/CHANGELOG.md
+++ b/packages/sdk-python/CHANGELOG.md
@@ -12,6 +12,10 @@ Onboarding CLI release. `pip install spanlens` now also installs a `spanlens` co
 - Flags: `--dry-run`, `--yes` (non-interactive), `--api-key`, `--server-url` (self-hosting).
 - `[project.scripts]` entry point so the command is available immediately after install. Output forces UTF-8 so the wizard renders on legacy Windows code pages.
 
+### Fixed
+
+- `configure_gemini()` now passes `transport="rest"` to `genai.configure(...)`. The default gRPC transport ignores an `https://` `api_endpoint`, so Gemini calls silently bypassed the proxy and were never logged. REST transport honours the proxy URL and sends the key as `x-goog-api-key`, which the proxy authenticates. Found during the CLI end-to-end smoke; OpenAI and Anthropic were already routing correctly.
+
 ### Verified
 
 - 48 unit tests across env writing, project detection, install-target construction, the AST patcher (including Unicode-offset safety and validity of every emitted file), the key-info client (mocked with `respx`), and the end-to-end wizard in `--dry-run` / `--yes` modes.

--- a/packages/sdk-python/spanlens/integrations/gemini.py
+++ b/packages/sdk-python/spanlens/integrations/gemini.py
@@ -80,6 +80,12 @@ def configure_gemini(
     endpoint. After calling, all ``genai.GenerativeModel(...).generate_content(...)``
     calls flow through Spanlens.
 
+    ``transport="rest"`` is mandatory here, not optional. The default gRPC
+    transport ignores an ``api_endpoint`` that is a full ``https://`` URL, so
+    requests silently bypass the proxy and never get logged. REST transport
+    honours the URL (including the ``/proxy/gemini`` path) and sends the key as
+    the ``x-goog-api-key`` header that the proxy authenticates against.
+
     Note:
         ``google.generativeai`` configures the endpoint *globally* per
         process — use this in single-tenant scripts. For multi-tenant
@@ -108,8 +114,10 @@ def configure_gemini(
 
     # google.generativeai accepts api_endpoint via client_options. The path
     # prefix (e.g. /v1beta) is added by the SDK; we only configure the host.
+    # transport="rest" is required so the https api_endpoint is actually used
+    # (the default gRPC transport ignores it and bypasses the proxy).
     client_options: Any = {"api_endpoint": proxy}
-    genai.configure(api_key=resolved_key, client_options=client_options)
+    genai.configure(api_key=resolved_key, transport="rest", client_options=client_options)
 
 
 __all__ = [

--- a/packages/sdk-python/tests/test_integrations.py
+++ b/packages/sdk-python/tests/test_integrations.py
@@ -153,3 +153,35 @@ def test_create_gemini_returns_httpx_client_with_auth(monkeypatch):
         assert client.headers["Authorization"] == "Bearer sl_test_gemini"
     finally:
         client.close()
+
+
+# ── configure_gemini (mocks google.generativeai so no optional dep needed) ──
+
+
+def test_configure_gemini_uses_rest_transport(monkeypatch):
+    """Regression guard: the default gRPC transport silently bypasses the
+    proxy (it ignores an https api_endpoint). configure_gemini() MUST pass
+    transport="rest" so calls are actually logged. See gemini.py."""
+    import sys
+    import types
+    from unittest.mock import MagicMock
+
+    fake = types.ModuleType("google.generativeai")
+    fake.configure = MagicMock()  # type: ignore[attr-defined]
+    google_pkg = sys.modules.get("google") or types.ModuleType("google")
+    monkeypatch.setitem(sys.modules, "google", google_pkg)
+    monkeypatch.setitem(sys.modules, "google.generativeai", fake)
+    monkeypatch.setenv("SPANLENS_API_KEY", "sl_test_gem")
+
+    from spanlens.integrations.gemini import (
+        DEFAULT_SPANLENS_GEMINI_PROXY,
+        configure_gemini,
+    )
+
+    configure_gemini()
+
+    fake.configure.assert_called_once()
+    kwargs = fake.configure.call_args.kwargs
+    assert kwargs["transport"] == "rest"
+    assert kwargs["api_key"] == "sl_test_gem"
+    assert kwargs["client_options"]["api_endpoint"] == DEFAULT_SPANLENS_GEMINI_PROXY


### PR DESCRIPTION
## Problem

Found during the Python CLI end-to-end smoke (PR #341). After `spanlens init` patches a Gemini project, the generated code calls `configure_gemini()`. That helper passed an `https://` `api_endpoint` to `genai.configure(...)` **under the default gRPC transport, which ignores it** — so Gemini calls silently bypassed the Spanlens proxy and produced **no dashboard row**, while still returning a normal response. OpenAI and Anthropic routed correctly.

## Fix

Pass `transport="rest"` to `genai.configure(...)`. REST transport honours the full proxy URL (including the `/proxy/gemini` path) and sends the key as `x-goog-api-key`, which the proxy's `authApiKey` middleware already accepts.

## Verification

- New unit test mocks `google.generativeai` and asserts `transport="rest"` + the proxy `api_endpoint` (no optional dep needed, CI-safe).
- Full suite: **154 passed, 1 skipped**; `ruff` clean.
- **Production end-to-end**: ran patched-style `configure_gemini()` + `GenerativeModel(...).generate_content(...)` against `www.spanlens.io`. Returned the exact expected text and **logged in `/requests` with status 200, cost $0.0000351**. Before the fix the same code logged nothing.

Folds into the unpublished `0.7.0`.