### PR TITLE
feat(server,web): eval_score quality alerts (alert-only)

### DIFF
--- a/apps/server/src/__tests__/evaluate-alerts.test.ts
+++ b/apps/server/src/__tests__/evaluate-alerts.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest'
+import { isAlertBreached, type AlertType } from '../lib/cron-jobs/evaluate-alerts.js'
+
+/**
+ * P2-9: eval_score is a quality FLOOR — it breaches when the average score
+ * drops to/below the threshold, the opposite direction from the budget /
+ * error_rate / latency_p95 CEILINGS. A regression that treats eval_score
+ * like the others would alert exactly when quality is GOOD and stay silent
+ * when it regresses, so this direction is the thing worth pinning.
+ */
+
+const CEILINGS: AlertType[] = ['budget', 'error_rate', 'latency_p95']
+
+describe('isAlertBreached', () => {
+  test.each(CEILINGS)('%s breaches when current rises to/above threshold', (type) => {
+    expect(isAlertBreached(type, 11, 10)).toBe(true) // above
+    expect(isAlertBreached(type, 10, 10)).toBe(true) // at (>=)
+    expect(isAlertBreached(type, 9, 10)).toBe(false) // below
+  })
+
+  test('eval_score breaches when the score drops to/below threshold (inverted)', () => {
+    expect(isAlertBreached('eval_score', 0.7, 0.8)).toBe(true) // below the floor
+    expect(isAlertBreached('eval_score', 0.8, 0.8)).toBe(true) // at (<=)
+    expect(isAlertBreached('eval_score', 0.9, 0.8)).toBe(false) // healthy, above the floor
+  })
+
+  test('eval_score does NOT use the ceiling direction', () => {
+    // A high score must never fire an eval_score alert (the regression we guard against).
+    expect(isAlertBreached('eval_score', 1.0, 0.8)).toBe(false)
+    // A ceiling metric with the same numbers WOULD fire — proving the direction differs.
+    expect(isAlertBreached('error_rate', 1.0, 0.8)).toBe(true)
+  })
+})

--- a/apps/server/src/api/alerts.ts
+++ b/apps/server/src/api/alerts.ts
@@ -10,7 +10,10 @@ alertsRouter.use('*', authJwt)
 
 const requireEdit = requireRole('admin', 'editor')
 
-const VALID_ALERT_TYPES = new Set(['budget', 'error_rate', 'latency_p95'])
+// eval_score (P2-9) is a quality FLOOR: it fires when the average eval score
+// over the window drops to/below the threshold (the others are ceilings that
+// fire when the metric rises to/above). Its threshold is a 0..1 score.
+const VALID_ALERT_TYPES = new Set(['budget', 'error_rate', 'latency_p95', 'eval_score'])
 const VALID_CHANNEL_KINDS = new Set(['email', 'slack', 'discord'])
 
 // ── GET /api/v1/alerts ──────────────────────────────────────────
