### PR TITLE
feat: pairwise (A vs B) judge mode for evals (P1-7 part 3)

### DIFF
--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -358,6 +358,8 @@ evalsRouter.post('/eval-runs', requireFullScope, async (c) => {
     runModel?: unknown
     sampleStrategy?: unknown
     generationTemperature?: unknown
+    mode?: unknown
+    promptVersionBId?: unknown
   }
   try {
     body = (await c.req.json()) as typeof body
@@ -403,15 +405,45 @@ evalsRouter.post('/eval-runs', requireFullScope, async (c) => {
     if (!runModel) throw new ApiError('VALIDATION_FAILED', 'runModel is required when source = dataset')
   }
 
+  // P1-7 (3/3): pairwise (A vs B) mode. Requires a dataset source + a second
+  // prompt version. Generation (run provider/model) is required because both
+  // versions must be executed to produce the two responses being compared.
+  const mode = body.mode === 'pairwise' ? 'pairwise' : 'single'
+  const promptVersionBId = typeof body.promptVersionBId === 'string' ? body.promptVersionBId.trim() : null
+  if (mode === 'pairwise') {
+    if (source !== 'dataset') throw new ApiError('VALIDATION_FAILED', 'pairwise mode requires source = dataset')
+    if (!promptVersionBId) throw new ApiError('VALIDATION_FAILED', 'promptVersionBId is required for a pairwise run')
+    if (promptVersionBId === promptVersionId) {
+      throw new ApiError('VALIDATION_FAILED', 'promptVersionBId must differ from promptVersionId')
+    }
+    if (!runProvider || !runModel) {
+      throw new ApiError('VALIDATION_FAILED', 'runProvider and runModel are required for a pairwise run')
+    }
+  }
+
   // Verify both belong to org
   const { data: evaluator } = await supabaseAdmin
     .from('evaluators')
-    .select('id')
+    .select('id, type')
     .eq('id', evaluatorId)
     .eq('organization_id', orgId)
     .is('archived_at', null)
     .maybeSingle()
   if (!evaluator) throw new ApiError('NOT_FOUND', 'Evaluator not found')
+  if (mode === 'pairwise' && evaluator.type !== 'llm_judge') {
+    throw new ApiError('VALIDATION_FAILED', 'pairwise mode requires an llm_judge evaluator')
+  }
+
+  // Verify version B belongs to org (pairwise only).
+  if (mode === 'pairwise' && promptVersionBId) {
+    const { data: pvB } = await supabaseAdmin
+      .from('prompt_versions')
+      .select('id')
+      .eq('id', promptVersionBId)
+      .eq('organization_id', orgId)
+      .maybeSingle()
+    if (!pvB) throw new ApiError('NOT_FOUND', 'promptVersionBId not found')
+  }
 
   const { data: pv } = await supabaseAdmin
     .from('prompt_versions')
@@ -446,6 +478,8 @@ evalsRouter.post('/eval-runs', requireFullScope, async (c) => {
       sample_to: source === 'production' ? sampleTo : null,
       status: 'pending',
       created_by: userId ?? null,
+      mode,
+      prompt_version_b_id: mode === 'pairwise' ? promptVersionBId : null,
     })
     .select()
     .single()
@@ -469,6 +503,8 @@ evalsRouter.post('/eval-runs', requireFullScope, async (c) => {
     runModel,
     sampleStrategy,
     generationTemperature,
+    mode,
+    promptVersionBId,
   }))
 
   return c.json({ success: true, data: run }, 202)

--- a/apps/server/src/lib/eval-runner.test.ts
+++ b/apps/server/src/lib/eval-runner.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   buildJudgePrompt,
   parseJudgeReply,
+  buildPairwiseJudgePrompt,
+  parsePairwiseReply,
   type TypedScoreConfig,
 } from './eval-runner.js'
 
@@ -309,6 +311,56 @@ describe('parseJudgeReply — CATEGORICAL', () => {
     expect(parseJudgeReply('{"value": 1}', {
       scale_min: 0, scale_max: 1, score_config: sc,
     })).toBeNull()
+  })
+})
+
+// ── P1-7 (3/3): pairwise judge ──────────────────────────────────────────────
+describe('buildPairwiseJudgePrompt', () => {
+  it('renders both responses under A and B with the criterion', () => {
+    const prompt = buildPairwiseJudgePrompt('Which is more helpful?', 'Answer one', 'Answer two')
+    expect(prompt).toContain('Criterion: Which is more helpful?')
+    expect(prompt).toContain('Response A:')
+    expect(prompt).toContain('Answer one')
+    expect(prompt).toContain('Response B:')
+    expect(prompt).toContain('Answer two')
+    expect(prompt).toContain('"winner": "A" | "B" | "tie"')
+  })
+
+  it('injects the rubric when present', () => {
+    const prompt = buildPairwiseJudgePrompt('crit', 'a', 'b', { rubric: 'prefer concise answers' })
+    expect(prompt).toContain('Scoring rubric (apply consistently):')
+    expect(prompt).toContain('prefer concise answers')
+  })
+
+  it('injects the reference (expected) answer when present', () => {
+    const prompt = buildPairwiseJudgePrompt('crit', 'a', 'b', { expected_output: 'the gold answer' })
+    expect(prompt).toContain('Reference (expected) answer')
+    expect(prompt).toContain('the gold answer')
+  })
+})
+
+describe('parsePairwiseReply', () => {
+  it('parses a winner of A / B / tie', () => {
+    expect(parsePairwiseReply('{"winner":"A","reasoning":"clearer"}')?.winner).toBe('A')
+    expect(parsePairwiseReply('{"winner":"B","reasoning":"more complete"}')?.winner).toBe('B')
+    expect(parsePairwiseReply('{"winner":"tie","reasoning":"equal"}')?.winner).toBe('tie')
+  })
+
+  it('is case-insensitive and strips markdown fences', () => {
+    expect(parsePairwiseReply('```json\n{"winner":"b"}\n```')?.winner).toBe('B')
+    expect(parsePairwiseReply('{"winner":"  A  "}')?.winner).toBe('A')
+  })
+
+  it('treats neither / equal / same as a tie', () => {
+    expect(parsePairwiseReply('{"winner":"neither"}')?.winner).toBe('tie')
+    expect(parsePairwiseReply('{"winner":"equal"}')?.winner).toBe('tie')
+    expect(parsePairwiseReply('{"winner":"same"}')?.winner).toBe('tie')
+  })
+
+  it('returns null on an unreadable winner or invalid JSON', () => {
+    expect(parsePairwiseReply('{"winner":"maybe"}')).toBeNull()
+    expect(parsePairwiseReply('{"reasoning":"no winner"}')).toBeNull()
+    expect(parsePairwiseReply('garbage')).toBeNull()
   })
 })
 

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -38,8 +38,11 @@ import { sampleStdDev } from './eval-runners/stats.js'
 import {
   buildJudgePrompt,
   parseJudgeReply,
+  buildPairwiseJudgePrompt,
+  parsePairwiseReply,
   type JudgeConfig,
   type TypedScoreConfig,
+  type PairwiseWinner,
 } from './eval-runners/judge-prompt.js'
 import {
   scoreEmbedding,
@@ -60,10 +63,11 @@ import {
   type SimpleEvalResult,
 } from './eval-runners/deterministic.js'
 
-export { buildJudgePrompt, parseJudgeReply, runRegex, runJsonSchema, runExactMatch, runContains }
+export { buildJudgePrompt, parseJudgeReply, buildPairwiseJudgePrompt, parsePairwiseReply, runRegex, runJsonSchema, runExactMatch, runContains }
 export type {
   JudgeConfig,
   TypedScoreConfig,
+  PairwiseWinner,
   RegexConfig,
   JsonSchemaConfig,
   ExactMatchConfig,
@@ -249,6 +253,159 @@ export async function generateForItem(
 // buildJudgePrompt + parseJudgeReply moved to ./eval-runners/judge-prompt.ts
 // (imported and re-exported above for backward compatibility).
 
+/** Gemini responseSchema for the single-judge path, keyed off the score config.
+ * Must match the JSON shape the prompt asks for or Gemini errors. */
+function geminiJudgeSchema(sc: TypedScoreConfig | null | undefined): Record<string, unknown> {
+  if (!sc || sc.data_type === 'NUMERIC') {
+    return { type: 'object', properties: { score: { type: 'number' }, reasoning: { type: 'string' } }, required: ['score', 'reasoning'] }
+  }
+  if (sc.data_type === 'BOOLEAN') {
+    return { type: 'object', properties: { value: { type: 'boolean' }, reasoning: { type: 'string' } }, required: ['value', 'reasoning'] }
+  }
+  // CATEGORICAL + TEXT both emit a string `value`.
+  return { type: 'object', properties: { value: { type: 'string' }, reasoning: { type: 'string' } }, required: ['value', 'reasoning'] }
+}
+
+/** Gemini responseSchema for the pairwise path. */
+const GEMINI_PAIRWISE_SCHEMA: Record<string, unknown> = {
+  type: 'object',
+  properties: { winner: { type: 'string' }, reasoning: { type: 'string' } },
+  required: ['winner', 'reasoning'],
+}
+
+type JudgeProvider = JudgeConfig['judge_provider']
+
+/**
+ * Low-level judge call: send `prompt` to the judge model and return the raw
+ * reply text + cost + tokens WITHOUT interpreting it. Shared by the absolute
+ * (callJudge) and pairwise (callPairwiseJudge) paths so the five provider
+ * integrations live in exactly one place. Returns null on any transport
+ * failure (non-ok / network), which the callers treat as a dropped sample.
+ *
+ * We hit each vendor API directly (not our own /proxy) on purpose — eval-runner
+ * runs server-side and these calls bypass the customer-facing proxy.
+ */
+async function judgeComplete(
+  provider: JudgeProvider,
+  model: string,
+  apiKey: string,
+  resourceUrl: string | null,
+  prompt: string,
+  geminiResponseSchema: Record<string, unknown>,
+): Promise<{ text: string; cost: number; tokens: number } | null> {
+  // OpenAI, Azure, Mistral, OpenRouter are all OpenAI-compatible chat
+  // completions; only the URL, auth header, and cost-table provider differ.
+  if (provider === 'openai' || provider === 'azure' || provider === 'mistral' || provider === 'openrouter') {
+    let url: string
+    let headers: Record<string, string>
+    if (provider === 'openai') {
+      url = 'https://api.openai.com/v1/chat/completions'
+      headers = { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` }
+    } else if (provider === 'mistral') {
+      url = 'https://api.mistral.ai/v1/chat/completions'
+      headers = { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` }
+    } else if (provider === 'openrouter') {
+      url = 'https://openrouter.ai/api/v1/chat/completions'
+      headers = { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` }
+    } else {
+      // Azure: per-key resource origin + api-key header. Without it we can't
+      // build the URL — fail rather than hit a wrong endpoint.
+      if (!resourceUrl) return null
+      url = `${resourceUrl}/openai/v1/chat/completions`
+      headers = { 'Content-Type': 'application/json', 'api-key': apiKey }
+    }
+    const res = await fetchWithRetry(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(buildOpenAIBody(
+        model,
+        [{ role: 'user', content: prompt }],
+        { temperature: 0, maxTokens: 200, responseFormat: { type: 'json_object' } },
+      )),
+    })
+    if (!res || !res.ok) return null
+    const json = await res.json() as {
+      choices: Array<{ message: { content: string } }>
+      usage: { prompt_tokens: number; completion_tokens: number; cost?: number }
+      model: string
+    }
+    const text = json.choices?.[0]?.message?.content ?? ''
+    const tokens = (json.usage?.prompt_tokens ?? 0) + (json.usage?.completion_tokens ?? 0)
+    // Azure bills at OpenAI prices; OpenRouter publishes the authoritative
+    // billed cost on usage.cost (same pattern as proxy/openrouter.ts).
+    let cost = 0
+    if (provider === 'openrouter' && typeof json.usage?.cost === 'number') {
+      cost = json.usage.cost
+    } else {
+      const costProvider = provider === 'azure' ? 'openai' : provider
+      cost = calculateCost(costProvider, json.model ?? model, {
+        promptTokens: json.usage?.prompt_tokens ?? 0,
+        completionTokens: json.usage?.completion_tokens ?? 0,
+      })?.totalCost ?? 0
+    }
+    return { text, cost, tokens }
+  }
+
+  if (provider === 'anthropic') {
+    const res = await fetchWithRetry('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' },
+      body: JSON.stringify({ model, max_tokens: 200, temperature: 0, messages: [{ role: 'user', content: prompt }] }),
+    })
+    if (!res || !res.ok) return null
+    const json = await res.json() as {
+      content: Array<{ type: string; text: string }>
+      usage: { input_tokens: number; output_tokens: number }
+      model: string
+    }
+    const text = json.content?.find((b) => b.type === 'text')?.text ?? ''
+    const tokens = (json.usage?.input_tokens ?? 0) + (json.usage?.output_tokens ?? 0)
+    const cost = calculateCost('anthropic', json.model ?? model, {
+      promptTokens: json.usage?.input_tokens ?? 0,
+      completionTokens: json.usage?.output_tokens ?? 0,
+    })?.totalCost ?? 0
+    return { text, cost, tokens }
+  }
+
+  // Gemini — JSON output enforced via responseMimeType + responseSchema so the
+  // reply is always parseable. The schema MUST match the prompt's JSON shape.
+  if (provider === 'gemini') {
+    const res = await fetchWithRetry(
+      `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [{ role: 'user', parts: [{ text: prompt }] }],
+          generationConfig: {
+            temperature: 0,
+            maxOutputTokens: 200,
+            responseMimeType: 'application/json',
+            responseSchema: geminiResponseSchema,
+          },
+        }),
+      },
+    )
+    if (!res || !res.ok) return null
+    const json = await res.json() as {
+      candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
+      usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number }
+      modelVersion?: string
+    }
+    const text = json.candidates?.[0]?.content?.parts?.[0]?.text ?? ''
+    const tokens = (json.usageMetadata?.promptTokenCount ?? 0) + (json.usageMetadata?.candidatesTokenCount ?? 0)
+    const cost = calculateCost('gemini', json.modelVersion ?? model, {
+      promptTokens: json.usageMetadata?.promptTokenCount ?? 0,
+      completionTokens: json.usageMetadata?.candidatesTokenCount ?? 0,
+    })?.totalCost ?? 0
+    return { text, cost, tokens }
+  }
+
+  // Unknown provider — explicit escape hatch so a future addition to the
+  // JudgeProvider union can't silently fall through to Gemini.
+  return null
+}
+
 /** Calls the judge LLM once. Returns null on failure (caller skips the sample).
  * Exported for unit tests (see generateForItem note above). */
 export async function callJudge(
@@ -272,282 +429,88 @@ export async function callJudge(
     anchors: config.anchors ?? null,
   })
 
