### PR TITLE
feat(server,web): embedding-similarity evaluator type (P2-12)

### DIFF
--- a/apps/server/src/__tests__/eval-embedding.test.ts
+++ b/apps/server/src/__tests__/eval-embedding.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cosineSimilarity, scoreEmbedding } from '../lib/eval-runners/embedding.js'
+import type { EmbeddingConfig } from '../lib/eval-runners/embedding.js'
+
+/**
+ * P2-12 embedding evaluator. cosineSimilarity is pure; scoreEmbedding wraps a
+ * multi-provider /embeddings call. Tests pin: the math, the score shape
+ * (cosine → 0..1 with threshold → value_boolean), azure routing (resource URL
+ * + api-key header, NOT Gemini/Bearer), and null-on-failure.
+ */
+
+const OPENAI_CONFIG: EmbeddingConfig = { provider: 'openai', model: 'text-embedding-3-small' }
+
+function mockEmbeddings(vectors: number[][], ok = true): ReturnType<typeof vi.fn> {
+  const fn = vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => ({ data: vectors.map((v) => ({ embedding: v })), usage: { total_tokens: 12 } }),
+    text: async () => '',
+  })
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('cosineSimilarity', () => {
+  test('identical vectors → 1', () => {
+    expect(cosineSimilarity([1, 2, 3], [1, 2, 3])).toBeCloseTo(1)
+  })
+  test('orthogonal vectors → 0', () => {
+    expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0)
+  })
+  test('opposite vectors → -1', () => {
+    expect(cosineSimilarity([1, 1], [-1, -1])).toBeCloseTo(-1)
+  })
+  test('degenerate input (empty / mismatched length / zero) → 0', () => {
+    expect(cosineSimilarity([], [])).toBe(0)
+    expect(cosineSimilarity([1, 2], [1])).toBe(0)
+    expect(cosineSimilarity([0, 0], [1, 1])).toBe(0)
+  })
+})
+
+describe('scoreEmbedding', () => {
+  test('returns cosine similarity as the score (clamped 0..1)', async () => {
+    // response embedding == reference embedding → similarity 1.0
+    mockEmbeddings([
+      [1, 0, 0],
+      [1, 0, 0],
+    ])
+    const outcome = await scoreEmbedding(OPENAI_CONFIG, 'response', 'reference', 'key', null)
+    expect(outcome?.score).toBeCloseTo(1)
+    expect(outcome?.value_number).toBeCloseTo(1)
+    expect(outcome?.value_boolean).toBeNull() // no threshold
+    expect(outcome?.reasoning).toContain('cosine similarity')
+  })
+
+  test('clamps a negative cosine to 0', async () => {
+    mockEmbeddings([
+      [1, 1],
+      [-1, -1],
+    ])
+    const outcome = await scoreEmbedding(OPENAI_CONFIG, 'r', 'ref', 'key', null)
+    expect(outcome?.score).toBe(0)
+  })
+
+  test('threshold sets value_boolean', async () => {
+    mockEmbeddings([
+      [1, 0],
+      [1, 0],
+    ])
+    const pass = await scoreEmbedding({ ...OPENAI_CONFIG, threshold: 0.8 }, 'r', 'ref', 'key', null)
+    expect(pass?.value_boolean).toBe(true)
+
+    mockEmbeddings([
+      [1, 0],
+      [0, 1],
+    ])
+    const fail = await scoreEmbedding({ ...OPENAI_CONFIG, threshold: 0.8 }, 'r', 'ref', 'key', null)
+    expect(fail?.value_boolean).toBe(false)
+  })
+
+  test('azure routes to the resource v1 endpoint with the api-key header', async () => {
+    const fetchMock = mockEmbeddings([
+      [1, 0],
+      [1, 0],
+    ])
+    await scoreEmbedding(
+      { provider: 'azure', model: 'text-embedding-3-small' },
+      'r',
+      'ref',
+      'key',
+      'https://my-res.openai.azure.com',
+    )
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit & { headers: Record<string, string> }]
+    expect(url).toBe('https://my-res.openai.azure.com/openai/v1/embeddings')
+    expect(url).not.toContain('generativelanguage.googleapis.com')
+    expect(init.headers['api-key']).toBe('key')
+    expect(init.headers['Authorization']).toBeUndefined()
+  })
+
+  test('returns null on a non-ok upstream response', async () => {
+    mockEmbeddings([[1]], false)
+    const outcome = await scoreEmbedding(OPENAI_CONFIG, 'r', 'ref', 'key', null)
+    expect(outcome).toBeNull()
+  })
+})

