### PR TITLE
feat: rubric + few-shot anchors + middle-out truncation for LLM judge (P1-7 part 2)

### DIFF
--- a/apps/server/src/__tests__/eval-truncate.test.ts
+++ b/apps/server/src/__tests__/eval-truncate.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { truncateMiddle, MAX_RESPONSE_CHARS } from '../lib/eval-runners/shared.js'
+
+describe('truncateMiddle', () => {
+  it('returns text unchanged when within the cap', () => {
+    const short = 'hello world'
+    expect(truncateMiddle(short, 100)).toBe(short)
+    expect(truncateMiddle(short, short.length)).toBe(short)
+  })
+
+  it('never exceeds the cap', () => {
+    const long = 'x'.repeat(10_000)
+    expect(truncateMiddle(long, 1000).length).toBeLessThanOrEqual(1000)
+  })
+
+  it('preserves BOTH the head and the tail (the conclusion is often at the end)', () => {
+    const head = 'HEAD'.repeat(500) // 2000 chars
+    const tail = 'TAIL'.repeat(500) // 2000 chars
+    const out = truncateMiddle(head + tail, 1000)
+    expect(out.startsWith('HEAD')).toBe(true)
+    expect(out.endsWith('TAIL')).toBe(true)
+    expect(out).toContain('truncated middle')
+  })
+
+  it('keeps more of the head than the tail (~60/40 split)', () => {
+    const text = 'a'.repeat(5000) + 'b'.repeat(5000)
+    const out = truncateMiddle(text, 1000)
+    const aCount = (out.match(/a/g) ?? []).length
+    const bCount = (out.match(/b/g) ?? []).length
+    expect(aCount).toBeGreaterThan(bCount)
+  })
+
+  it('defaults to MAX_RESPONSE_CHARS', () => {
+    const long = 'y'.repeat(MAX_RESPONSE_CHARS + 1000)
+    expect(truncateMiddle(long).length).toBeLessThanOrEqual(MAX_RESPONSE_CHARS)
+  })
+
+  it('falls back to a head slice when the cap is too small for both ends', () => {
+    const long = 'z'.repeat(100)
+    const out = truncateMiddle(long, 10)
+    expect(out).toBe('z'.repeat(10))
+    expect(out).not.toContain('truncated')
+  })
+})

