### PR TITLE
docs(web): legal pages compliance update

### DIFF
--- a/apps/server/src/api/userConsent.ts
+++ b/apps/server/src/api/userConsent.ts
@@ -5,7 +5,7 @@ import { ApiError } from '../lib/errors.js'
 
 /**
  * /api/v1/me/consent — append-only record of the user's acceptance
- * of the Terms of Service and Privacy Policy at signup (and any
+ * of the Terms of Service, Privacy Policy, and DPA at signup (and any
  * subsequent re-acceptance prompts when those documents are revised).
  *
  *   POST /me/consent  body: { documents: [{ document, version }, ...] }
@@ -21,8 +21,8 @@ export const userConsentRouter = new Hono<JwtContext>()
 
 userConsentRouter.use('*', authJwt)
 
-type AllowedDocument = 'terms' | 'privacy'
-const ALLOWED_DOCUMENTS: readonly AllowedDocument[] = ['terms', 'privacy'] as const
+type AllowedDocument = 'terms' | 'privacy' | 'dpa'
+const ALLOWED_DOCUMENTS: readonly AllowedDocument[] = ['terms', 'privacy', 'dpa'] as const
 
 interface ConsentItem {
   document: AllowedDocument
@@ -85,7 +85,7 @@ userConsentRouter.post('/', async (c) => {
     return c.json(
       {
         error:
-          'documents must be a non-empty array of { document: "terms"|"privacy", version: string }',
+          'documents must be a non-empty array of { document: "terms"|"privacy"|"dpa", version: string }',
       },
       400,
     )

--- a/apps/web/app/dpa/page.tsx
+++ b/apps/web/app/dpa/page.tsx
@@ -9,7 +9,7 @@ export const metadata = {
     'Spanlens Data Processing Addendum (DPA) for customers subject to GDPR or UK GDPR. Incorporates the EU Standard Contractual Clauses (Module 2).',
 }
 
-const EFFECTIVE_DATE = '2026-05-18'
+const EFFECTIVE_DATE = '2026-06-15'
 
 export default function DPAPage() {
   return (
@@ -432,6 +432,108 @@ export default function DPAPage() {
             <strong>Competent supervisory authority (Annex I.C):</strong> the Irish
             Data Protection Commission (DPC), as the supervisory authority of the Member
             State chosen under Clause 13(a).
+          </li>
+        </ul>
+
+        <h2 id="annex-b">Annex B, Description of the Transfer (Annex I-B to the SCCs)</h2>
+        <p className="text-sm text-muted-foreground">
+          Applies where SCCs are incorporated under Section 14 of this DPA.
+        </p>
+        <ul>
+          <li>
+            <strong>Categories of data subjects:</strong> (i) the Customer&apos;s
+            personnel who hold Spanlens accounts; (ii) end users of the Customer&apos;s
+            applications whose personal data appears in LLM request bodies.
+          </li>
+          <li>
+            <strong>Categories of personal data transferred:</strong> account profile
+            (email, display name); LLM request and response bodies (which may contain
+            any personal data submitted by the Customer or its end users, truncated to
+            10 KB); telemetry (token counts, latency, cost, model identifiers);
+            security-scan match flags (masked 6-character samples only); billing
+            metadata (Paddle customer / subscription identifiers); technical logs
+            (IP address, user agent).
+          </li>
+          <li>
+            <strong>Sensitive data transferred:</strong> none requested by Spanlens.
+            If the Customer submits sensitive categories of personal data (GDPR Art. 9)
+            in LLM request bodies, the Customer is responsible for ensuring an
+            appropriate legal basis. Use the{' '}
+            <code>X-Spanlens-Log-Body: meta</code> header to suppress body storage for
+            such traffic.
+          </li>
+          <li>
+            <strong>Nature and purpose of the processing:</strong> hosting,
+            transmission, storage, and analytical processing of Customer Personal Data
+            to provide the LLM observability service; forwarding of LLM requests to
+            upstream providers designated by the Customer.
+          </li>
+          <li>
+            <strong>Duration of the transfer:</strong> ongoing for the term of the
+            Customer&apos;s account, including the post-termination retention windows
+            described in the Privacy Policy.
+          </li>
+          <li>
+            <strong>Frequency of the transfer:</strong> continuous; real-time with
+            each LLM request routed through the proxy.
+          </li>
+          <li>
+            <strong>Competent supervisory authority (Annex I.C):</strong> the Irish
+            Data Protection Commission (DPC), as set out in Annex A above.
+          </li>
+        </ul>
+
+        <h2 id="annex-c">Annex C, Technical and Organisational Measures (Annex II to the SCCs)</h2>
+        <p className="text-sm text-muted-foreground">
+          Applies where SCCs are incorporated under Section 14 of this DPA. These
+          measures supplement and are detailed in Section 7 of this DPA.
+        </p>
+        <ul>
+          <li>
+            <strong>Encryption in transit:</strong> TLS 1.2 or higher enforced on
+            all connections between clients, the Spanlens proxy / API, and all
+            subprocessors.
+          </li>
+          <li>
+            <strong>Encryption at rest:</strong> Customer-supplied LLM provider API
+            keys encrypted with AES-256-GCM; master key held in infrastructure-level
+            secret storage outside the application database. Supabase and ClickHouse
+            Cloud additionally encrypt all data at rest at the storage layer.
+          </li>
+          <li>
+            <strong>Access controls and authentication:</strong> dashboard access
+            requires an authenticated Supabase session; Row-Level Security policies
+            enforced at the database layer; service-role key restricted to server-side
+            operations only; all reads from the multi-tenant{' '}
+            <code>requests</code> table are filtered by{' '}
+            <code>organization_id</code> at the query layer, enforced by lint rules
+            and CODEOWNERS.
+          </li>
+          <li>
+            <strong>Data minimisation and pseudonymisation:</strong> upstream-provider
+            authorization headers stripped from stored request bodies; security
+            scan matches stored as 6-character masked samples only; API key hashes
+            (not raw keys) used for rate-limit counters.
+          </li>
+          <li>
+            <strong>Integrity and availability:</strong> regional redundancy and
+            automated backups via Supabase (point-in-time recovery) and ClickHouse
+            Cloud (automated snapshots).
+          </li>
+          <li>
+            <strong>Vulnerability and patch management:</strong> Dependabot monitors
+            dependency vulnerabilities; CodeQL runs static analysis on every pull
+            request; GitHub Push Protection blocks accidental secret commits.
+          </li>
+          <li>
+            <strong>Testing:</strong> automated unit test suite covering
+            multi-tenancy guarantees, webhook handlers, and billing idempotency runs
+            on every change.
+          </li>
+          <li>
+            <strong>Breach detection and response:</strong> breach notification to
+            the Customer within 72 hours of Spanlens becoming aware of a Personal
+            Data Breach, as set out in Section 11 of this DPA.
           </li>
         </ul>
 

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -9,7 +9,7 @@ export const metadata = {
     'How Spanlens collects, uses, and protects your data. Covers PIPA (Korea) and GDPR (EU) disclosures and your rights as a data subject.',
 }
 
-const EFFECTIVE_DATE = '2026-05-18'
+const EFFECTIVE_DATE = '2026-06-15'
 
 export default function PrivacyPage() {
   return (
@@ -40,8 +40,18 @@ export default function PrivacyPage() {
           <li><strong>E-commerce Registration Number:</strong> 2025-Gyeonggi-Gwangju-2133</li>
           <li><strong>Jurisdiction:</strong> Republic of Korea</li>
           <li>
-            <strong>Privacy Officer:</strong> Jeon Haesung ,{' '}
+            <strong>Privacy Officer:</strong> Jeon Haeseong,{' '}
             <a href="mailto:support@spanlens.io">support@spanlens.io</a>
+          </li>
+          <li>
+            <strong>EU/EEA Representative (GDPR Art. 27):</strong> Spanlens
+            processes personal data of EU/EEA residents from the Republic of
+            Korea. We are evaluating formal representative designation under
+            Art. 27 in proportion to our EU processing volume. In the interim,
+            EU/EEA residents may direct all GDPR-related inquiries directly to
+            our Privacy Officer at{' '}
+            <a href="mailto:support@spanlens.io">support@spanlens.io</a>; we
+            will respond within 30 days.
           </li>
         </ul>
 
@@ -102,7 +112,7 @@ export default function PrivacyPage() {
 
         <h3>Technical logs</h3>
         <ul>
-          <li>IP address (briefly, in network-layer logs)</li>
+          <li>IP address (retained in server logs for up to 30 days)</li>
           <li>User agent</li>
           <li>Session cookies set by our authentication provider</li>
           <li>Timestamps of login and usage</li>
@@ -237,7 +247,12 @@ export default function PrivacyPage() {
           <li>Rectification (Art. 16)</li>
           <li>Erasure / &ldquo;right to be forgotten&rdquo; (Art. 17)</li>
           <li>Restriction of processing (Art. 18)</li>
-          <li>Data portability, export in machine-readable format (Art. 20)</li>
+          <li>
+            Data portability (Art. 20) &mdash; export your request history and
+            traces from the Settings page in your dashboard, or email{' '}
+            <a href="mailto:support@spanlens.io">support@spanlens.io</a>{' '}
+            for a full account data export in JSON format.
+          </li>
           <li>Objection to processing based on legitimate interests (Art. 21)</li>
           <li>Lodging a complaint with your national Data Protection Authority</li>
         </ul>
@@ -248,12 +263,26 @@ export default function PrivacyPage() {
           to 60 days for complex requests, with notice).
         </p>
 
+        <h3>Under US state privacy laws</h3>
+        <p>
+          Spanlens does not sell your personal data or share it for cross-context
+          behavioral advertising. California residents and residents of other US states with
+          applicable privacy laws (Virginia, Colorado, Connecticut, etc.) may submit requests
+          to know, correct, delete, or opt out of any applicable data practices by emailing{' '}
+          <a href="mailto:support@spanlens.io">support@spanlens.io</a> from the address
+          associated with your account. We respond within <strong>45 days</strong>{' '}
+          (extendable by 45 days where reasonably necessary, with notice).
+        </p>
+
         <h2 id="children">9. Children&apos;s privacy</h2>
         <p>
-          Spanlens is not directed at children under 14. Korean law prohibits processing
-          personal data of children under 14 without explicit guardian consent. We do not
-          knowingly collect such data. If you believe a child has provided data to us, contact
-          us and we will delete it.
+          Spanlens is not directed at children under 14 (Korean PIPA minimum age) or under
+          16 years old &mdash; or the minimum age set by your EU Member State, which may be
+          no lower than 13 &mdash; (GDPR Art. 8). Korean law prohibits processing personal
+          data of children under 14 without explicit guardian consent; EU law requires
+          verifiable consent from a person holding parental responsibility for children below
+          the applicable national age threshold. We do not knowingly collect such data. If you
+          believe a child has provided data to us, contact us and we will delete it.
         </p>
 
         <h2 id="cookies">10. Cookies</h2>

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
 import { writeWorkspaceCookie } from '@/lib/workspace-cookie'
-import { TERMS_VERSION, PRIVACY_VERSION } from '@/lib/legal-versions'
+import { TERMS_VERSION, PRIVACY_VERSION, DPA_VERSION } from '@/lib/legal-versions'
 import { GithubIcon, GoogleIcon } from '@/components/ui/provider-icons'
 
 /**
@@ -30,6 +30,7 @@ async function recordSignupConsent(accessToken: string): Promise<void> {
         documents: [
           { document: 'terms', version: TERMS_VERSION },
           { document: 'privacy', version: PRIVACY_VERSION },
+          { document: 'dpa', version: DPA_VERSION },
         ],
       }),
     })
@@ -260,8 +261,10 @@ function SignupPageInner() {
               <p className="text-[11px] text-text-faint leading-snug mb-2">
                 By continuing with Google or GitHub, you agree to our{' '}
                 <Link href="/terms" target="_blank" className="text-text-muted hover:text-text transition-colors underline underline-offset-2">Terms</Link>
-                {' '}and{' '}
-                <Link href="/privacy" target="_blank" className="text-text-muted hover:text-text transition-colors underline underline-offset-2">Privacy Policy</Link>.
+                ,{' '}
+                <Link href="/privacy" target="_blank" className="text-text-muted hover:text-text transition-colors underline underline-offset-2">Privacy Policy</Link>
+                , and{' '}
+                <Link href="/dpa" target="_blank" className="text-text-muted hover:text-text transition-colors underline underline-offset-2">DPA</Link>.
               </p>
 
               {/* Divider */}