--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -3,6 +3,7 @@ import { authJwtOrApiKey, type DualAuthContext } from '../middleware/authJwtOrAp
 import { requireFullScope } from '../middleware/requireFullScope.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { runEvalRun, estimateJudgeCostUsd } from '../lib/eval-runner.js'
+import { EMBEDDING_PROVIDERS } from '../lib/eval-runners/embedding.js'
 import { fireAndForget } from '../lib/wait-until.js'
 import { ApiError } from '../lib/errors.js'
 
@@ -45,7 +46,7 @@ evalsRouter.post('/evaluators', requireFullScope, async (c) => {
 
   if (!promptName) throw new ApiError('VALIDATION_FAILED', 'promptName is required')
   if (!name) throw new ApiError('VALIDATION_FAILED', 'name is required')
-  const VALID_EVALUATOR_TYPES = ['llm_judge', 'regex', 'json_schema', 'exact_match', 'contains']
+  const VALID_EVALUATOR_TYPES = ['llm_judge', 'regex', 'json_schema', 'exact_match', 'contains', 'embedding']
   if (!VALID_EVALUATOR_TYPES.includes(type)) {
     throw new ApiError('VALIDATION_FAILED', `type must be one of: ${VALID_EVALUATOR_TYPES.join(', ')}`)
   }
@@ -104,13 +105,31 @@ evalsRouter.post('/evaluators', requireFullScope, async (c) => {
       caseSensitive: config.caseSensitive === true,
       trim: config.trim !== false,
     }
-  } else {
-    // type === 'contains'
+  } else if (type === 'contains') {
     const substring = typeof config.substring === 'string' ? config.substring : ''
     if (!substring) throw new ApiError('VALIDATION_FAILED', 'config.substring is required')
     validatedConfig = {
       substring,
       caseSensitive: config.caseSensitive === true,
+    }
+  } else {
+    // type === 'embedding'
+    const provider = typeof config.provider === 'string' ? config.provider : ''
+    const model = typeof config.model === 'string' ? config.model.trim() : ''
+    if (!EMBEDDING_PROVIDERS.includes(provider as (typeof EMBEDDING_PROVIDERS)[number])) {
+      throw new ApiError('VALIDATION_FAILED', `config.provider must be one of: ${EMBEDDING_PROVIDERS.join(', ')}`)
+    }
+    if (!model) throw new ApiError('VALIDATION_FAILED', 'config.model is required')
+    const referenceText = typeof config.reference_text === 'string' ? config.reference_text : null
+    const threshold = typeof config.threshold === 'number' ? config.threshold : null
+    if (threshold != null && (threshold < 0 || threshold > 1)) {
+      throw new ApiError('VALIDATION_FAILED', 'config.threshold must be between 0 and 1')
+    }
+    validatedConfig = {
+      provider,
+      model,
+      ...(referenceText ? { reference_text: referenceText } : {}),
+      ...(threshold != null ? { threshold } : {}),
     }
   }
 

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -31,13 +31,18 @@ import { buildOpenAIBody } from './playground-runner.js'
 import { startInternalTrace } from './internal-tracing.js'
 // Extracted sub-modules. Re-exported below so existing import sites
 // (`from '../lib/eval-runner.js'`) keep working unchanged.
-import { extractResponseText } from './eval-runners/shared.js'
+import { extractResponseText, fetchWithRetry } from './eval-runners/shared.js'
 import {
   buildJudgePrompt,
   parseJudgeReply,
   type JudgeConfig,
   type TypedScoreConfig,
 } from './eval-runners/judge-prompt.js'
+import {
+  scoreEmbedding,
+  EMBEDDING_PROVIDERS,
+  type EmbeddingConfig,
+} from './eval-runners/embedding.js'
 import {
   runRegex,
   runJsonSchema,
@@ -66,43 +71,12 @@ export type {
 // P1-3: concurrency + retry are env-configurable (defaults preserve prior
 // behaviour). Generation gets its own pool so a large dataset can't fire all
 // items at once (the old uncapped Promise.all).
+// P1-3: concurrency is env-configurable (defaults preserve prior behaviour).
+// Generation gets its own pool so a large dataset can't fire all items at once.
+// fetchWithRetry / EVAL_MAX_RETRIES live in eval-runners/shared.ts (shared with
+// the embedding path).
 const JUDGE_CONCURRENCY = Number(process.env['EVAL_JUDGE_CONCURRENCY']) || 5
 const GENERATION_CONCURRENCY = Number(process.env['EVAL_GENERATION_CONCURRENCY']) || 5
-const MAX_RETRIES = Number(process.env['EVAL_MAX_RETRIES']) || 3
-
-function evalSleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
-/**
- * fetch with exponential backoff on transient failures (429, 5xx, network
- * error). Returns the final Response (which may still be non-ok) or null if
- * every attempt threw. Callers already treat a non-ok / null result as a
- * dropped sample, so this only adds resilience — it never changes the
- * success contract. Back-off: 250ms, 500ms, 1000ms (× MAX_RETRIES).
- */
-async function fetchWithRetry(
-  url: string,
-  init: RequestInit,
-  retries: number = MAX_RETRIES,
-): Promise<Response | null> {
-  let last: Response | null = null
-  for (let attempt = 0; attempt <= retries; attempt++) {
-    try {
-      const res = await fetch(url, init)
-      // Success, or a non-retryable client error (4xx other than 429) — done.
-      if (res.ok || !(res.status === 429 || (res.status >= 500 && res.status < 600))) {
-        return res
-      }
-      last = res
-    } catch {
-      // Network error / abort — retry.
-      last = null
-    }
-    if (attempt < retries) await evalSleep(250 * Math.pow(2, attempt))
-  }
-  return last
-}
 
 interface JudgeOutcome {
   // For NUMERIC configs (and the legacy NULL path) this stays the
@@ -718,7 +692,49 @@ export async function runEvalRun(input: RunInput): Promise<void> {
       return
     }
 
-    const config = evaluator.config as unknown as JudgeConfig
+    // Judge and embedding both resolve a provider key (+ azure resource URL),
+    // then share the sample gathering + scoring loop below. `config` (judge)
+    // and `embedConfig` (embedding) are mutually exclusive; `scoringKey` /
+    // `scoringResourceUrl` carry whichever applies into the scoring loop.
+    const isEmbedding = evaluator.type === 'embedding'
+    let config: JudgeConfig = {} as JudgeConfig
+    let embedConfig: EmbeddingConfig | null = null
+    let scoringKey: string
+    let scoringResourceUrl: string | null = null
+
+    if (isEmbedding) {
+      embedConfig = evaluator.config as unknown as EmbeddingConfig
+      if (!embedConfig?.provider || !embedConfig?.model) {
+        throw new Error('Embedding evaluator config missing required fields (provider / model)')
+      }
+      if (!(EMBEDDING_PROVIDERS as string[]).includes(embedConfig.provider)) {
+        throw new Error(`Unsupported embedding provider: ${embedConfig.provider}`)
+      }
+      const { data: pkRow, error: pkErr } = await supabaseAdmin
+        .from('provider_keys')
+        .select('id, provider, encrypted_key, provider_metadata')
+        .eq('organization_id', organizationId)
+        .eq('provider', embedConfig.provider)
+        .eq('is_active', true)
+        .limit(1)
+        .maybeSingle()
+      if (pkErr || !pkRow) {
+        throw new Error(`No active ${embedConfig.provider} provider key found for embedding`)
+      }
+      const key = await aes256Decrypt(pkRow.encrypted_key as string)
+      if (!key) throw new Error('Failed to decrypt embedding provider key')
+      scoringKey = key
+      const meta = (pkRow.provider_metadata as Record<string, unknown> | null) ?? {}
+      scoringResourceUrl = typeof meta['resource_url'] === 'string' ? meta['resource_url'] : null
+      if (embedConfig.provider === 'azure') {
+        if (!scoringResourceUrl) {
+          throw new Error('Azure embedding provider key is missing resource_url — re-register it')
+        }
+        const safe = validateOutboundUrlSync(scoringResourceUrl)
+        if (!safe.ok) throw new Error(`Azure embedding resource_url rejected: ${safe.message}`)
+      }
+    } else {
+    config = evaluator.config as unknown as JudgeConfig
     if (!config?.criterion || !config?.judge_provider || !config?.judge_model) {
       throw new Error('Evaluator config missing required fields (criterion / judge_provider / judge_model)')
     }
@@ -785,6 +801,9 @@ export async function runEvalRun(input: RunInput): Promise<void> {
       if (!safe.ok) {
         throw new Error(`Azure judge resource_url rejected: ${safe.message}`)
       }
+    }
+      scoringKey = judgeKey
+      scoringResourceUrl = judgeResourceUrl
     }
 
     // ── Gather samples (production requests OR dataset items) ──────────────
@@ -974,19 +993,30 @@ export async function runEvalRun(input: RunInput): Promise<void> {
     // gets ended with status='error' instead of leaving a dangling
     // LIVE span.
     const outcomes = await pool(preparedSamples, JUDGE_CONCURRENCY, async (sample): Promise<SampleOutcome | null> => {
-      const span = internalTrace.startSpan('llm_judge', {
+      const span = internalTrace.startSpan(isEmbedding ? 'embedding' : 'llm_judge', {
         spanType: 'llm',
         metadata: {
-          judge_provider: config.judge_provider,
-          judge_model: config.judge_model,
+          judge_provider: isEmbedding ? embedConfig!.provider : config.judge_provider,
+          judge_model: isEmbedding ? embedConfig!.model : config.judge_model,
           request_id: sample.requestId,
           dataset_item_id: sample.datasetItemId,
         },
       })
       try {
-        const outcome = await callJudge(config, sample.responseText, judgeKey, judgeResourceUrl, sample.expectedOutput)
+        let outcome: JudgeOutcome | null
+        if (isEmbedding) {
+          // Reference: dataset golden answer wins, else the config default.
+          const reference = sample.expectedOutput ?? embedConfig!.reference_text ?? null
+          if (!reference) {
+            span.end({ status: 'error', errorMessage: 'no reference (expected_output / reference_text)' })
+            return null
+          }
+          outcome = await scoreEmbedding(embedConfig!, sample.responseText, reference, scoringKey, scoringResourceUrl)
+        } else {
+          outcome = await callJudge(config, sample.responseText, scoringKey, scoringResourceUrl, sample.expectedOutput)
+        }
         if (!outcome) {
-          span.end({ status: 'error', errorMessage: 'callJudge returned null' })
+          span.end({ status: 'error', errorMessage: isEmbedding ? 'scoreEmbedding returned null' : 'callJudge returned null' })
           return null
         }
         span.end({

--- a/apps/server/src/lib/eval-runners/embedding.ts
+++ b/apps/server/src/lib/eval-runners/embedding.ts
@@ -1,0 +1,157 @@
+/**
+ * Embedding-similarity evaluator (P2-12).
+ *
+ * Scores how semantically close a response is to a reference answer via the
+ * cosine similarity of their embeddings — a 0..1 NUMERIC score. It works on
+ * both eval sources because it only needs a (response, reference) pair:
+ *   - production: reference = config.reference_text (one ideal answer)
+ *   - dataset:    reference = the item's expected_output (golden set),
+ *                 falling back to config.reference_text
+ *
+ * The (response, reference) pairing + sample gathering live in
+ * runEvalRun; this module is the pure-ish scorer (embed + cosine).
+ */
+
+import { calculateCost } from '../cost.js'
+import { fetchWithRetry, MAX_RESPONSE_CHARS } from './shared.js'
+
+/** OpenAI-compatible providers share one /embeddings shape; gemini differs;
+ * anthropic has no embeddings API (rejected at config validation). */
+export type EmbeddingProvider = 'openai' | 'azure' | 'mistral' | 'openrouter' | 'gemini'
+
+export const EMBEDDING_PROVIDERS: EmbeddingProvider[] = ['openai', 'azure', 'mistral', 'openrouter', 'gemini']
+
+export interface EmbeddingConfig {
+  provider: EmbeddingProvider
+  model: string
+  /** Reference text to compare each response against. Required for the
+   * production source; for dataset items the item's expected_output wins. */
+  reference_text?: string | null
+  /** When set, value_boolean = similarity >= threshold (0..1). */
+  threshold?: number | null
+}
+
+/** Structurally identical to JudgeOutcome so the scoring loop is uniform. */
+export interface EmbeddingOutcome {
+  score: number
+  value_number: number
+  value_string: null
+  value_boolean: boolean | null
+  reasoning: string
+  cost: number
+  tokens: number
+}
+
+/** Cosine similarity of two equal-length vectors; 0 for degenerate input. */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length === 0 || a.length !== b.length) return 0
+  let dot = 0
+  let normA = 0
+  let normB = 0
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i]!
+    const y = b[i]!
+    dot += x * y
+    normA += x * x
+    normB += y * y
+  }
+  if (normA === 0 || normB === 0) return 0
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB))
+}
+
+/**
+ * Embed an array of texts. Returns parallel embeddings + token usage, or null
+ * on any failure (caller drops the sample). OpenAI-compatible providers share
+ * one request/response shape; gemini uses batchEmbedContents.
+ */
+async function embedTexts(
+  provider: EmbeddingProvider,
+  model: string,
+  apiKey: string,
+  resourceUrl: string | null,
+  texts: string[],
+): Promise<{ embeddings: number[][]; tokens: number } | null> {
+  if (provider === 'gemini') {
+    const res = await fetchWithRetry(
+      `https://generativelanguage.googleapis.com/v1beta/models/${model}:batchEmbedContents?key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          requests: texts.map((t) => ({ model: `models/${model}`, content: { parts: [{ text: t }] } })),
+        }),
+      },
+    )
+    if (!res || !res.ok) return null
+    const json = (await res.json()) as { embeddings?: Array<{ values?: number[] }> }
+    const embeddings = (json.embeddings ?? []).map((e) => e.values ?? [])
+    if (embeddings.length !== texts.length || embeddings.some((e) => e.length === 0)) return null
+    // Gemini batchEmbedContents does not return token usage.
+    return { embeddings, tokens: 0 }
+  }
+
+  // OpenAI-compatible: openai / azure / mistral / openrouter.
+  let url: string
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (provider === 'azure') {
+    if (!resourceUrl) return null
+    url = `${resourceUrl}/openai/v1/embeddings`
+    headers['api-key'] = apiKey
+  } else {
+    const base =
+      provider === 'mistral'
+        ? 'https://api.mistral.ai/v1'
+        : provider === 'openrouter'
+          ? 'https://openrouter.ai/api/v1'
+          : 'https://api.openai.com/v1'
+    url = `${base}/embeddings`
+    headers['Authorization'] = `Bearer ${apiKey}`
+  }
+
+  const res = await fetchWithRetry(url, { method: 'POST', headers, body: JSON.stringify({ model, input: texts }) })
+  if (!res || !res.ok) return null
+  const json = (await res.json()) as {
+    data?: Array<{ embedding?: number[] }>
+    usage?: { prompt_tokens?: number; total_tokens?: number }
+  }
+  const embeddings = (json.data ?? []).map((d) => d.embedding ?? [])
+  if (embeddings.length !== texts.length || embeddings.some((e) => e.length === 0)) return null
+  return { embeddings, tokens: json.usage?.total_tokens ?? json.usage?.prompt_tokens ?? 0 }
+}
+
+/**
+ * Score one sample: cosine similarity between the response and the reference.
+ * Returns null on embedding failure so the caller drops the sample.
+ */
+export async function scoreEmbedding(
+  config: EmbeddingConfig,
+  responseText: string,
+  reference: string,
+  apiKey: string,
+  resourceUrl: string | null,
+): Promise<EmbeddingOutcome | null> {
+  // Truncate both sides to the same cap as the judge prompt — embedding models
+  // have their own token limits and the tail rarely changes the similarity.
+  const a = responseText.length > MAX_RESPONSE_CHARS ? responseText.slice(0, MAX_RESPONSE_CHARS) : responseText
+  const b = reference.length > MAX_RESPONSE_CHARS ? reference.slice(0, MAX_RESPONSE_CHARS) : reference
+
+  const result = await embedTexts(config.provider, config.model, apiKey, resourceUrl, [a, b])
+  if (!result || result.embeddings.length !== 2) return null
+
+  const sim = cosineSimilarity(result.embeddings[0]!, result.embeddings[1]!)
+  const score = Math.max(0, Math.min(1, sim))
+  // Azure bills embeddings at OpenAI prices (same as the chat path).
+  const costProvider = config.provider === 'azure' ? 'openai' : config.provider
+  const cost = calculateCost(costProvider, config.model, { promptTokens: result.tokens, completionTokens: 0 })?.totalCost ?? 0
+  const threshold = typeof config.threshold === 'number' ? config.threshold : null
+
+  return {
+    score,
+    value_number: score,
+    value_string: null,
+    value_boolean: threshold != null ? score >= threshold : null,
+    reasoning: `cosine similarity ${score.toFixed(4)}${threshold != null ? ` (threshold ${threshold})` : ''}`,
+    cost,
+    tokens: result.tokens,
+  }
+}

--- a/apps/server/src/lib/eval-runners/shared.ts
+++ b/apps/server/src/lib/eval-runners/shared.ts
@@ -8,6 +8,42 @@
 /** Cap on the response text fed into the judge prompt or a regex. */
 export const MAX_RESPONSE_CHARS = 4000
 
+/** Retry attempts for LLM / embedding calls (env-tunable). */
+export const EVAL_MAX_RETRIES = Number(process.env['EVAL_MAX_RETRIES']) || 3
+
+function evalSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * fetch with exponential backoff on transient failures (429, 5xx, network
+ * error). Returns the final Response (which may still be non-ok) or null if
+ * every attempt threw. Callers treat a non-ok / null result as a dropped
+ * sample, so this only adds resilience — it never changes the success
+ * contract. Back-off: 250ms, 500ms, 1000ms (× EVAL_MAX_RETRIES). Shared by
+ * the judge path (eval-runner.ts) and the embedding path (embedding.ts).
+ */
+export async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  retries: number = EVAL_MAX_RETRIES,
+): Promise<Response | null> {
+  let last: Response | null = null
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(url, init)
+      if (res.ok || !(res.status === 429 || (res.status >= 500 && res.status < 600))) {
+        return res
+      }
+      last = res
+    } catch {
+      last = null
+    }
+    if (attempt < retries) await evalSleep(250 * Math.pow(2, attempt))
+  }
+  return last
+}
+
 /**
  * Extract the assistant response text from a stored response_body. Handles
  * the three provider shapes Spanlens proxies today: OpenAI chat.completion,

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -219,7 +219,7 @@ function NewEvaluatorDialog({
   // llm_judge evaluators today, so the selector defaults to that even
   // when initialTemplate is set.
   const [evaluatorType, setEvaluatorType] = useState<
-    'llm_judge' | 'regex' | 'json_schema' | 'exact_match' | 'contains'
+    'llm_judge' | 'regex' | 'json_schema' | 'exact_match' | 'contains' | 'embedding'
   >('llm_judge')
   const [regexPattern, setRegexPattern] = useState('')
   const [regexFlags, setRegexFlags] = useState('')
@@ -229,6 +229,11 @@ function NewEvaluatorDialog({
   const [exactCaseSensitive, setExactCaseSensitive] = useState(false)
   const [containsSubstring, setContainsSubstring] = useState('')
   const [containsCaseSensitive, setContainsCaseSensitive] = useState(false)
+  // embedding config (P2-12)
+  const [embedProvider, setEmbedProvider] = useState('openai')
+  const [embedModel, setEmbedModel] = useState('text-embedding-3-small')
+  const [embedReferenceText, setEmbedReferenceText] = useState('')
+  const [embedThreshold, setEmbedThreshold] = useState('')
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -303,7 +308,7 @@ function NewEvaluatorDialog({
           type: 'exact_match',
           config: { value: exactValue, caseSensitive: exactCaseSensitive },
         })
-      } else {
+      } else if (evaluatorType === 'contains') {
         if (!containsSubstring) {
           setError('Substring is required')
           return
@@ -314,6 +319,27 @@ function NewEvaluatorDialog({
           type: 'contains',
           config: { substring: containsSubstring, caseSensitive: containsCaseSensitive },
         })
+      } else {
+        if (!embedModel.trim()) {
+          setError('Embedding model is required')
+          return
+        }
+        const threshold = embedThreshold.trim() ? Number(embedThreshold) : undefined
+        if (threshold !== undefined && (!Number.isFinite(threshold) || threshold < 0 || threshold > 1)) {
+          setError('Threshold must be between 0 and 1')
+          return
+        }
+        await createMutation.mutateAsync({
+          promptName,
+          name: name.trim(),
+          type: 'embedding',
+          config: {
+            provider: embedProvider,
+            model: embedModel.trim(),
+            ...(embedReferenceText.trim() ? { reference_text: embedReferenceText.trim() } : {}),
+            ...(threshold !== undefined ? { threshold } : {}),
+          },
+        })
       }
       onClose()
       setName(''); setCriterion(''); setPromptName('')
@@ -321,6 +347,7 @@ function NewEvaluatorDialog({
       setJsonSchemaText('{\n  "type": "object"\n}')
       setExactValue(''); setExactCaseSensitive(false)
       setContainsSubstring(''); setContainsCaseSensitive(false)
+      setEmbedReferenceText(''); setEmbedThreshold('')
       setEvaluatorType('llm_judge')
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create')
@@ -372,7 +399,9 @@ function NewEvaluatorDialog({
             <Select
               value={evaluatorType}
               onValueChange={(v) =>
-                setEvaluatorType(v as 'llm_judge' | 'regex' | 'json_schema' | 'exact_match' | 'contains')
+                setEvaluatorType(
+                  v as 'llm_judge' | 'regex' | 'json_schema' | 'exact_match' | 'contains' | 'embedding',
+                )
               }
             >
               <SelectTrigger><SelectValue /></SelectTrigger>
@@ -382,6 +411,7 @@ function NewEvaluatorDialog({
                 <SelectItem value="json_schema">JSON Schema (structure check)</SelectItem>
                 <SelectItem value="exact_match">Exact match (equals a value)</SelectItem>
                 <SelectItem value="contains">Contains (substring present)</SelectItem>
+                <SelectItem value="embedding">Embedding similarity (semantic)</SelectItem>
               </SelectContent>
             </Select>
             <p className="font-mono text-[10.5px] text-text-faint mt-1">
@@ -393,7 +423,9 @@ function NewEvaluatorDialog({
                     ? 'Deterministic 0/1 — passes when the response parses as JSON and matches the schema.'
                     : evaluatorType === 'exact_match'
                       ? 'Deterministic 0/1 — passes when the response equals the expected value.'
-                      : 'Deterministic 0/1 — passes when the response contains the substring.'}
+                      : evaluatorType === 'contains'
+                        ? 'Deterministic 0/1 — passes when the response contains the substring.'
+                        : 'Cosine similarity (0..1) of the response vs a reference answer. Uses your provider key.'}
             </p>
           </div>
 
@@ -552,6 +584,68 @@ function NewEvaluatorDialog({
                 Passes when the response contains this text. Case-insensitive unless checked.
               </p>
             </div>
+          )}
+
+          {evaluatorType === 'embedding' && (
+            <>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                    Embedding provider
+                  </label>
+                  <Select value={embedProvider} onValueChange={setEmbedProvider}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="openai">OpenAI</SelectItem>
+                      <SelectItem value="azure">Azure</SelectItem>
+                      <SelectItem value="mistral">Mistral</SelectItem>
+                      <SelectItem value="openrouter">OpenRouter</SelectItem>
+                      <SelectItem value="gemini">Gemini</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div>
+                  <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                    Model
+                  </label>
+                  <input
+                    type="text"
+                    value={embedModel}
+                    onChange={(e) => setEmbedModel(e.target.value)}
+                    placeholder="text-embedding-3-small"
+                    required
+                    className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong"
+                  />
+                </div>
+              </div>
+              <div>
+                <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                  Reference text
+                </label>
+                <textarea
+                  value={embedReferenceText}
+                  onChange={(e) => setEmbedReferenceText(e.target.value)}
+                  rows={3}
+                  placeholder="The ideal answer to compare responses against…"
+                  className="w-full px-2 py-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong resize-none"
+                />
+                <p className="font-mono text-[10.5px] text-text-faint mt-1">
+                  Used for production runs. Dataset items use their own expected_output when present.
+                </p>
+              </div>
+              <div>
+                <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                  Pass threshold (optional, 0–1)
+                </label>
+                <input
+                  type="text"
+                  value={embedThreshold}
+                  onChange={(e) => setEmbedThreshold(e.target.value)}
+                  placeholder="e.g. 0.8"
+                  className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong"
+                />
+              </div>
+            </>
           )}
 
           {/* Optional typed score config (LLM-as-judge only). When omitted

--- a/apps/web/app/docs/features/evals/page.tsx
+++ b/apps/web/app/docs/features/evals/page.tsx
@@ -83,16 +83,20 @@ export default function EvalsDocs() {
         <li><code>name</code>, e.g. &quot;Helpfulness check&quot;</li>
         <li>
           <code>type</code>, one of <code>llm_judge</code>, <code>regex</code>,{' '}
-          <code>json_schema</code>, <code>exact_match</code>, or <code>contains</code>.
-          The <code>regex</code> type checks the response body against a configured
-          pattern and scores 1 on match. The <code>json_schema</code> type validates the
-          response body against a JSON Schema document via Ajv and scores 1 on valid.
-          {' '}<code>exact_match</code> (config <code>value</code>, optional{' '}
+          <code>json_schema</code>, <code>exact_match</code>, <code>contains</code>, or{' '}
+          <code>embedding</code>. The <code>regex</code> type checks the response body
+          against a configured pattern and scores 1 on match. The <code>json_schema</code>{' '}
+          type validates the response body against a JSON Schema document via Ajv and
+          scores 1 on valid. <code>exact_match</code> (config <code>value</code>, optional{' '}
           <code>caseSensitive</code> / <code>trim</code>) scores 1 when the response
           equals the value; <code>contains</code> (config <code>substring</code>,
           optional <code>caseSensitive</code>) scores 1 when the substring is present.
-          The four deterministic evaluators are free of LLM cost since no judge model
-          is called.
+          The four deterministic types are free of LLM cost. <code>embedding</code>{' '}
+          (config <code>provider</code> / <code>model</code>, optional{' '}
+          <code>reference_text</code> / <code>threshold</code>) scores the cosine
+          similarity (0–1) of the response vs a reference answer — the reference is the
+          dataset item&apos;s <code>expected_output</code> when present, otherwise{' '}
+          <code>reference_text</code>; it calls an embeddings API on your provider key.
         </li>
         <li>
           <code>config</code>:
@@ -400,11 +404,11 @@ if (run.status !== 'completed' || (run.avg_score ?? 0) < 0.8) {
       <h2>Limitations</h2>
       <ul>
         <li>
-          <strong>Five evaluator types ship today.</strong> <code>llm_judge</code> (model
+          <strong>Six evaluator types ship today.</strong> <code>llm_judge</code> (model
           scores 0–1), <code>regex</code>, <code>json_schema</code>,{' '}
-          <code>exact_match</code>, and <code>contains</code>. The four deterministic types
-          run on production samples with no LLM cost. Embedding-similarity and custom-code
-          evaluators are planned for a later release.
+          <code>exact_match</code>, <code>contains</code> (the four deterministic types run
+          with no LLM cost), and <code>embedding</code> (cosine similarity via your
+          provider key). Custom-code (JS) evaluators are planned for a later release.
         </li>
         <li>
           <strong>One evaluator run at a time.</strong> Concurrent runs on the same evaluator

--- a/apps/web/lib/queries/use-evals.ts
+++ b/apps/web/lib/queries/use-evals.ts
@@ -113,6 +113,13 @@ export interface ContainsConfig {
   caseSensitive?: boolean
 }
 
+export interface EmbeddingConfig {
+  provider: string
+  model: string
+  reference_text?: string
+  threshold?: number
+}
+
 export type CreateEvaluatorInput =
   | {
       promptName: string
@@ -146,6 +153,12 @@ export type CreateEvaluatorInput =
       name: string
       type: 'contains'
       config: ContainsConfig
+    }
+  | {
+      promptName: string
+      name: string
+      type: 'embedding'
+      config: EmbeddingConfig
     }
 
 export function useCreateEvaluator() {


### PR DESCRIPTION
Phase 3 / **P2-12** (part 2): the `embedding` evaluator — completes the evaluator-types work alongside #347 (exact_match + contains).

## What it does
Scores the **cosine similarity (0–1)** of a response vs a reference answer via an embeddings API. It needs only a `(response, reference)` pair, so it works on **both** eval sources:
- **production**: reference = `config.reference_text`
- **dataset (golden set)**: reference = the item's `expected_output`, falling back to `reference_text`

## Providers
OpenAI-compatible (`openai` / `azure` / `mistral` / `openrouter`) share one `/embeddings` shape; `gemini` uses `batchEmbedContents`; `anthropic` has no embeddings API and is rejected at config validation.

## Implementation
- **`eval-runners/embedding.ts`** (new): `cosineSimilarity` + multi-provider `embedText` + `scoreEmbedding` (returns a JudgeOutcome-compatible shape).
- **`fetchWithRetry` / `EVAL_MAX_RETRIES` moved to `eval-runners/shared.ts`** so the judge path and embedding path share the backoff without an import cycle.
- **`runEvalRun` refactor**: branches config/key resolution and per-sample scoring on evaluator type. Sample gathering, aggregation, and result rows are **unchanged** — embedding produces NUMERIC scores so the existing avg path applies. Azure embedding reuses the `resource_url` + `api-key` + SSRF guard.
- **`POST /evaluators`**: validates the embedding config (provider in the supported set, model required, threshold 0..1).
- **Dashboard**: "New evaluator" dialog gains the embedding type (provider / model / reference_text / threshold). Docs updated (five → six types).

## Verification
- server: typecheck + lint + test (1130 passed, +9). The judge path's 53 existing eval tests still pass after the `runEvalRun` refactor.
- web: typecheck + lint; docs render 200 in preview.

## Tests
`cosineSimilarity` (identical / orthogonal / opposite / degenerate); `scoreEmbedding` (score = clamped cosine, threshold → value_boolean, azure routes to the resource v1 endpoint with `api-key`, null on non-ok).

## Scope
Custom-code (JS) evaluators remain deferred (need a server-side sandbox). This completes P2-12.