### PR TITLE
feat(server,web,db): auto-run evaluators on new prompt version (P2-10)

### DIFF
--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -33,6 +33,12 @@ evalsRouter.post('/evaluators', requireFullScope, async (c) => {
     // 4B.1c — optional pointer at a typed score config. NULL preserves
     // the legacy NUMERIC 0..1 behaviour.
     scoreConfigId?: unknown
+    // P2-10 — auto-run on new prompt version (golden regression suite).
+    autoRunOnVersion?: unknown
+    autoRunDatasetId?: unknown
+    autoRunProvider?: unknown
+    autoRunModel?: unknown
+    autoRunSampleSize?: unknown
   }
   try {
     body = (await c.req.json()) as typeof body
@@ -162,6 +168,39 @@ evalsRouter.post('/evaluators', requireFullScope, async (c) => {
     scoreConfigId = sc.id
   }
 
+  // P2-10 — auto-run config (golden regression suite). When enabled, a new
+  // version of this evaluator's prompt auto-triggers a dataset eval run. New
+  // versions have no production traffic, so a dataset + run model are required.
+  const autoRunOnVersion = body.autoRunOnVersion === true
+  let autoRunDatasetId: string | null = null
+  let autoRunProvider: string | null = null
+  let autoRunModel: string | null = null
+  let autoRunSampleSize: number | null = null
+  if (autoRunOnVersion) {
+    autoRunDatasetId = typeof body.autoRunDatasetId === 'string' ? body.autoRunDatasetId.trim() : ''
+    autoRunProvider = typeof body.autoRunProvider === 'string' ? body.autoRunProvider : ''
+    autoRunModel = typeof body.autoRunModel === 'string' ? body.autoRunModel.trim() : ''
+    const RUN_PROVIDERS = ['openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter']
+    if (!autoRunDatasetId) throw new ApiError('VALIDATION_FAILED', 'autoRunDatasetId is required when autoRunOnVersion is true')
+    if (!RUN_PROVIDERS.includes(autoRunProvider)) {
+      throw new ApiError('VALIDATION_FAILED', `autoRunProvider must be one of: ${RUN_PROVIDERS.join(', ')}`)
+    }
+    if (!autoRunModel) throw new ApiError('VALIDATION_FAILED', 'autoRunModel is required when autoRunOnVersion is true')
+    autoRunSampleSize = typeof body.autoRunSampleSize === 'number' ? Math.round(body.autoRunSampleSize) : 50
+    if (autoRunSampleSize < 1 || autoRunSampleSize > 1000) {
+      throw new ApiError('VALIDATION_FAILED', 'autoRunSampleSize must be between 1 and 1000')
+    }
+    // Verify the dataset belongs to this org.
+    const { data: ds } = await supabaseAdmin
+      .from('datasets')
+      .select('id')
+      .eq('id', autoRunDatasetId)
+      .eq('organization_id', orgId)
+      .is('archived_at', null)
+      .maybeSingle()
+    if (!ds) throw new ApiError('NOT_FOUND', 'autoRunDatasetId not found')
+  }
+
   const { data, error } = await supabaseAdmin
     .from('evaluators')
     .insert({
@@ -172,6 +211,11 @@ evalsRouter.post('/evaluators', requireFullScope, async (c) => {
       config: validatedConfig,
       created_by: userId ?? null,
       score_config_id: scoreConfigId,
+      auto_run_on_version: autoRunOnVersion,
+      auto_run_dataset_id: autoRunDatasetId,
+      auto_run_provider: autoRunProvider,
+      auto_run_model: autoRunModel,
+      auto_run_sample_size: autoRunSampleSize,
     })
     .select()
     .single()

--- a/apps/server/src/api/prompts.ts
+++ b/apps/server/src/api/prompts.ts
@@ -6,6 +6,7 @@ import { comparePromptVersions } from '../lib/prompt-compare.js'
 import { invalidatePromptName } from '../lib/prompt-cache.js'
 import { enqueueDeletion } from '../lib/pending-deletions.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
+import { startEvalRun } from '../lib/eval-runner.js'
 import { requestsScope, selectRequests } from '../lib/requests-query.js'
 import { parsePositiveFloat } from '../lib/params.js'
 import { ApiError } from '../lib/errors.js'
@@ -318,6 +319,35 @@ promptsRouter.post('/', requireEdit, async (c) => {
       project_id: data.project_id,
     },
   })
+
+  // P2-10: auto-run evaluators flagged for version creation (golden regression
+  // suite). A new version has no production traffic yet, so each is a DATASET
+  // run that generates responses for the evaluator's golden dataset and scores
+  // them. Fire-and-forget — version creation must not wait on (or fail from)
+  // the eval runs. Only evaluators that opted in (auto_run_on_version=true)
+  // run; the DB CHECK guarantees the dataset/provider/model are set.
+  const { data: autoEvals } = await supabaseAdmin
+    .from('evaluators')
+    .select('id, auto_run_dataset_id, auto_run_provider, auto_run_model, auto_run_sample_size')
+    .eq('organization_id', orgId)
+    .eq('prompt_name', name)
+    .eq('auto_run_on_version', true)
+    .is('archived_at', null)
+
+  for (const ev of autoEvals ?? []) {
+    if (!ev.auto_run_dataset_id || !ev.auto_run_provider || !ev.auto_run_model) continue
+    await startEvalRun(c, {
+      organizationId: orgId,
+      evaluatorId: ev.id,
+      promptVersionId: data.id,
+      source: 'dataset',
+      datasetId: ev.auto_run_dataset_id,
+      sampleSize: ev.auto_run_sample_size ?? 50,
+      runProvider: ev.auto_run_provider,
+      runModel: ev.auto_run_model,
+      createdBy: userId,
+    })
+  }
 
   return c.json({ success: true, data }, 201)
 })

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -22,7 +22,9 @@
  * so concurrency is not needed.
  */
 
+import type { Context } from 'hono'
 import { supabaseAdmin } from './db.js'
+import { fireAndForget } from './wait-until.js'
 import { requestsScope, selectRequests } from './requests-query.js'
 import { aes256Decrypt } from './crypto.js'
 import { validateOutboundUrlSync } from './safe-url.js'
@@ -1155,6 +1157,67 @@ export async function runEvalRun(input: RunInput): Promise<void> {
       errorMessage: err instanceof Error ? err.message : 'Unknown error',
     })
   }