--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -83,7 +83,60 @@ evalsRouter.post('/evaluators', requireFullScope, async (c) => {
     if (!(scaleMax > scaleMin)) {
       throw new ApiError('VALIDATION_FAILED', 'config.scale_max must be greater than scale_min')
     }
-    validatedConfig = { criterion, judge_provider: judgeProvider, judge_model: judgeModel, scale_min: scaleMin, scale_max: scaleMax }
+
+    // P1-7 — optional rubric (free-form guidance) + few-shot calibration
+    // anchors. Both are stored verbatim on the config jsonb and injected into
+    // the judge prompt; absent fields keep the prompt byte-identical.
+    const RUBRIC_MAX = 4000
+    const ANCHORS_MAX = 10
+    const ANCHOR_RESPONSE_MAX = 4000
+    const ANCHOR_REASONING_MAX = 500
+    const rubric = typeof config.rubric === 'string' ? config.rubric.trim() : ''
+    if (rubric.length > RUBRIC_MAX) {
+      throw new ApiError('VALIDATION_FAILED', `config.rubric must be at most ${RUBRIC_MAX} characters`)
+    }
+    const anchors: Array<{ response: string; score: number; reasoning?: string }> = []
+    if (config.anchors !== undefined) {
+      if (!Array.isArray(config.anchors)) {
+        throw new ApiError('VALIDATION_FAILED', 'config.anchors must be an array')
+      }
+      if (config.anchors.length > ANCHORS_MAX) {
+        throw new ApiError('VALIDATION_FAILED', `config.anchors supports at most ${ANCHORS_MAX} examples`)
+      }
+      for (const raw of config.anchors) {
+        if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+          throw new ApiError('VALIDATION_FAILED', 'each anchor must be an object')
+        }
+        const a = raw as Record<string, unknown>
+        const response = typeof a.response === 'string' ? a.response.trim() : ''
+        const score = typeof a.score === 'number' ? a.score : NaN
+        if (!response) throw new ApiError('VALIDATION_FAILED', 'each anchor needs a non-empty response')
+        if (response.length > ANCHOR_RESPONSE_MAX) {
+          throw new ApiError('VALIDATION_FAILED', `anchor response must be at most ${ANCHOR_RESPONSE_MAX} characters`)
+        }
+        if (!Number.isFinite(score) || score < scaleMin || score > scaleMax) {
+          throw new ApiError('VALIDATION_FAILED', `anchor score must be a number between ${scaleMin} and ${scaleMax}`)
+        }
+        const reasoning = typeof a.reasoning === 'string' ? a.reasoning.trim() : ''
+        // Cap reasoning too: unlike `response` (truncated to 280 chars in the
+        // prompt) it is embedded verbatim into every judge call, so an
+        // oversized note would silently inflate token cost / blow the context.
+        if (reasoning.length > ANCHOR_REASONING_MAX) {
+          throw new ApiError('VALIDATION_FAILED', `anchor reasoning must be at most ${ANCHOR_REASONING_MAX} characters`)
+        }
+        anchors.push({ response, score, ...(reasoning ? { reasoning } : {}) })
+      }
+    }
+
+    validatedConfig = {
+      criterion,
+      judge_provider: judgeProvider,
+      judge_model: judgeModel,
+      scale_min: scaleMin,
+      scale_max: scaleMax,
+      ...(rubric ? { rubric } : {}),
+      ...(anchors.length > 0 ? { anchors } : {}),
+    }
   } else if (type === 'regex') {
     const pattern = typeof config.pattern === 'string' ? config.pattern : ''
     const flags = typeof config.flags === 'string' ? config.flags : ''

--- a/apps/server/src/lib/eval-runner.test.ts
+++ b/apps/server/src/lib/eval-runner.test.ts
@@ -50,6 +50,79 @@ describe('buildJudgePrompt — expected_output reference', () => {
   })
 })
 