-  // Helper that turns a parsed judge reply into the JudgeOutcome the
-  // caller stores. NUMERIC and legacy paths normalise into 0..1 so the
-  // `score` column stays consistent with pre-4B.1c rows.
-  function buildOutcome(
-    parsed: NonNullable<ReturnType<typeof parseJudgeReply>>,
-    cost: number,
-    tokens: number,
-  ): JudgeOutcome {
-    const sc = config.score_config
-    if (!sc || sc.data_type === 'NUMERIC') {
-      // Legacy: clamp + normalise to 0..1 against scale_min / scale_max.
-      // parseJudgeReply already returned a clamped value, so we just
-      // shift + scale here.
-      const min = sc?.min_value ?? config.scale_min
-      const max = sc?.max_value ?? config.scale_max
-      const range = max - min || 1
-      const raw = parsed.value_number ?? parsed.score ?? 0
-      const normalised = (raw - min) / range
-      return {
-        score: normalised,
-        value_number: normalised,
-        value_string: null,
-        value_boolean: null,
-        reasoning: parsed.reasoning,
-        cost,
-        tokens,
-      }
-    }
-    // Typed paths — value columns are already populated by the parser.
-    return {
-      score: null,
-      value_number: parsed.value_number,
-      value_string: parsed.value_string,
-      value_boolean: parsed.value_boolean,
-      reasoning: parsed.reasoning,
-      cost,
-      tokens,
-    }
-  }
-
-  if (config.judge_provider === 'openai') {
-    const res = await fetchWithRetry('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify(buildOpenAIBody(
-        config.judge_model,
-        [{ role: 'user', content: prompt }],
-        { temperature: 0, maxTokens: 200, responseFormat: { type: 'json_object' } },
-      )),
-    })
-    if (!res || !res.ok) return null
-    const json = await res.json() as {
-      choices: Array<{ message: { content: string } }>
-      usage: { prompt_tokens: number; completion_tokens: number }
-      model: string
-    }
-    const text = json.choices?.[0]?.message?.content ?? ''
-    const parsed = parseJudgeReply(text, {
-      scale_min: config.scale_min,
-      scale_max: config.scale_max,
-      score_config: config.score_config ?? null,
-    })
-    if (!parsed) return null
-    const tokens = (json.usage?.prompt_tokens ?? 0) + (json.usage?.completion_tokens ?? 0)
-    const cost = calculateCost('openai', json.model ?? config.judge_model, {
-      promptTokens: json.usage?.prompt_tokens ?? 0,
-      completionTokens: json.usage?.completion_tokens ?? 0,
-    })?.totalCost ?? 0
-    return buildOutcome(parsed, cost, tokens)
-  }
-
-  // Mistral + OpenRouter are both OpenAI-compatible chat completion APIs,
-  // so the request shape is identical to the openai branch above. Only the
-  // base URL + cost provider tag differ.
-  if (config.judge_provider === 'mistral' || config.judge_provider === 'openrouter') {
-    const url = config.judge_provider === 'mistral'
-      ? 'https://api.mistral.ai/v1/chat/completions'
-      : 'https://openrouter.ai/api/v1/chat/completions'
-    const res = await fetchWithRetry(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify(buildOpenAIBody(
-        config.judge_model,
-        [{ role: 'user', content: prompt }],
-        { temperature: 0, maxTokens: 200, responseFormat: { type: 'json_object' } },
-      )),
-    })
-    if (!res || !res.ok) return null
-    const json = await res.json() as {
-      choices: Array<{ message: { content: string } }>
-      usage: { prompt_tokens: number; completion_tokens: number; cost?: number }
-      model: string
-    }
-    const text = json.choices?.[0]?.message?.content ?? ''
-    const parsed = parseJudgeReply(text, {
-      scale_min: config.scale_min,
-      scale_max: config.scale_max,
-      score_config: config.score_config ?? null,
-    })
-    if (!parsed) return null
-    const tokens = (json.usage?.prompt_tokens ?? 0) + (json.usage?.completion_tokens ?? 0)
-    // OpenRouter publishes the authoritative billed cost on usage.cost — prefer
-    // it over the local table lookup (same pattern as proxy/openrouter.ts).
-    let cost = 0
-    if (config.judge_provider === 'openrouter' && typeof json.usage?.cost === 'number') {
-      cost = json.usage.cost
-    } else {
-      cost = calculateCost(config.judge_provider, json.model ?? config.judge_model, {
-        promptTokens: json.usage?.prompt_tokens ?? 0,
-        completionTokens: json.usage?.completion_tokens ?? 0,
-      })?.totalCost ?? 0
-    }
-    return buildOutcome(parsed, cost, tokens)
-  }
-
-  if (config.judge_provider === 'anthropic') {
-    const res = await fetchWithRetry('https://api.anthropic.com/v1/messages', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': apiKey,
-        'anthropic-version': '2023-06-01',
-      },
-      body: JSON.stringify({
-        model: config.judge_model,
-        max_tokens: 200,
-        temperature: 0,
-        messages: [{ role: 'user', content: prompt }],
-      }),
-    })
-    if (!res || !res.ok) return null
-    const json = await res.json() as {
-      content: Array<{ type: string; text: string }>
-      usage: { input_tokens: number; output_tokens: number }
-      model: string
-    }
-    const text = json.content?.find((b) => b.type === 'text')?.text ?? ''
-    const parsed = parseJudgeReply(text, {
-      scale_min: config.scale_min,
-      scale_max: config.scale_max,
-      score_config: config.score_config ?? null,
-    })
-    if (!parsed) return null
-    const tokens = (json.usage?.input_tokens ?? 0) + (json.usage?.output_tokens ?? 0)
-    const cost = calculateCost('anthropic', json.model ?? config.judge_model, {
-      promptTokens: json.usage?.input_tokens ?? 0,
-      completionTokens: json.usage?.output_tokens ?? 0,
-    })?.totalCost ?? 0
-    return buildOutcome(parsed, cost, tokens)
-  }
-
-  if (config.judge_provider === 'azure') {
-    // Azure OpenAI v1 endpoint is OpenAI-compatible (same request/response +
-    // json_object response_format). Differences vs. the openai branch: the
-    // base URL is the per-key Azure resource origin, auth is the `api-key`
-    // header, and Azure bills at OpenAI prices so cost uses the 'openai' table
-    // (mirrors proxy/azure.ts). Without resource_url we can't build the URL —
-    // fail the sample rather than hit a wrong endpoint.
-    if (!resourceUrl) return null
-    const res = await fetchWithRetry(`${resourceUrl}/openai/v1/chat/completions`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'api-key': apiKey,
-      },
-      body: JSON.stringify(buildOpenAIBody(
-        config.judge_model,
-        [{ role: 'user', content: prompt }],
-        { temperature: 0, maxTokens: 200, responseFormat: { type: 'json_object' } },
-      )),
-    })
-    if (!res || !res.ok) return null
-    const json = await res.json() as {
-      choices: Array<{ message: { content: string } }>
-      usage: { prompt_tokens: number; completion_tokens: number }
-      model: string
-    }
-    const text = json.choices?.[0]?.message?.content ?? ''
-    const parsed = parseJudgeReply(text, {
-      scale_min: config.scale_min,
-      scale_max: config.scale_max,
-      score_config: config.score_config ?? null,
-    })
-    if (!parsed) return null
-    const tokens = (json.usage?.prompt_tokens ?? 0) + (json.usage?.completion_tokens ?? 0)
-    const cost = calculateCost('openai', json.model ?? config.judge_model, {
-      promptTokens: json.usage?.prompt_tokens ?? 0,
-      completionTokens: json.usage?.completion_tokens ?? 0,
-    })?.totalCost ?? 0
-    return buildOutcome(parsed, cost, tokens)
-  }
-
-  // Gemini — JSON output enforced via responseMimeType + responseSchema. This
-  // matches OpenAI's `response_format: json_object` strictness so the judge
-  // reply is always parseable. We hit `generateContent` directly (not our
-  // /proxy) because eval-runner runs on the server — calls to api.openai.com
-  // and generativelanguage.googleapis.com bypass our own proxy on purpose.
-  const geminiRes = await fetchWithRetry(
-    `https://generativelanguage.googleapis.com/v1beta/models/${config.judge_model}:generateContent?key=${apiKey}`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        contents: [{ role: 'user', parts: [{ text: prompt }] }],
-        generationConfig: {
-          temperature: 0,
-          maxOutputTokens: 200,
-          responseMimeType: 'application/json',
-          // The Gemini responseSchema MUST match the prompt we ship for
-          // the active score config or the model returns a schema error.
-          // For BOOLEAN / CATEGORICAL / TEXT we ask for `value`; for
-          // legacy NUMERIC we keep `score` so old runs are byte-identical.
-          responseSchema: (() => {
-            const sc = config.score_config
-            if (!sc || sc.data_type === 'NUMERIC') {
-              return {
-                type: 'object',
-                properties: {
-                  score: { type: 'number' },
-                  reasoning: { type: 'string' },
-                },
-                required: ['score', 'reasoning'],
-              }
-            }
-            if (sc.data_type === 'BOOLEAN') {
-              return {
-                type: 'object',
-                properties: {
-                  value: { type: 'boolean' },
-                  reasoning: { type: 'string' },
-                },
-                required: ['value', 'reasoning'],
-              }
-            }
-            // CATEGORICAL + TEXT both emit strings; the parser validates
-            // CATEGORICAL against the allow-list afterwards.
-            return {
-              type: 'object',
-              properties: {
-                value: { type: 'string' },
-                reasoning: { type: 'string' },
-              },
-              required: ['value', 'reasoning'],
-            }
-          })(),
-        },
-      }),
-    },
+  const res = await judgeComplete(
+    config.judge_provider,
+    config.judge_model,
+    apiKey,
+    resourceUrl,
+    prompt,
+    geminiJudgeSchema(config.score_config),
   )