+}
+
+/** Input for startEvalRun — the subset POST /eval-runs and the auto-run hook share. */
+export interface StartEvalRunInput {
+  organizationId: string
+  evaluatorId: string
+  promptVersionId: string
+  source: 'production' | 'dataset'
+  datasetId?: string | null
+  sampleSize: number
+  sampleFrom?: string | null
+  sampleTo?: string | null
+  /** A provider string (validated upstream); cast to EvalProvider internally. */
+  runProvider?: string | null
+  runModel?: string | null
+  sampleStrategy?: 'recent' | 'random' | null
+  generationTemperature?: number | null
+  createdBy?: string | null
+}
+
+/**
+ * Insert an eval_runs row and kick the run off in the background via
+ * fireAndForget. Shared by the manual POST /eval-runs and the
+ * auto-run-on-version hook (P2-10). Returns the new run id, or null if the
+ * insert failed (caller decides whether that's fatal).
+ */
+export async function startEvalRun(c: Context, input: StartEvalRunInput): Promise<{ id: string } | null> {
+  const { data: run, error } = await supabaseAdmin
+    .from('eval_runs')
+    .insert({
+      organization_id: input.organizationId,
+      evaluator_id: input.evaluatorId,
+      prompt_version_id: input.promptVersionId,
+      source: input.source,
+      dataset_id: input.source === 'dataset' ? (input.datasetId ?? null) : null,
+      sample_size: input.sampleSize,
+      sample_from: input.source === 'production' ? (input.sampleFrom ?? null) : null,
+      sample_to: input.source === 'production' ? (input.sampleTo ?? null) : null,
+      status: 'pending',
+      created_by: input.createdBy ?? null,
+    })
+    .select('id')
+    .single()
+  if (error || !run) return null
+
+  fireAndForget(c, runEvalRun({
+    evalRunId: run.id,
+    organizationId: input.organizationId,
+    evaluatorId: input.evaluatorId,
+    promptVersionId: input.promptVersionId,
+    source: input.source,
+    datasetId: input.datasetId ?? null,
+    sampleSize: input.sampleSize,
+    sampleFrom: input.sampleFrom ?? null,
+    sampleTo: input.sampleTo ?? null,
+    runProvider: (input.runProvider ?? null) as EvalProvider | null,
+    runModel: input.runModel ?? null,
+    sampleStrategy: input.sampleStrategy ?? null,
+    generationTemperature: input.generationTemperature ?? null,
+  }))
+  return run
 }
 
 /** Convenience: estimate judge cost before running (rough heuristic). */

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -18,6 +18,7 @@ import {
   useEstimateEvalCost,
   type Evaluator,
   type EvalRunStatus,
+  type CreateEvaluatorInput,
 } from '@/lib/queries/use-evals'
 import { usePrompts, usePromptVersions } from '@/lib/queries/use-prompts'
 import type { PromptVersion } from '@/lib/queries/use-prompts'
