### PR TITLE
feat(server,web): exact_match + contains evaluator types (P2-12)

### DIFF
--- a/apps/server/src/__tests__/eval-runner-code-evaluators.test.ts
+++ b/apps/server/src/__tests__/eval-runner-code-evaluators.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { runJsonSchema, runRegex } from '../lib/eval-runner.js'
+import { runJsonSchema, runRegex, runExactMatch, runContains } from '../lib/eval-runner.js'
 
 /**
  * R-7 Phase 1: pure functions for the two deterministic evaluator types.
@@ -106,5 +106,52 @@ describe('runJsonSchema', () => {
     )
     expect(r.score).toBe(1)
     expect(r.value_boolean).toBe(true)
+  })
+})
+
+describe('runExactMatch', () => {
+  test('case-insensitive + trimmed by default', () => {
+    const r = runExactMatch({ value: 'Approved' }, '  approved \n')
+    expect(r.score).toBe(1)
+    expect(r.value_boolean).toBe(true)
+    expect(r.reasoning).toContain('exact match')
+  })
+
+  test('mismatch reports both expected and actual', () => {
+    const r = runExactMatch({ value: 'yes' }, 'no')
+    expect(r.score).toBe(0)
+    expect(r.reasoning).toContain('yes')
+    expect(r.reasoning).toContain('no')
+  })
+
+  test('caseSensitive: true distinguishes case', () => {
+    expect(runExactMatch({ value: 'OK', caseSensitive: true }, 'ok').score).toBe(0)
+    expect(runExactMatch({ value: 'OK', caseSensitive: true }, 'OK').score).toBe(1)
+  })
+
+  test('trim: false keeps surrounding whitespace significant', () => {
+    expect(runExactMatch({ value: 'hi', trim: false }, ' hi ').score).toBe(0)
+    expect(runExactMatch({ value: 'hi', trim: false }, 'hi').score).toBe(1)
+  })
+})
+
+describe('runContains', () => {
+  test('case-insensitive substring match by default', () => {
+    const r = runContains({ substring: 'ERROR' }, 'fatal error occurred')
+    expect(r.score).toBe(1)
+    expect(r.value_boolean).toBe(true)
+    expect(r.reasoning).toContain('contains')
+  })
+
+  test('absent substring fails with actionable reasoning', () => {
+    const r = runContains({ substring: 'success' }, 'request failed')
+    expect(r.score).toBe(0)
+    expect(r.reasoning).toContain('does not contain')
+    expect(r.reasoning).toContain('success')
+  })
+
+  test('caseSensitive: true respects case', () => {
+    expect(runContains({ substring: 'OK', caseSensitive: true }, 'status: ok').score).toBe(0)
+    expect(runContains({ substring: 'OK', caseSensitive: true }, 'status: OK').score).toBe(1)
   })
 })

--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -45,8 +45,9 @@ evalsRouter.post('/evaluators', requireFullScope, async (c) => {
 
   if (!promptName) throw new ApiError('VALIDATION_FAILED', 'promptName is required')
   if (!name) throw new ApiError('VALIDATION_FAILED', 'name is required')
-  if (type !== 'llm_judge' && type !== 'regex' && type !== 'json_schema') {
-    throw new ApiError('VALIDATION_FAILED', 'type must be one of: llm_judge, regex, json_schema')
+  const VALID_EVALUATOR_TYPES = ['llm_judge', 'regex', 'json_schema', 'exact_match', 'contains']
+  if (!VALID_EVALUATOR_TYPES.includes(type)) {
+    throw new ApiError('VALIDATION_FAILED', `type must be one of: ${VALID_EVALUATOR_TYPES.join(', ')}`)
   }
 
   if (!body.config || typeof body.config !== 'object' || Array.isArray(body.config)) {
@@ -90,12 +91,27 @@ evalsRouter.post('/evaluators', requireFullScope, async (c) => {
       throw new ApiError('VALIDATION_FAILED', `invalid regex pattern: ${message}`)
     }
     validatedConfig = { pattern, flags }
-  } else {
-    // type === 'json_schema'
+  } else if (type === 'json_schema') {
     if (!config.schema || typeof config.schema !== 'object' || Array.isArray(config.schema)) {
       throw new ApiError('VALIDATION_FAILED', 'config.schema must be a JSON Schema object')
     }
     validatedConfig = { schema: config.schema }
+  } else if (type === 'exact_match') {
+    const value = typeof config.value === 'string' ? config.value : ''
+    if (!value) throw new ApiError('VALIDATION_FAILED', 'config.value is required')
+    validatedConfig = {
+      value,
+      caseSensitive: config.caseSensitive === true,
+      trim: config.trim !== false,
+    }
+  } else {
+    // type === 'contains'
+    const substring = typeof config.substring === 'string' ? config.substring : ''
+    if (!substring) throw new ApiError('VALIDATION_FAILED', 'config.substring is required')
+    validatedConfig = {
+      substring,
+      caseSensitive: config.caseSensitive === true,
+    }
   }
 
   // Verify prompt exists for this org

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -41,18 +41,25 @@ import {
 import {
   runRegex,
   runJsonSchema,
+  runExactMatch,
+  runContains,
   runSimpleEvalRun,
   type RegexConfig,
   type JsonSchemaConfig,
+  type ExactMatchConfig,
+  type ContainsConfig,
+  type DeterministicEvaluatorType,
   type SimpleEvalResult,
 } from './eval-runners/deterministic.js'
 
-export { buildJudgePrompt, parseJudgeReply, runRegex, runJsonSchema }
+export { buildJudgePrompt, parseJudgeReply, runRegex, runJsonSchema, runExactMatch, runContains }
 export type {
   JudgeConfig,
   TypedScoreConfig,
   RegexConfig,
   JsonSchemaConfig,
+  ExactMatchConfig,
+  ContainsConfig,
   SimpleEvalResult,
 }
 
@@ -687,14 +694,14 @@ export async function runEvalRun(input: RunInput): Promise<void> {
       throw new Error('Evaluator not found')
     }
 
-    // R-7 Phase 1: deterministic types short-circuit before the
-    // LLM-as-judge config validation + provider-key resolution. Dataset
-    // source is not yet supported for these types — Phase 2 will lift
-    // the runProvider/runModel pieces of the dataset path so they can
-    // share it.
-    if (evaluator.type === 'regex' || evaluator.type === 'json_schema') {
+    // Deterministic types (regex / json_schema / exact_match / contains)
+    // short-circuit before the LLM-as-judge config validation +
+    // provider-key resolution. Dataset source is not yet supported for
+    // these types — they score production responses synchronously.
+    const DETERMINISTIC_TYPES: DeterministicEvaluatorType[] = ['regex', 'json_schema', 'exact_match', 'contains']
+    if ((DETERMINISTIC_TYPES as string[]).includes(evaluator.type)) {
       if (source === 'dataset') {
-        throw new Error(`evaluator type '${evaluator.type}' currently only supports source='production' (dataset coming in R-7 Phase 2)`)
+        throw new Error(`evaluator type '${evaluator.type}' currently only supports source='production'`)
       }
       await runSimpleEvalRun(
         evalRunId,
@@ -703,8 +710,8 @@ export async function runEvalRun(input: RunInput): Promise<void> {
         sampleSize,
         sampleFrom,
         sampleTo,
-        evaluator.type,
-        evaluator.config as unknown as RegexConfig | JsonSchemaConfig,
+        evaluator.type as DeterministicEvaluatorType,
+        evaluator.config as unknown as RegexConfig | JsonSchemaConfig | ExactMatchConfig | ContainsConfig,
       )
       // Internal trace closes via the outer finally — note `samples` count
       // and aggregate the simple path produced via internalTrace.end below.

--- a/apps/server/src/lib/eval-runners/deterministic.ts
+++ b/apps/server/src/lib/eval-runners/deterministic.ts
@@ -29,6 +29,25 @@ export interface JsonSchemaConfig {
   schema: unknown
 }
 
+export interface ExactMatchConfig {
+  /** The exact string the response must equal. */
+  value: string
+  /** Default false — comparison is case-insensitive unless set. */
+  caseSensitive?: boolean
+  /** Default true — both sides are trimmed before comparing. */
+  trim?: boolean
+}
+
+export interface ContainsConfig {
+  /** Substring the response must contain. */
+  substring: string
+  /** Default false — search is case-insensitive unless set. */
+  caseSensitive?: boolean
+}
+
+/** Evaluator types scored synchronously with no provider key / network. */
+export type DeterministicEvaluatorType = 'regex' | 'json_schema' | 'exact_match' | 'contains'
+
 /**
  * Deterministic 0/1 outcome shared by both code evaluator types. Matches
  * the JudgeOutcome shape on the columns the eval_results table actually
@@ -118,6 +137,58 @@ export function runJsonSchema(
   return { score: 0, value_boolean: false, reasoning }
 }
 
+/** Truncate a value for a readable reasoning line. */
+function snippet(s: string, max = 80): string {
+  return s.length > max ? s.slice(0, max) + '…' : s
+}
+
+/**
+ * runExactMatch — pass iff the response equals the configured value.
+ * Case-insensitive and trimmed by default (the common intent for a short
+ * canonical answer like "yes" / "approved").
+ */
+export function runExactMatch(config: ExactMatchConfig, output: string): SimpleEvalResult {
+  let a = output
+  let b = config.value
+  if (config.trim !== false) {
+    a = a.trim()
+    b = b.trim()
+  }
+  if (!config.caseSensitive) {
+    a = a.toLowerCase()
+    b = b.toLowerCase()
+  }
+  const matched = a === b
+  return {
+    score: matched ? 1 : 0,
+    value_boolean: matched,
+    reasoning: matched
+      ? `exact match: "${snippet(config.value)}"`
+      : `expected "${snippet(config.value)}" but got "${snippet(output)}"`,
+  }
+}
+
+/**
+ * runContains — pass iff the response contains the configured substring.
+ * Case-insensitive by default.
+ */
+export function runContains(config: ContainsConfig, output: string): SimpleEvalResult {
+  let haystack = output
+  let needle = config.substring
+  if (!config.caseSensitive) {
+    haystack = haystack.toLowerCase()
+    needle = needle.toLowerCase()
+  }
+  const matched = haystack.includes(needle)
+  return {
+    score: matched ? 1 : 0,
+    value_boolean: matched,
+    reasoning: matched
+      ? `contains "${snippet(config.substring)}"`
+      : `does not contain "${snippet(config.substring)}"`,
+  }
+}
+
 /**
  * Run a deterministic eval against the production sample set. Mirrors
  * the sample-fetch step of runEvalRun (LLM-as-judge production path)
@@ -132,8 +203,8 @@ export async function runSimpleEvalRun(
   sampleSize: number,
   sampleFrom: string | null | undefined,
   sampleTo: string | null | undefined,
-  evaluatorType: 'regex' | 'json_schema',
-  config: RegexConfig | JsonSchemaConfig,
+  evaluatorType: DeterministicEvaluatorType,
+  config: RegexConfig | JsonSchemaConfig | ExactMatchConfig | ContainsConfig,
 ): Promise<void> {
   const sampleFilters: string[] = [
     'prompt_version_id = {promptVersionId:UUID}',
@@ -178,7 +249,11 @@ export async function runSimpleEvalRun(
       const result: SimpleEvalResult =
         evaluatorType === 'regex'
           ? runRegex(config as RegexConfig, responseText)
-          : runJsonSchema(config as JsonSchemaConfig, responseText)
+          : evaluatorType === 'json_schema'
+            ? runJsonSchema(config as JsonSchemaConfig, responseText)
+            : evaluatorType === 'exact_match'
+              ? runExactMatch(config as ExactMatchConfig, responseText)
+              : runContains(config as ContainsConfig, responseText)
 
       return {
         // organization_id is NOT NULL on eval_results — omitting it (the prior

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -218,12 +218,17 @@ function NewEvaluatorDialog({
   // pattern field or a JSON Schema textarea. Templates always create
   // llm_judge evaluators today, so the selector defaults to that even
   // when initialTemplate is set.
-  const [evaluatorType, setEvaluatorType] = useState<'llm_judge' | 'regex' | 'json_schema'>(
-    'llm_judge',
-  )
+  const [evaluatorType, setEvaluatorType] = useState<
+    'llm_judge' | 'regex' | 'json_schema' | 'exact_match' | 'contains'
+  >('llm_judge')
   const [regexPattern, setRegexPattern] = useState('')
   const [regexFlags, setRegexFlags] = useState('')
   const [jsonSchemaText, setJsonSchemaText] = useState('{\n  "type": "object"\n}')
+  // exact_match / contains config (P2-12)
+  const [exactValue, setExactValue] = useState('')
+  const [exactCaseSensitive, setExactCaseSensitive] = useState(false)
+  const [containsSubstring, setContainsSubstring] = useState('')
+  const [containsCaseSensitive, setContainsCaseSensitive] = useState(false)
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -269,7 +274,7 @@ function NewEvaluatorDialog({
           type: 'regex',
           config: { pattern: regexPattern, flags: regexFlags },
         })
-      } else {
+      } else if (evaluatorType === 'json_schema') {
         let parsedSchema: unknown
         try {
           parsedSchema = JSON.parse(jsonSchemaText)
@@ -287,11 +292,35 @@ function NewEvaluatorDialog({
           type: 'json_schema',
           config: { schema: parsedSchema },
         })
+      } else if (evaluatorType === 'exact_match') {
+        if (!exactValue) {
+          setError('Expected value is required')
+          return
+        }
+        await createMutation.mutateAsync({
+          promptName,
+          name: name.trim(),
+          type: 'exact_match',
+          config: { value: exactValue, caseSensitive: exactCaseSensitive },
+        })
+      } else {
+        if (!containsSubstring) {
+          setError('Substring is required')
+          return
+        }
+        await createMutation.mutateAsync({
+          promptName,
+          name: name.trim(),
+          type: 'contains',
+          config: { substring: containsSubstring, caseSensitive: containsCaseSensitive },
+        })
       }
       onClose()
       setName(''); setCriterion(''); setPromptName('')
       setRegexPattern(''); setRegexFlags('')
       setJsonSchemaText('{\n  "type": "object"\n}')
+      setExactValue(''); setExactCaseSensitive(false)
+      setContainsSubstring(''); setContainsCaseSensitive(false)
       setEvaluatorType('llm_judge')
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create')
@@ -342,13 +371,17 @@ function NewEvaluatorDialog({
             </label>
             <Select
               value={evaluatorType}
-              onValueChange={(v) => setEvaluatorType(v as 'llm_judge' | 'regex' | 'json_schema')}
+              onValueChange={(v) =>
+                setEvaluatorType(v as 'llm_judge' | 'regex' | 'json_schema' | 'exact_match' | 'contains')
+              }
             >
               <SelectTrigger><SelectValue /></SelectTrigger>
               <SelectContent>
                 <SelectItem value="llm_judge">LLM as judge</SelectItem>
                 <SelectItem value="regex">Regex (pattern match)</SelectItem>
                 <SelectItem value="json_schema">JSON Schema (structure check)</SelectItem>
+                <SelectItem value="exact_match">Exact match (equals a value)</SelectItem>
+                <SelectItem value="contains">Contains (substring present)</SelectItem>
               </SelectContent>
             </Select>
             <p className="font-mono text-[10.5px] text-text-faint mt-1">
@@ -356,7 +389,11 @@ function NewEvaluatorDialog({
                 ? 'Judge model scores 0..1 against a free-form criterion.'
                 : evaluatorType === 'regex'
                   ? 'Deterministic 0/1 — passes when the pattern matches the response.'
-                  : 'Deterministic 0/1 — passes when the response parses as JSON and matches the schema.'}
+                  : evaluatorType === 'json_schema'
+                    ? 'Deterministic 0/1 — passes when the response parses as JSON and matches the schema.'
+                    : evaluatorType === 'exact_match'
+                      ? 'Deterministic 0/1 — passes when the response equals the expected value.'
+                      : 'Deterministic 0/1 — passes when the response contains the substring.'}
             </p>
           </div>
 
@@ -459,6 +496,60 @@ function NewEvaluatorDialog({
               />
               <p className="font-mono text-[10.5px] text-text-faint mt-1">
                 Standard JSON Schema (draft-07). Default accepts any object.
+              </p>
+            </div>
+          )}
+
+          {evaluatorType === 'exact_match' && (
+            <div>
+              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                Expected value
+              </label>
+              <input
+                type="text"
+                value={exactValue}
+                onChange={(e) => setExactValue(e.target.value)}
+                placeholder="e.g. approved"
+                required
+                className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong"
+              />
+              <label className="flex items-center gap-2 mt-2 font-mono text-[11px] text-text-muted">
+                <input
+                  type="checkbox"
+                  checked={exactCaseSensitive}
+                  onChange={(e) => setExactCaseSensitive(e.target.checked)}
+                />
+                Case-sensitive
+              </label>
+              <p className="font-mono text-[10.5px] text-text-faint mt-1">
+                Trimmed before comparing. Case-insensitive unless checked.
+              </p>
+            </div>
+          )}
+
+          {evaluatorType === 'contains' && (
+            <div>
+              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                Substring
+              </label>
+              <input
+                type="text"
+                value={containsSubstring}
+                onChange={(e) => setContainsSubstring(e.target.value)}
+                placeholder="e.g. order confirmed"
+                required
+                className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong"
+              />
+              <label className="flex items-center gap-2 mt-2 font-mono text-[11px] text-text-muted">
+                <input
+                  type="checkbox"
+                  checked={containsCaseSensitive}
+                  onChange={(e) => setContainsCaseSensitive(e.target.checked)}
+                />
+                Case-sensitive
+              </label>
+              <p className="font-mono text-[10.5px] text-text-faint mt-1">
+                Passes when the response contains this text. Case-insensitive unless checked.
               </p>
             </div>
           )}

--- a/apps/web/app/docs/features/evals/page.tsx
+++ b/apps/web/app/docs/features/evals/page.tsx
@@ -82,12 +82,17 @@ export default function EvalsDocs() {
         <li><code>prompt_name</code>, which prompt this evaluator targets</li>
         <li><code>name</code>, e.g. &quot;Helpfulness check&quot;</li>
         <li>
-          <code>type</code>, one of <code>llm_judge</code>, <code>regex</code>, or{' '}
-          <code>json_schema</code>. The <code>regex</code> type checks the response body
-          against a configured pattern and scores 1 on match (or 0 if you flag
-          {' '}<code>must_not_match</code>). The <code>json_schema</code> type validates the
+          <code>type</code>, one of <code>llm_judge</code>, <code>regex</code>,{' '}
+          <code>json_schema</code>, <code>exact_match</code>, or <code>contains</code>.
+          The <code>regex</code> type checks the response body against a configured
+          pattern and scores 1 on match. The <code>json_schema</code> type validates the
           response body against a JSON Schema document via Ajv and scores 1 on valid.
-          Both code evaluators are free of LLM cost since no judge model is called.
+          {' '}<code>exact_match</code> (config <code>value</code>, optional{' '}
+          <code>caseSensitive</code> / <code>trim</code>) scores 1 when the response
+          equals the value; <code>contains</code> (config <code>substring</code>,
+          optional <code>caseSensitive</code>) scores 1 when the substring is present.
+          The four deterministic evaluators are free of LLM cost since no judge model
+          is called.
         </li>
         <li>
           <code>config</code>:
@@ -395,10 +400,10 @@ if (run.status !== 'completed' || (run.avg_score ?? 0) < 0.8) {
       <h2>Limitations</h2>
       <ul>
         <li>
-          <strong>Three evaluator types ship today.</strong> <code>llm_judge</code> uses a
-          model to score, <code>regex</code> checks the response against a pattern with
-          configurable match expectation, and <code>json_schema</code> validates the
-          response body against a JSON Schema document. Length and embedding similarity
+          <strong>Five evaluator types ship today.</strong> <code>llm_judge</code> (model
+          scores 0–1), <code>regex</code>, <code>json_schema</code>,{' '}
+          <code>exact_match</code>, and <code>contains</code>. The four deterministic types
+          run on production samples with no LLM cost. Embedding-similarity and custom-code
           evaluators are planned for a later release.
         </li>
         <li>

--- a/apps/web/lib/queries/use-evals.ts
+++ b/apps/web/lib/queries/use-evals.ts
@@ -102,6 +102,17 @@ export interface JsonSchemaConfig {
   schema: unknown
 }
 
+export interface ExactMatchConfig {
+  value: string
+  caseSensitive?: boolean
+  trim?: boolean
+}
+
+export interface ContainsConfig {
+  substring: string
+  caseSensitive?: boolean
+}
+
 export type CreateEvaluatorInput =
   | {
       promptName: string
@@ -123,6 +134,18 @@ export type CreateEvaluatorInput =
       name: string
       type: 'json_schema'
       config: JsonSchemaConfig
+    }
+  | {
+      promptName: string
+      name: string
+      type: 'exact_match'
+      config: ExactMatchConfig
+    }
+  | {
+      promptName: string
+      name: string
+      type: 'contains'
+      config: ContainsConfig
     }
 
 export function useCreateEvaluator() {


### PR DESCRIPTION
Phase 3 / **P2-12** (part 1): two new deterministic evaluator types.

## New types
- **`exact_match`** — passes when the response equals `config.value`. Trimmed + case-insensitive by default (the common intent for a short canonical answer like "approved"); `caseSensitive` / `trim` opt-outs.
- **`contains`** — passes when the response contains `config.substring`. Case-insensitive by default.

Both are pure 0/1 scorers with actionable reasoning, mirroring `runRegex` / `runJsonSchema`, and run on production samples with **no LLM cost**.

## Wiring
- `deterministic.ts`: `runExactMatch` / `runContains` + `DeterministicEvaluatorType` union.
- `eval-runner.ts`: deterministic short-circuit now routes all four sync types.
- `evals.ts`: `POST /evaluators` validates the two new types + their config.
- **Dashboard**: "New evaluator" dialog gains both types with their config fields (value/caseSensitive/trim, substring/caseSensitive).
- **Docs**: evals page updated (three → five evaluator types).

## Scope
Custom-code and embedding-similarity evaluators are intentionally **not** here:
- **embedding** is a networked multi-provider feature (provider keys, embedding API per provider, cosine, SSRF surface) — it gets its own focused PR.
- **custom JS** needs a server-side sandbox — deferred.

## Verification
- server: typecheck + lint + test (1121 passed, +7)
- web: typecheck + lint; docs render 200 in preview

## Tests
`runExactMatch` (default case-insensitive+trim, mismatch reasoning, `caseSensitive`, `trim:false`) and `runContains` (substring match, absent, `caseSensitive`).