-  if (!geminiRes || !geminiRes.ok) return null
-  const geminiJson = await geminiRes.json() as {
-    candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
-    usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number }
-    modelVersion?: string
-  }
-  const geminiText = geminiJson.candidates?.[0]?.content?.parts?.[0]?.text ?? ''
-  const geminiParsed = parseJudgeReply(geminiText, {
+  if (!res) return null
+
+  const parsed = parseJudgeReply(res.text, {
     scale_min: config.scale_min,
     scale_max: config.scale_max,
     score_config: config.score_config ?? null,
   })
-  if (!geminiParsed) return null
-  const geminiTokens =
-    (geminiJson.usageMetadata?.promptTokenCount ?? 0) +
-    (geminiJson.usageMetadata?.candidatesTokenCount ?? 0)
-  const geminiCost = calculateCost('gemini', geminiJson.modelVersion ?? config.judge_model, {
-    promptTokens: geminiJson.usageMetadata?.promptTokenCount ?? 0,
-    completionTokens: geminiJson.usageMetadata?.candidatesTokenCount ?? 0,
-  })?.totalCost ?? 0
-  return buildOutcome(geminiParsed, geminiCost, geminiTokens)
+  if (!parsed) return null
+
+  // Turn the parsed reply into the stored JudgeOutcome. NUMERIC / legacy
+  // normalise into 0..1 so the `score` column stays consistent with pre-4B.1c
+  // rows; typed paths carry the value_* columns straight through.
+  const sc = config.score_config
+  if (!sc || sc.data_type === 'NUMERIC') {
+    const min = sc?.min_value ?? config.scale_min
+    const max = sc?.max_value ?? config.scale_max
+    const range = max - min || 1
+    const raw = parsed.value_number ?? parsed.score ?? 0
+    const normalised = (raw - min) / range
+    return {
+      score: normalised,
+      value_number: normalised,
+      value_string: null,
+      value_boolean: null,
+      reasoning: parsed.reasoning,
+      cost: res.cost,
+      tokens: res.tokens,
+    }
+  }
+  return {
+    score: null,
+    value_number: parsed.value_number,
+    value_string: parsed.value_string,
+    value_boolean: parsed.value_boolean,
+    reasoning: parsed.reasoning,
+    cost: res.cost,
+    tokens: res.tokens,
+  }
+}
+
+/** Outcome of one pairwise comparison (P1-7 3/3). `winner` is in PROMPT terms
+ * (A vs B as shown to the judge); the caller un-swaps it for counterbalancing. */
+export interface PairwiseOutcome {
+  winner: PairwiseWinner
+  reasoning: string
+  cost: number
+  tokens: number
+}
+
+/** Calls the judge once to compare two responses. Returns null on failure. */
+export async function callPairwiseJudge(
+  config: JudgeConfig,
+  responseA: string,
+  responseB: string,
+  apiKey: string,
+  resourceUrl: string | null,
+  expectedOutput: string | null = null,
+): Promise<PairwiseOutcome | null> {
+  const prompt = buildPairwiseJudgePrompt(config.criterion, responseA, responseB, {
+    rubric: config.rubric ?? null,
+    expected_output: expectedOutput,
+  })
+  const res = await judgeComplete(
+    config.judge_provider,
+    config.judge_model,
+    apiKey,
+    resourceUrl,
+    prompt,
+    GEMINI_PAIRWISE_SCHEMA,
+  )
+  if (!res) return null
+  const parsed = parsePairwiseReply(res.text)
+  if (!parsed) return null
+  return { winner: parsed.winner, reasoning: parsed.reasoning, cost: res.cost, tokens: res.tokens }
 }
 
 /** Runs a small async pool with concurrency cap. */
@@ -596,12 +559,49 @@ interface RunInput {
    */
   runProvider?: EvalProvider | null
   runModel?: string | null
+  /** P1-7 (3/3): 'single' (default, absolute scoring) or 'pairwise' (A vs B
+   * head-to-head). Pairwise requires source='dataset' + promptVersionBId. */
+  mode?: 'single' | 'pairwise' | null
+  /** The "B" prompt version compared against promptVersionId ("A"). Pairwise only. */
+  promptVersionBId?: string | null
 }
 
 /** Result of one sample's scoring, shared between production and dataset paths. */
 interface SampleOutcome extends JudgeOutcome {
   requestId: string | null
   datasetItemId: string | null
+}
+
+/**
+ * Resolve + decrypt an active provider key for an org, returning the plaintext
+ * key and (for Azure) its validated resource origin. Throws a clear message on
+ * a missing key or an Azure key without a usable resource_url. Used by the
+ * pairwise path (P1-7 3/3); the single path inlines equivalent logic.
+ */
+async function resolveProviderKey(
+  organizationId: string,
+  provider: EvalProvider,
+  label: string,
+): Promise<{ key: string; resourceUrl: string | null }> {
+  const { data: pkRow, error } = await supabaseAdmin
+    .from('provider_keys')
+    .select('encrypted_key, provider_metadata')
+    .eq('organization_id', organizationId)
+    .eq('provider', provider)
+    .eq('is_active', true)
+    .limit(1)
+    .maybeSingle()
+  if (error || !pkRow) throw new Error(`No active ${provider} provider key found for ${label}`)
+  const key = await aes256Decrypt(pkRow.encrypted_key as string)
+  if (!key) throw new Error(`Failed to decrypt ${label} provider key`)
+  const meta = (pkRow.provider_metadata as Record<string, unknown> | null) ?? {}
+  const resourceUrl = typeof meta['resource_url'] === 'string' ? meta['resource_url'] : null
+  if (provider === 'azure') {
+    if (!resourceUrl) throw new Error(`Azure ${label} provider key is missing resource_url — re-register it`)
+    const safe = validateOutboundUrlSync(resourceUrl)
+    if (!safe.ok) throw new Error(`Azure ${label} resource_url rejected: ${safe.message}`)
+  }
+  return { key, resourceUrl }
 }
 
 // ─── R-7 Phase 1: deterministic evaluator types ──────────────────────────
@@ -635,6 +635,8 @@ export async function runEvalRun(input: RunInput): Promise<void> {
     runModel,
     sampleStrategy,
     generationTemperature,
+    mode,
+    promptVersionBId,
   } = input
 
   // Mark running
@@ -695,6 +697,193 @@ export async function runEvalRun(input: RunInput): Promise<void> {
       )
       // Internal trace closes via the outer finally — note `samples` count
       // and aggregate the simple path produced via internalTrace.end below.
+      return
+    }
+
+    // ── P1-7 (3/3): pairwise (A vs B) comparison run ──────────────────────
+    // Compares two prompt versions head-to-head on the same dataset inputs.
+    // Each comparison stores score = 1 (B wins) / 0 (A wins) / 0.5 (tie), so
+    // avg_score is B's win-rate and the 95% CI machinery applies for free.
+    if (mode === 'pairwise') {
+      if (evaluator.type !== 'llm_judge') {
+        throw new Error(`pairwise mode requires an llm_judge evaluator, got '${evaluator.type}'`)
+      }
+      if (source !== 'dataset') throw new Error('pairwise mode requires source = dataset')
+      if (!datasetId) throw new Error('datasetId is required for a pairwise run')
+      if (!promptVersionBId) throw new Error('promptVersionBId is required for a pairwise run')
+      if (!runProvider || !runModel) {
+        throw new Error('runProvider and runModel are required for a pairwise run')
+      }
+
+      const pairConfig = evaluator.config as unknown as JudgeConfig
+      if (!pairConfig?.criterion || !pairConfig?.judge_provider || !pairConfig?.judge_model) {
+        throw new Error('Evaluator config missing required fields (criterion / judge_provider / judge_model)')
+      }
+
+      const judge = await resolveProviderKey(organizationId, pairConfig.judge_provider, 'judge')
+      const gen = await resolveProviderKey(organizationId, runProvider, 'prompt generation')
+
+      // Resolve both versions' content.
+      const loadContent = async (id: string): Promise<string> => {
+        const { data, error } = await supabaseAdmin
+          .from('prompt_versions')
+          .select('content')
+          .eq('id', id)
+          .eq('organization_id', organizationId)
+          .maybeSingle()
+        if (error || !data) throw new Error(`Prompt version not found: ${id}`)
+        return data.content as string
+      }
+      const contentA = await loadContent(promptVersionId)
+      const contentB = await loadContent(promptVersionBId)
+
+      const { data: items, error: itemsErr } = await supabaseAdmin
+        .from('dataset_items')
+        .select('id, input, expected_output')
+        .eq('dataset_id', datasetId)
+        .eq('organization_id', organizationId)
+        .order('created_at', { ascending: false })
+        .limit(sampleSize)
+      if (itemsErr) throw new Error(`Dataset items fetch failed: ${itemsErr.message}`)
+
+      // Generate a response from BOTH versions for each item (capped pool).
+      const genTemp = generationTemperature ?? 0
+      type PairSample = { datasetItemId: string; respA: string; respB: string; expectedOutput: string | null }
+      const generated = await pool(items ?? [], GENERATION_CONCURRENCY, async (i): Promise<PairSample | null> => {
+        const input2 = i.input as Record<string, unknown>
+        const [a, b] = await Promise.all([
+          generateForItem(contentA, input2, runProvider, runModel, gen.key, gen.resourceUrl, genTemp),
+          generateForItem(contentB, input2, runProvider, runModel, gen.key, gen.resourceUrl, genTemp),
+        ])
+        // Both must succeed — a comparison needs two responses.
+        if (!a || !b) return null
+        return { datasetItemId: i.id as string, respA: a, respB: b, expectedOutput: (i.expected_output as string | null) ?? null }
+      })
+      // Counterbalance position bias: alternate which response is shown first.
+      const preparedPairs = generated
+        .filter((g): g is PairSample => g !== null)
+        .map((p, idx) => ({ ...p, swap: idx % 2 === 1 }))
+
+      if (preparedPairs.length === 0) {
+        await supabaseAdmin
+          .from('eval_runs')
+          .update({
+            status: 'completed',
+            scored_count: 0,
+            attempted_count: 0,
+            failed_count: 0,
+            avg_score: null,
+            a_wins: 0,
+            b_wins: 0,
+            ties: 0,
+            error: 'No dataset items produced a response from both versions.',
+            completed_at: new Date().toISOString(),
+          })
+          .eq('id', evalRunId)
+        internalTrace.end({ status: 'completed', metadata: { scored_count: 0, mode: 'pairwise' } })
+        return
+      }
+
+      type Comparison = { datasetItemId: string; winner: 'a' | 'b' | 'tie'; score: number; reasoning: string; cost: number; tokens: number }
+      const comparisons = await pool(preparedPairs, JUDGE_CONCURRENCY, async (pair): Promise<Comparison | null> => {
+        const span = internalTrace.startSpan('llm_judge_pairwise', {
+          spanType: 'llm',
+          metadata: {
+            judge_provider: pairConfig.judge_provider,
+            judge_model: pairConfig.judge_model,
+            dataset_item_id: pair.datasetItemId,
+            swapped: pair.swap,
+          },
+        })
+        try {
+          // `first` is shown as "A" in the prompt, `second` as "B".
+          const first = pair.swap ? pair.respB : pair.respA
+          const second = pair.swap ? pair.respA : pair.respB
+          const out = await callPairwiseJudge(pairConfig, first, second, judge.key, judge.resourceUrl, pair.expectedOutput)
+          if (!out) {
+            span.end({ status: 'error', errorMessage: 'callPairwiseJudge returned null' })
+            return null
+          }
+          // Map the prompt-side winner (A/B/tie) back to the real version,
+          // undoing the swap.
+          let winner: 'a' | 'b' | 'tie'
+          if (out.winner === 'tie') winner = 'tie'
+          else if (out.winner === 'A') winner = pair.swap ? 'b' : 'a'
+          else winner = pair.swap ? 'a' : 'b'
+          const score = winner === 'b' ? 1 : winner === 'a' ? 0 : 0.5
+          span.end({
+            status: 'completed',
+            output: { winner, reasoning: out.reasoning },
+            costUsd: out.cost,
+            totalTokens: out.tokens,
+          })
+          return { datasetItemId: pair.datasetItemId, winner, score, reasoning: out.reasoning, cost: out.cost, tokens: out.tokens }
+        } catch (err) {
+          span.end({ status: 'error', errorMessage: err instanceof Error ? err.message : 'pairwise judge threw' })
+          return null
+        }
+      })
+
+      const scored = comparisons.filter((c): c is Comparison => c !== null)
+      if (scored.length === 0) {
+        await supabaseAdmin
+          .from('eval_runs')
+          .update({
+            status: 'failed',
+            scored_count: 0,
+            attempted_count: preparedPairs.length,
+            failed_count: preparedPairs.length,
+            error: 'All pairwise judge calls failed. Check judge model name and provider key.',
+            completed_at: new Date().toISOString(),
+          })
+          .eq('id', evalRunId)
+        internalTrace.end({ status: 'error', errorMessage: 'All pairwise judge calls failed', metadata: { mode: 'pairwise' } })
+        return
+      }
+
+      const aWins = scored.filter((s) => s.winner === 'a').length
+      const bWins = scored.filter((s) => s.winner === 'b').length
+      const ties = scored.filter((s) => s.winner === 'tie').length
+      const scoreValues = scored.map((s) => s.score)
+      const avgScore = scoreValues.reduce((a, b) => a + b, 0) / scoreValues.length
+      const scoreStddev = sampleStdDev(scoreValues)
+      const totalCost = scored.reduce((sum, s) => sum + s.cost, 0)
+
+      const { error: insErr } = await supabaseAdmin.from('eval_results').insert(
+        scored.map((s) => ({
+          organization_id: organizationId,
+          eval_run_id: evalRunId,
+          request_id: null,
+          dataset_item_id: s.datasetItemId,
+          score: s.score,
+          winner: s.winner,
+          reasoning: s.reasoning,
+          judge_cost_usd: s.cost,
+          judge_tokens: s.tokens,
+        })),
+      )
+      if (insErr) throw new Error(`Result insert failed: ${insErr.message}`)
+
+      await supabaseAdmin
+        .from('eval_runs')
+        .update({
+          status: 'completed',
+          scored_count: scored.length,
+          attempted_count: preparedPairs.length,
+          failed_count: preparedPairs.length - scored.length,
+          avg_score: avgScore,
+          score_stddev: scoreStddev,
+          a_wins: aWins,
+          b_wins: bWins,
+          ties,
+          total_cost_usd: totalCost,
+          completed_at: new Date().toISOString(),
+        })
+        .eq('id', evalRunId)
+      internalTrace.end({
+        status: 'completed',
+        metadata: { scored_count: scored.length, a_wins: aWins, b_wins: bWins, ties, avg_score: avgScore, mode: 'pairwise' },
+      })
       return
     }
 