@@ -328,9 +331,11 @@ function SignupPageInner() {
                   />
                   <span className="text-[12px] text-text-muted leading-relaxed">
                     I agree to the{' '}
-                    <Link href="/terms" target="_blank" className="text-text hover:opacity-80 transition-opacity">Terms</Link>
-                    {' '}and{' '}
-                    <Link href="/privacy" target="_blank" className="text-text hover:opacity-80 transition-opacity">Privacy Policy</Link>.
+                    <Link href="/terms" target="_blank" className="text-text hover:opacity-80 transition-opacity">Terms of Service</Link>
+                    ,{' '}
+                    <Link href="/privacy" target="_blank" className="text-text hover:opacity-80 transition-opacity">Privacy Policy</Link>
+                    , and{' '}
+                    <Link href="/dpa" target="_blank" className="text-text hover:opacity-80 transition-opacity">Data Processing Addendum</Link>.
                   </span>
                 </label>
 

--- a/apps/web/app/subprocessors/page.tsx
+++ b/apps/web/app/subprocessors/page.tsx
@@ -9,7 +9,7 @@ export const metadata = {
     'The complete list of subprocessors Spanlens engages to operate the service, including data hosting locations and the purpose of each engagement.',
 }
 
-const EFFECTIVE_DATE = '2026-05-18'
+const EFFECTIVE_DATE = '2026-06-15'
 
 export default function SubprocessorsPage() {
   return (
@@ -229,6 +229,25 @@ export default function SubprocessorsPage() {
                 pre-transmission filters (<code>beforeSend</code>).
               </td>
               <td>USA (Sentry US tenant).</td>
+              <td>EU SCCs.</td>
+            </tr>
+            <tr>
+              <td>
+                <strong>Better Stack Inc.</strong>
+                <br />
+                <span className="text-xs text-muted-foreground">
+                  (San Francisco, CA, USA)
+                </span>
+              </td>
+              <td>
+                Uptime monitoring and on-call incident alerting for service
+                availability.
+              </td>
+              <td>
+                Endpoint URLs, HTTP status codes, and response times. No request
+                bodies or personal data in payloads.
+              </td>
+              <td>USA.</td>
               <td>EU SCCs.</td>
             </tr>
           </tbody>

--- a/apps/web/app/terms/page.tsx
+++ b/apps/web/app/terms/page.tsx
@@ -9,7 +9,7 @@ export const metadata = {
     'The agreement governing your use of Spanlens. Covers accounts, billing, the 14-day refund policy, acceptable use, and liability.',
 }
 
-const EFFECTIVE_DATE = '2026-05-17'
+const EFFECTIVE_DATE = '2026-06-15'
 
 export default function TermsPage() {
   return (
@@ -192,9 +192,12 @@ export default function TermsPage() {
         <p>
           <strong>Our service remains ours.</strong> The Spanlens software, dashboard, SDK
           (<code>@spanlens/sdk</code>), CLI (<code>@spanlens/cli</code>), proxy infrastructure,
-          documentation, brand assets, and related materials are owned by Oceancode. The SDK
-          and CLI are distributed under the MIT license; the server and dashboard are
-          source-available under the terms stated in our GitHub repository.
+          documentation, brand assets, and related materials are owned by Oceancode. The
+          SDK, CLI, server, and dashboard are open-sourced under the{' '}
+          <a href="https://github.com/spanlens/Spanlens/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a>
+          {' '}(see{' '}
+          <a href="https://github.com/spanlens/Spanlens" target="_blank" rel="noopener noreferrer">github.com/spanlens/Spanlens</a>
+          {' '}for the full license text).
         </p>
 
         <h2 id="availability">9. Service availability</h2>

--- a/apps/web/lib/legal-versions.ts
+++ b/apps/web/lib/legal-versions.ts
@@ -9,6 +9,8 @@
  * sign up will be recorded as accepting the new version.
  */
 
-export const TERMS_VERSION = '2026-05-17'
+export const TERMS_VERSION = '2026-06-15'
 
-export const PRIVACY_VERSION = '2026-05-18'
+export const PRIVACY_VERSION = '2026-06-15'
+
+export const DPA_VERSION = '2026-06-15'

--- a/supabase/migrations/20260618100000_user_consents_allow_dpa.sql
+++ b/supabase/migrations/20260618100000_user_consents_allow_dpa.sql
@@ -1,0 +1,20 @@
+-- Migration: allow 'dpa' in user_consents.document
+--
+-- The original 20260518100000_user_consents.sql CHECK constraint only allowed
+-- ('terms', 'privacy'). docs/legal-compliance-update added a DPA document and
+-- signup now posts {document: 'dpa', version: DPA_VERSION} alongside terms +
+-- privacy. Without this migration the server-side ALLOWED_DOCUMENTS gate
+-- rejects the batch (HTTP 400), and because the client fetch().catch() does
+-- not fire on HTTP errors, the entire consent batch (including terms +
+-- privacy) silently fails to record — breaking the audit log for every new
+-- signup.
+--
+-- Idempotent: drops the legacy constraint by name then re-adds it with the
+-- expanded allow-list.
+
+ALTER TABLE user_consents
+  DROP CONSTRAINT IF EXISTS user_consents_document_check;
+
+ALTER TABLE user_consents
+  ADD CONSTRAINT user_consents_document_check
+  CHECK (document IN ('terms', 'privacy', 'dpa'));


### PR DESCRIPTION
## Summary

- **Privacy Policy**: EU representative note (Art. 27), GDPR/PIPA children age distinction (16 vs 14), CCPA/US state laws section, data portability mechanism explanation, IP retention clarified from "briefly" to "up to 30 days", Privacy Officer comma fix, date updated
- **Terms of Service**: MIT License with GitHub link replaces ambiguous "source-available" language, date aligned
- **Subprocessors**: Better Stack Inc. added to communications table
- **DPA**: Annex I-B (description of transfer) and Annex II (technical and organisational measures) added for full SCC completion
- **Signup**: DPA linked in consent checkbox and OAuth notice; DPA version recorded in `user_consents` via `recordSignupConsent`
- **legal-versions.ts**: `DPA_VERSION` added, all versions bumped to `2026-06-15`

## Test plan

- [ ] Visit `/privacy` — verify EU representative note in §1, US privacy laws section in §8, updated children's age language in §9
- [ ] Visit `/terms` — verify MIT License link points to GitHub, date shows 2026-06-15
- [ ] Visit `/subprocessors` — verify Better Stack row appears in communications table
- [ ] Visit `/dpa` — verify Annex I-B and Annex II sections present after Annex A
- [ ] Visit `/signup` — verify consent checkbox reads "Terms of Service, Privacy Policy, and Data Processing Addendum" with all three linked
- [ ] Test OAuth signup path — verify DPA linked in the implicit consent notice below SSO buttons