@@ -51,10 +54,15 @@ alertsRouter.post('/', requireEdit, async (c) => {
     throw new ApiError('VALIDATION_FAILED', 'name is required')
   }
   if (typeof body.type !== 'string' || !VALID_ALERT_TYPES.has(body.type)) {
-    throw new ApiError('VALIDATION_FAILED', 'type must be budget | error_rate | latency_p95')
+    throw new ApiError('VALIDATION_FAILED', 'type must be budget | error_rate | latency_p95 | eval_score')
   }
   if (typeof body.threshold !== 'number' || body.threshold <= 0) {
     throw new ApiError('VALIDATION_FAILED', 'threshold must be a positive number')
+  }
+  // eval_score thresholds are 0..1 (avg_score is normalized). Reject out-of-range
+  // values up front — a threshold > 1 would fire on every run (score can't exceed 1).
+  if (body.type === 'eval_score' && body.threshold > 1) {
+    throw new ApiError('VALIDATION_FAILED', 'eval_score threshold must be between 0 and 1')
   }
 
   const insert = {

--- a/apps/server/src/lib/cron-jobs/evaluate-alerts.ts
+++ b/apps/server/src/lib/cron-jobs/evaluate-alerts.ts
@@ -21,16 +21,30 @@ import { deliverToChannel, type AlertNotification } from '../notifiers.js'
 import { emitWebhookEvent } from '../webhook-emit.js'
 import { logError } from '../structured-logger.js'
 
+export type AlertType = 'budget' | 'error_rate' | 'latency_p95' | 'eval_score'
+
 export interface AlertRow {
   id: string
   organization_id: string
   project_id: string | null
   name: string
-  type: 'budget' | 'error_rate' | 'latency_p95'
+  type: AlertType
   threshold: number
   window_minutes: number
   cooldown_minutes: number
   last_triggered_at: string | null
+}
+
+/**
+ * Whether `current` breaches the alert threshold. Direction depends on the
+ * metric: budget / error_rate / latency_p95 are CEILINGS (breach when the
+ * value rises to/above the threshold), while eval_score is a quality FLOOR
+ * (breach when the score drops to/below it). Exported + pure so the
+ * inverted eval_score direction is unit-testable without the full cron.
+ */
+export function isAlertBreached(type: AlertType, current: number, threshold: number): boolean {
+  if (type === 'eval_score') return current <= threshold
+  return current >= threshold
 }
 
 export interface ChannelRow {
@@ -46,6 +60,35 @@ export interface EvaluateAlertsJobResult {
 }
 
 async function computeMetric(alert: AlertRow): Promise<number | null> {
+  // eval_score reads from Supabase (eval_runs), not ClickHouse. It is the
+  // mean of completed runs' avg_score over the window. Returns null when no
+  // completed runs scored in the window (no data → don't fire). eval_runs has
+  // no project_id, so project-scoped eval_score alerts fall back to org-level.
+  if (alert.type === 'eval_score') {
+    const windowStartIso = new Date(Date.now() - alert.window_minutes * 60 * 1000).toISOString()
+    const { data, error } = await supabaseAdmin
+      .from('eval_runs')
+      .select('avg_score')
+      .eq('organization_id', alert.organization_id)
+      .eq('status', 'completed')
+      .gte('completed_at', windowStartIso)
+      .not('avg_score', 'is', null)
+    if (error) {
+      logError('CRON_JOB_FAILED', {
+        jobName: 'evaluate-alerts',
+        orgId: alert.organization_id,
+        alertId: alert.id,
+        kind: 'compute_metric_eval_score',
+      }, error)
+      return null
+    }
+    const scores = (data ?? [])
+      .map((r) => r.avg_score)
+      .filter((s): s is number => s != null)
+    if (scores.length === 0) return null
+    return scores.reduce((a, b) => a + b, 0) / scores.length
+  }
+
   const windowStart = new Date(Date.now() - alert.window_minutes * 60 * 1000)
     .toISOString()
     .replace('T', ' ')
@@ -131,7 +174,12 @@ export async function runEvaluateAlertsJob(): Promise<EvaluateAlertsJobResult> {
     }
 
     const current = await computeMetric(alert)
-    if (current == null || current < alert.threshold) {
+    if (current == null) {
+      // No data in the window (or a metric error) — can't assert a breach.
+      report.push({ alert_id: alert.id, fired: false, reason: 'no_data' })
+      continue
+    }
+    if (!isAlertBreached(alert.type, current, alert.threshold)) {
       report.push({ alert_id: alert.id, fired: false, reason: 'under_threshold' })
       continue
     }

--- a/apps/server/src/lib/notifiers.ts
+++ b/apps/server/src/lib/notifiers.ts
@@ -17,7 +17,7 @@ export interface NotificationChannelRow {
 
 export interface AlertNotification {
   alertName: string
-  alertType: 'budget' | 'error_rate' | 'latency_p95'
+  alertType: 'budget' | 'error_rate' | 'latency_p95' | 'eval_score'
   threshold: number
   currentValue: number
   windowMinutes: number
@@ -31,6 +31,8 @@ function formatAlertValue(
 ): string {
   if (type === 'budget') return `$${value.toFixed(4)}`
   if (type === 'error_rate') return `${(value * 100).toFixed(1)}%`
+  // eval_score is a normalized 0..1 quality score; show it as a percentage.
+  if (type === 'eval_score') return `${(value * 100).toFixed(1)}%`
   return `${Math.round(value)}ms`
 }
 
@@ -40,7 +42,9 @@ function buildSubject(n: AlertNotification): string {
       ? 'Budget threshold'
       : n.alertType === 'error_rate'
         ? 'Error rate'
-        : 'p95 latency'
+        : n.alertType === 'eval_score'
+          ? 'Eval score'
+          : 'p95 latency'
   return `[Spanlens] ${verb} alert: ${n.alertName}`
 }
 
@@ -101,7 +105,13 @@ export async function sendSlackAlert(
   n: AlertNotification,
 ): Promise<DeliveryResult> {
   const color =
-    n.alertType === 'budget' ? '#eab308' : n.alertType === 'error_rate' ? '#ef4444' : '#f97316'
+    n.alertType === 'budget'
+      ? '#eab308'
+      : n.alertType === 'error_rate'
+        ? '#ef4444'
+        : n.alertType === 'eval_score'
+          ? '#a855f7'
+          : '#f97316'
   try {
     const res = await fetch(webhookUrl, {
       method: 'POST',

--- a/apps/web/app/(dashboard)/alerts/[id]/alert-detail-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/[id]/alert-detail-client.tsx
@@ -31,12 +31,14 @@ import { cn, formatDateTime } from '@/lib/utils'
 function fmtThreshold(type: AlertType, threshold: number): string {
   if (type === 'budget') return `$${threshold}`
   if (type === 'error_rate') return `${(threshold * 100).toFixed(1)}%`
+  if (type === 'eval_score') return `${(threshold * 100).toFixed(1)}%`
   return `${threshold}ms`
 }
 
 function kindLabel(type: AlertType): string {
   if (type === 'budget') return 'BUDGET'
   if (type === 'error_rate') return 'ERROR RATE'
+  if (type === 'eval_score') return 'EVAL SCORE'
   return 'P95 LATENCY'
 }
 
@@ -258,8 +260,14 @@ export function AlertDetailClient() {
           <div className="border border-border rounded-xl bg-bg-elev px-5 py-4 mb-5">
             <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-2">Trigger</div>
             <code className="font-mono text-[13px] text-text">
-              {alert.type === 'budget' ? 'sum(cost)' : alert.type === 'error_rate' ? 'error_rate' : 'p95(latency)'}
-              {' '}&gt; {fmtThreshold(alert.type, alert.threshold)}
+              {alert.type === 'budget'
+                ? 'sum(cost)'
+                : alert.type === 'error_rate'
+                  ? 'error_rate'
+                  : alert.type === 'eval_score'
+                    ? 'avg(eval_score)'
+                    : 'p95(latency)'}
+              {' '}{alert.type === 'eval_score' ? '<' : '>'} {fmtThreshold(alert.type, alert.threshold)}
               {' '}for {alert.window_minutes}m
             </code>
             <p className="text-[12px] text-text-muted mt-2 leading-relaxed">

--- a/apps/web/app/(dashboard)/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/alerts-client.tsx
@@ -21,13 +21,28 @@ import { cn, formatDateTime } from '@/lib/utils'
 function fmtThreshold(type: AlertType, threshold: number): string {
   if (type === 'budget') return `$${threshold}`
   if (type === 'error_rate') return `${(threshold * 100).toFixed(1)}%`
+  if (type === 'eval_score') return `${(threshold * 100).toFixed(1)}%`
   return `${threshold}ms`
 }
 
 function kindLabel(type: AlertType): string {
   if (type === 'budget') return 'BUDGET'
   if (type === 'error_rate') return 'ERROR RATE'
+  if (type === 'eval_score') return 'EVAL SCORE'
   return 'P95 LATENCY'
+}
+
+// eval_score is a quality floor (fires when score drops BELOW). The others
+// are ceilings (fire when the metric rises ABOVE).
+function alertComparator(type: AlertType): '<' | '>' {
+  return type === 'eval_score' ? '<' : '>'
+}
+
+function alertMetricLabel(type: AlertType): string {
+  if (type === 'budget') return 'sum(cost)'
+  if (type === 'error_rate') return 'error_rate'
+  if (type === 'eval_score') return 'avg(eval_score)'
+  return 'p95(latency)'
 }
 
 function isRecentlyFired(lastTriggeredAt: string | null): boolean {
@@ -97,8 +112,8 @@ function AlertRuleRow({
         </div>
         <div className="font-mono text-[11px] text-text-muted">
           <span className="text-text-faint">trigger </span>
-          {a.type === 'budget' ? 'sum(cost)' : a.type === 'error_rate' ? 'error_rate' : 'p95(latency)'}{' '}
-          &gt; {fmtThreshold(a.type, a.threshold)}
+          {alertMetricLabel(a.type)}{' '}
+          {alertComparator(a.type)} {fmtThreshold(a.type, a.threshold)}
           <span className="text-text-faint"> for </span>{a.window_minutes}m
           {a.last_triggered_at && (
             <span className="text-text-faint ml-2">· last fired {formatDateTime(a.last_triggered_at)}</span>
@@ -727,12 +742,13 @@ export function AlertsClient() {
                   <SelectItem value="budget">Budget (USD)</SelectItem>
                   <SelectItem value="error_rate">Error rate (0–1)</SelectItem>
                   <SelectItem value="latency_p95">p95 latency (ms)</SelectItem>
+                  <SelectItem value="eval_score">Eval score (0–1, fires below)</SelectItem>
                 </SelectContent>
               </Select>
             </div>
             <div className="grid grid-cols-3 gap-3">
               {[
-                { label: 'Threshold', value: newThreshold, onChange: setNewThreshold, placeholder: newType === 'budget' ? '10' : newType === 'error_rate' ? '0.05' : '2000' },
+                { label: 'Threshold', value: newThreshold, onChange: setNewThreshold, placeholder: newType === 'budget' ? '10' : newType === 'error_rate' ? '0.05' : newType === 'eval_score' ? '0.8' : '2000' },
                 { label: 'Window (min)', value: newWindow, onChange: setNewWindow, placeholder: '60' },
                 { label: 'Cooldown (min)', value: newCooldown, onChange: setNewCooldown, placeholder: '60' },
               ].map((f) => (

--- a/apps/web/app/docs/features/alerts/page.tsx
+++ b/apps/web/app/docs/features/alerts/page.tsx
@@ -53,6 +53,15 @@ export default function AlertsDocs() {
             <td>95th percentile response time</td>
             <td>&ldquo;Alert if p95 &gt; 5000ms in the last 15 minutes&rdquo;</td>
           </tr>
+          <tr>
+            <td><code>eval_score</code></td>
+            <td>
+              Mean of completed <a href="/docs/features/evals">eval</a> runs&apos; avg score
+              over the window (0&ndash;1). A quality <strong>floor</strong>: fires when the
+              score drops to/below the threshold, the opposite direction from the others.
+            </td>
+            <td>&ldquo;Alert if avg eval score &lt; 0.8 in the last 24 hours&rdquo;</td>
+          </tr>
         </tbody>
       </table>
 
@@ -175,8 +184,10 @@ Content-Type: application/json
           through those services if you need escalation, but we don&apos;t natively integrate.
         </li>
         <li>
-          <strong>Fixed metric set.</strong> Only budget / error_rate / latency_p95 today. Custom
-          SQL or anomaly-based rules are roadmap items.
+          <strong>Fixed metric set.</strong> Only budget / error_rate / latency_p95 / eval_score
+          today. Custom SQL or anomaly-based rules are roadmap items. Note that
+          <code>eval_score</code> is org-level: <code>eval_runs</code> has no project_id, so a
+          project filter on an eval_score rule is ignored.
         </li>
         <li>
           <strong>Quota-overage warning emails run on a separate cron</strong> (hourly). Org

--- a/apps/web/lib/queries/types.ts
+++ b/apps/web/lib/queries/types.ts
@@ -365,7 +365,7 @@ export interface CheckoutResponse {
 
 // ── Alerts ─────────────────────────────────────────────────────
 
-export type AlertType = 'budget' | 'error_rate' | 'latency_p95'
+export type AlertType = 'budget' | 'error_rate' | 'latency_p95' | 'eval_score'
 export type ChannelKind = 'email' | 'slack' | 'discord'
 
 export interface AlertRow {


### PR DESCRIPTION
Phase 1 / **P2-9** of the eval improvements: wire eval results into the alerts pipeline so a quality regression actually notifies someone. Per product decision this is **alert-only** — no prompt-version promotion gate.

## The inverted direction
Existing alert types (`budget` / `error_rate` / `latency_p95`) are **ceilings**: they fire when the metric rises to/above the threshold. `eval_score` is a quality **floor**: it fires when the mean of completed eval runs' `avg_score` over the window drops to/below a 0..1 threshold. That direction is centralized in a pure, exported `isAlertBreached(type, current, threshold)` and unit-tested, because a regression here would alert exactly when quality is *good* and stay silent when it regresses.

## Changes
- **alerts.ts**: accept `eval_score`; reject a threshold > 1 for it.
- **evaluate-alerts.ts**: `eval_score` reads from Supabase (`eval_runs`), not ClickHouse — mean of completed runs' `avg_score` in the window; no completed runs → `null` → no fire (reported as `no_data`). Direction-aware firing via `isAlertBreached`.
- **notifiers.ts**: render `eval_score` (percentage value, "Eval score" subject, purple Slack swatch).
- **web**: alerts list / detail / create-dialog show `eval_score` with a `<` comparator and percentage threshold; `AlertType` widened.
- **docs**: alerts page documents the type and its org-level scope.

## Scope note
`eval_runs` has no `project_id`, so a project filter on an `eval_score` rule is ignored (org-level). Documented in the limitations.

## No migration
`alerts.type` has no DB CHECK constraint (app-layer validation only), so no migration is needed.

## Verification
- server: typecheck + lint + test (1110 passed, +5 `isAlertBreached`)
- web: typecheck + lint; docs + demo alerts pages render 200 in preview

## Tests
`evaluate-alerts.test.ts`: ceilings breach at/above threshold; `eval_score` breaches at/below (inverted); a high score never fires an `eval_score` alert while a ceiling metric with the same numbers does.

---
Completes Phase 1 of the eval improvements alongside #344 (P2-8, CI/SDK execution).