@@ -1185,6 +1374,10 @@ export interface StartEvalRunInput {
   sampleStrategy?: 'recent' | 'random' | null
   generationTemperature?: number | null
   createdBy?: string | null
+  /** P1-7 (3/3): 'single' (default) or 'pairwise'. */
+  mode?: 'single' | 'pairwise' | null
+  /** The "B" prompt version for a pairwise run. */
+  promptVersionBId?: string | null
 }
 
 /**
@@ -1194,6 +1387,7 @@ export interface StartEvalRunInput {
  * insert failed (caller decides whether that's fatal).
  */
 export async function startEvalRun(c: Context, input: StartEvalRunInput): Promise<{ id: string } | null> {
+  const isPairwise = input.mode === 'pairwise'
   const { data: run, error } = await supabaseAdmin
     .from('eval_runs')
     .insert({
@@ -1207,6 +1401,9 @@ export async function startEvalRun(c: Context, input: StartEvalRunInput): Promis
       sample_to: input.source === 'production' ? (input.sampleTo ?? null) : null,
       status: 'pending',
       created_by: input.createdBy ?? null,
+      mode: isPairwise ? 'pairwise' : 'single',
+      // The DB CHECK forbids a pairwise row without its B version.
+      prompt_version_b_id: isPairwise ? (input.promptVersionBId ?? null) : null,
     })
     .select('id')
     .single()
@@ -1226,6 +1423,8 @@ export async function startEvalRun(c: Context, input: StartEvalRunInput): Promis
     runModel: input.runModel ?? null,
     sampleStrategy: input.sampleStrategy ?? null,
     generationTemperature: input.generationTemperature ?? null,
+    mode: isPairwise ? 'pairwise' : 'single',
+    promptVersionBId: input.promptVersionBId ?? null,
   }))
   return run
 }

