### PR TITLE
feat(server,sdk): run evals from CI/SDK via dual-auth (prompt CI)

### DIFF
--- a/apps/server/src/__tests__/eval-runs-dual-auth.test.ts
+++ b/apps/server/src/__tests__/eval-runs-dual-auth.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import { authJwtOrApiKey, type DualAuthContext } from '../middleware/authJwtOrApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
+import { _clearAuthCacheForTests } from '../middleware/authJwt.js'
+import { installOnError } from './helpers/install-on-error.js'
+
+/**
+ * P2-8: the evals router is dual-auth so CI/SDK can run evals with an
+ * sl_live_* key. Spend/write routes (eval-run trigger, evaluator CRUD)
+ * additionally mount requireFullScope. These tests pin the auth matrix on
+ * the exact middleware composition the router uses:
+ *
+ *   write route (authJwtOrApiKey + requireFullScope):
+ *     full sl_live_ key  → allowed
+ *     public sl_live_pub_ key → 403 PUBLIC_KEY_WRITE_FORBIDDEN
+ *     JWT                → allowed (requireFullScope is a no-op off the key path)
+ *   read route (authJwtOrApiKey only):
+ *     public key         → allowed
+ */
+
+const FULL_KEY = 'sl_live_fullkey0123456789abcdef'
+const PUBLIC_KEY = 'sl_live_pub_publickey0123456789'
+const JWT_TOKEN = 'fake-jwt-token-12345'
+
+const FULL_HASH = 'full-hash'
+const PUBLIC_HASH = 'public-hash'
+
+vi.mock('../lib/crypto.js', () => ({
+  sha256Hex: async (raw: string) => {
+    if (raw === FULL_KEY) return FULL_HASH
+    if (raw === PUBLIC_KEY) return PUBLIC_HASH
+    return 'invalid'
+  },
+}))
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: (table: string) => ({
+      select: (_cols: string) => ({
+        eq: (col: string, val: string) => ({
+          eq: (_col2: string, _val2: unknown) => ({
+            single: async () => {
+              if (table === 'api_keys' && col === 'key_hash') {
+                if (val === FULL_HASH) {
+                  return {
+                    data: {
+                      id: 'api-key-full',
+                      project_id: 'proj-1',
+                      organization_id: null,
+                      scope: 'full',
+                      projects: { organization_id: 'org-full', organizations: { plan: 'pro' } },
+                      organizations: null,
+                    },
+                    error: null,
+                  }
+                }
+                if (val === PUBLIC_HASH) {
+                  return {
+                    data: {
+                      id: 'api-key-public',
+                      project_id: null,
+                      organization_id: 'org-public',
+                      scope: 'public',
+                      projects: null,
+                      organizations: { plan: 'pro' },
+                    },
+                    error: null,
+                  }
+                }
+              }
+              return { data: null, error: { message: 'not found' } }
+            },
+            maybeSingle: async () => ({ data: null }),
+          }),
+          order: () => ({
+            limit: () => ({
+              maybeSingle: async () => ({
+                data: { organization_id: 'org-from-jwt', role: 'admin' },
+              }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  },
+  supabaseClient: {
+    auth: {
+      getUser: async (token: string) =>
+        token === JWT_TOKEN
+          ? { data: { user: { id: 'user-1', email: 'jwt@example.com' } }, error: null }
+          : { data: { user: null }, error: { message: 'invalid token' } },
+    },
+  },
+}))
+
+function buildApp() {
+  const app = new Hono<DualAuthContext>()
+  app.use('*', authJwtOrApiKey)
+  // Mirrors evalsRouter: write route guarded, read route open.
+  app.post('/eval-runs', requireFullScope, (c) =>
+    c.json({ ok: true, orgId: c.get('orgId'), scope: c.get('apiKeyScope') ?? null }),
+  )
+  app.get('/eval-runs', (c) => c.json({ ok: true, orgId: c.get('orgId') }))
+  installOnError(app)
+  return app
+}
+
+describe('evals dual-auth + full-scope guard', () => {
+  beforeEach(() => {
+    _clearAuthCacheForTests()
+  })
+
+  test('full sl_live_ key may trigger a run (write route)', async () => {
+    const res = await buildApp().request('/eval-runs', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${FULL_KEY}` },
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { orgId: string; scope: string }
+    expect(body.orgId).toBe('org-full')
+    expect(body.scope).toBe('full')
+  })
+
+  test('public sl_live_pub_ key is rejected on the write route', async () => {
+    const res = await buildApp().request('/eval-runs', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${PUBLIC_KEY}` },
+    })
+    expect(res.status).toBe(403)
+    const body = (await res.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('PUBLIC_KEY_WRITE_FORBIDDEN')
+  })
+
+  test('JWT passes the write route (requireFullScope is a no-op off the key path)', async () => {
+    const res = await buildApp().request('/eval-runs', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${JWT_TOKEN}` },
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { orgId: string; scope: string | null }
+    expect(body.orgId).toBe('org-from-jwt')
+    expect(body.scope).toBeNull()
+  })
+
+  test('public key may read runs (read route, no guard)', async () => {
+    const res = await buildApp().request('/eval-runs', {
+      headers: { Authorization: `Bearer ${PUBLIC_KEY}` },
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { orgId: string }
+    expect(body.orgId).toBe('org-public')
+  })
+})

--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -1,18 +1,25 @@
 import { Hono } from 'hono'
-import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { authJwtOrApiKey, type DualAuthContext } from '../middleware/authJwtOrApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { runEvalRun, estimateJudgeCostUsd } from '../lib/eval-runner.js'
 import { fireAndForget } from '../lib/wait-until.js'
 import { ApiError } from '../lib/errors.js'
 
-export const evalsRouter = new Hono<JwtContext>()
+// P2-8: evals are dual-auth so CI / SDK can run them with an sl_live_* key,
+// not just a dashboard JWT — this is the "prompt CI" enabler. Reads accept
+// full + public keys; routes that write evaluator config or spend the
+// provider key (evaluator CRUD, eval-run trigger) add requireFullScope so a
+// public (sl_live_pub_*) key stays read-only. requireFullScope is a no-op on
+// the JWT path (apiKeyScope is unset), so dashboard behaviour is unchanged.
+export const evalsRouter = new Hono<DualAuthContext>()
 
-evalsRouter.use('*', authJwt)
+evalsRouter.use('*', authJwtOrApiKey)
 
 // ── Evaluators (定義) ────────────────────────────────────────────────────────
 
 // POST /api/v1/evaluators — create a reusable evaluator
-evalsRouter.post('/evaluators', async (c) => {
+evalsRouter.post('/evaluators', requireFullScope, async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
@@ -184,7 +191,7 @@ evalsRouter.get('/evaluator-templates', async (c) => {
 })
 
 // DELETE /api/v1/evaluators/:id — soft delete (archive)
-evalsRouter.delete('/evaluators/:id', async (c) => {
+evalsRouter.delete('/evaluators/:id', requireFullScope, async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
@@ -202,7 +209,7 @@ evalsRouter.delete('/evaluators/:id', async (c) => {
 // ── Eval runs (실행) ─────────────────────────────────────────────────────────
 
 // POST /api/v1/eval-runs — kick off a run (returns immediately, run executes in background)
-evalsRouter.post('/eval-runs', async (c) => {
+evalsRouter.post('/eval-runs', requireFullScope, async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')

--- a/apps/web/app/docs/features/evals/page.tsx
+++ b/apps/web/app/docs/features/evals/page.tsx
@@ -272,6 +272,16 @@ export default function EvalsDocs() {
         </tbody>
       </table>
 
+      <p>
+        These endpoints accept either a dashboard session (Supabase JWT) or a
+        full-access Spanlens API key (<code>sl_live_*</code>), so you can drive
+        evals from CI as well as the dashboard. Read endpoints also accept a
+        public key (<code>sl_live_pub_*</code>); the write endpoints (create
+        evaluator, start a run) require a full key and reject a public key with{' '}
+        <code>PUBLIC_KEY_WRITE_FORBIDDEN</code>, since a run spends your
+        provider key.
+      </p>
+
       <h2>Example, create and run an evaluator</h2>
       <CodeBlock language="bash">{`# 1. Define the evaluator
 curl https://server.spanlens.io/api/v1/evaluators \\
@@ -320,6 +330,39 @@ curl https://server.spanlens.io/api/v1/eval-runs \\
 # 3. Poll for results (status: pending → running → completed)
 curl https://server.spanlens.io/api/v1/eval-runs/<run-id> \\
   -H "Authorization: Bearer $SPANLENS_JWT"`}</CodeBlock>
+
+      <h2>Run from CI (prompt CI)</h2>
+      <p>
+        Gate a prompt change on its eval score. The SDK&apos;s{' '}
+        <code>client.evals.run()</code> triggers a run with a full{' '}
+        <code>sl_live_*</code> key, polls until it finishes, and returns the
+        scored run so the job can fail the build when quality regresses. Unlike
+        tracing (fire-and-forget), this call blocks and throws on failure.
+      </p>
+      <CodeBlock language="typescript">{`import { SpanlensClient } from '@spanlens/sdk'
+
+// Use a full-access key (sl_live_*), not a public key.
+const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+
+const run = await client.evals.run({
+  evaluatorId: process.env.EVALUATOR_ID!,
+  promptVersionId: process.env.PROMPT_VERSION_ID!,
+  sampleSize: 50,
+})
+
+console.log(\`scored \${run.scored_count}/\${run.attempted_count}, avg \${run.avg_score}\`)
+
+// Quality gate: fail the build if the average drops below the bar.
+if (run.status !== 'completed' || (run.avg_score ?? 0) < 0.8) {
+  console.error('Eval gate failed')
+  process.exit(1)
+}`}</CodeBlock>
+      <p>
+        Pass <code>{`{ wait: false }`}</code> to return immediately after the run
+        is queued, or tune <code>pollIntervalMs</code> /{' '}
+        <code>timeoutMs</code>. Use <code>client.evals.getResults(run.id)</code>{' '}
+        to read the lowest-scoring samples for a CI log.
+      </p>
 
       <h2>Limitations</h2>
       <ul>

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/__tests__/evals.test.ts
+++ b/packages/sdk/src/__tests__/evals.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SpanlensClient } from '../client.js'
+import { SpanlensApiError } from '../transport.js'
+import type { EvalRun } from '../evals.js'
+
+/**
+ * P2-8 SDK contract: client.evals.run() triggers a run and (by default)
+ * polls to completion, returning the scored run so CI can gate on it.
+ * Blocking + throwing — a failed run must fail the build, and a public
+ * key must surface PUBLIC_KEY_WRITE_FORBIDDEN.
+ *
+ * fetch is stubbed via vi.stubGlobal (vi.spyOn doesn't intercept the SDK's
+ * direct global fetch in Node) with a fresh Response per call.
+ */
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function makeRun(over: Partial<EvalRun>): EvalRun {
+  return {
+    id: 'run_1',
+    organization_id: 'org_1',
+    evaluator_id: 'ev_1',
+    prompt_version_id: 'pv_1',
+    dataset_id: null,
+    source: 'production',
+    sample_size: 50,
+    status: 'pending',
+    scored_count: 0,
+    attempted_count: 0,
+    failed_count: 0,
+    avg_score: null,
+    total_cost_usd: 0,
+    error: null,
+    started_at: '2026-06-14T00:00:00Z',
+    completed_at: null,
+    ...over,
+  }
+}
+
+describe('client.evals', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('run() posts the trigger then polls until completed and returns the scored run', async () => {
+    fetchMock
+      // POST /eval-runs → pending
+      .mockResolvedValueOnce(jsonResponse({ success: true, data: makeRun({ status: 'pending' }) }))
+      // first poll → running
+      .mockResolvedValueOnce(jsonResponse({ success: true, data: makeRun({ status: 'running' }) }))
+      // second poll → completed
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          data: makeRun({ status: 'completed', scored_count: 48, attempted_count: 50, failed_count: 2, avg_score: 0.82 }),
+        }),
+      )
+
+    const client = new SpanlensClient({ apiKey: 'sl_live_full', baseUrl: 'https://api.test' })
+    const run = await client.evals.run(
+      { evaluatorId: 'ev_1', promptVersionId: 'pv_1', sampleSize: 50 },
+      { pollIntervalMs: 1 },
+    )
+
+    expect(run.status).toBe('completed')
+    expect(run.avg_score).toBe(0.82)
+    expect(run.scored_count).toBe(48)
+
+    // First call is the POST with a camelCase body the server expects.
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://api.test/api/v1/eval-runs')
+    expect(init.method).toBe('POST')
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer sl_live_full' })
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      evaluatorId: 'ev_1',
+      promptVersionId: 'pv_1',
+      source: 'production',
+      sampleSize: 50,
+    })
+    // 1 POST + 2 polls.
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('run({ wait: false }) returns immediately after the trigger', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: makeRun({ status: 'pending' }) }))
+
+    const client = new SpanlensClient({ apiKey: 'sl_live_full', baseUrl: 'https://api.test' })
+    const run = await client.evals.run({ evaluatorId: 'ev_1', promptVersionId: 'pv_1' }, { wait: false })
+
+    expect(run.status).toBe('pending')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('run() throws SpanlensApiError when a public key hits the write route', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        { error: { code: 'PUBLIC_KEY_WRITE_FORBIDDEN', message: 'Public API key cannot perform write operations.' } },
+        403,
+      ),
+    )
+
+    const client = new SpanlensClient({ apiKey: 'sl_live_pub_xyz', baseUrl: 'https://api.test' })
+    await expect(
+      client.evals.run({ evaluatorId: 'ev_1', promptVersionId: 'pv_1' }),
+    ).rejects.toThrowError(SpanlensApiError)
+  })
+
+  it('run() stops polling and returns a failed run (no infinite loop)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ success: true, data: makeRun({ status: 'pending' }) }))
+      .mockResolvedValueOnce(
+        jsonResponse({ success: true, data: makeRun({ status: 'failed', error: 'All judge calls failed' }) }),
+      )
+
+    const client = new SpanlensClient({ apiKey: 'sl_live_full', baseUrl: 'https://api.test' })
+    const run = await client.evals.run({ evaluatorId: 'ev_1', promptVersionId: 'pv_1' }, { pollIntervalMs: 1 })
+
+    expect(run.status).toBe('failed')
+    expect(run.error).toContain('failed')
+  })
+
+  it('getResults() returns the per-sample rows', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ success: true, data: [{ id: 'r1', eval_run_id: 'run_1', score: 0.4 }] }),
+    )
+
+    const client = new SpanlensClient({ apiKey: 'sl_live_full', baseUrl: 'https://api.test' })
+    const results = await client.evals.getResults('run_1')
+
+    expect(results).toHaveLength(1)
+    expect(results[0]?.score).toBe(0.4)
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe('https://api.test/api/v1/eval-runs/run_1/results')
+  })
+})

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,6 +1,7 @@
 import { createTransport, type Transport } from './transport.js'
 import { createTrace, TraceHandle } from './trace.js'
 import { makeBufferingTransport, shouldSample, validateSampleRate } from './sampler.js'
