### PR TITLE
feat(server,sdk): eval reliability — retries, random sampling, reproducible generation, golden-set scoring

### DIFF
--- a/apps/server/src/__tests__/eval-runner-azure.test.ts
+++ b/apps/server/src/__tests__/eval-runner-azure.test.ts
@@ -87,6 +87,7 @@ describe('generateForItem — azure', () => {
       'gpt-4o-mini',
       KEY,
       RESOURCE,
+      0,
     )
 
     expect(out).toBe('generated answer')
@@ -105,8 +106,43 @@ describe('generateForItem — azure', () => {
       'gpt-4o-mini',
       KEY,
       null,
+      0,
     )
     expect(out).toBeNull()
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('callJudge — retry on transient errors (P1-3)', () => {
+  test('retries a 503 and succeeds on the next attempt', async () => {
+    const fn = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 503, json: async () => ({}), text: async () => '' })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          choices: [{ message: { content: '{"score": 5, "reasoning": "great"}' } }],
+          usage: { prompt_tokens: 10, completion_tokens: 5 },
+          model: 'gpt-4o-mini',
+        }),
+        text: async () => '',
+      })
+    vi.stubGlobal('fetch', fn)
+
+    const outcome = await callJudge(baseConfig, 'resp', KEY, RESOURCE)
+
+    expect(fn).toHaveBeenCalledTimes(2)
+    // scale 1..5, score 5 → normalized 1.0
+    expect(outcome?.score).toBeCloseTo(1)
+  })
+
+  test('does NOT retry a 400 (non-retryable client error)', async () => {
+    const fn = vi.fn().mockResolvedValue({ ok: false, status: 400, json: async () => ({}), text: async () => '' })
+    vi.stubGlobal('fetch', fn)
+
+    const outcome = await callJudge(baseConfig, 'resp', KEY, RESOURCE)
+
+    expect(outcome).toBeNull()
+    expect(fn).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -224,6 +224,8 @@ evalsRouter.post('/eval-runs', requireFullScope, async (c) => {
     sampleTo?: unknown
     runProvider?: unknown
     runModel?: unknown
+    sampleStrategy?: unknown
+    generationTemperature?: unknown
   }
   try {
     body = (await c.req.json()) as typeof body
@@ -238,11 +240,19 @@ evalsRouter.post('/eval-runs', requireFullScope, async (c) => {
   const sampleSize = typeof body.sampleSize === 'number' ? Math.round(body.sampleSize) : 50
   const sampleFrom = typeof body.sampleFrom === 'string' ? body.sampleFrom : null
   const sampleTo = typeof body.sampleTo === 'string' ? body.sampleTo : null
+  // P1-4 / P1-5: sampling strategy (default 'recent' = legacy) and generation
+  // temperature (default 0 = reproducible).
+  const sampleStrategy = body.sampleStrategy === 'random' ? 'random' : 'recent'
+  const generationTemperature =
+    typeof body.generationTemperature === 'number' ? body.generationTemperature : 0
 
   if (!evaluatorId) throw new ApiError('VALIDATION_FAILED', 'evaluatorId is required')
   if (!promptVersionId) throw new ApiError('VALIDATION_FAILED', 'promptVersionId is required')
   if (sampleSize < 1 || sampleSize > 1000) {
     throw new ApiError('VALIDATION_FAILED', 'sampleSize must be between 1 and 1000')
+  }
+  if (generationTemperature < 0 || generationTemperature > 2) {
+    throw new ApiError('VALIDATION_FAILED', 'generationTemperature must be between 0 and 2')
   }
   if (source === 'dataset' && !datasetId) {
     throw new ApiError('VALIDATION_FAILED', 'datasetId is required when source = dataset')
@@ -325,6 +335,8 @@ evalsRouter.post('/eval-runs', requireFullScope, async (c) => {
     sampleTo,
     runProvider,
     runModel,
+    sampleStrategy,
+    generationTemperature,
   }))
 
   return c.json({ success: true, data: run }, 202)

--- a/apps/server/src/lib/eval-runner.test.ts
+++ b/apps/server/src/lib/eval-runner.test.ts
@@ -25,6 +25,31 @@ describe('buildJudgePrompt — legacy NUMERIC path (score_config = null)', () =>
   })
 })
 
+// ── P1-6: expected_output (golden answer) injection ──────────────────────────
+describe('buildJudgePrompt — expected_output reference', () => {
+  it('injects the reference block when expected_output is present', () => {
+    const prompt = buildJudgePrompt('Is it correct?', 'Paris', {
+      scale_min: 0,
+      scale_max: 1,
+      expected_output: 'The capital of France is Paris.',
+    })
+    expect(prompt).toContain('Reference (expected) answer')
+    expect(prompt).toContain('The capital of France is Paris.')
+    expect(prompt).toContain('compare against')
+  })
+
+  it('omits the reference block when expected_output is null/absent (byte-identical to before)', () => {
+    const withNull = buildJudgePrompt('Is it correct?', 'Paris', {
+      scale_min: 0,
+      scale_max: 1,
+      expected_output: null,
+    })
+    const without = buildJudgePrompt('Is it correct?', 'Paris', { scale_min: 0, scale_max: 1 })
+    expect(withNull).not.toContain('Reference (expected) answer')
+    expect(withNull).toBe(without)
+  })
+})
+
 describe('buildJudgePrompt — NUMERIC score_config', () => {
   it('uses min/max from the score_config when present', () => {
     const sc: TypedScoreConfig = {

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -56,7 +56,46 @@ export type {
   SimpleEvalResult,
 }
 
-const JUDGE_CONCURRENCY = 5
+// P1-3: concurrency + retry are env-configurable (defaults preserve prior
+// behaviour). Generation gets its own pool so a large dataset can't fire all
+// items at once (the old uncapped Promise.all).
+const JUDGE_CONCURRENCY = Number(process.env['EVAL_JUDGE_CONCURRENCY']) || 5
+const GENERATION_CONCURRENCY = Number(process.env['EVAL_GENERATION_CONCURRENCY']) || 5
+const MAX_RETRIES = Number(process.env['EVAL_MAX_RETRIES']) || 3
+
+function evalSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * fetch with exponential backoff on transient failures (429, 5xx, network
+ * error). Returns the final Response (which may still be non-ok) or null if
+ * every attempt threw. Callers already treat a non-ok / null result as a
+ * dropped sample, so this only adds resilience — it never changes the
+ * success contract. Back-off: 250ms, 500ms, 1000ms (× MAX_RETRIES).
+ */
+async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  retries: number = MAX_RETRIES,
+): Promise<Response | null> {
+  let last: Response | null = null
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(url, init)
+      // Success, or a non-retryable client error (4xx other than 429) — done.
+      if (res.ok || !(res.status === 429 || (res.status >= 500 && res.status < 600))) {
+        return res
+      }
+      last = res
+    } catch {
+      // Network error / abort — retry.
+      last = null
+    }
+    if (attempt < retries) await evalSleep(250 * Math.pow(2, attempt))
+  }
+  return last
+}
 
 interface JudgeOutcome {
   // For NUMERIC configs (and the legacy NULL path) this stays the
@@ -97,6 +136,9 @@ export async function generateForItem(
   /** Azure resource origin (provider_keys.provider_metadata.resource_url).
    * Required when provider === 'azure'; ignored otherwise. */
   resourceUrl: string | null,
+  /** Generation temperature (P1-5). Defaults to 0 at the run boundary for a
+   * reproducible eval; was a hardcoded 0.7 before. */
+  temperature: number,
 ): Promise<string | null> {
   // The dataset-item shape allows either `variables` (template substitution)
   // or `messages` (already-formatted chat). Translate to a single user
@@ -119,16 +161,16 @@ export async function generateForItem(
 
   try {
     if (provider === 'openai') {
-      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      const res = await fetchWithRetry('https://api.openai.com/v1/chat/completions', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
         body: JSON.stringify(buildOpenAIBody(
           model,
           [{ role: 'system', content: promptContent }, { role: 'user', content: userContent }],
-          { temperature: 0.7, maxTokens: 1024 },
+          { temperature, maxTokens: 1024 },
         )),
       })
-      if (!res.ok) return null
+      if (!res || !res.ok) return null
       const json = await res.json() as { choices: Array<{ message: { content: string } }> }
       return json.choices?.[0]?.message?.content ?? null
     }
@@ -137,22 +179,22 @@ export async function generateForItem(
       const url = provider === 'mistral'
         ? 'https://api.mistral.ai/v1/chat/completions'
         : 'https://openrouter.ai/api/v1/chat/completions'
-      const res = await fetch(url, {
+      const res = await fetchWithRetry(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
         body: JSON.stringify(buildOpenAIBody(
           model,
           [{ role: 'system', content: promptContent }, { role: 'user', content: userContent }],
-          { temperature: 0.7, maxTokens: 1024 },
+          { temperature, maxTokens: 1024 },
         )),
       })
-      if (!res.ok) return null
+      if (!res || !res.ok) return null
       const json = await res.json() as { choices: Array<{ message: { content: string } }> }
       return json.choices?.[0]?.message?.content ?? null
     }
 
     if (provider === 'anthropic') {
-      const res = await fetch('https://api.anthropic.com/v1/messages', {
+      const res = await fetchWithRetry('https://api.anthropic.com/v1/messages', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -162,12 +204,12 @@ export async function generateForItem(
         body: JSON.stringify({
           model,
           max_tokens: 1024,
-          temperature: 0.7,
+          temperature,
           system: promptContent,
           messages: [{ role: 'user', content: userContent }],
         }),
       })
-      if (!res.ok) return null
+      if (!res || !res.ok) return null
       const json = await res.json() as { content: Array<{ type: string; text: string }> }
       return json.content?.find((b) => b.type === 'text')?.text ?? null
     }
@@ -177,22 +219,22 @@ export async function generateForItem(
       // shape, but the base URL is the per-key resource origin and auth uses
       // the `api-key` header instead of Bearer. Mirrors proxy/azure.ts.
       if (!resourceUrl) return null
-      const res = await fetch(`${resourceUrl}/openai/v1/chat/completions`, {
+      const res = await fetchWithRetry(`${resourceUrl}/openai/v1/chat/completions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'api-key': apiKey },
         body: JSON.stringify(buildOpenAIBody(
           model,
           [{ role: 'system', content: promptContent }, { role: 'user', content: userContent }],
-          { temperature: 0.7, maxTokens: 1024 },
+          { temperature, maxTokens: 1024 },
         )),
       })
-      if (!res.ok) return null
+      if (!res || !res.ok) return null
       const json = await res.json() as { choices: Array<{ message: { content: string } }> }
       return json.choices?.[0]?.message?.content ?? null
     }
 
     // Gemini
-    const res = await fetch(
+    const res = await fetchWithRetry(
       `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
       {
         method: 'POST',
@@ -200,11 +242,11 @@ export async function generateForItem(
         body: JSON.stringify({
           systemInstruction: { parts: [{ text: promptContent }] },
           contents: [{ role: 'user', parts: [{ text: userContent }] }],
-          generationConfig: { temperature: 0.7, maxOutputTokens: 1024 },
+          generationConfig: { temperature, maxOutputTokens: 1024 },
         }),
       },
     )
-    if (!res.ok) return null
+    if (!res || !res.ok) return null
     const json = await res.json() as {
       candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
     }
@@ -232,11 +274,15 @@ export async function callJudge(
   /** Azure resource origin (provider_keys.provider_metadata.resource_url).
    * Required when config.judge_provider === 'azure'; ignored otherwise. */
   resourceUrl: string | null,
+  /** Golden answer (P1-6). When present (dataset items with expected_output)
+   * it is injected into the prompt as a reference for the judge. */
+  expectedOutput: string | null = null,
 ): Promise<JudgeOutcome | null> {
   const prompt = buildJudgePrompt(config.criterion, responseText, {
     scale_min: config.scale_min,
     scale_max: config.scale_max,
     score_config: config.score_config ?? null,
+    expected_output: expectedOutput,
   })
 
   // Helper that turns a parsed judge reply into the JudgeOutcome the
@@ -280,7 +326,7 @@ export async function callJudge(
   }
 
   if (config.judge_provider === 'openai') {
-    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    const res = await fetchWithRetry('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -292,7 +338,7 @@ export async function callJudge(
         { temperature: 0, maxTokens: 200, responseFormat: { type: 'json_object' } },
       )),
     })
-    if (!res.ok) return null
+    if (!res || !res.ok) return null
     const json = await res.json() as {
       choices: Array<{ message: { content: string } }>
       usage: { prompt_tokens: number; completion_tokens: number }
@@ -320,7 +366,7 @@ export async function callJudge(
     const url = config.judge_provider === 'mistral'
       ? 'https://api.mistral.ai/v1/chat/completions'
       : 'https://openrouter.ai/api/v1/chat/completions'
-    const res = await fetch(url, {
+    const res = await fetchWithRetry(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -332,7 +378,7 @@ export async function callJudge(
         { temperature: 0, maxTokens: 200, responseFormat: { type: 'json_object' } },
       )),
     })
-    if (!res.ok) return null
+    if (!res || !res.ok) return null
     const json = await res.json() as {
       choices: Array<{ message: { content: string } }>
       usage: { prompt_tokens: number; completion_tokens: number; cost?: number }
@@ -361,7 +407,7 @@ export async function callJudge(
   }
 
   if (config.judge_provider === 'anthropic') {
-    const res = await fetch('https://api.anthropic.com/v1/messages', {
+    const res = await fetchWithRetry('https://api.anthropic.com/v1/messages', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -375,7 +421,7 @@ export async function callJudge(
         messages: [{ role: 'user', content: prompt }],
       }),
     })
-    if (!res.ok) return null
+    if (!res || !res.ok) return null
     const json = await res.json() as {
       content: Array<{ type: string; text: string }>
       usage: { input_tokens: number; output_tokens: number }
@@ -404,7 +450,7 @@ export async function callJudge(
     // (mirrors proxy/azure.ts). Without resource_url we can't build the URL —
     // fail the sample rather than hit a wrong endpoint.
     if (!resourceUrl) return null
-    const res = await fetch(`${resourceUrl}/openai/v1/chat/completions`, {
+    const res = await fetchWithRetry(`${resourceUrl}/openai/v1/chat/completions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -416,7 +462,7 @@ export async function callJudge(
         { temperature: 0, maxTokens: 200, responseFormat: { type: 'json_object' } },
       )),
     })
-    if (!res.ok) return null
+    if (!res || !res.ok) return null
     const json = await res.json() as {
       choices: Array<{ message: { content: string } }>
       usage: { prompt_tokens: number; completion_tokens: number }
@@ -442,7 +488,7 @@ export async function callJudge(
   // reply is always parseable. We hit `generateContent` directly (not our
   // /proxy) because eval-runner runs on the server — calls to api.openai.com
   // and generativelanguage.googleapis.com bypass our own proxy on purpose.
-  const geminiRes = await fetch(
+  const geminiRes = await fetchWithRetry(
     `https://generativelanguage.googleapis.com/v1beta/models/${config.judge_model}:generateContent?key=${apiKey}`,
     {
       method: 'POST',
@@ -494,7 +540,7 @@ export async function callJudge(
       }),
     },
   )
-  if (!geminiRes.ok) return null
+  if (!geminiRes || !geminiRes.ok) return null
   const geminiJson = await geminiRes.json() as {
     candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
     usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number }
@@ -548,6 +594,12 @@ interface RunInput {
   sampleSize: number
   sampleFrom?: string | null
   sampleTo?: string | null
+  /** P1-4: 'recent' (created_at DESC, default) keeps the legacy behaviour;
+   * 'random' (ORDER BY rand()) draws a representative, non-recency-biased
+   * sample. Production source only. */
+  sampleStrategy?: 'recent' | 'random' | null
+  /** P1-5: generation temperature for dataset runs. Defaults to 0 (reproducible). */
+  generationTemperature?: number | null
   /**
    * When source = 'dataset', the prompt content must be executed against each
    * item's input to produce a response — THEN that response is judged.
@@ -594,6 +646,8 @@ export async function runEvalRun(input: RunInput): Promise<void> {
     sampleTo,
     runProvider,
     runModel,
+    sampleStrategy,
+    generationTemperature,
   } = input
 
   // Mark running
@@ -731,6 +785,8 @@ export async function runEvalRun(input: RunInput): Promise<void> {
       responseText: string
       requestId: string | null
       datasetItemId: string | null
+      /** P1-6: golden answer for dataset items; null for production samples. */
+      expectedOutput: string | null
     }
     let preparedSamples: SampleRow[] = []
 
@@ -765,7 +821,9 @@ export async function runEvalRun(input: RunInput): Promise<void> {
           scope,
           select: 'id, response_body',
           filters: sampleFilters.join(' AND '),
-          orderBy: 'created_at DESC',
+          // P1-4: 'random' draws a representative sample (rand()); 'recent'
+          // (default) preserves the legacy latest-N behaviour.
+          orderBy: sampleStrategy === 'random' ? 'rand()' : 'created_at DESC',
           limit: sampleSize,
           params: sampleParams,
         })
@@ -785,6 +843,7 @@ export async function runEvalRun(input: RunInput): Promise<void> {
             responseText: extractResponseText(parsed) ?? '',
             requestId: s.id,
             datasetItemId: null,
+            expectedOutput: null,
           }
         })
         .filter((s) => s.responseText.length > 0)
@@ -834,41 +893,52 @@ export async function runEvalRun(input: RunInput): Promise<void> {
         }
       }
 
-      // 2. Fetch all items in the dataset (no expected_output filter — we
-      //    generate fresh responses, so items without a golden answer are
-      //    still scorable on the criterion alone)
+      // 2. Fetch all items in the dataset. expected_output (P1-6) is the golden
+      //    answer; items without one are still scorable on the criterion alone.
       const { data: items, error: itemsErr } = await supabaseAdmin
         .from('dataset_items')
-        .select('id, input')
+        .select('id, input, expected_output')
         .eq('dataset_id', datasetId)
         .eq('organization_id', organizationId)
         .order('created_at', { ascending: false })
         .limit(sampleSize)
       if (itemsErr) throw new Error(`Dataset items fetch failed: ${itemsErr.message}`)
 
-      // 3. Generate a response for each item by running the prompt against
-      //    its input. Failures (network, model rejection) are dropped — the
-      //    eval still completes with whatever scored.
-      const generated = await Promise.all(
-        (items ?? []).map(async (i) => {
-          const out = await generateForItem(
-            promptContent,
-            i.input as Record<string, unknown>,
-            runProvider,
-            runModel,
-            runApiKey,
-            runResourceUrl,
-          )
-          return out ? { responseText: out, datasetItemId: i.id as string } : null
-        }),
-      )
+      // 3. Generate a response for each item by running the prompt against its
+      //    input. P1-5: capped at GENERATION_CONCURRENCY (was an uncapped
+      //    Promise.all) and at temperature genTemp (default 0, reproducible).
+      //    Failures (network, model rejection) are dropped — the eval still
+      //    completes with whatever scored.
+      const genTemp = generationTemperature ?? 0
+      const generated = await pool(items ?? [], GENERATION_CONCURRENCY, async (i) => {
+        const out = await generateForItem(
+          promptContent,
+          i.input as Record<string, unknown>,
+          runProvider,
+          runModel,
+          runApiKey,
+          runResourceUrl,
+          genTemp,
+        )
+        return out
+          ? {
+              responseText: out,
+              datasetItemId: i.id as string,
+              expectedOutput: (i.expected_output as string | null) ?? null,
+            }
+          : null
+      })
 
       preparedSamples = generated
-        .filter((g): g is { responseText: string; datasetItemId: string } => g !== null && g.responseText.length > 0)
+        .filter(
+          (g): g is { responseText: string; datasetItemId: string; expectedOutput: string | null } =>
+            g !== null && g.responseText.length > 0,
+        )
         .map((g) => ({
           responseText: g.responseText,
           requestId: null,
           datasetItemId: g.datasetItemId,
+          expectedOutput: g.expectedOutput,
         }))
     }
 
@@ -907,7 +977,7 @@ export async function runEvalRun(input: RunInput): Promise<void> {
         },
       })
       try {
-        const outcome = await callJudge(config, sample.responseText, judgeKey, judgeResourceUrl)
+        const outcome = await callJudge(config, sample.responseText, judgeKey, judgeResourceUrl, sample.expectedOutput)
         if (!outcome) {
           span.end({ status: 'error', errorMessage: 'callJudge returned null' })
           return null

--- a/apps/server/src/lib/eval-runners/judge-prompt.ts
+++ b/apps/server/src/lib/eval-runners/judge-prompt.ts
@@ -50,11 +50,31 @@ export interface JudgeConfig {
 export function buildJudgePrompt(
   criterion: string,
   responseText: string,
-  config: { scale_min: number; scale_max: number; score_config?: TypedScoreConfig | null },
+  config: {
+    scale_min: number
+    scale_max: number
+    score_config?: TypedScoreConfig | null
+    /** P1-6: golden answer for golden-set comparison. Injected as a reference
+     * the judge compares against; omitted when null so criterion-only scoring
+     * is byte-identical to before. */
+    expected_output?: string | null
+  },
 ): string {
   const truncated = responseText.length > MAX_RESPONSE_CHARS
     ? responseText.slice(0, MAX_RESPONSE_CHARS) + '… [truncated]'
     : responseText
+
+  // Reference (expected) answer, also truncated to the same cap.
+  const expected = config.expected_output
+  const referenceBlock = expected
+    ? `
+
+Reference (expected) answer to compare against:
+"""
+${expected.length > MAX_RESPONSE_CHARS ? expected.slice(0, MAX_RESPONSE_CHARS) + '… [truncated]' : expected}
+"""
+Judge how well the response matches the reference while still satisfying the criterion.`
+    : ''
 
   const intro = `You are an evaluator. Score the assistant response below against this criterion.
 
@@ -63,7 +83,7 @@ Criterion: ${criterion}
 Response to evaluate:
 """
 ${truncated}
-"""`
+"""${referenceBlock}`
 
   const sc = config.score_config
 

--- a/apps/web/app/docs/features/evals/page.tsx
+++ b/apps/web/app/docs/features/evals/page.tsx
@@ -364,6 +364,34 @@ if (run.status !== 'completed' || (run.avg_score ?? 0) < 0.8) {
         to read the lowest-scoring samples for a CI log.
       </p>
 
+      <h2>Reproducibility &amp; reliability options</h2>
+      <ul>
+        <li>
+          <strong><code>sampleStrategy</code></strong> (production source):{' '}
+          <code>recent</code> (default) scores the latest N requests;{' '}
+          <code>random</code> draws a representative sample (<code>ORDER BY rand()</code>)
+          without recency bias.
+        </li>
+        <li>
+          <strong><code>generationTemperature</code></strong> (dataset source): the
+          temperature used to generate each response before judging. Defaults to{' '}
+          <code>0</code> so a re-run produces the same answers; raise it to sample
+          variability on purpose.
+        </li>
+        <li>
+          <strong>Golden-set scoring.</strong> Dataset items with an{' '}
+          <code>expected_output</code> now have it injected into the judge prompt as a
+          reference, so the judge compares the response against the expected answer
+          instead of scoring on the criterion alone.
+        </li>
+        <li>
+          <strong>Retries.</strong> Judge and generation calls retry transient failures
+          (429 / 5xx / network) with exponential backoff. Concurrency and retry counts
+          are tunable via <code>EVAL_JUDGE_CONCURRENCY</code>,{' '}
+          <code>EVAL_GENERATION_CONCURRENCY</code>, and <code>EVAL_MAX_RETRIES</code>.
+        </li>
+      </ul>
+
       <h2>Limitations</h2>
       <ul>
         <li>

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/evals.ts
+++ b/packages/sdk/src/evals.ts
@@ -73,6 +73,10 @@ export interface RunEvalInput {
   sampleSize?: number
   sampleFrom?: string
   sampleTo?: string
+  /** Production sampling: 'recent' (default) or 'random' (representative). */
+  sampleStrategy?: 'recent' | 'random'
+  /** Dataset generation temperature, 0..2. Defaults to 0 (reproducible). */
+  generationTemperature?: number
   /** Required when source = 'dataset'. */
   runProvider?: string
   /** Required when source = 'dataset'. */
@@ -124,6 +128,8 @@ export class EvalsApi {
       sampleSize: input.sampleSize ?? 50,
       sampleFrom: input.sampleFrom,
       sampleTo: input.sampleTo,
+      sampleStrategy: input.sampleStrategy,
+      generationTemperature: input.generationTemperature,
       runProvider: input.runProvider,
       runModel: input.runModel,
     })


### PR DESCRIPTION
Phase 2 of the eval improvements (P1-3 .. P1-6). All runtime params — **no migration**.

## P1-3 — retries + tunable concurrency
Judge and generation calls had no retry, so a single 429/5xx dropped the sample. Added `fetchWithRetry` (exponential backoff on 429/5xx/network) around every LLM call. Concurrency and retry count are env-tunable: `EVAL_JUDGE_CONCURRENCY` / `EVAL_GENERATION_CONCURRENCY` / `EVAL_MAX_RETRIES` (defaults 5/5/3).

## P1-4 — random sampling
Production sampling was always "latest N" (`created_at DESC`) — recency-biased. Added `sampleStrategy`: `recent` (default, unchanged) | `random` (`ORDER BY rand()`, representative).

## P1-5 — reproducible generation
Dataset generation was hardcoded at temperature `0.7` and fired every item with an uncapped `Promise.all`. `generationTemperature` is now a param (default `0`, reproducible) and generation is capped at `GENERATION_CONCURRENCY` via the existing `pool()`.

## P1-6 — golden-set scoring
Dataset items' `expected_output` was fetched-but-unused (the doc even admitted it was a "future enhancement"). It's now injected into the judge prompt as a reference when present; criterion-only scoring stays byte-identical when absent.

## Surface
- **API**: `POST /eval-runs` accepts `sampleStrategy` + `generationTemperature` (validated 0..2).
- **SDK 0.8.0**: `client.evals.run()` threads both options through.
- **Docs**: `/docs/features/evals` gains a "Reproducibility & reliability options" section.

## Verification
- server: typecheck + lint + test (1114 passed, +4)
- sdk: typecheck + test (128) + build
- web: typecheck + lint; docs render 200 in preview

## Tests
- `buildJudgePrompt` reference injection: present when `expected_output` set; **byte-identical** to before when absent.
- `callJudge` retry: retries a 503 then succeeds (2 fetch calls); does **not** retry a 400 (1 call).

---
Continues the eval roadmap after Phase 0 (#343) and Phase 1 (#344 P2-8, #345 P2-9).