@@ -154,6 +155,7 @@ function NewEvaluatorDialog({
 }) {
   const prompts = usePrompts()
   const createMutation = useCreateEvaluator()
+  const datasets = useDatasets()
   const { data: modelsCatalog } = useModels()
   // Map the catalog's full shape down to the openai/anthropic strings that
   // this picker needs. Gemini is excluded — the eval API only supports
@@ -234,6 +236,24 @@ function NewEvaluatorDialog({
   const [embedModel, setEmbedModel] = useState('text-embedding-3-small')
   const [embedReferenceText, setEmbedReferenceText] = useState('')
   const [embedThreshold, setEmbedThreshold] = useState('')
+  // auto-run on new prompt version (P2-10)
+  const [autoRunOnVersion, setAutoRunOnVersion] = useState(false)
+  const [autoRunDatasetId, setAutoRunDatasetId] = useState('')
+  const [autoRunProvider, setAutoRunProvider] = useState<EvalProvider>('openai')
+  const [autoRunModel, setAutoRunModel] = useState('gpt-4o-mini')
+
+  // P2-10: auto-run config is common to all evaluator types, so wrap the
+  // mutation to fold it into every create call instead of repeating it.
+  const autoRunFields = autoRunOnVersion
+    ? {
+        autoRunOnVersion: true as const,
+        autoRunDatasetId,
+        autoRunProvider,
+        autoRunModel: autoRunModel.trim(),
+      }
+    : { autoRunOnVersion: false as const }
+  const submitEvaluator = (input: CreateEvaluatorInput) =>
+    createMutation.mutateAsync({ ...input, ...autoRunFields })
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -242,13 +262,17 @@ function NewEvaluatorDialog({
       setError('Prompt and name are required')
       return
     }
+    if (autoRunOnVersion && (!autoRunDatasetId || !autoRunModel.trim())) {
+      setError('Auto-run needs a dataset and a model')
+      return
+    }
     try {
       if (evaluatorType === 'llm_judge') {
         if (!criterion.trim()) {
           setError('Criterion is required for LLM-as-judge evaluators')
           return
         }
-        await createMutation.mutateAsync({
+        await submitEvaluator({
           promptName,
           name: name.trim(),
           config: {
@@ -273,7 +297,7 @@ function NewEvaluatorDialog({
           setError(err instanceof Error ? err.message : 'Invalid regex')
           return
         }
-        await createMutation.mutateAsync({
+        await submitEvaluator({
           promptName,
           name: name.trim(),
           type: 'regex',
@@ -291,7 +315,7 @@ function NewEvaluatorDialog({
           setError('Schema must be a JSON object')
           return
         }
-        await createMutation.mutateAsync({
+        await submitEvaluator({
           promptName,
           name: name.trim(),
           type: 'json_schema',
@@ -302,7 +326,7 @@ function NewEvaluatorDialog({
           setError('Expected value is required')
           return
         }
-        await createMutation.mutateAsync({
+        await submitEvaluator({
           promptName,
           name: name.trim(),
           type: 'exact_match',
@@ -313,7 +337,7 @@ function NewEvaluatorDialog({
           setError('Substring is required')
           return
         }
-        await createMutation.mutateAsync({
+        await submitEvaluator({
           promptName,
           name: name.trim(),
           type: 'contains',
@@ -329,7 +353,7 @@ function NewEvaluatorDialog({
           setError('Threshold must be between 0 and 1')
           return
         }
-        await createMutation.mutateAsync({
+        await submitEvaluator({
           promptName,
           name: name.trim(),
           type: 'embedding',
@@ -348,6 +372,7 @@ function NewEvaluatorDialog({
       setExactValue(''); setExactCaseSensitive(false)
       setContainsSubstring(''); setContainsCaseSensitive(false)
       setEmbedReferenceText(''); setEmbedThreshold('')
+      setAutoRunOnVersion(false); setAutoRunDatasetId(''); setAutoRunModel('gpt-4o-mini')
       setEvaluatorType('llm_judge')
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create')
@@ -677,6 +702,70 @@ function NewEvaluatorDialog({
               </p>
             </div>
           )}
+
+          {/* P2-10: auto-run on new prompt version (golden regression suite). */}
+          <div className="border-t border-border pt-3">
+            <label className="flex items-center gap-2 font-mono text-[11.5px] text-text-muted">
+              <input
+                type="checkbox"
+                checked={autoRunOnVersion}
+                onChange={(e) => setAutoRunOnVersion(e.target.checked)}
+              />
+              Auto-run on each new version of this prompt
+            </label>
+            <p className="font-mono text-[10.5px] text-text-faint mt-1">
+              Runs this evaluator against a dataset whenever a new version is created. Spends your provider key.
+            </p>
+            {autoRunOnVersion && (
+              <div className="mt-2 space-y-2">
+                <div>
+                  <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                    Dataset
+                  </label>
+                  <Select {...(autoRunDatasetId ? { value: autoRunDatasetId } : {})} onValueChange={setAutoRunDatasetId}>
+                    <SelectTrigger><SelectValue placeholder="Select dataset…" /></SelectTrigger>
+                    <SelectContent>
+                      {(datasets.data ?? []).map((d) => (
+                        <SelectItem key={d.id} value={d.id}>{d.name}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                      Run provider
+                    </label>
+                    <Select value={autoRunProvider} onValueChange={(v) => {
+                        const p = v as EvalProvider
+                        setAutoRunProvider(p)
+                        setAutoRunModel(judgeModels[p][0] ?? '')
+                      }}>
+                      <SelectTrigger><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        {PROVIDER_OPTIONS.map((opt) => (
+                          <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                      Run model
+                    </label>
+                    <Select {...(autoRunModel ? { value: autoRunModel } : {})} onValueChange={setAutoRunModel}>
+                      <SelectTrigger><SelectValue placeholder="Select model…" /></SelectTrigger>
+                      <SelectContent>
+                        {judgeModels[autoRunProvider].map((m) => (
+                          <SelectItem key={m} value={m}>{m}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
 
           {error && (
             <p className="font-mono text-[11.5px] text-bad">{error}</p>

--- a/apps/web/app/docs/features/evals/page.tsx
+++ b/apps/web/app/docs/features/evals/page.tsx
@@ -401,6 +401,26 @@ if (run.status !== 'completed' || (run.avg_score ?? 0) < 0.8) {
         </li>
       </ul>
 
+      <h2>Auto-run on a new version (golden regression suite)</h2>
+      <p>
+        Turn an evaluator into a regression gate: enable <strong>Auto-run on each
+        new version</strong> on the evaluator (or pass{' '}
+        <code>autoRunOnVersion</code> + <code>autoRunDatasetId</code> /{' '}
+        <code>autoRunProvider</code> / <code>autoRunModel</code> to{' '}
+        <code>POST /api/v1/evaluators</code>). Whenever a new version of that
+        evaluator&apos;s prompt is created, Spanlens automatically runs the
+        evaluator against the chosen dataset and scores it — no manual trigger.
+      </p>
+      <p>
+        It is a <strong>dataset</strong> run, not production: a brand-new version
+        has no traffic yet, so the run generates responses for the golden dataset
+        with the configured model and scores them. Pair it with an{' '}
+        <code>eval_score</code> <a href="/docs/features/alerts">alert</a> to be
+        notified when a version regresses, and with{' '}
+        <code>expected_output</code> on the dataset items for golden-set scoring.
+        Auto-runs spend your provider key, so they are opt-in per evaluator.
+      </p>
+
       <h2>Limitations</h2>
       <ul>
         <li>

--- a/apps/web/lib/queries/use-evals.ts
+++ b/apps/web/lib/queries/use-evals.ts
@@ -120,7 +120,16 @@ export interface EmbeddingConfig {
   threshold?: number
 }
 
-export type CreateEvaluatorInput =
+/** P2-10 — auto-run-on-version config, common to every evaluator type. */
+export interface AutoRunFields {
+  autoRunOnVersion?: boolean
+  autoRunDatasetId?: string
+  autoRunProvider?: string
+  autoRunModel?: string
+  autoRunSampleSize?: number
+}
+
+export type CreateEvaluatorInput = AutoRunFields & (
   | {
       promptName: string
       name: string
@@ -160,6 +169,7 @@ export type CreateEvaluatorInput =
       type: 'embedding'
       config: EmbeddingConfig
     }
+)
 
 export function useCreateEvaluator() {
   const qc = useQueryClient()
@@ -173,6 +183,14 @@ export function useCreateEvaluator() {
       }
       if (input.type === undefined || input.type === 'llm_judge') {
         if (input.scoreConfigId) body.scoreConfigId = input.scoreConfigId
+      }
+      // P2-10 auto-run config (common to all types).
+      if (input.autoRunOnVersion) {
+        body.autoRunOnVersion = true
+        body.autoRunDatasetId = input.autoRunDatasetId
+        body.autoRunProvider = input.autoRunProvider
+        body.autoRunModel = input.autoRunModel
+        if (input.autoRunSampleSize != null) body.autoRunSampleSize = input.autoRunSampleSize
       }
       const res = await apiPost<ApiEnvelope<Evaluator>>('/api/v1/evaluators', body)
       return res.data

--- a/supabase/migrations/20260615020000_evaluator_auto_run.sql
+++ b/supabase/migrations/20260615020000_evaluator_auto_run.sql
@@ -1,0 +1,40 @@
+-- P2-10: auto-run an evaluator when a new version of its prompt is created
+-- (the "golden regression suite"). A just-created version has no production
+-- traffic, so the auto-run is a DATASET run — it generates responses for a
+-- golden dataset with a chosen model, then scores them. The dataset + run
+-- model are therefore evaluator-specific, so the opt-in lives on the
+-- evaluator.
+--
+-- All additive + nullable (gotcha #25). The consistency CHECK makes it
+-- impossible to enable auto-run without the dataset / provider / model it
+-- needs — closing the "app allows it, DB stores a half-config" gap that the
+-- untyped client otherwise leaves open.
+
+ALTER TABLE evaluators
+  ADD COLUMN IF NOT EXISTS auto_run_on_version boolean NOT NULL DEFAULT false;
+
+ALTER TABLE evaluators
+  ADD COLUMN IF NOT EXISTS auto_run_dataset_id uuid REFERENCES public.datasets(id) ON DELETE SET NULL;
+
+ALTER TABLE evaluators
+  ADD COLUMN IF NOT EXISTS auto_run_provider text;
+
+ALTER TABLE evaluators
+  ADD COLUMN IF NOT EXISTS auto_run_model text;
+
+ALTER TABLE evaluators
+  ADD COLUMN IF NOT EXISTS auto_run_sample_size int;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.evaluators'::regclass
+      AND conname = 'evaluators_auto_run_requires_config'
+  ) THEN
+    ALTER TABLE evaluators ADD CONSTRAINT evaluators_auto_run_requires_config CHECK (
+      auto_run_on_version = false
+      OR (auto_run_dataset_id IS NOT NULL AND auto_run_provider IS NOT NULL AND auto_run_model IS NOT NULL)
+    );
+  END IF;
+END $$;

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -793,6 +793,11 @@ export type Database = {
       evaluators: {
         Row: {
           archived_at: string | null
+          auto_run_dataset_id: string | null
+          auto_run_model: string | null
+          auto_run_on_version: boolean
+          auto_run_provider: string | null
+          auto_run_sample_size: number | null
           config: Json
           created_at: string
           created_by: string | null
@@ -805,6 +810,11 @@ export type Database = {
         }
         Insert: {
           archived_at?: string | null
+          auto_run_dataset_id?: string | null
+          auto_run_model?: string | null
+          auto_run_on_version?: boolean
+          auto_run_provider?: string | null
+          auto_run_sample_size?: number | null
           config: Json
           created_at?: string
           created_by?: string | null
@@ -817,6 +827,11 @@ export type Database = {
         }
         Update: {
           archived_at?: string | null
+          auto_run_dataset_id?: string | null
+          auto_run_model?: string | null
+          auto_run_on_version?: boolean
+          auto_run_provider?: string | null
+          auto_run_sample_size?: number | null
           config?: Json
           created_at?: string
           created_by?: string | null


### PR DESCRIPTION
Phase 3 / **P2-10**: turns an evaluator into a golden regression gate — when a new version of its prompt is created, the evaluator auto-runs and scores, no manual trigger. This closes the **"prompt CI" loop** alongside #344 (P2-8 run from CI) and #345 (P2-9 score alerts): **create version → auto-eval → `eval_score` alert.**

## Why a dataset run
A brand-new version has no production traffic, so the auto-run is a **dataset** run: it generates responses for a golden dataset with a chosen model, then scores them. The dataset + run model are evaluator-specific, so the opt-in lives on the evaluator.

## Changes
- **Migration**: additive `auto_run_on_version` / `auto_run_dataset_id` / `auto_run_provider` / `auto_run_model` / `auto_run_sample_size`, plus a CHECK (`evaluators_auto_run_requires_config`) so enabling auto-run without the dataset/provider/model is **impossible at the DB layer** — not just app-layer validation (the lesson from the type-CHECK hotfix #349).
- **`eval-runner.ts`**: new `startEvalRun(c, input)` — insert eval_runs row + `fireAndForget(runEvalRun)` — shared by the auto-run hook.
- **`prompts.ts`**: `POST /` (version create) fires `startEvalRun` for each opted-in evaluator of that prompt, after the version is committed (fire-and-forget; version creation never waits on or fails from the runs).
- **`evals.ts`**: `POST /evaluators` accepts + validates the auto-run config (dataset belongs to org, provider valid, sampleSize 1..1000).
- **Dashboard**: "New evaluator" dialog gains an "Auto-run on each new version" toggle with dataset + run provider/model pickers. Docs add a section.

## Verification
- server: typecheck + lint + test (1130 passed, no regression)
- web: typecheck + lint; docs render 200 in preview

## Notes
- The auto-run path is DB-integration (route handler + helper inserting verified-real columns); the config-consistency invariant is enforced by the DB CHECK, consistent with this codebase's test boundary (pure functions + middleware).
- `types.ts` hand-edited for the new columns (Docker/local-supabase unavailable); regenerate with `supabase gen types` on the next schema change.

Built on top of the #349 hotfix (which restored the missing `evaluators.type` CHECK widening for exact_match/contains/embedding).