+// ── P1-7: rubric + few-shot calibration anchors ─────────────────────────────
+describe('buildJudgePrompt — rubric', () => {
+  it('injects the rubric block when present', () => {
+    const prompt = buildJudgePrompt('Is it helpful?', 'Paris', {
+      scale_min: 0,
+      scale_max: 1,
+      rubric: '1.0 = fully correct; 0 = wrong',
+    })
+    expect(prompt).toContain('Scoring rubric (apply consistently):')
+    expect(prompt).toContain('1.0 = fully correct; 0 = wrong')
+  })
+
+  it('omits the rubric block when absent (byte-identical to before)', () => {
+    const withEmpty = buildJudgePrompt('Is it helpful?', 'Paris', {
+      scale_min: 0,
+      scale_max: 1,
+      rubric: '   ',
+    })
+    const without = buildJudgePrompt('Is it helpful?', 'Paris', { scale_min: 0, scale_max: 1 })
+    expect(withEmpty).not.toContain('Scoring rubric')
+    expect(withEmpty).toBe(without)
+  })
+})
+
+describe('buildJudgePrompt — calibration anchors', () => {
+  it('injects anchors on the NUMERIC / legacy path', () => {
+    const prompt = buildJudgePrompt('Is it helpful?', 'Paris', {
+      scale_min: 0,
+      scale_max: 1,
+      anchors: [
+        { response: 'A complete, correct answer', score: 1, reasoning: 'nailed it' },
+        { response: 'Totally wrong', score: 0 },
+      ],
+    })
+    expect(prompt).toContain('Calibration examples (anchor your scoring to these):')
+    expect(prompt).toContain('A complete, correct answer')
+    expect(prompt).toContain('→ score 1')
+    expect(prompt).toContain('(nailed it)')
+    expect(prompt).toContain('→ score 0')
+  })
+
+  it('flattens newlines inside an anchor response to keep one line per example', () => {
+    const prompt = buildJudgePrompt('crit', 'resp', {
+      scale_min: 0,
+      scale_max: 1,
+      anchors: [{ response: 'line one\nline two', score: 0.5 }],
+    })
+    expect(prompt).toContain('line one line two')
+    expect(prompt).not.toContain('line one\nline two')
+  })
+
+  it('does NOT inject numeric anchors on a typed (BOOLEAN) config', () => {
+    const sc: TypedScoreConfig = {
+      id: 'a', data_type: 'BOOLEAN',
+      min_value: null, max_value: null, categories: null,
+      bool_true_label: null, bool_false_label: null,
+    }
+    const prompt = buildJudgePrompt('crit', 'resp', {
+      scale_min: 0,
+      scale_max: 1,
+      score_config: sc,
+      anchors: [{ response: 'x', score: 1 }],
+    })
+    expect(prompt).not.toContain('Calibration examples')
+  })
+
+  it('omits the anchors block when empty (byte-identical to before)', () => {
+    const withEmpty = buildJudgePrompt('crit', 'resp', { scale_min: 0, scale_max: 1, anchors: [] })
+    const without = buildJudgePrompt('crit', 'resp', { scale_min: 0, scale_max: 1 })
+    expect(withEmpty).toBe(without)
+  })
+})
+
 describe('buildJudgePrompt — NUMERIC score_config', () => {
   it('uses min/max from the score_config when present', () => {
     const sc: TypedScoreConfig = {

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -267,6 +267,9 @@ export async function callJudge(
     scale_max: config.scale_max,
     score_config: config.score_config ?? null,
     expected_output: expectedOutput,
+    // P1-7: rubric + few-shot anchors carried on the evaluator config.
+    rubric: config.rubric ?? null,
+    anchors: config.anchors ?? null,
   })
 
   // Helper that turns a parsed judge reply into the JudgeOutcome the

--- a/apps/server/src/lib/eval-runners/judge-prompt.ts
+++ b/apps/server/src/lib/eval-runners/judge-prompt.ts
@@ -12,7 +12,7 @@
  * runner import a single module instead of two.
  */
 
-import { MAX_RESPONSE_CHARS } from './shared.js'
+import { MAX_RESPONSE_CHARS, truncateMiddle } from './shared.js'
 
 /**
  * Minimal projection of the score_configs row that the runner actually
@@ -29,6 +29,19 @@ export interface TypedScoreConfig {
   bool_false_label: string | null
 }
 
+/**
+ * P1-7 — a calibration anchor: an example response paired with the score it
+ * should receive. A few of these "anchor" the judge so its scale matches the
+ * operator's intent (the standard few-shot fix for judge drift). The score is
+ * on the evaluator's own [scale_min, scale_max] numeric scale, so anchors are
+ * only injected on the NUMERIC / legacy path.
+ */
+export interface JudgeAnchor {
+  response: string
+  score: number
+  reasoning?: string
+}
+
 export interface JudgeConfig {
   criterion: string
   judge_provider: 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
@@ -41,6 +54,12 @@ export interface JudgeConfig {
   // normalises to 0..1, and only the `score` column is filled. When
   // non-NULL we route through the type-aware prompt + parser below.
   score_config?: TypedScoreConfig | null
+  // P1-7 — optional free-form scoring rubric, injected for every type. Helps
+  // the judge apply consistent standards. Omitted from the prompt when absent
+  // so existing evaluators are byte-identical.
+  rubric?: string
+  // P1-7 — optional few-shot calibration anchors (NUMERIC / legacy path only).
+  anchors?: JudgeAnchor[]
 }
 
 /**
@@ -58,27 +77,40 @@ export function buildJudgePrompt(
      * the judge compares against; omitted when null so criterion-only scoring
      * is byte-identical to before. */
     expected_output?: string | null
+    /** P1-7: free-form scoring rubric, injected for every type when present. */
+    rubric?: string | null
+    /** P1-7: few-shot calibration anchors (NUMERIC / legacy path only). */
+    anchors?: JudgeAnchor[] | null
   },
 ): string {
-  const truncated = responseText.length > MAX_RESPONSE_CHARS
-    ? responseText.slice(0, MAX_RESPONSE_CHARS) + '… [truncated]'
-    : responseText
+  // P1-7: middle-out truncation keeps the start AND the end of a long response
+  // (the conclusion is often where the answer lives) instead of head-only.
+  const truncated = truncateMiddle(responseText, MAX_RESPONSE_CHARS)
 
-  // Reference (expected) answer, also truncated to the same cap.
+  // Reference (expected) answer, also truncated middle-out to the same cap.
   const expected = config.expected_output
   const referenceBlock = expected
     ? `
 
 Reference (expected) answer to compare against:
 """
-${expected.length > MAX_RESPONSE_CHARS ? expected.slice(0, MAX_RESPONSE_CHARS) + '… [truncated]' : expected}
+${truncateMiddle(expected, MAX_RESPONSE_CHARS)}
 """
 Judge how well the response matches the reference while still satisfying the criterion.`
     : ''
 
+  // P1-7: optional rubric block, applied to every score type.
+  const rubric = config.rubric?.trim()
+  const rubricBlock = rubric
+    ? `
+
+Scoring rubric (apply consistently):
+${rubric}`
+    : ''
+
   const intro = `You are an evaluator. Score the assistant response below against this criterion.
 
-Criterion: ${criterion}
+Criterion: ${criterion}${rubricBlock}
 
 Response to evaluate:
 """
@@ -87,11 +119,25 @@ ${truncated}
 
   const sc = config.score_config
 
-  // Legacy NUMERIC path — unchanged from before 4B.1c.
+  // P1-7: few-shot calibration anchors. Only meaningful on the NUMERIC / legacy
+  // path (anchor.score is a number on [scale_min, scale_max]); typed configs
+  // still get the rubric above but not numeric anchors.
+  const anchors = config.anchors ?? []
+  const anchorsBlock = (!sc || sc.data_type === 'NUMERIC') && anchors.length > 0
+    ? `
+
+Calibration examples (anchor your scoring to these):
+${anchors
+  .map((a) => `- Response: "${truncateMiddle(a.response, 280).replace(/\n/g, ' ')}" → score ${a.score}${a.reasoning ? ` (${a.reasoning})` : ''}`)
+  .join('\n')}`
+    : ''
+
+  // Legacy NUMERIC path — unchanged from before 4B.1c except the optional
+  // rubric (intro) + anchors blocks, both of which collapse to '' when absent.
   if (!sc || sc.data_type === 'NUMERIC') {
     const min = sc?.min_value ?? config.scale_min
     const max = sc?.max_value ?? config.scale_max
-    return `${intro}
+    return `${intro}${anchorsBlock}
 
 Reply ONLY in JSON with this exact shape:
 {"score": <number between ${min} and ${max}>, "reasoning": "<one short sentence>"}

--- a/apps/server/src/lib/eval-runners/shared.ts
+++ b/apps/server/src/lib/eval-runners/shared.ts
@@ -8,6 +8,27 @@
 /** Cap on the response text fed into the judge prompt or a regex. */
 export const MAX_RESPONSE_CHARS = 4000
 
+/**
+ * Truncate text to at most `max` characters while preserving BOTH ends (P1-7).
+ *
+ * A long LLM response often states its actual answer or conclusion at the very
+ * end, so head-only truncation (`slice(0, max)`) can hide the exact thing the
+ * judge is scoring. This keeps the first ~60% and last ~40% of the budget with
+ * an elision marker in the middle. Short text passes through unchanged so the
+ * common case is byte-identical to before.
+ */
+export function truncateMiddle(text: string, max: number = MAX_RESPONSE_CHARS): string {
+  if (text.length <= max) return text
+  const marker = '\n…[truncated middle]…\n'
+  // Degenerate case: budget too small to keep both ends meaningfully — fall
+  // back to a plain head slice so we never return more than `max` chars.
+  if (max <= marker.length + 2) return text.slice(0, max)
+  const budget = max - marker.length
+  const headLen = Math.ceil(budget * 0.6)
+  const tailLen = budget - headLen
+  return text.slice(0, headLen) + marker + text.slice(text.length - tailLen)
+}
+
 /** Retry attempts for LLM / embedding calls (env-tunable). */
 export const EVAL_MAX_RETRIES = Number(process.env['EVAL_MAX_RETRIES']) || 3
 

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -19,6 +19,7 @@ import {
   type Evaluator,
   type EvalRunStatus,
   type CreateEvaluatorInput,
+  type JudgeAnchor,
 } from '@/lib/queries/use-evals'
 import { usePrompts, usePromptVersions } from '@/lib/queries/use-prompts'
 import type { PromptVersion } from '@/lib/queries/use-prompts'
@@ -216,6 +217,10 @@ function NewEvaluatorDialog({
   )
   const [scaleMin] = useState(0)
   const [scaleMax] = useState(1)
+  // P1-7 — optional judge-prompt quality controls (llm_judge only). Rubric is
+  // free-form guidance; anchors are few-shot calibration examples.
+  const [rubric, setRubric] = useState('')
+  const [anchors, setAnchors] = useState<JudgeAnchor[]>([])
   // Optional pointer at a workspace score_config. Empty string = use the
   // legacy NUMERIC 0..1 path (omits scoreConfigId from the POST body so
   // the server keeps the historic behaviour for pre-4B.1c evaluators).
@@ -281,6 +286,11 @@ function NewEvaluatorDialog({
           setError('Criterion is required for LLM-as-judge evaluators')
           return
         }
+        // P1-7: keep only complete anchors (a response + a numeric score in range).
+        const cleanAnchors = anchors
+          .map((a) => ({ ...a, response: a.response.trim(), reasoning: a.reasoning?.trim() }))
+          .filter((a) => a.response && Number.isFinite(a.score) && a.score >= scaleMin && a.score <= scaleMax)
+          .map((a) => ({ response: a.response, score: a.score, ...(a.reasoning ? { reasoning: a.reasoning } : {}) }))
         await submitEvaluator({
           promptName,
           name: name.trim(),
@@ -290,6 +300,8 @@ function NewEvaluatorDialog({
             judge_model: judgeModel,
             scale_min: scaleMin,
             scale_max: scaleMax,
+            ...(rubric.trim() ? { rubric: rubric.trim() } : {}),
+            ...(cleanAnchors.length > 0 ? { anchors: cleanAnchors } : {}),
           },
           ...(scoreConfigId ? { scoreConfigId } : {}),
         })
@@ -514,6 +526,101 @@ function NewEvaluatorDialog({
                   </Select>
                 </div>
               </div>
+
+              {/* P1-7: optional rubric + few-shot calibration anchors. Collapsed
+                  by default so the common case stays a one-field form. */}
+              <details className="border border-border rounded-[5px] px-3 py-2">
+                <summary className="font-mono text-[11px] text-text-muted cursor-pointer select-none">
+                  Advanced: rubric &amp; calibration anchors (optional)
+                </summary>
+                <div className="mt-3 space-y-3">
+                  <div>
+                    <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                      Scoring rubric
+                    </label>
+                    <textarea
+                      value={rubric}
+                      onChange={(e) => setRubric(e.target.value)}
+                      rows={3}
+                      placeholder="e.g. 1.0 = fully correct and complete · 0.5 = partially correct · 0 = wrong or off-topic"
+                      className="w-full px-2 py-2 rounded-[5px] border border-border bg-bg font-mono text-[11.5px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong resize-y"
+                    />
+                    <p className="font-mono text-[10.5px] text-text-faint mt-1">
+                      Free-form guidance injected into the judge prompt for consistent scoring.
+                    </p>
+                  </div>
+
+                  <div>
+                    <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                      Calibration anchors
+                    </label>
+                    <div className="space-y-2">
+                      {anchors.map((a, i) => (
+                        <div key={i} className="border border-border rounded-[5px] p-2 space-y-2">
+                          <div className="flex gap-2 items-start">
+                            <textarea
+                              value={a.response}
+                              onChange={(e) =>
+                                setAnchors((prev) => prev.map((x, j) => (j === i ? { ...x, response: e.target.value } : x)))
+                              }
+                              rows={2}
+                              placeholder="Example response…"
+                              className="flex-1 px-2 py-1.5 rounded-[4px] border border-border bg-bg font-mono text-[11.5px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong resize-y"
+                            />
+                            <div className="flex flex-col gap-1 w-[64px] shrink-0">
+                              <input
+                                type="number"
+                                step={0.1}
+                                min={scaleMin}
+                                max={scaleMax}
+                                value={Number.isFinite(a.score) ? String(a.score) : ''}
+                                onChange={(e) =>
+                                  setAnchors((prev) =>
+                                    prev.map((x, j) =>
+                                      j === i ? { ...x, score: e.target.value === '' ? NaN : Number(e.target.value) } : x,
+                                    ),
+                                  )
+                                }
+                                placeholder="score"
+                                className="w-full h-8 px-2 rounded-[4px] border border-border bg-bg font-mono text-[11.5px] text-text text-center placeholder:text-text-faint focus:outline-none focus:border-border-strong"
+                              />
+                              <button
+                                type="button"
+                                onClick={() => setAnchors((prev) => prev.filter((_, j) => j !== i))}
+                                className="h-7 flex items-center justify-center rounded-[4px] border border-border text-text-faint hover:text-bad hover:border-bad/40 transition-colors"
+                                aria-label="Remove anchor"
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </button>
+                            </div>
+                          </div>
+                          <input
+                            type="text"
+                            value={a.reasoning ?? ''}
+                            onChange={(e) =>
+                              setAnchors((prev) => prev.map((x, j) => (j === i ? { ...x, reasoning: e.target.value } : x)))
+                            }
+                            placeholder="why this score (optional)"
+                            className="w-full h-8 px-2 rounded-[4px] border border-border bg-bg font-mono text-[11px] text-text-muted placeholder:text-text-faint focus:outline-none focus:border-border-strong"
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    {anchors.length < 10 && (
+                      <button
+                        type="button"
+                        onClick={() => setAnchors((prev) => [...prev, { response: '', score: Number.NaN }])}
+                        className="mt-2 font-mono text-[11px] px-2 py-1 rounded-[4px] border border-border hover:bg-bg-elev flex items-center gap-1 transition-colors"
+                      >
+                        <Plus className="h-3 w-3" /> Add anchor
+                      </button>
+                    )}
+                    <p className="font-mono text-[10.5px] text-text-faint mt-1">
+                      Example response → score ({scaleMin}–{scaleMax}). Anchors the judge&apos;s scale. Up to 10.
+                    </p>
+                  </div>
+                </div>
+              </details>
             </>
           )}
 

--- a/apps/web/app/docs/features/evals/page.tsx
+++ b/apps/web/app/docs/features/evals/page.tsx
@@ -407,6 +407,47 @@ if (run.status !== 'completed' || (ci?.high ?? run.avg_score ?? 0) < GATE) {
   process.exit(1)
 }`}</CodeBlock>
 
+      <h2>Tuning the judge: rubric &amp; calibration anchors</h2>
+      <p>
+        A bare criterion leaves the judge to invent its own scale, so scores
+        drift run to run. Two optional fields on an LLM-judge evaluator make
+        scoring consistent (set them under <em>Advanced</em> when creating the
+        evaluator, or pass them in <code>config</code> to{' '}
+        <code>POST /api/v1/evaluators</code>):
+      </p>
+      <ul>
+        <li>
+          <strong><code>rubric</code></strong> — free-form guidance injected into
+          the prompt, e.g. <code>1.0 = fully correct and complete · 0.5 =
+          partially correct · 0 = wrong</code>. Applies to every score type.
+        </li>
+        <li>
+          <strong><code>anchors</code></strong> — up to 10 few-shot calibration
+          examples, each an example <code>response</code> paired with the{' '}
+          <code>score</code> it should get (and an optional{' '}
+          <code>reasoning</code>). The judge anchors its scale to these. Numeric
+          judges only.
+        </li>
+      </ul>
+      <CodeBlock language="json">{`// POST /api/v1/evaluators  (config excerpt)
+{
+  "criterion": "Is the answer factually correct and complete?",
+  "judge_provider": "openai",
+  "judge_model": "gpt-4o-mini",
+  "scale_min": 0,
+  "scale_max": 1,
+  "rubric": "1.0 = correct and complete · 0.5 = correct but missing detail · 0 = wrong",
+  "anchors": [
+    { "response": "Paris is the capital of France.", "score": 1, "reasoning": "correct and complete" },
+    { "response": "I think it's somewhere in Europe.", "score": 0.3, "reasoning": "vague, no answer" }
+  ]
+}`}</CodeBlock>
+      <p>
+        Long responses are truncated to a character cap before judging, but{' '}
+        <strong>middle-out</strong>: the start and the end are both kept (the
+        actual answer often lives in the conclusion) with the middle elided.
+      </p>
+
       <h2>Reproducibility &amp; reliability options</h2>
       <ul>
         <li>

--- a/apps/web/lib/queries/use-evals.ts
+++ b/apps/web/lib/queries/use-evals.ts
@@ -6,12 +6,23 @@ import type { ApiEnvelope } from './types'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
+/** P1-7 — a few-shot calibration anchor (example response + the score it should get). */
+export interface JudgeAnchor {
+  response: string
+  score: number
+  reasoning?: string
+}
+
 export interface JudgeConfig {
   criterion: string
   judge_provider: 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
   judge_model: string
   scale_min: number
   scale_max: number
+  /** P1-7 — optional free-form scoring rubric injected into the judge prompt. */
+  rubric?: string
+  /** P1-7 — optional few-shot calibration anchors (NUMERIC judges). */
+  anchors?: JudgeAnchor[]
 }
 
 export interface Evaluator {


### PR DESCRIPTION
## P1-7 (2/3): make LLM-judge scoring consistent

A bare criterion lets the judge invent its own scale, so scores drift between runs and the same response can score differently. This adds two optional, additive controls plus a truncation fix.

### Changes
- **Rubric** (`config.rubric`) — free-form scoring guidance injected into the judge prompt for **every** score type. e.g. `1.0 = correct and complete · 0.5 = partial · 0 = wrong`.
- **Calibration anchors** (`config.anchors`) — up to 10 few-shot `{ response, score, reasoning? }` examples that anchor the judge's scale. NUMERIC/legacy path only (anchor score is numeric).
- **Middle-out truncation** — long responses (and golden references) now keep the **start and the end** instead of head-only `slice(0, MAX)`. The answer often lives in the conclusion, which head-only truncation hid. New `truncateMiddle()` helper.
- **Config on jsonb, no migration.** Server validates rubric/anchor lengths, anchor count (≤10), and score range (untyped `supabaseAdmin` + no DB CHECK → app-layer is the only gate). `anchor.reasoning` is also length-capped since it goes into the prompt verbatim.
- **Web** — collapsed "Advanced: rubric & calibration anchors" section on the create-evaluator form; `JudgeConfig` / `JudgeAnchor` types.
- **Docs** — "Tuning the judge" section + middle-out note.

### Byte-identity
When rubric/anchors are absent, the prompt is unchanged. Middle-out only differs from before for responses over the 4000-char cap (intended).

### Test plan
- [x] `buildJudgePrompt`: rubric injection + omission (byte-identical), anchor injection on numeric path, newline flattening, **not** injected on typed BOOLEAN config, empty-anchors byte-identity.
- [x] `truncateMiddle`: never exceeds cap, preserves both ends, ~60/40 head/tail split, tiny-max head-slice fallback, default = `MAX_RESPONSE_CHARS`.
- [x] `pnpm typecheck` (all packages), `pnpm --filter server lint`, `pnpm --filter web lint` — clean. 97 server eval tests pass.
- [x] Code review: 1 HIGH (`anchor.reasoning` was uncapped → fixed with a 500-char cap).
- Note: the create-evaluator form is dashboard-only (auth-gated), so it's typecheck/lint-verified rather than browser-verified; the prompt-injection behavior it drives is fully unit-tested.

### Follow-up
- P1-7 (3/3): pairwise (A vs B) judge mode (largest, new run type).
