### PR TITLE
fix(web): nested-button hydration error + responsive correlation cards on evals

### DIFF
--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -1518,7 +1518,9 @@ function CorrelationCard({ promptName }: { promptName: string }) {
             <p className="font-mono text-[11px] text-text-faint mb-0.5 truncate">
               {promptName}
             </p>
-            <div className="flex items-baseline gap-2">
+            {/* flex-wrap so the "Pearson r · …" label drops below the big
+                number instead of overflowing the card on narrow (2-up) widths. */}
+            <div className="flex items-baseline flex-wrap gap-x-2 gap-y-0.5">
               <span className={cn('font-mono text-[22px] font-medium', rColor)}>
                 {r == null ? '—' : r.toFixed(2)}
               </span>
@@ -1556,7 +1558,9 @@ function CorrelationRow({ evaluators }: { evaluators: Evaluator[] }) {
       <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-3">
         <span>LLM judge vs Human agreement</span>
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+      {/* 2-up only at lg+ (1024px): below that the cards are too narrow for
+          the scatter plot + metrics side by side, so go full-width. */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
         {promptNames.map((name) => (
           <CorrelationCard key={name} promptName={name} />
         ))}

--- a/apps/web/app/demo/evals/page.tsx
+++ b/apps/web/app/demo/evals/page.tsx
@@ -70,7 +70,9 @@ function CorrelationCard({ promptName }: { promptName: string }) {
         <div className="flex-1 min-w-0 space-y-2">
           <div>
             <p className="font-mono text-[11px] text-text-faint mb-0.5 truncate">{promptName}</p>
-            <div className="flex items-baseline gap-2">
+            {/* flex-wrap so the "Pearson r · …" label drops below the big
+                number instead of overflowing the card on narrow (2-up) widths. */}
+            <div className="flex items-baseline flex-wrap gap-x-2 gap-y-0.5">
               <span className={cn('font-mono text-[22px] font-medium', rColor)}>
                 {r == null ? '—' : r.toFixed(2)}
               </span>
@@ -214,10 +216,20 @@ function EvaluatorRow({
 
   return (
     <div className="border-b border-border last:border-0">
-      <button
-        type="button"
+      {/* Outer container is a div, not a button: HTML forbids nested buttons,
+          and we need the Run/Delete buttons inside the same row. Keyboard
+          activation is preserved via role="button" + Enter/Space handlers. */}
+      <div
+        role="button"
+        tabIndex={0}
         onClick={() => setExpanded((v) => !v)}
-        className="w-full flex items-center px-[16px] py-[12px] hover:bg-bg-muted transition-colors text-left"
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            setExpanded((v) => !v)
+          }
+        }}
+        className="w-full flex items-center px-[16px] py-[12px] hover:bg-bg-muted transition-colors text-left cursor-pointer"
       >
         <div className="flex-1 min-w-0">
           <p className="font-mono text-[13px] text-text font-medium truncate">{evaluator.name}</p>
@@ -248,7 +260,7 @@ function EvaluatorRow({
             <Trash2 className="h-3.5 w-3.5" />
           </button>
         </div>
-      </button>
+      </div>
       {expanded && (
         <div className="bg-bg-muted/50 px-[16px] py-[10px] border-t border-border">
           <p className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
@@ -319,7 +331,9 @@ export default function DemoEvalsPage() {
             <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-3">
               <span>LLM judge vs Human agreement</span>
             </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {/* 2-up only at lg+ (1024px): below that the cards are too narrow
+                for the scatter plot + metrics side by side, so go full-width. */}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
               {promptNames.map((name) => <CorrelationCard key={name} promptName={name} />)}
             </div>
           </div>


### PR DESCRIPTION
## Two evals-page UI bugs

### 1. Nested-button hydration error (demo evals)
`EvaluatorRow` on `/demo/evals` wrapped the Run/Delete buttons inside an outer `<button>` (the clickable row). HTML forbids nested interactive content, so React logged `<button> cannot be a descendant of <button>` hydration errors (the "2 Issues" badge in Next.js dev tools).

**Fix:** make the row a `div` with `role="button"` + `tabIndex={0}` + Enter/Space `onKeyDown`, mirroring the dashboard page's existing pattern. Inner buttons become valid markup; click + keyboard activation and `stopPropagation` are preserved.

### 2. Correlation cards overflow at narrow widths
The "LLM judge vs Human agreement" cards put the big Pearson `r` number and the `Pearson r · Strong` label on a single non-wrapping flex row, so the label bled past the card's right edge when the cards were narrow (2-up). Reported with a screenshot showing `-1.00 Pea… Str` clipped at the edge.

**Fix:**
- `flex-wrap` on the number+label row → label drops below the number when tight.
- Bump the 2-column split from `md` (768px) to `lg` (1024px) → cards stay full-width with the label inline until there's genuinely room.

Both fixes applied to the demo page **and** the real dashboard evals page (the dashboard already had the `role="button"` fix; only the card layout changed there).

### Verification (browser preview)
- `/demo/evals` console: **no more** `<button> cannot be a descendant of <button>` errors (was the "2 Issues" badge).
- Correlation cards clean at **375 / 840 / 1280px** — no overflow; full-width single column below `lg`, comfortable 2-up at `lg+`.
- Interaction chain intact: row expand (click + role=button) → select run → detail panel renders `±4.5 · 95% CI` + score distribution.
- `pnpm --filter web typecheck` / `pnpm --filter web lint` — clean.
