### PR TITLE
feat: agent trajectory evaluation (P2-11)

### DIFF
--- a/apps/server/src/__tests__/eval-trajectory.test.ts
+++ b/apps/server/src/__tests__/eval-trajectory.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import {
+  serializeTrajectory,
+  buildTrajectoryJudgePrompt,
+  type TrajectorySpan,
+  type TrajectoryTrace,
+} from '../lib/eval-runners/trajectory.js'
+
+const trace: TrajectoryTrace = { name: 'support-agent', status: 'completed', duration_ms: 1234 }
+
+function span(over: Partial<TrajectorySpan>): TrajectorySpan {
+  return {
+    name: 'step',
+    span_type: 'llm',
+    status: 'completed',
+    input: null,
+    output: null,
+    error_message: null,
+    started_at: '2026-06-15T00:00:00.000Z',
+    ...over,
+  }
+}
+
+describe('serializeTrajectory', () => {
+  it('returns empty string when there are no spans', () => {
+    expect(serializeTrajectory(trace, [])).toBe('')
+  })
+
+  it('renders a header with trace name, step count, and duration', () => {
+    const out = serializeTrajectory(trace, [span({})])
+    expect(out).toContain('Agent trace: "support-agent"')
+    expect(out).toContain('overall status: completed')
+    expect(out).toContain('1 steps')
+    expect(out).toContain('1234ms total')
+  })
+
+  it('orders steps by start time, not array order', () => {
+    const out = serializeTrajectory(trace, [
+      span({ name: 'second', started_at: '2026-06-15T00:00:02.000Z' }),
+      span({ name: 'first', started_at: '2026-06-15T00:00:01.000Z' }),
+    ])
+    const firstIdx = out.indexOf('first')
+    const secondIdx = out.indexOf('second')
+    expect(firstIdx).toBeGreaterThan(-1)
+    expect(firstIdx).toBeLessThan(secondIdx)
+    expect(out).toContain('Step 1 [llm] first')
+    expect(out).toContain('Step 2 [llm] second')
+  })
+
+  it('renders span_type, input, output, and error', () => {
+    const out = serializeTrajectory(trace, [
+      span({ span_type: 'tool', name: 'search', input: { q: 'weather' }, output: 'sunny', status: 'completed' }),
+      span({ span_type: 'llm', name: 'answer', status: 'error', error_message: 'rate limited', started_at: '2026-06-15T00:00:01.000Z' }),
+    ])
+    expect(out).toContain('[tool] search')
+    expect(out).toContain('Input: {"q":"weather"}')
+    expect(out).toContain('Output: sunny')
+    expect(out).toContain('(status: error)')
+    expect(out).toContain('Error: rate limited')
+  })
+
+  it('collapses whitespace and truncates long values', () => {
+    const longOutput = 'x'.repeat(5000)
+    const out = serializeTrajectory(trace, [span({ output: longOutput })])
+    // Each step's output is capped well under the raw length.
+    expect(out.length).toBeLessThan(2000)
+  })
+})
+
+describe('buildTrajectoryJudgePrompt', () => {
+  it('frames the task as judging a trajectory and asks for a numeric score', () => {
+    const prompt = buildTrajectoryJudgePrompt('Did the agent resolve the ticket?', 'Step 1 ...', {
+      scale_min: 0,
+      scale_max: 1,
+    })
+    expect(prompt).toContain('TRAJECTORY')
+    expect(prompt).toContain('Criterion: Did the agent resolve the ticket?')
+    expect(prompt).toContain('Step 1 ...')
+    expect(prompt).toContain('"score": <number between 0 and 1>')
+    expect(prompt).toMatch(/tool/i)
+  })
+
+  it('injects the rubric when present', () => {
+    const prompt = buildTrajectoryJudgePrompt('crit', 'traj', { scale_min: 0, scale_max: 1, rubric: 'no redundant tool calls' })
+    expect(prompt).toContain('Scoring rubric (apply consistently):')
+    expect(prompt).toContain('no redundant tool calls')
+  })
+
+  it('omits the rubric block when absent', () => {
+    const prompt = buildTrajectoryJudgePrompt('crit', 'traj', { scale_min: 0, scale_max: 1 })
+    expect(prompt).not.toContain('Scoring rubric')
+  })
+})