--- a/apps/server/src/lib/eval-runners/judge-prompt.ts
+++ b/apps/server/src/lib/eval-runners/judge-prompt.ts
@@ -274,3 +274,101 @@ export function parseJudgeReply(
     reasoning,
   }
 }
+
+// ─── P1-7 (3/3): pairwise (A vs B) judge ─────────────────────────────────────
+
+/** Which response won a pairwise comparison, as labelled IN THE PROMPT. */
+export type PairwiseWinner = 'A' | 'B' | 'tie'
+
+/**
+ * Build a pairwise comparison prompt: the judge is shown two responses to the
+ * same input and picks which better satisfies the criterion (or "tie"). This
+ * is a relative judgment, which is far more consistent than two independent
+ * absolute scores.
+ *
+ * Position bias (judges favour whichever response is shown first) is mitigated
+ * by the CALLER, which counterbalances the A/B presentation order across the
+ * sample and un-swaps the verdict — this function renders the two responses in
+ * whatever order it is handed.
+ */
+export function buildPairwiseJudgePrompt(
+  criterion: string,
+  responseA: string,
+  responseB: string,
+  config: {
+    /** P1-7: optional rubric, same as the single-judge path. */
+    rubric?: string | null
+    /** P1-6: optional golden reference both responses are compared against. */
+    expected_output?: string | null
+  } = {},
+): string {
+  const a = truncateMiddle(responseA, MAX_RESPONSE_CHARS)
+  const b = truncateMiddle(responseB, MAX_RESPONSE_CHARS)
+
+  const rubric = config.rubric?.trim()
+  const rubricBlock = rubric
+    ? `
+
+Scoring rubric (apply consistently):
+${rubric}`
+    : ''
+
+  const expected = config.expected_output
+  const referenceBlock = expected
+    ? `
+
+Reference (expected) answer both responses should match:
+"""
+${truncateMiddle(expected, MAX_RESPONSE_CHARS)}
+"""`
+    : ''
+
+  return `You are comparing two assistant responses to the SAME request to decide which one better satisfies the criterion.
+
+Criterion: ${criterion}${rubricBlock}${referenceBlock}
+
+Response A:
+"""
+${a}
+"""
+
+Response B:
+"""
+${b}
+"""
+
+Decide which response better satisfies the criterion. Judge only on the criterion, not on length or style. If they are genuinely equal, answer "tie".
+
+Reply ONLY in JSON with this exact shape:
+{"winner": "A" | "B" | "tie", "reasoning": "<one short sentence>"}
+
+No prose outside the JSON. No markdown fences.`
+}
+
+/**
+ * Parse a pairwise judge reply into a winner + reasoning. Tolerant of the
+ * usual model drift: case, markdown fences, and "neither/equal/same" synonyms
+ * for a tie. Returns null when no winner can be read (caller drops the sample).
+ */
+export function parsePairwiseReply(
+  text: string,
+): { winner: PairwiseWinner; reasoning: string } | null {
+  let cleaned = text.trim()
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/, '').trim()
+  }
+  let parsed: { winner?: unknown; reasoning?: unknown }
+  try {
+    parsed = JSON.parse(cleaned) as typeof parsed
+  } catch {
+    return null
+  }
+  const raw = typeof parsed.winner === 'string' ? parsed.winner.trim().toLowerCase() : ''
+  let winner: PairwiseWinner | null = null
+  if (raw === 'a') winner = 'A'
+  else if (raw === 'b') winner = 'B'
+  else if (raw === 'tie' || raw === 'neither' || raw === 'equal' || raw === 'same') winner = 'tie'
+  if (!winner) return null
+  const reasoning = typeof parsed.reasoning === 'string' ? parsed.reasoning.trim() : ''
+  return { winner, reasoning }
+}

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -929,6 +929,10 @@ function RunEvaluatorDialog({
 
   const [versionIdRaw, setVersionId] = useState('')
   const [source, setSource] = useState<'production' | 'dataset'>('production')
+  // P1-7 (3/3): pairwise (A vs B) comparison. Pairwise is dataset-only, so
+  // switching to it forces the dataset source.
+  const [mode, setMode] = useState<'single' | 'pairwise'>('single')
+  const [versionBId, setVersionBId] = useState('')
   const [datasetId, setDatasetId] = useState('')
   const [sampleSize, setSampleSize] = useState(50)
   const [days, setDays] = useState(7)
@@ -998,20 +1002,28 @@ function RunEvaluatorDialog({
     void estimateMutate({ sampleSize, judgeModel }).catch(() => null)
   }, [sampleSize, judgeModel, estimateMutate])
 
+  // Pairwise is dataset-only; the single/pairwise toggle drives the source.
+  const effectiveSource = mode === 'pairwise' ? 'dataset' : source
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setError('')
     if (!versionId) { setError('Select a version'); return }
-    if (source === 'dataset' && !datasetId) { setError('Select a dataset'); return }
-    if (source === 'dataset' && !runModel) { setError('Select a model to run the prompt'); return }
+    if (mode === 'pairwise') {
+      if (!versionBId) { setError('Select version B to compare against'); return }
+      if (versionBId === versionId) { setError('Version B must differ from version A'); return }
+    }
+    if (effectiveSource === 'dataset' && !datasetId) { setError('Select a dataset'); return }
+    if (effectiveSource === 'dataset' && !runModel) { setError('Select a model to run the prompt'); return }
     try {
       const run = await createRun.mutateAsync({
         evaluatorId: evaluator.id,
         promptVersionId: versionId,
-        source,
+        source: effectiveSource,
         sampleSize,
-        ...(source === 'dataset' && datasetId && { datasetId, runProvider, runModel }),
-        ...(source === 'production' && {
+        ...(mode === 'pairwise' && { mode: 'pairwise', promptVersionBId: versionBId }),
+        ...(effectiveSource === 'dataset' && datasetId && { datasetId, runProvider, runModel }),
+        ...(effectiveSource === 'production' && {
           sampleFrom: new Date(Date.now() - days * 86400_000).toISOString(),
         }),
       })
@@ -1028,9 +1040,37 @@ function RunEvaluatorDialog({
           <DialogTitle>Run evaluation · {evaluator.name}</DialogTitle>
         </DialogHeader>
         <form onSubmit={(e) => void handleSubmit(e)} className="space-y-3 mt-3">
+          {/* Mode toggle: single (absolute score) vs pairwise (A vs B). */}
           <div>
             <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
-              Version
+              Comparison mode
+            </label>
+            <div className="flex gap-1 p-0.5 border border-border rounded-[5px] bg-bg-elev font-mono text-[11px]">
+              <button
+                type="button"
+                onClick={() => setMode('single')}
+                className={`flex-1 px-3 py-1 rounded-[3px] ${mode === 'single' ? 'bg-text text-bg' : 'text-text-muted'}`}
+              >
+                Single (score)
+              </button>
+              <button
+                type="button"
+                onClick={() => { setMode('pairwise'); setSource('dataset') }}
+                className={`flex-1 px-3 py-1 rounded-[3px] ${mode === 'pairwise' ? 'bg-text text-bg' : 'text-text-muted'}`}
+              >
+                Pairwise (A vs B)
+              </button>
+            </div>
+            {mode === 'pairwise' && (
+              <p className="font-mono text-[10px] text-text-faint mt-1">
+                Runs both versions on the same dataset and asks the judge which wins. Reports B&apos;s win-rate.
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+              {mode === 'pairwise' ? 'Version A (baseline)' : 'Version'}
             </label>
             <Select {...(versionId ? { value: versionId } : {})} onValueChange={setVersionId}>
               <SelectTrigger><SelectValue placeholder="Select version…" /></SelectTrigger>
@@ -1042,7 +1082,24 @@ function RunEvaluatorDialog({
             </Select>
           </div>
 
-          {/* Source toggle */}
+          {mode === 'pairwise' && (
+            <div>
+              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                Version B (candidate)
+              </label>
+              <Select {...(versionBId ? { value: versionBId } : {})} onValueChange={setVersionBId}>
+                <SelectTrigger><SelectValue placeholder="Select version to compare…" /></SelectTrigger>
+                <SelectContent>
+                  {(versions.data ?? []).map((v) => (
+                    <SelectItem key={v.id} value={v.id}>v{v.version}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* Source toggle — hidden in pairwise mode (always dataset). */}
+          {mode === 'single' && (
           <div>
             <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
               Sample source
@@ -1064,8 +1121,9 @@ function RunEvaluatorDialog({
               </button>
             </div>
           </div>
+          )}
 
-          {source === 'dataset' && (
+          {effectiveSource === 'dataset' && (
             <div>
               <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
                 Dataset
@@ -1153,7 +1211,7 @@ function RunEvaluatorDialog({
           )}
 
           <div className="grid grid-cols-2 gap-3">
-            {source === 'production' && (
+            {effectiveSource === 'production' && (
               <div>
                 <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
                   Last N days
@@ -1169,7 +1227,7 @@ function RunEvaluatorDialog({
                 </Select>
               </div>
             )}
-            <div className={source === 'dataset' ? 'col-span-2' : ''}>
+            <div className={effectiveSource === 'dataset' ? 'col-span-2' : ''}>
               <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
                 Sample size
               </label>
@@ -1328,11 +1386,14 @@ function RunDetailPanel({ runId, onClose }: { runId: string; onClose: () => void
         {/* KPIs */}
         <div className="grid grid-cols-3 gap-2">
           <div className="bg-bg-muted border border-border rounded-[5px] px-3 py-2">
-            <p className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-text-faint">Avg score</p>
+            <p className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-text-faint">
+              {r.mode === 'pairwise' ? 'B win-rate' : 'Avg score'}
+            </p>
             <p className={cn('font-mono text-[16px] font-medium tabular-nums', scoreColor(r.avg_score))}>{fmtScore(r.avg_score)}</p>
             {/* P1-7: 95% CI half-width so a small-sample average reads as less
                 certain. Hidden when there's no interval (single sample / typed
-                config without a mean / pre-migration row). */}
+                config without a mean / pre-migration row). For pairwise this is
+                the CI on the win-rate. */}
             {(() => {
               const m = ciMargin95(r.score_stddev, r.scored_count)
               return m != null && r.avg_score != null ? (
@@ -1343,7 +1404,9 @@ function RunDetailPanel({ runId, onClose }: { runId: string; onClose: () => void
             })()}
           </div>
           <div className="bg-bg-muted border border-border rounded-[5px] px-3 py-2">
-            <p className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-text-faint">Samples</p>
+            <p className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-text-faint">
+              {r.mode === 'pairwise' ? 'Comparisons' : 'Samples'}
+            </p>
             <p className="font-mono text-[16px] text-text font-medium">{r.scored_count}</p>
           </div>
           <div className="bg-bg-muted border border-border rounded-[5px] px-3 py-2">
@@ -1351,6 +1414,15 @@ function RunDetailPanel({ runId, onClose }: { runId: string; onClose: () => void
             <p className="font-mono text-[16px] text-text font-medium">{fmtUsd(r.total_cost_usd)}</p>
           </div>
         </div>
+
+        {/* P1-7 (3/3): pairwise win/loss/tie breakdown. */}
+        {r.mode === 'pairwise' && (r.b_wins != null || r.a_wins != null || r.ties != null) && (
+          <div className="flex items-center gap-2 font-mono text-[11px]">
+            <span className="px-2 py-1 rounded-[4px] bg-good/10 text-good border border-good/30">B wins {r.b_wins ?? 0}</span>
+            <span className="px-2 py-1 rounded-[4px] bg-bad/10 text-bad border border-bad/30">A wins {r.a_wins ?? 0}</span>
+            <span className="px-2 py-1 rounded-[4px] bg-bg-elev text-text-faint border border-border">Ties {r.ties ?? 0}</span>
+          </div>
+        )}
 
         {/* Scoring-rate warning (P0-2): when some judge calls failed, the avg
             reflects only the scored samples — say so instead of passing a

--- a/apps/web/app/docs/features/evals/page.tsx
+++ b/apps/web/app/docs/features/evals/page.tsx
@@ -448,6 +448,50 @@ if (run.status !== 'completed' || (ci?.high ?? run.avg_score ?? 0) < GATE) {
         actual answer often lives in the conclusion) with the middle elided.
       </p>
 
+      <h2>Pairwise comparison (A vs B)</h2>
+      <p>
+        Absolute scores drift, and a 0.84-vs-0.81 gap is often noise. A pairwise
+        run instead shows the judge BOTH versions&apos; responses to the same
+        input and asks which one wins. Relative judgments are far more
+        consistent, so a win-rate is a more trustworthy signal than two separate
+        averages. Pick <strong>Pairwise (A vs B)</strong> when running an
+        evaluator, choose a baseline (A) and a candidate (B), and a dataset.
+      </p>
+      <ul>
+        <li>Each item is run through both versions, then judged head-to-head.</li>
+        <li>
+          <strong>Position bias is counterbalanced</strong> — the judge favours
+          whichever response it sees first, so Spanlens alternates the A/B
+          presentation order across the sample and un-swaps the verdict.
+        </li>
+        <li>
+          The run reports <strong>B&apos;s win-rate</strong> as{' '}
+          <code>avg_score</code> (1 = B wins, 0 = A wins, 0.5 = tie) plus a{' '}
+          <code>b_wins</code> / <code>a_wins</code> / <code>ties</code> tally,
+          and the 95% confidence interval applies to the win-rate.
+        </li>
+      </ul>
+      <CodeBlock language="typescript">{`import { SpanlensClient, scoreConfidenceInterval } from '@spanlens/sdk'
+
+const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+const run = await client.evals.run({
+  evaluatorId: process.env.EVALUATOR_ID!,
+  mode: 'pairwise',
+  promptVersionId: BASELINE_VERSION_ID,   // A
+  promptVersionBId: CANDIDATE_VERSION_ID, // B
+  source: 'dataset',
+  datasetId: process.env.DATASET_ID!,
+  runProvider: 'openai',
+  runModel: 'gpt-4o-mini',
+  sampleSize: 100,
+})
+
+const ci = scoreConfidenceInterval(run) // CI on B's win-rate
+// Ship B only if it beats A with the interval clearing 50%.
+if ((ci?.low ?? run.avg_score ?? 0) > 0.5) {
+  console.log(\`B wins \${run.b_wins}/\${run.scored_count} — promote it\`)
+}`}</CodeBlock>
+
       <h2>Reproducibility &amp; reliability options</h2>
       <ul>
         <li>

--- a/apps/web/lib/queries/use-evals.ts
+++ b/apps/web/lib/queries/use-evals.ts
@@ -47,6 +47,15 @@ export interface EvalRun {
   /** Optional dataset link. Set when source is 'dataset'. */
   dataset_id?: string | null
   source: 'production' | 'dataset'
+  /** P1-7 (3/3): 'single' (absolute scoring) or 'pairwise' (A vs B). Older rows
+   * created before the migration have no value — treat undefined as 'single'. */
+  mode?: 'single' | 'pairwise'
+  /** The "B" prompt version for a pairwise run (compared against prompt_version_id = A). */
+  prompt_version_b_id?: string | null
+  /** Pairwise tally. Null/absent for single-mode runs. */
+  a_wins?: number | null
+  b_wins?: number | null
+  ties?: number | null
   sample_size: number
   sample_from: string | null
   sample_to: string | null
@@ -81,6 +90,8 @@ export interface EvalResult {
   judge_cost_usd: number
   judge_tokens: number
   created_at: string
+  /** P1-7 (3/3): pairwise winner ('a' | 'b' | 'tie'); null for single-mode results. */
+  winner?: 'a' | 'b' | 'tie' | null
 }
 
 // ── Evaluators ──────────────────────────────────────────────────────────────
@@ -292,6 +303,10 @@ export interface CreateEvalRunInput {
    *  then gets scored by the judge. */
   runProvider?: 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
   runModel?: string
+  /** P1-7 (3/3): 'pairwise' compares promptVersionId (A) vs promptVersionBId (B).
+   *  Requires source = 'dataset' + runProvider/runModel. */
+  mode?: 'single' | 'pairwise'
+  promptVersionBId?: string
 }
 
 export function useCreateEvalRun() {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @spanlens/sdk changelog
 
+## 0.10.0
+
+Pairwise (A vs B) eval runs (P1-7) — compare two prompt versions head-to-head.
+
+### Added
+
+- `RunEvalInput.mode: 'single' | 'pairwise'` and `RunEvalInput.promptVersionBId`. With `mode: 'pairwise'`, the run generates a response from both `promptVersionId` (A) and `promptVersionBId` (B) for each dataset item and asks the judge which wins. Requires `source: 'dataset'` + `runProvider`/`runModel`.
+- `EvalRun.mode`, `EvalRun.prompt_version_b_id`, and the `a_wins` / `b_wins` / `ties` tally. The completed run's `avg_score` is B's win-rate (1 = B wins, 0 = A wins, 0.5 = tie), so `scoreConfidenceInterval(run)` gives a CI on the win-rate.
+- `EvalResult.winner: 'a' | 'b' | 'tie'` per comparison.
+
 ## 0.9.0
 
 Confidence intervals on eval scores (P1-7) — tell a real regression from sampling noise in CI.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/evals.ts
+++ b/packages/sdk/src/evals.ts
@@ -34,6 +34,15 @@ export interface EvalRun {
   prompt_version_id: string
   dataset_id: string | null
   source: 'production' | 'dataset'
+  /** P1-7 (3/3): 'single' (absolute scoring) or 'pairwise' (A vs B). Absent on
+   * rows created before the feature — treat undefined as 'single'. */
+  mode?: 'single' | 'pairwise'
+  /** The "B" prompt version for a pairwise run (vs prompt_version_id = A). */
+  prompt_version_b_id?: string | null
+  /** Pairwise tally (null/absent for single-mode runs). avg_score is B's win-rate. */
+  a_wins?: number | null
+  b_wins?: number | null
+  ties?: number | null
   sample_size: number
   status: EvalRunStatus
   /** Samples that were successfully scored. */
@@ -64,6 +73,8 @@ export interface EvalResult {
   value_number: number | null
   value_string: string | null
   value_boolean: boolean | null
+  /** P1-7 (3/3): pairwise winner ('a' | 'b' | 'tie'); null for single-mode results. */
+  winner?: 'a' | 'b' | 'tie' | null
 }
 
 export interface RunEvalInput {
@@ -85,6 +96,12 @@ export interface RunEvalInput {
   runProvider?: string
   /** Required when source = 'dataset'. */
   runModel?: string
+  /** P1-7 (3/3): 'pairwise' compares promptVersionId (A) against
+   * promptVersionBId (B) head-to-head. Requires source = 'dataset' +
+   * runProvider/runModel. The completed run's avg_score is B's win-rate. */
+  mode?: 'single' | 'pairwise'
+  /** The "B" prompt version for a pairwise run. Required when mode = 'pairwise'. */
+  promptVersionBId?: string
 }
 
 export interface RunEvalOptions {
@@ -136,6 +153,8 @@ export class EvalsApi {
       generationTemperature: input.generationTemperature,
       runProvider: input.runProvider,
       runModel: input.runModel,
+      mode: input.mode,
+      promptVersionBId: input.promptVersionBId,
     })
 
     if (options.wait === false) return created

--- a/supabase/migrations/20260615040000_eval_runs_pairwise.sql
+++ b/supabase/migrations/20260615040000_eval_runs_pairwise.sql
@@ -1,0 +1,64 @@
+-- P1-7 (3/3): pairwise (A vs B) judge mode.
+--
+-- A single-version run scores ONE prompt version on an absolute scale.
+-- A pairwise run compares TWO versions head-to-head on the same dataset inputs
+-- and asks the judge which response is better. Relative judgments are far more
+-- consistent than absolute scores (the "LLM arena" method), so a B-vs-A
+-- win-rate is a more trustworthy signal than "B scored 0.84 vs A's 0.81".
+--
+-- We deliberately reuse avg_score / score_stddev instead of new aggregate
+-- columns: each comparison stores score = 1.0 when B wins, 0.0 when A wins,
+-- 0.5 on a tie, so avg_score IS B's win-rate and the 95% CI from P1-7 part 1
+-- applies to it for free. a_wins / b_wins / ties carry the raw tally for the
+-- dashboard breakdown.
+--
+-- All additive (gotcha #25). mode defaults to 'single' so existing rows and the
+-- single-version code path are byte-identical. Consistency CHECKs make a
+-- pairwise run without its B version, or an out-of-range winner, impossible at
+-- the DB level (the untyped supabaseAdmin client can't catch those in app code).
+
+ALTER TABLE eval_runs
+  ADD COLUMN IF NOT EXISTS mode text NOT NULL DEFAULT 'single';
+
+ALTER TABLE eval_runs
+  ADD COLUMN IF NOT EXISTS prompt_version_b_id uuid REFERENCES public.prompt_versions(id) ON DELETE SET NULL;
+
+ALTER TABLE eval_runs ADD COLUMN IF NOT EXISTS a_wins integer;
+ALTER TABLE eval_runs ADD COLUMN IF NOT EXISTS b_wins integer;
+ALTER TABLE eval_runs ADD COLUMN IF NOT EXISTS ties integer;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.eval_runs'::regclass AND conname = 'eval_runs_mode_check'
+  ) THEN
+    ALTER TABLE eval_runs ADD CONSTRAINT eval_runs_mode_check CHECK (mode IN ('single', 'pairwise'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.eval_runs'::regclass AND conname = 'eval_runs_pairwise_requires_b'
+  ) THEN
+    ALTER TABLE eval_runs ADD CONSTRAINT eval_runs_pairwise_requires_b CHECK (
+      mode <> 'pairwise' OR prompt_version_b_id IS NOT NULL
+    );
+  END IF;
+END $$;
+
+-- Per-comparison winner for pairwise rows ('a' | 'b' | 'tie'); NULL for
+-- single-mode results (which use score / value_* columns instead).
+ALTER TABLE eval_results
+  ADD COLUMN IF NOT EXISTS winner text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.eval_results'::regclass AND conname = 'eval_results_winner_check'
+  ) THEN
+    ALTER TABLE eval_results ADD CONSTRAINT eval_results_winner_check CHECK (
+      winner IS NULL OR winner IN ('a', 'b', 'tie')
+    );
+  END IF;
+END $$;


### PR DESCRIPTION
## P1-7 (3/3): pairwise (A vs B) judge mode

The final P1-7 piece. Absolute LLM-judge scores drift run to run, and a 0.84-vs-0.81 gap is usually noise. **Pairwise** mode shows the judge BOTH versions' responses to the same input and asks which wins — a relative judgment, which is far more consistent (the "LLM arena" method). The result is a **win-rate**, a more trustworthy signal than two separate averages.

### Changes
- **db** (`20260615040000_eval_runs_pairwise.sql`, additive + idempotent) — `eval_runs.mode` (`single`|`pairwise`, default `single`), `prompt_version_b_id`, `a_wins`/`b_wins`/`ties`; `eval_results.winner` (`a`|`b`|`tie`). CHECK constraints enforce mode validity, pairwise-requires-B, and winner range at the DB level (the untyped `supabaseAdmin` can't).
- **server** — pairwise branch in `runEvalRun`: generates a response from **both** versions per dataset item, then judges head-to-head. **Position bias is counterbalanced** (alternate A/B order per item, un-swap the verdict). Reuses `avg_score`/`score_stddev`: score = 1 (B wins) / 0 (A wins) / 0.5 (tie), so `avg_score` **is** B's win-rate and the part-1 95% CI applies for free.
- **refactor** — the 5 judge provider integrations are extracted into a shared `judgeComplete()` so the absolute and pairwise paths share them. Behaviour preserved (verified by the existing azure/provider tests); hardened with an explicit gemini branch + unknown-provider escape hatch.
- **api** — `POST /eval-runs` accepts `mode` + `promptVersionBId` with full validation (dataset-only, distinct B, `llm_judge`, B-belongs-to-org, run provider/model).
- **web** — "Pairwise (A vs B)" toggle + Version B picker on the run dialog; run detail panel shows B win-rate + a B/A/ties breakdown.
- **sdk 0.10.0** — `RunEvalInput.mode`/`promptVersionBId`, `EvalRun.a_wins`/`b_wins`/`ties`, `EvalResult.winner`. `scoreConfidenceInterval(run)` gives a CI on the win-rate.
- **docs** — "Pairwise comparison (A vs B)" section with a promote-if-B-beats-A CI gate.

### Test plan
- [x] `buildPairwiseJudgePrompt` (A/B render, rubric, reference) + `parsePairwiseReply` (case, markdown fences, tie synonyms, null on garbage).
- [x] `pnpm typecheck` (all), `pnpm --filter server lint`, `pnpm --filter web lint` — clean. 104 server eval tests + 131 SDK tests pass; SDK builds.
- [x] **Code review** (0 CRITICAL): swap/un-swap mapping verified correct, migration idempotent, every written column matches the migration, provider behaviour preserved by the refactor. 2 HIGH were confirmed pre-existing patterns (not regressions); applied the recommended gemini-branch hardening.
- Note: the run dialog is dashboard-only (auth-gated) and a live pairwise run spends real provider keys, so the UI is typecheck/lint-verified and the judge logic is unit-tested rather than executed end-to-end here.

### Deploy ordering
`deploy-server.yml` runs migrate → deploy, so the columns exist before the runner writes them. Additive + `mode` defaults to `single`, so existing rows and the single-mode path are unchanged.

This completes P1-7 (confidence intervals → rubric/anchors → pairwise).