+import { createEvalsApi, type EvalsApi } from './evals.js'
 import type { SpanlensConfig, TraceOptions } from './types.js'
 
 /**
@@ -20,13 +21,34 @@ import type { SpanlensConfig, TraceOptions } from './types.js'
 export class SpanlensClient {
   private readonly transport: Transport
   private readonly sampleRate: number
+  private _evals: EvalsApi | undefined
+
+  /** Config kept so the lazily-built evals API can reuse apiKey + baseUrl. */
+  private readonly config: SpanlensConfig
 
   constructor(config: SpanlensConfig) {
     if (!config.apiKey || config.apiKey.trim().length === 0) {
       throw new Error('[spanlens] apiKey is required')
     }
+    this.config = config
     this.sampleRate = validateSampleRate(config.sampleRate)
     this.transport = createTransport(config)
+  }
+
+  /**
+   * Evals API — trigger prompt evaluations from CI / scripts and read back
+   * the score to gate on. Blocking and throws on failure (unlike tracing,
+   * which is fire-and-forget). Requires a full `sl_live_*` key — a public
+   * `sl_live_pub_*` key gets PUBLIC_KEY_WRITE_FORBIDDEN on run().
+   */
+  get evals(): EvalsApi {
+    if (!this._evals) {
+      this._evals = createEvalsApi({
+        apiKey: this.config.apiKey,
+        ...(this.config.baseUrl ? { baseUrl: this.config.baseUrl } : {}),
+      })
+    }
+    return this._evals
   }
 
   /**

--- a/packages/sdk/src/evals.ts
+++ b/packages/sdk/src/evals.ts
@@ -1,0 +1,225 @@
+/**
+ * Evals API — run prompt evaluations from CI / scripts.
+ *
+ * Unlike the ingest transport (fire-and-forget, silent, retries swallowed),
+ * this client is BLOCKING and THROWS on failure: a CI job needs an eval that
+ * fails to fail the build, and needs to read back the score to gate on it.
+ *
+ * @example  Fail the build when quality regresses.
+ *   const client = new SpanlensClient({ apiKey: 'sl_live_...' }) // full key, not pub
+ *   const run = await client.evals.run({
+ *     evaluatorId: 'ev_...',
+ *     promptVersionId: 'pv_...',
+ *     sampleSize: 50,
+ *   })
+ *   if ((run.avg_score ?? 0) < 0.8) {
+ *     console.error(`avg score ${run.avg_score} below gate`)
+ *     process.exit(1)
+ *   }
+ */
+
+import { SpanlensApiError } from './transport.js'
+
+const DEFAULT_BASE_URL = 'https://spanlens-server.vercel.app'
+const DEFAULT_POLL_INTERVAL_MS = 2000
+const DEFAULT_TIMEOUT_MS = 300_000
+
+export type EvalRunStatus = 'pending' | 'running' | 'completed' | 'failed'
+
+/** An eval run as returned by the API (snake_case, 1:1 with the REST shape). */
+export interface EvalRun {
+  id: string
+  organization_id: string
+  evaluator_id: string
+  prompt_version_id: string
+  dataset_id: string | null
+  source: 'production' | 'dataset'
+  sample_size: number
+  status: EvalRunStatus
+  /** Samples that were successfully scored. */
+  scored_count: number
+  /** Samples sent to the judge after the empty-response filter. */
+  attempted_count: number
+  /** Samples whose scoring failed (attempted - scored). */
+  failed_count: number
+  /** Mean score in 0..1 (NUMERIC) / pass-rate (BOOLEAN); null for other types or empty runs. */
+  avg_score: number | null
+  total_cost_usd: number
+  error: string | null
+  started_at: string
+  completed_at: string | null
+}
+
+export interface EvalResult {
+  id: string
+  eval_run_id: string
+  request_id: string | null
+  dataset_item_id: string | null
+  score: number | null
+  reasoning: string | null
+  value_number: number | null
+  value_string: string | null
+  value_boolean: boolean | null
+}
+
+export interface RunEvalInput {
+  evaluatorId: string
+  promptVersionId: string
+  /** Defaults to 'production' (samples recent traffic for the prompt version). */
+  source?: 'production' | 'dataset'
+  /** Required when source = 'dataset'. */
+  datasetId?: string
+  /** 1..1000, defaults to 50. */
+  sampleSize?: number
+  sampleFrom?: string
+  sampleTo?: string
+  /** Required when source = 'dataset'. */
+  runProvider?: string
+  /** Required when source = 'dataset'. */
+  runModel?: string
+}
+
+export interface RunEvalOptions {
+  /** Poll until the run reaches a terminal state. Default true. */
+  wait?: boolean
+  /** Poll cadence in ms. Default 2000. */
+  pollIntervalMs?: number
+  /** Give up after this many ms of polling. Default 300000 (5 min). */
+  timeoutMs?: number
+}
+
+interface EvalsApiConfig {
+  apiKey: string
+  baseUrl: string
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export class EvalsApi {
+  private readonly apiKey: string
+  private readonly baseUrl: string
+
+  constructor(config: EvalsApiConfig) {
+    this.apiKey = config.apiKey
+    this.baseUrl = config.baseUrl.replace(/\/$/, '')
+  }
+
+  /**
+   * Trigger an eval run. By default waits for it to finish and returns the
+   * completed run (with avg_score / scored_count populated). Pass
+   * `{ wait: false }` to return immediately after the run is queued.
+   *
+   * Throws SpanlensApiError on a 4xx (e.g. a public key hitting this
+   * write route → PUBLIC_KEY_WRITE_FORBIDDEN), and a plain Error on a
+   * server error, network failure, or wait timeout.
+   */
+  async run(input: RunEvalInput, options: RunEvalOptions = {}): Promise<EvalRun> {
+    const created = await this.request<EvalRun>('POST', '/api/v1/eval-runs', {
+      evaluatorId: input.evaluatorId,
+      promptVersionId: input.promptVersionId,
+      source: input.source ?? 'production',
+      datasetId: input.datasetId,
+      sampleSize: input.sampleSize ?? 50,
+      sampleFrom: input.sampleFrom,
+      sampleTo: input.sampleTo,
+      runProvider: input.runProvider,
+      runModel: input.runModel,
+    })
+
+    if (options.wait === false) return created
+
+    const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    const deadline = Date.now() + timeoutMs
+
+    let run = created
+    while (run.status === 'pending' || run.status === 'running') {
+      if (Date.now() > deadline) {
+        throw new Error(
+          `[spanlens] eval run ${run.id} did not finish within ${timeoutMs}ms (last status: ${run.status})`,
+        )
+      }
+      await sleep(pollIntervalMs)
+      run = await this.getRun(run.id)
+    }
+    return run
+  }
+
+  /** Fetch a single run by id. */
+  getRun(id: string): Promise<EvalRun> {
+    return this.request<EvalRun>('GET', `/api/v1/eval-runs/${encodeURIComponent(id)}`)
+  }
+
+  /** List recent runs, optionally filtered by evaluator / prompt version. */
+  listRuns(filter: { evaluatorId?: string; promptVersionId?: string } = {}): Promise<EvalRun[]> {
+    const params = new URLSearchParams()
+    if (filter.evaluatorId) params.set('evaluatorId', filter.evaluatorId)
+    if (filter.promptVersionId) params.set('promptVersionId', filter.promptVersionId)
+    const qs = params.toString()
+    return this.request<EvalRun[]>('GET', `/api/v1/eval-runs${qs ? `?${qs}` : ''}`)
+  }
+
+  /** Fetch the per-sample results for a run. */
+  getResults(id: string): Promise<EvalResult[]> {
+    return this.request<EvalResult[]>('GET', `/api/v1/eval-runs/${encodeURIComponent(id)}/results`)
+  }
+
+  private async request<T>(method: 'GET' | 'POST', path: string, body?: unknown): Promise<T> {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    })
+
+    const text = await res.text().catch(() => '')
+
+    if (!res.ok) {
+      const apiError = parseApiError(text, res.status)
+      if (apiError) throw apiError
+      throw new Error(`[spanlens] ${method} ${path} -> ${res.status} ${text.slice(0, 200)}`)
+    }
+
+    // Success envelope: { success: true, data: T }
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      throw new Error(`[spanlens] ${method} ${path} returned a non-JSON body`)
+    }
+    const env = parsed as { data?: T }
+    return env.data as T
+  }
+}
+
+/** Parse a standard ApiErrorEnvelope into a typed SpanlensApiError, or null. */
+function parseApiError(text: string, status: number): SpanlensApiError | null {
+  if (!text) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    return null
+  }
+  if (parsed == null || typeof parsed !== 'object') return null
+  const maybe = parsed as { error?: { code?: unknown; message?: unknown; details?: unknown; requestId?: unknown } }
+  if (maybe.error == null || typeof maybe.error !== 'object') return null
+  if (typeof maybe.error.code !== 'string' || typeof maybe.error.message !== 'string') return null
+  return new SpanlensApiError({
+    code: maybe.error.code,
+    message: maybe.error.message,
+    status,
+    ...(maybe.error.details && typeof maybe.error.details === 'object'
+      ? { details: maybe.error.details as Record<string, unknown> }
+      : {}),
+    requestId: typeof maybe.error.requestId === 'string' ? maybe.error.requestId : null,
+  })
+}
+
+export function createEvalsApi(config: { apiKey: string; baseUrl?: string }): EvalsApi {
+  return new EvalsApi({ apiKey: config.apiKey, baseUrl: config.baseUrl ?? DEFAULT_BASE_URL })
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -7,6 +7,16 @@ export { parseOpenAIUsage, parseAnthropicUsage, parseGeminiUsage } from './parse
 // that follow the standard envelope. See transport.ts for the shape.
 export { SpanlensApiError } from './transport.js'
 
+// Evals API (CI / script-driven prompt evaluation — "prompt CI").
+export { EvalsApi } from './evals.js'
+export type {
+  EvalRun,
+  EvalResult,
+  EvalRunStatus,
+  RunEvalInput,
+  RunEvalOptions,
+} from './evals.js'
+
 export type {
   SpanlensConfig,
   TraceOptions,


### PR DESCRIPTION
Phase 1 / **P2-8** of the eval improvements: make evals runnable from CI/SDK, not just the dashboard. This is the core of the "prompt CI" story — gate a prompt change on its eval score.

## Server
`evalsRouter` switched from `authJwt`-only to `authJwtOrApiKey`:
- **Reads** (`GET /eval-runs`, `:id`, `:id/results`) accept a dashboard JWT, a full `sl_live_*` key, or a public `sl_live_pub_*` key.
- **Writes/spend** (`POST /evaluators`, `DELETE /evaluators/:id`, `POST /eval-runs`) add `requireFullScope` — a no-op on the JWT path, but blocks a public key with `PUBLIC_KEY_WRITE_FORBIDDEN`. A run spends the provider key, so it must not be triggerable from a key meant to be publicly exposed.
- Sibling routers are unaffected — their own `authJwt` still rejects non-JWT auth, so dual-auth doesn't leak access to datasets/experiments/etc.

## SDK (`@spanlens/sdk` 0.6.1 → 0.7.0)
New `client.evals` API: `run` / `getRun` / `listRuns` / `getResults`. Unlike tracing (fire-and-forget, silent), it **blocks and throws** so a failed eval fails the build. `run()` triggers a run, polls to completion, and returns the scored run.

```ts
const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! }) // full key
const run = await client.evals.run({ evaluatorId, promptVersionId, sampleSize: 50 })
if (run.status !== 'completed' || (run.avg_score ?? 0) < 0.8) process.exit(1)
```

## Docs
`/docs/features/evals` gains a "Run from CI" section + a dual-auth note on the API table.

## Verification
- server: typecheck + lint + test (1105 passed, +4 dual-auth)
- sdk: typecheck + test (128 passed, +5 evals) + build
- web: typecheck + lint; docs page renders 200 in preview

## Tests
- `eval-runs-dual-auth.test.ts`: full key → write allowed; public key → 403 `PUBLIC_KEY_WRITE_FORBIDDEN`; JWT → allowed; public key → read allowed.
- `evals.test.ts` (SDK): poll-to-completion returns scored run; `wait:false` returns immediately; public key throws `SpanlensApiError`; failed run terminates the poll loop; `getResults` shape.

## Follow-up
**P2-9** (the other half of Phase 1) — quality-score alerts + prompt-version promotion gate — is a separate change.