--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -30,6 +30,8 @@ evalsRouter.post('/evaluators', requireFullScope, async (c) => {
     name?: unknown
     type?: unknown
     config?: unknown
+    // P2-11 — trajectory evaluators target traces by name, not a prompt.
+    traceName?: unknown
     // 4B.1c — optional pointer at a typed score config. NULL preserves
     // the legacy NUMERIC 0..1 behaviour.
     scoreConfigId?: unknown
@@ -46,13 +48,21 @@ evalsRouter.post('/evaluators', requireFullScope, async (c) => {
     throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
   }
 
-  const promptName = typeof body.promptName === 'string' ? body.promptName.trim() : ''
   const name = typeof body.name === 'string' ? body.name.trim() : ''
   const type = typeof body.type === 'string' ? body.type.trim() : 'llm_judge'
+  // P2-11: trajectory evaluators bind to a TRACE name, not a prompt. We reuse
+  // the prompt_name column to hold it (it's just the grouping label), so the
+  // existing list UI groups trajectory evaluators under their trace name.
+  const traceName = typeof body.traceName === 'string' ? body.traceName.trim() : ''
+  const promptName = type === 'trajectory'
+    ? traceName
+    : (typeof body.promptName === 'string' ? body.promptName.trim() : '')
 
-  if (!promptName) throw new ApiError('VALIDATION_FAILED', 'promptName is required')
+  if (!promptName) {
+    throw new ApiError('VALIDATION_FAILED', type === 'trajectory' ? 'traceName is required' : 'promptName is required')
+  }
   if (!name) throw new ApiError('VALIDATION_FAILED', 'name is required')
-  const VALID_EVALUATOR_TYPES = ['llm_judge', 'regex', 'json_schema', 'exact_match', 'contains', 'embedding']
+  const VALID_EVALUATOR_TYPES = ['llm_judge', 'regex', 'json_schema', 'exact_match', 'contains', 'embedding', 'trajectory']
   if (!VALID_EVALUATOR_TYPES.includes(type)) {
     throw new ApiError('VALIDATION_FAILED', `type must be one of: ${VALID_EVALUATOR_TYPES.join(', ')}`)
   }
@@ -171,8 +181,7 @@ evalsRouter.post('/evaluators', requireFullScope, async (c) => {
       substring,
       caseSensitive: config.caseSensitive === true,
     }
-  } else {
-    // type === 'embedding'
+  } else if (type === 'embedding') {
     const provider = typeof config.provider === 'string' ? config.provider : ''
     const model = typeof config.model === 'string' ? config.model.trim() : ''
     if (!EMBEDDING_PROVIDERS.includes(provider as (typeof EMBEDDING_PROVIDERS)[number])) {
@@ -190,15 +199,51 @@ evalsRouter.post('/evaluators', requireFullScope, async (c) => {
       ...(referenceText ? { reference_text: referenceText } : {}),
       ...(threshold != null ? { threshold } : {}),
     }
+  } else {
+    // type === 'trajectory' (P2-11). LLM-as-judge over an agent trace; binds to
+    // a trace name (carried in config.trace_name) instead of a prompt version.
+    const criterion = typeof config.criterion === 'string' ? config.criterion.trim() : ''
+    const judgeProvider = typeof config.judge_provider === 'string' ? config.judge_provider : ''
+    const judgeModel = typeof config.judge_model === 'string' ? config.judge_model.trim() : ''
+    const scaleMin = typeof config.scale_min === 'number' ? config.scale_min : 0
+    const scaleMax = typeof config.scale_max === 'number' ? config.scale_max : 1
+    const rubric = typeof config.rubric === 'string' ? config.rubric.trim() : ''
+    if (!criterion) throw new ApiError('VALIDATION_FAILED', 'config.criterion is required')
+    const VALID_JUDGE_PROVIDERS = ['openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter']
+    if (!VALID_JUDGE_PROVIDERS.includes(judgeProvider)) {
+      throw new ApiError('VALIDATION_FAILED', `config.judge_provider must be one of: ${VALID_JUDGE_PROVIDERS.join(', ')}`)
+    }
+    if (!judgeModel) throw new ApiError('VALIDATION_FAILED', 'config.judge_model is required')
+    if (!(scaleMax > scaleMin)) {
+      throw new ApiError('VALIDATION_FAILED', 'config.scale_max must be greater than scale_min')
+    }
+    if (rubric.length > 4000) {
+      throw new ApiError('VALIDATION_FAILED', 'config.rubric must be at most 4000 characters')
+    }
+    // trace_name carried in config (authoritative for the runner); we also
+    // stored it as prompt_name above for grouping.
+    validatedConfig = {
+      criterion,
+      judge_provider: judgeProvider,
+      judge_model: judgeModel,
+      scale_min: scaleMin,
+      scale_max: scaleMax,
+      trace_name: traceName,
+      ...(rubric ? { rubric } : {}),
+    }
   }
 
-  // Verify prompt exists for this org
-  const { count: promptCount } = await supabaseAdmin
-    .from('prompt_versions')
-    .select('id', { count: 'exact', head: true })
-    .eq('organization_id', orgId)
-    .eq('name', promptName)
-  if (!promptCount) throw new ApiError('NOT_FOUND', 'Prompt not found')
+  // Verify the prompt exists for this org — EXCEPT trajectory evaluators, whose
+  // prompt_name holds a trace name (not a prompt). Trace names are free-form
+  // (the customer's SDK chose them), so there's nothing to verify against.
+  if (type !== 'trajectory') {
+    const { count: promptCount } = await supabaseAdmin
+      .from('prompt_versions')
+      .select('id', { count: 'exact', head: true })
+      .eq('organization_id', orgId)
+      .eq('name', promptName)
+    if (!promptCount) throw new ApiError('NOT_FOUND', 'Prompt not found')
+  }
 
   // Optional score config — only meaningful for LLM-as-judge runs.
   // Verified to belong to the same org so a caller can't bind an
@@ -381,14 +426,27 @@ evalsRouter.post('/eval-runs', requireFullScope, async (c) => {
     typeof body.generationTemperature === 'number' ? body.generationTemperature : 0
 
   if (!evaluatorId) throw new ApiError('VALIDATION_FAILED', 'evaluatorId is required')
-  if (!promptVersionId) throw new ApiError('VALIDATION_FAILED', 'promptVersionId is required')
+
+  // Fetch the evaluator early — its type decides whether this is a trajectory
+  // run (P2-11), which targets traces by name and has NO prompt version.
+  const { data: evaluator } = await supabaseAdmin
+    .from('evaluators')
+    .select('id, type')
+    .eq('id', evaluatorId)
+    .eq('organization_id', orgId)
+    .is('archived_at', null)
+    .maybeSingle()
+  if (!evaluator) throw new ApiError('NOT_FOUND', 'Evaluator not found')
+  const isTrajectory = evaluator.type === 'trajectory'
+
+  if (!isTrajectory && !promptVersionId) throw new ApiError('VALIDATION_FAILED', 'promptVersionId is required')
   if (sampleSize < 1 || sampleSize > 1000) {
     throw new ApiError('VALIDATION_FAILED', 'sampleSize must be between 1 and 1000')
   }
   if (generationTemperature < 0 || generationTemperature > 2) {
     throw new ApiError('VALIDATION_FAILED', 'generationTemperature must be between 0 and 2')
   }
-  if (source === 'dataset' && !datasetId) {
+  if (!isTrajectory && source === 'dataset' && !datasetId) {
     throw new ApiError('VALIDATION_FAILED', 'datasetId is required when source = dataset')
   }
 
@@ -400,7 +458,7 @@ evalsRouter.post('/eval-runs', requireFullScope, async (c) => {
       ? (body.runProvider as RunProvider)
       : null
   const runModel = typeof body.runModel === 'string' ? body.runModel.trim() : null
-  if (source === 'dataset') {
+  if (!isTrajectory && source === 'dataset') {
     if (!runProvider) throw new ApiError('VALIDATION_FAILED', 'runProvider is required when source = dataset')
     if (!runModel) throw new ApiError('VALIDATION_FAILED', 'runModel is required when source = dataset')
   }
@@ -421,15 +479,6 @@ evalsRouter.post('/eval-runs', requireFullScope, async (c) => {
     }
   }
 
-  // Verify both belong to org
-  const { data: evaluator } = await supabaseAdmin
-    .from('evaluators')
-    .select('id, type')
-    .eq('id', evaluatorId)
-    .eq('organization_id', orgId)
-    .is('archived_at', null)
-    .maybeSingle()
-  if (!evaluator) throw new ApiError('NOT_FOUND', 'Evaluator not found')
   if (mode === 'pairwise' && evaluator.type !== 'llm_judge') {
     throw new ApiError('VALIDATION_FAILED', 'pairwise mode requires an llm_judge evaluator')
   }
@@ -445,16 +494,20 @@ evalsRouter.post('/eval-runs', requireFullScope, async (c) => {
     if (!pvB) throw new ApiError('NOT_FOUND', 'promptVersionBId not found')
   }
 
-  const { data: pv } = await supabaseAdmin
-    .from('prompt_versions')
-    .select('id')
-    .eq('id', promptVersionId)
-    .eq('organization_id', orgId)
-    .maybeSingle()
-  if (!pv) throw new ApiError('NOT_FOUND', 'Prompt version not found')
+  // Verify the prompt version belongs to org — skipped for trajectory runs,
+  // which have no prompt version (they target traces by name).
+  if (!isTrajectory) {
+    const { data: pv } = await supabaseAdmin
+      .from('prompt_versions')
+      .select('id')
+      .eq('id', promptVersionId)
+      .eq('organization_id', orgId)
+      .maybeSingle()
+    if (!pv) throw new ApiError('NOT_FOUND', 'Prompt version not found')
+  }
 
-  // Verify dataset belongs to org if requested
-  if (source === 'dataset' && datasetId) {
+  // Verify dataset belongs to org if requested (not for trajectory).
+  if (!isTrajectory && source === 'dataset' && datasetId) {
     const { data: ds } = await supabaseAdmin
       .from('datasets')
       .select('id')
@@ -470,9 +523,10 @@ evalsRouter.post('/eval-runs', requireFullScope, async (c) => {
     .insert({
       organization_id: orgId,
       evaluator_id: evaluatorId,
-      prompt_version_id: promptVersionId,
+      // Trajectory runs have no prompt version; the runner fills trace_name.
+      prompt_version_id: isTrajectory ? null : promptVersionId,
       source,
-      dataset_id: source === 'dataset' ? datasetId : null,
+      dataset_id: !isTrajectory && source === 'dataset' ? datasetId : null,
       sample_size: sampleSize,
       sample_from: source === 'production' ? sampleFrom : null,
       sample_to: source === 'production' ? sampleTo : null,
@@ -489,11 +543,13 @@ evalsRouter.post('/eval-runs', requireFullScope, async (c) => {
   }
 
   // Kick off the worker in background. The HTTP caller polls GET /eval-runs/:id.
+  // Trajectory runs have no prompt version (the runner reads the evaluator's
+  // config.trace_name); pass null.
   fireAndForget(c, runEvalRun({
     evalRunId: run.id,
     organizationId: orgId,
     evaluatorId,
-    promptVersionId,
+    promptVersionId: isTrajectory ? null : promptVersionId,
     source,
     datasetId,
     sampleSize,

--- a/apps/server/src/api/prompts.ts
+++ b/apps/server/src/api/prompts.ts
@@ -332,6 +332,10 @@ promptsRouter.post('/', requireEdit, async (c) => {
     .eq('organization_id', orgId)
     .eq('prompt_name', name)
     .eq('auto_run_on_version', true)
+    // P2-11: trajectory evaluators score traces, not prompt versions — they
+    // must never be auto-run on a new prompt version (their prompt_name holds a
+    // trace name, so a name collision could otherwise match them here).
+    .neq('type', 'trajectory')
     .is('archived_at', null)
 
   for (const ev of autoEvals ?? []) {

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -35,6 +35,7 @@ import { startInternalTrace } from './internal-tracing.js'
 // (`from '../lib/eval-runner.js'`) keep working unchanged.
 import { extractResponseText, fetchWithRetry } from './eval-runners/shared.js'
 import { sampleStdDev } from './eval-runners/stats.js'
+import { serializeTrajectory, buildTrajectoryJudgePrompt, type TrajectorySpan } from './eval-runners/trajectory.js'
 import {
   buildJudgePrompt,
   parseJudgeReply,
@@ -513,6 +514,44 @@ export async function callPairwiseJudge(
   return { winner: parsed.winner, reasoning: parsed.reasoning, cost: res.cost, tokens: res.tokens }
 }
 
+/** Outcome of judging one agent trajectory (P2-11). `score` is normalised 0..1. */
+export interface TrajectoryOutcome {
+  score: number
+  reasoning: string
+  cost: number
+  tokens: number
+}
+
+/** Calls the judge once on a serialized agent trajectory. Returns null on failure. */
+export async function callTrajectoryJudge(
+  config: JudgeConfig,
+  trajectoryText: string,
+  apiKey: string,
+  resourceUrl: string | null,
+): Promise<TrajectoryOutcome | null> {
+  const prompt = buildTrajectoryJudgePrompt(config.criterion, trajectoryText, {
+    scale_min: config.scale_min,
+    scale_max: config.scale_max,
+    rubric: config.rubric ?? null,
+  })
+  const res = await judgeComplete(
+    config.judge_provider,
+    config.judge_model,
+    apiKey,
+    resourceUrl,
+    prompt,
+    geminiJudgeSchema(null),
+  )
+  if (!res) return null
+  const parsed = parseJudgeReply(res.text, { scale_min: config.scale_min, scale_max: config.scale_max })
+  if (!parsed) return null
+  // Normalise to 0..1 against the configured scale, same as the legacy path.
+  const range = config.scale_max - config.scale_min || 1
+  const raw = parsed.value_number ?? parsed.score ?? 0
+  const normalised = (raw - config.scale_min) / range
+  return { score: normalised, reasoning: parsed.reasoning, cost: res.cost, tokens: res.tokens }
+}
+
 /** Runs a small async pool with concurrency cap. */
 async function pool<T, R>(
   items: T[],
@@ -537,7 +576,8 @@ interface RunInput {
   evalRunId: string
   organizationId: string
   evaluatorId: string
-  promptVersionId: string
+  /** null for trajectory runs (P2-11), which score traces by name. */
+  promptVersionId: string | null
   source: 'production' | 'dataset'
   /** Required when source = 'dataset' */
   datasetId?: string | null
@@ -685,6 +725,7 @@ export async function runEvalRun(input: RunInput): Promise<void> {
       if (source === 'dataset') {
         throw new Error(`evaluator type '${evaluator.type}' currently only supports source='production'`)
       }
+      if (promptVersionId == null) throw new Error('promptVersionId is required for this evaluator type')
       await runSimpleEvalRun(
         evalRunId,
         organizationId,
@@ -699,6 +740,170 @@ export async function runEvalRun(input: RunInput): Promise<void> {
       // and aggregate the simple path produced via internalTrace.end below.
       return
     }
+
+    // ── P2-11: agent trajectory evaluation ────────────────────────────────
+    // Scores the whole agent trace (ordered spans) against a criterion, not a
+    // single response. Targets traces by name (config.trace_name); no prompt
+    // version. Numeric 0..1 score so avg_score + the 95% CI apply for free.
+    if (evaluator.type === 'trajectory') {
+      const trajConfig = evaluator.config as unknown as JudgeConfig & { trace_name?: string }
+      if (!trajConfig?.criterion || !trajConfig?.judge_provider || !trajConfig?.judge_model) {
+        throw new Error('Trajectory evaluator config missing required fields (criterion / judge_provider / judge_model)')
+      }
+      const traceName = typeof trajConfig.trace_name === 'string' ? trajConfig.trace_name.trim() : ''
+      if (!traceName) throw new Error('Trajectory evaluator config missing trace_name')
+
+      const judge = await resolveProviderKey(organizationId, trajConfig.judge_provider, 'judge')
+
+      // Record what this run is scoring so the dashboard can label it before
+      // the run finishes.
+      await supabaseAdmin.from('eval_runs').update({ trace_name: traceName }).eq('id', evalRunId)
+
+      // Sample the most recent N traces with this name (optional time window).
+      let traceQuery = supabaseAdmin
+        .from('traces')
+        .select('id, name, status, duration_ms')
+        .eq('organization_id', organizationId)
+        .eq('name', traceName)
+        .order('started_at', { ascending: false })
+        .limit(sampleSize)
+      if (sampleFrom) traceQuery = traceQuery.gte('started_at', sampleFrom)
+      if (sampleTo) traceQuery = traceQuery.lte('started_at', sampleTo)
+      const { data: traces, error: tracesErr } = await traceQuery
+      if (tracesErr) throw new Error(`Trace fetch failed: ${tracesErr.message}`)
+
+      if (!traces || traces.length === 0) {
+        await supabaseAdmin
+          .from('eval_runs')
+          .update({
+            status: 'completed',
+            scored_count: 0,
+            attempted_count: 0,
+            failed_count: 0,
+            avg_score: null,
+            error: `No traces named "${traceName}" found in the selected window.`,
+            completed_at: new Date().toISOString(),
+          })
+          .eq('id', evalRunId)
+        internalTrace.end({ status: 'completed', metadata: { scored_count: 0, mode: 'trajectory' } })
+        return
+      }
+
+      type TrajResult = { traceId: string; score: number; reasoning: string; cost: number; tokens: number }
+      const outcomes = await pool(traces, JUDGE_CONCURRENCY, async (tr): Promise<TrajResult | null> => {
+        const span = internalTrace.startSpan('trajectory_judge', {
+          spanType: 'llm',
+          metadata: { judge_provider: trajConfig.judge_provider, judge_model: trajConfig.judge_model, trace_id: tr.id },
+        })
+        try {
+          // Cap spans per trace so a runaway agent can't blow the prompt.
+          const { data: spanRows, error: spansErr } = await supabaseAdmin
+            .from('spans')
+            .select('name, span_type, status, input, output, error_message, started_at')
+            .eq('trace_id', tr.id)
+            .eq('organization_id', organizationId)
+            .order('started_at', { ascending: true })
+            .limit(200)
+          if (spansErr || !spanRows || spanRows.length === 0) {
+            span.end({ status: 'error', errorMessage: 'no spans for trace' })
+            return null
+          }
+          const trajSpans: TrajectorySpan[] = spanRows.map((s) => ({
+            name: s.name as string,
+            span_type: s.span_type as string,
+            status: s.status as string,
+            input: s.input,
+            output: s.output,
+            error_message: (s.error_message as string | null) ?? null,
+            started_at: s.started_at as string,
+          }))
+          const text = serializeTrajectory(
+            { name: tr.name as string, status: tr.status as string, duration_ms: (tr.duration_ms as number | null) ?? null },
+            trajSpans,
+          )
+          if (!text) {
+            span.end({ status: 'error', errorMessage: 'empty trajectory' })
+            return null
+          }
+          const out = await callTrajectoryJudge(trajConfig, text, judge.key, judge.resourceUrl)
+          if (!out) {
+            span.end({ status: 'error', errorMessage: 'callTrajectoryJudge returned null' })
+            return null
+          }
+          span.end({
+            status: 'completed',
+            output: { score: out.score, reasoning: out.reasoning },
+            costUsd: out.cost,
+            totalTokens: out.tokens,
+          })
+          return { traceId: tr.id as string, score: out.score, reasoning: out.reasoning, cost: out.cost, tokens: out.tokens }
+        } catch (err) {
+          span.end({ status: 'error', errorMessage: err instanceof Error ? err.message : 'trajectory judge threw' })
+          return null
+        }
+      })
+
+      const scoredTraj = outcomes.filter((o): o is TrajResult => o !== null)
+      if (scoredTraj.length === 0) {
+        await supabaseAdmin
+          .from('eval_runs')
+          .update({
+            status: 'failed',
+            scored_count: 0,
+            attempted_count: traces.length,
+            failed_count: traces.length,
+            error: 'All trajectory judge calls failed. Check judge model name and provider key.',
+            completed_at: new Date().toISOString(),
+          })
+          .eq('id', evalRunId)
+        internalTrace.end({ status: 'error', errorMessage: 'All trajectory judge calls failed', metadata: { mode: 'trajectory' } })
+        return
+      }
+
+      const trajScores = scoredTraj.map((s) => s.score)
+      const trajAvg = trajScores.reduce((a, b) => a + b, 0) / trajScores.length
+      const trajStddev = sampleStdDev(trajScores)
+      const trajCost = scoredTraj.reduce((sum, s) => sum + s.cost, 0)
+
+      const { error: insErr } = await supabaseAdmin.from('eval_results').insert(
+        scoredTraj.map((s) => ({
+          organization_id: organizationId,
+          eval_run_id: evalRunId,
+          request_id: null,
+          dataset_item_id: null,
+          trace_id: s.traceId,
+          score: s.score,
+          reasoning: s.reasoning,
+          judge_cost_usd: s.cost,
+          judge_tokens: s.tokens,
+        })),
+      )
+      if (insErr) throw new Error(`Result insert failed: ${insErr.message}`)
+
+      await supabaseAdmin
+        .from('eval_runs')
+        .update({
+          status: 'completed',
+          scored_count: scoredTraj.length,
+          attempted_count: traces.length,
+          failed_count: traces.length - scoredTraj.length,
+          avg_score: trajAvg,
+          score_stddev: trajStddev,
+          total_cost_usd: trajCost,
+          completed_at: new Date().toISOString(),
+        })
+        .eq('id', evalRunId)
+      internalTrace.end({
+        status: 'completed',
+        metadata: { scored_count: scoredTraj.length, attempted_count: traces.length, avg_score: trajAvg, mode: 'trajectory' },
+      })
+      return
+    }
+
+    // Past this point every path (pairwise / judge / embedding, production +
+    // dataset) needs a prompt version. Only trajectory runs are null, and they
+    // returned above — narrow the type for the rest of the function.
+    if (promptVersionId == null) throw new Error('promptVersionId is required for this run')
 
     // ── P1-7 (3/3): pairwise (A vs B) comparison run ──────────────────────
     // Compares two prompt versions head-to-head on the same dataset inputs.
@@ -1362,7 +1567,9 @@ export async function runEvalRun(input: RunInput): Promise<void> {
 export interface StartEvalRunInput {
   organizationId: string
   evaluatorId: string
-  promptVersionId: string
+  /** null for trajectory runs. The P2-10 auto-run hook never targets trajectory
+   *  evaluators (they aren't prompt-bound), but keep this nullable for safety. */
+  promptVersionId: string | null
   source: 'production' | 'dataset'
   datasetId?: string | null
   sampleSize: number
@@ -1393,7 +1600,7 @@ export async function startEvalRun(c: Context, input: StartEvalRunInput): Promis
     .insert({
       organization_id: input.organizationId,
       evaluator_id: input.evaluatorId,
-      prompt_version_id: input.promptVersionId,
+      prompt_version_id: input.promptVersionId ?? null,
       source: input.source,
       dataset_id: input.source === 'dataset' ? (input.datasetId ?? null) : null,
       sample_size: input.sampleSize,

--- a/apps/server/src/lib/eval-runners/trajectory.ts
+++ b/apps/server/src/lib/eval-runners/trajectory.ts
@@ -1,0 +1,124 @@
+/**
+ * P2-11: agent trajectory evaluation.
+ *
+ * Existing evaluators judge a single response text. A trajectory evaluator
+ * judges the whole AGENT TRACE — the ordered sequence of spans (LLM calls,
+ * tool calls, intermediate steps) — against a criterion. This reuses the
+ * tracing data that is Spanlens's differentiator: "did the agent take the
+ * right steps", not just "is the final answer good".
+ *
+ * This module is the pure, side-effect-free core: serialize a trace's spans
+ * into a readable transcript, and build the judge prompt over it. The runner
+ * (eval-runner.ts) fetches the spans + calls the judge LLM.
+ */
+
+import { truncateMiddle, MAX_RESPONSE_CHARS } from './shared.js'
+
+/** Minimal projection of a span the serializer needs (spans table subset). */
+export interface TrajectorySpan {
+  name: string
+  span_type: string
+  status: string
+  input: unknown
+  output: unknown
+  error_message: string | null
+  /** ISO timestamp — used only to order steps by execution time. */
+  started_at: string
+}
+
+/** Minimal projection of the trace header. */
+export interface TrajectoryTrace {
+  name: string
+  status: string
+  duration_ms: number | null
+}
+
+// Per-step caps. A trajectory can have many steps, so each step's input/output
+// is kept short; the overall transcript is capped again in the prompt builder.
+const STEP_INPUT_MAX = 600
+const STEP_OUTPUT_MAX = 800
+const STEP_ERROR_MAX = 300
+// The judge sees a larger budget than a single response — a trajectory is many
+// steps — but still bounded so a runaway agent can't blow the context window.
+const TRAJECTORY_MAX_CHARS = MAX_RESPONSE_CHARS * 2
+
+/** Render a jsonb value to a compact one-line string, truncated middle-out. */
+function stringifyValue(v: unknown, max: number): string {
+  if (v == null) return ''
+  let s: string
+  if (typeof v === 'string') {
+    s = v
+  } else {
+    try {
+      s = JSON.stringify(v)
+    } catch {
+      s = String(v)
+    }
+  }
+  // Collapse whitespace so each step stays on a predictable number of lines.
+  return truncateMiddle(s.replace(/\s+/g, ' ').trim(), max)
+}
+
+/**
+ * Serialize a trace's spans into a step-by-step transcript. Spans are ordered
+ * by start time (execution order). Returns '' when there are no spans so the
+ * caller can skip a trace with nothing to judge.
+ */
+export function serializeTrajectory(trace: TrajectoryTrace, spans: TrajectorySpan[]): string {
+  if (spans.length === 0) return ''
+  // Parse to epoch ms so ordering is robust to offset format variation
+  // (Supabase may return +00:00 or Z); a lexical compare would be fragile.
+  const ordered = [...spans].sort((a, b) => new Date(a.started_at).getTime() - new Date(b.started_at).getTime())
+
+  const header =
+    `Agent trace: "${trace.name}" — overall status: ${trace.status}, ${ordered.length} steps` +
+    (trace.duration_ms != null ? `, ${trace.duration_ms}ms total` : '')
+
+  const steps = ordered.map((s, i) => {
+    const lines = [`Step ${i + 1} [${s.span_type}] ${s.name} (status: ${s.status})`]
+    const input = stringifyValue(s.input, STEP_INPUT_MAX)
+    const output = stringifyValue(s.output, STEP_OUTPUT_MAX)
+    if (input) lines.push(`  Input: ${input}`)
+    if (output) lines.push(`  Output: ${output}`)
+    if (s.error_message) lines.push(`  Error: ${truncateMiddle(s.error_message, STEP_ERROR_MAX)}`)
+    return lines.join('\n')
+  })
+
+  return [header, '', ...steps].join('\n')
+}
+
+/**
+ * Build the trajectory judge prompt. Numeric-only (the score normalises to
+ * 0..1 like the legacy llm_judge path), with the same optional rubric.
+ */
+export function buildTrajectoryJudgePrompt(
+  criterion: string,
+  trajectoryText: string,
+  config: { scale_min: number; scale_max: number; rubric?: string | null },
+): string {
+  const min = config.scale_min
+  const max = config.scale_max
+  const rubric = config.rubric?.trim()
+  const rubricBlock = rubric
+    ? `
+
+Scoring rubric (apply consistently):
+${rubric}`
+    : ''
+
+  return `You are evaluating an AI agent's TRAJECTORY — the sequence of steps and tool calls it took to reach its result, not just the final answer.
+
+Criterion: ${criterion}${rubricBlock}
+
+Agent trajectory (steps in execution order):
+"""
+${truncateMiddle(trajectoryText, TRAJECTORY_MAX_CHARS)}
+"""
+
+Judge how well the trajectory satisfies the criterion. Consider whether the agent took appropriate steps, called the right tools in a sensible order, avoided unnecessary or failed steps, and accomplished the goal.
+
+Reply ONLY in JSON with this exact shape:
+{"score": <number between ${min} and ${max}>, "reasoning": "<one short sentence>"}
+
+No prose outside the JSON. No markdown fences.`
+}

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -235,8 +235,10 @@ function NewEvaluatorDialog({
   // llm_judge evaluators today, so the selector defaults to that even
   // when initialTemplate is set.
   const [evaluatorType, setEvaluatorType] = useState<
-    'llm_judge' | 'regex' | 'json_schema' | 'exact_match' | 'contains' | 'embedding'
+    'llm_judge' | 'regex' | 'json_schema' | 'exact_match' | 'contains' | 'embedding' | 'trajectory'
   >('llm_judge')
+  // P2-11 — trajectory evaluators target traces by name instead of a prompt.
+  const [traceName, setTraceName] = useState('')
   const [regexPattern, setRegexPattern] = useState('')
   const [regexFlags, setRegexFlags] = useState('')
   const [jsonSchemaText, setJsonSchemaText] = useState('{\n  "type": "object"\n}')
@@ -272,8 +274,14 @@ function NewEvaluatorDialog({
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setError('')
-    if (!promptName || !name.trim()) {
-      setError('Prompt and name are required')
+    if (!name.trim()) {
+      setError('Name is required')
+      return
+    }
+    if (evaluatorType === 'trajectory') {
+      if (!traceName.trim()) { setError('Trace name is required for trajectory evaluators'); return }
+    } else if (!promptName) {
+      setError('Prompt is required')
       return
     }
     if (autoRunOnVersion && (!autoRunDatasetId || !autoRunModel.trim())) {
@@ -281,7 +289,26 @@ function NewEvaluatorDialog({
       return
     }
     try {
-      if (evaluatorType === 'llm_judge') {
+      if (evaluatorType === 'trajectory') {
+        if (!criterion.trim()) {
+          setError('Criterion is required for trajectory evaluators')
+          return
+        }
+        await submitEvaluator({
+          name: name.trim(),
+          type: 'trajectory',
+          traceName: traceName.trim(),
+          config: {
+            criterion: criterion.trim(),
+            judge_provider: judgeProvider,
+            judge_model: judgeModel,
+            scale_min: scaleMin,
+            scale_max: scaleMax,
+            trace_name: traceName.trim(),
+            ...(rubric.trim() ? { rubric: rubric.trim() } : {}),
+          },
+        })
+      } else if (evaluatorType === 'llm_judge') {
         if (!criterion.trim()) {
           setError('Criterion is required for LLM-as-judge evaluators')
           return
@@ -387,7 +414,7 @@ function NewEvaluatorDialog({
         })
       }
       onClose()
-      setName(''); setCriterion(''); setPromptName('')
+      setName(''); setCriterion(''); setPromptName(''); setTraceName('')
       setRegexPattern(''); setRegexFlags('')
       setJsonSchemaText('{\n  "type": "object"\n}')
       setExactValue(''); setExactCaseSensitive(false)
@@ -407,19 +434,37 @@ function NewEvaluatorDialog({
           <DialogTitle>New evaluator</DialogTitle>
         </DialogHeader>
         <form onSubmit={(e) => void handleSubmit(e)} className="space-y-3 mt-3">
-          <div>
-            <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
-              Prompt
-            </label>
-            <Select {...(promptName ? { value: promptName } : {})} onValueChange={setPromptName}>
-              <SelectTrigger><SelectValue placeholder="Select prompt…" /></SelectTrigger>
-              <SelectContent>
-                {(prompts.data ?? []).map((p: PromptVersion) => (
-                  <SelectItem key={p.id} value={p.name}>{p.name}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+          {evaluatorType === 'trajectory' ? (
+            <div>
+              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                Trace name
+              </label>
+              <input
+                type="text"
+                value={traceName}
+                onChange={(e) => setTraceName(e.target.value)}
+                placeholder="e.g. customer-support-agent"
+                className="w-full h-9 px-2 rounded-[5px] border border-border bg-bg font-mono text-[12px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong"
+              />
+              <p className="font-mono text-[10.5px] text-text-faint mt-1">
+                The trace name your SDK sets (<code>createTrace(&quot;…&quot;)</code>). Recent traces with this name are scored.
+              </p>
+            </div>
+          ) : (
+            <div>
+              <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
+                Prompt
+              </label>
+              <Select {...(promptName ? { value: promptName } : {})} onValueChange={setPromptName}>
+                <SelectTrigger><SelectValue placeholder="Select prompt…" /></SelectTrigger>
+                <SelectContent>
+                  {(prompts.data ?? []).map((p: PromptVersion) => (
+                    <SelectItem key={p.id} value={p.name}>{p.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
 
           <div>
             <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
@@ -446,13 +491,14 @@ function NewEvaluatorDialog({
               value={evaluatorType}
               onValueChange={(v) =>
                 setEvaluatorType(
-                  v as 'llm_judge' | 'regex' | 'json_schema' | 'exact_match' | 'contains' | 'embedding',
+                  v as 'llm_judge' | 'regex' | 'json_schema' | 'exact_match' | 'contains' | 'embedding' | 'trajectory',
                 )
               }
             >
               <SelectTrigger><SelectValue /></SelectTrigger>
               <SelectContent>
                 <SelectItem value="llm_judge">LLM as judge</SelectItem>
+                <SelectItem value="trajectory">Agent trajectory (judge the trace)</SelectItem>
                 <SelectItem value="regex">Regex (pattern match)</SelectItem>
                 <SelectItem value="json_schema">JSON Schema (structure check)</SelectItem>
                 <SelectItem value="exact_match">Exact match (equals a value)</SelectItem>
@@ -463,7 +509,9 @@ function NewEvaluatorDialog({
             <p className="font-mono text-[10.5px] text-text-faint mt-1">
               {evaluatorType === 'llm_judge'
                 ? 'Judge model scores 0..1 against a free-form criterion.'
-                : evaluatorType === 'regex'
+                : evaluatorType === 'trajectory'
+                  ? 'Judge model scores 0..1 over the whole agent trace (tool-call sequence), not just the final text.'
+                  : evaluatorType === 'regex'
                   ? 'Deterministic 0/1 — passes when the pattern matches the response.'
                   : evaluatorType === 'json_schema'
                     ? 'Deterministic 0/1 — passes when the response parses as JSON and matches the schema.'
@@ -475,7 +523,7 @@ function NewEvaluatorDialog({
             </p>
           </div>
 
-          {evaluatorType === 'llm_judge' && (
+          {(evaluatorType === 'llm_judge' || evaluatorType === 'trajectory') && (
             <>
               <div>
                 <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
@@ -528,7 +576,10 @@ function NewEvaluatorDialog({
               </div>
 
               {/* P1-7: optional rubric + few-shot calibration anchors. Collapsed
-                  by default so the common case stays a one-field form. */}
+                  by default so the common case stays a one-field form. Anchors
+                  are response examples, which don't apply to a trajectory, so
+                  this whole block is llm_judge-only. */}
+              {evaluatorType === 'llm_judge' && (
               <details className="border border-border rounded-[5px] px-3 py-2">
                 <summary className="font-mono text-[11px] text-text-muted cursor-pointer select-none">
                   Advanced: rubric &amp; calibration anchors (optional)
@@ -621,6 +672,7 @@ function NewEvaluatorDialog({
                   </div>
                 </div>
               </details>
+              )}
             </>
           )}
 
@@ -1004,10 +1056,26 @@ function RunEvaluatorDialog({
 
   // Pairwise is dataset-only; the single/pairwise toggle drives the source.
   const effectiveSource = mode === 'pairwise' ? 'dataset' : source
+  // P2-11 — a trajectory evaluator scores traces (by name), so the run dialog
+  // collapses to just a sample size + time window; no version / source.
+  const isTrajectory = evaluator.type === 'trajectory'
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setError('')
+    if (isTrajectory) {
+      try {
+        const run = await createRun.mutateAsync({
+          evaluatorId: evaluator.id,
+          sampleSize,
+          sampleFrom: new Date(Date.now() - days * 86400_000).toISOString(),
+        })
+        onRunCreated(run.id)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to start')
+      }
+      return
+    }
     if (!versionId) { setError('Select a version'); return }
     if (mode === 'pairwise') {
       if (!versionBId) { setError('Select version B to compare against'); return }
@@ -1040,6 +1108,15 @@ function RunEvaluatorDialog({
           <DialogTitle>Run evaluation · {evaluator.name}</DialogTitle>
         </DialogHeader>
         <form onSubmit={(e) => void handleSubmit(e)} className="space-y-3 mt-3">
+          {isTrajectory && (
+            <p className="font-mono text-[11px] text-text-muted bg-bg-muted border border-border rounded-[5px] p-3">
+              Scores recent agent traces named{' '}
+              <span className="text-text">{evaluator.prompt_name}</span> against the criterion.
+              No prompt version needed.
+            </p>
+          )}
+          {!isTrajectory && (
+          <>
           {/* Mode toggle: single (absolute score) vs pairwise (A vs B). */}
           <div>
             <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
@@ -1210,8 +1287,11 @@ function RunEvaluatorDialog({
             </div>
           )}
 
+          </>
+          )}
+
           <div className="grid grid-cols-2 gap-3">
-            {effectiveSource === 'production' && (
+            {(effectiveSource === 'production' || isTrajectory) && (
               <div>
                 <label className="block font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-1">
                   Last N days
@@ -1266,7 +1346,7 @@ function RunEvaluatorDialog({
             </button>
             <button
               type="submit"
-              disabled={createRun.isPending || !versionId}
+              disabled={createRun.isPending || (!isTrajectory && !versionId)}
               className="font-mono text-[11.5px] px-3 py-[6px] rounded-[5px] bg-text text-bg font-medium hover:opacity-90 transition-opacity disabled:opacity-40 flex items-center gap-1.5"
             >
               {createRun.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : <Play className="h-3 w-3" />}
@@ -1383,6 +1463,12 @@ function RunDetailPanel({ runId, onClose }: { runId: string; onClose: () => void
       </div>
 
       <div className="p-4 space-y-4">
+        {/* P2-11: trajectory runs score traces, not a prompt version. */}
+        {r.trace_name && (
+          <p className="font-mono text-[11px] text-text-muted">
+            Trajectory · trace <span className="text-text">{r.trace_name}</span>
+          </p>
+        )}
         {/* KPIs */}
         <div className="grid grid-cols-3 gap-2">
           <div className="bg-bg-muted border border-border rounded-[5px] px-3 py-2">

--- a/apps/web/app/docs/features/evals/page.tsx
+++ b/apps/web/app/docs/features/evals/page.tsx
@@ -492,6 +492,39 @@ if ((ci?.low ?? run.avg_score ?? 0) > 0.5) {
   console.log(\`B wins \${run.b_wins}/\${run.scored_count} — promote it\`)
 }`}</CodeBlock>
 
+      <h2>Agent trajectory evaluation</h2>
+      <p>
+        Every other evaluator scores a single response. A{' '}
+        <strong>trajectory</strong> evaluator scores the whole agent trace, the
+        ordered sequence of spans (LLM calls, tool calls, intermediate steps),
+        against a criterion. It reuses the tracing data you already send, so you
+        can judge <em>how</em> the agent worked, not just its final answer.
+      </p>
+      <ul>
+        <li>
+          A trajectory evaluator binds to a <strong>trace name</strong> (the name
+          your SDK passes to <code>createTrace()</code>), not a prompt. Create it
+          under <em>Type → Agent trajectory</em> and give it the trace name + a
+          criterion.
+        </li>
+        <li>
+          Running it samples the most recent N traces with that name, serializes
+          each one&apos;s steps in execution order, and the judge scores the
+          trajectory 0..1. The run reports the average + the same 95% confidence
+          interval.
+        </li>
+        <li>
+          From the SDK, a trajectory run needs only the evaluator id (no prompt
+          version): <code>client.evals.run({`{ evaluatorId, sampleSize: 50 }`})</code>.
+        </li>
+      </ul>
+      <p>
+        Write criteria about the <em>process</em>: &ldquo;did the agent call the
+        search tool before answering&rdquo;, &ldquo;were there redundant or
+        failed tool calls&rdquo;, &ldquo;did it follow the required steps in
+        order&rdquo;.
+      </p>
+
       <h2>Reproducibility &amp; reliability options</h2>
       <ul>
         <li>

--- a/apps/web/lib/queries/use-evals.ts
+++ b/apps/web/lib/queries/use-evals.ts
@@ -23,14 +23,25 @@ export interface JudgeConfig {
   rubric?: string
   /** P1-7 — optional few-shot calibration anchors (NUMERIC judges). */
   anchors?: JudgeAnchor[]
+  /** P2-11 — for trajectory evaluators: the trace name being scored. */
+  trace_name?: string
 }
+
+export type EvaluatorType =
+  | 'llm_judge'
+  | 'regex'
+  | 'json_schema'
+  | 'exact_match'
+  | 'contains'
+  | 'embedding'
+  | 'trajectory'
 
 export interface Evaluator {
   id: string
   organization_id: string
   prompt_name: string
   name: string
-  type: 'llm_judge'
+  type: EvaluatorType
   config: JudgeConfig
   created_by: string | null
   created_at: string
@@ -56,6 +67,8 @@ export interface EvalRun {
   a_wins?: number | null
   b_wins?: number | null
   ties?: number | null
+  /** P2-11 — for trajectory runs: the trace name that was scored (prompt_version_id is null). */
+  trace_name?: string | null
   sample_size: number
   sample_from: string | null
   sample_to: string | null
@@ -92,6 +105,8 @@ export interface EvalResult {
   created_at: string
   /** P1-7 (3/3): pairwise winner ('a' | 'b' | 'tie'); null for single-mode results. */
   winner?: 'a' | 'b' | 'tie' | null
+  /** P2-11 — for trajectory results: the evaluated trace id. */
+  trace_id?: string | null
 }
 
 // ── Evaluators ──────────────────────────────────────────────────────────────
@@ -195,6 +210,13 @@ export type CreateEvaluatorInput = AutoRunFields & (
       type: 'embedding'
       config: EmbeddingConfig
     }
+  | {
+      // P2-11 — trajectory evaluator binds to a TRACE name, not a prompt.
+      name: string
+      type: 'trajectory'
+      traceName: string
+      config: JudgeConfig
+    }
 )
 
 export function useCreateEvaluator() {
@@ -202,13 +224,17 @@ export function useCreateEvaluator() {
   return useMutation({
     mutationFn: async (input: CreateEvaluatorInput) => {
       const body: Record<string, unknown> = {
-        promptName: input.promptName,
         name: input.name,
         type: input.type ?? 'llm_judge',
         config: input.config,
       }
-      if (input.type === undefined || input.type === 'llm_judge') {
-        if (input.scoreConfigId) body.scoreConfigId = input.scoreConfigId
+      if (input.type === 'trajectory') {
+        body.traceName = input.traceName
+      } else {
+        body.promptName = input.promptName
+        if (input.type === undefined || input.type === 'llm_judge') {
+          if (input.scoreConfigId) body.scoreConfigId = input.scoreConfigId
+        }
       }
       // P2-10 auto-run config (common to all types).
       if (input.autoRunOnVersion) {
@@ -222,7 +248,8 @@ export function useCreateEvaluator() {
       return res.data
     },
     onSuccess: (_data, vars) => {
-      void qc.invalidateQueries({ queryKey: evaluatorsQueryKey(vars.promptName) })
+      const groupKey = vars.type === 'trajectory' ? vars.traceName : vars.promptName
+      void qc.invalidateQueries({ queryKey: evaluatorsQueryKey(groupKey) })
       void qc.invalidateQueries({ queryKey: evaluatorsQueryKey() })
     },
   })
@@ -293,7 +320,8 @@ export function useEvalResults(runId: string | null) {
 
 export interface CreateEvalRunInput {
   evaluatorId: string
-  promptVersionId: string
+  /** Required for all run types except trajectory (which targets traces by name). */
+  promptVersionId?: string
   source?: 'production' | 'dataset'
   datasetId?: string
   sampleSize: number

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @spanlens/sdk changelog
 
+## 0.11.0
+
+Agent trajectory evaluation (P2-11) — score the whole trace, not just the final text.
+
+### Added
+
+- `RunEvalInput.promptVersionId` is now optional. A trajectory evaluator scores recent traces by name, so a run needs only `evaluatorId` (+ optional `sampleSize` / `sampleFrom`). Example: `client.evals.run({ evaluatorId, sampleSize: 50 })`.
+- `EvalRun.trace_name` — for trajectory runs, the trace name that was scored. `EvalRun.prompt_version_id` is `null` for these runs.
+
 ## 0.10.0
 
 Pairwise (A vs B) eval runs (P1-7) — compare two prompt versions head-to-head.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/evals.ts
+++ b/packages/sdk/src/evals.ts
@@ -31,8 +31,11 @@ export interface EvalRun {
   id: string
   organization_id: string
   evaluator_id: string
-  prompt_version_id: string
+  /** null for trajectory runs (P2-11), which score traces by name. */
+  prompt_version_id: string | null
   dataset_id: string | null
+  /** P2-11 — for trajectory runs: the trace name that was scored. */
+  trace_name?: string | null
   source: 'production' | 'dataset'
   /** P1-7 (3/3): 'single' (absolute scoring) or 'pairwise' (A vs B). Absent on
    * rows created before the feature — treat undefined as 'single'. */
@@ -79,7 +82,9 @@ export interface EvalResult {
 
 export interface RunEvalInput {
   evaluatorId: string
-  promptVersionId: string
+  /** Required for all run types except trajectory evaluators (P2-11), which
+   * score traces by name and have no prompt version. */
+  promptVersionId?: string
   /** Defaults to 'production' (samples recent traffic for the prompt version). */
   source?: 'production' | 'dataset'
   /** Required when source = 'dataset'. */

--- a/supabase/migrations/20260615050000_eval_trajectory.sql
+++ b/supabase/migrations/20260615050000_eval_trajectory.sql
@@ -1,0 +1,41 @@
+-- P2-11: agent trajectory evaluation.
+--
+-- Existing evaluators score a single response text. A trajectory evaluator
+-- (evaluators.type='trajectory') scores the whole agent TRACE — the ordered
+-- sequence of spans (LLM + tool calls) — against a criterion, reusing the
+-- tracing data that is Spanlens's differentiator.
+--
+-- A trajectory evaluator targets traces by NAME (stored in its config jsonb),
+-- not a prompt version. So a trajectory eval_run has no prompt_version_id —
+-- make it nullable — and records the trace name it sampled. Per-result rows
+-- link to the evaluated trace instead of a request / dataset item.
+--
+-- All additive (gotcha #25). Widening the evaluators type CHECK is mandatory:
+-- the untyped supabaseAdmin client would otherwise INSERT a 'trajectory' row
+-- that fails at runtime with 23514 (gotcha: PR #347/#348 hit exactly this).
+
+-- 1) Allow the 'trajectory' evaluator type. Drop + re-add so the migration is
+--    idempotent regardless of which prior types the CHECK already listed.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.evaluators'::regclass AND conname = 'evaluators_type_check'
+  ) THEN
+    ALTER TABLE evaluators DROP CONSTRAINT evaluators_type_check;
+  END IF;
+  ALTER TABLE evaluators ADD CONSTRAINT evaluators_type_check CHECK (
+    type IN ('llm_judge', 'regex', 'json_schema', 'exact_match', 'contains', 'embedding', 'trajectory')
+  );
+END $$;
+
+-- 2) A trajectory run has no prompt version. Make the column nullable (existing
+--    rows keep their value; this is a non-breaking relaxation) and record the
+--    trace name that was sampled.
+ALTER TABLE eval_runs ALTER COLUMN prompt_version_id DROP NOT NULL;
+ALTER TABLE eval_runs ADD COLUMN IF NOT EXISTS trace_name text;
+
+-- 3) Per-result link to the evaluated trace (NULL for non-trajectory results,
+--    which use request_id / dataset_item_id). No FK — same pragmatic choice as
+--    spans.parent_span_id (gotcha #4): traces can be pruned independently.
+ALTER TABLE eval_results ADD COLUMN IF NOT EXISTS trace_id uuid;


### PR DESCRIPTION
## P2-11: agent trajectory evaluation

Every other evaluator scores a single response. A **trajectory** evaluator scores the whole agent trace, the ordered sequence of spans (LLM + tool calls), against a criterion. It reuses the tracing data that is Spanlens's differentiator, so you judge *how* the agent worked, not just its final answer.

### Changes
- **db** (`20260615050000_eval_trajectory.sql`, additive + idempotent) — new evaluator type `trajectory` (CHECK widened to 7 types); `eval_runs.prompt_version_id` made **nullable** (trajectory runs have no prompt version) + `eval_runs.trace_name`; `eval_results.trace_id`.
- **server** — trajectory branch in `runEvalRun` samples the most recent N traces with the evaluator's `trace_name`, fetches up to 200 spans each, serializes them in execution order (`eval-runners/trajectory.ts`), and LLM-judges the trajectory. Numeric 0..1, so `avg_score` + the P1-7 95% CI apply for free. **Org-scoped on both the traces and spans queries.**
- **binding** — a trajectory evaluator targets a trace **name** (`config.trace_name`), not a prompt; its `prompt_name` holds the trace name for grouping. `POST /evaluators` skips the prompt-exists check for trajectory; `POST /eval-runs` skips the prompt-version requirement and inserts `prompt_version_id` null.
- **web** — "Agent trajectory" evaluator type (trace name + criterion + judge); the run dialog collapses to sample size + time window; run detail shows the trace.
- **sdk 0.11.0** — `RunEvalInput.promptVersionId` optional (trajectory runs need only `evaluatorId`); `EvalRun.trace_name`.
- **docs** — "Agent trajectory evaluation" section.

### Test plan
- [x] `serializeTrajectory` (ordering by start time, span_type/input/output/error rendering, truncation) + `buildTrajectoryJudgePrompt` (framing, rubric) — 8 tests.
- [x] `pnpm typecheck` (all), `pnpm --filter server lint` / `web lint` — clean. 112 server eval tests pass; SDK 131 pass + builds.
- [x] **Code review** (0 CRITICAL): fixed 3 HIGH boundary issues — gated the dataset checks behind `!isTrajectory`, made `RunInput`/`StartEvalRunInput.promptVersionId` nullable (narrowed where non-trajectory paths consume it), excluded trajectory evaluators from the P2-10 auto-run hook. Migration confirmed safe (nullable relax is non-breaking; CHECK drop+re-add idempotent; org-scoping correct; all written columns match).
- Note: the dashboard is auth-gated and a live run spends provider keys, so the UI is typecheck/lint-verified and the serializer/prompt are unit-tested rather than executed end-to-end here.

### Deploy ordering
`deploy-server.yml` runs migrate → deploy, so the columns exist before the runner writes them.

This is the last of the eval P-track headline items (P0–P2).
