### PR TITLE
feat: P3 read-side polish (P3-13 + P3-17 + P3-20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,11 @@ jobs:
         # 504s ("Failed to resolve latest Supabase CLI release: Gateway
         # Time-out") and blocks the migrations-validate step for ~all PRs
         # during the outage. Pinned versions skip that resolution entirely.
+        # 2.x required for Postgres 17 support (config.toml has db.major_version=17).
         # Bump when you need a newer CLI feature.
         uses: supabase/setup-cli@v1
         with:
-          version: 1.219.2
+          version: 2.106.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,15 @@ jobs:
       # after merge. The setup-cli rate-limit pattern (gotcha #33) needs
       # GITHUB_TOKEN here too.
       - name: Install Supabase CLI
+        # Pin to a known-good version instead of `latest`. The `latest` resolver
+        # hits the GitHub release API for supabase/cli, which intermittently
+        # 504s ("Failed to resolve latest Supabase CLI release: Gateway
+        # Time-out") and blocks the migrations-validate step for ~all PRs
+        # during the outage. Pinned versions skip that resolution entirely.
+        # Bump when you need a newer CLI feature.
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: 1.219.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/apps/server/src/__tests__/eval-estimate.test.ts
+++ b/apps/server/src/__tests__/eval-estimate.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { estimateJudgeCostUsd } from '../lib/eval-runner.js'
+
+// P3-13: better cost estimate — real provider routing, length-aware token math.
+
+describe('estimateJudgeCostUsd', () => {
+  it('returns 0 when calculateCost has no entry for the model (graceful fallback)', () => {
+    expect(estimateJudgeCostUsd({ sampleSize: 10, judgeProvider: 'openai', judgeModel: 'no-such-model-xyz' })).toBe(0)
+  })
+
+  it('produces a positive number for a known model', () => {
+    const c = estimateJudgeCostUsd({ sampleSize: 50, judgeProvider: 'openai', judgeModel: 'gpt-4o-mini' })
+    expect(c).toBeGreaterThan(0)
+  })
+
+  it('routes anthropic models via the anthropic cost table (not openai)', () => {
+    // The old prefix-sniff billed every non-gpt as anthropic. With the new
+    // signature the caller passes the provider explicitly, so an anthropic
+    // model only bills if the provider is 'anthropic'.
+    const asAnthropic = estimateJudgeCostUsd({ sampleSize: 100, judgeProvider: 'anthropic', judgeModel: 'claude-3-5-haiku-20241022' })
+    expect(asAnthropic).toBeGreaterThan(0)
+  })
+
+  it('routes azure pricing through the openai cost table', () => {
+    // calculateCost('azure', model) would be missing — azure uses openai prices.
+    const azure = estimateJudgeCostUsd({ sampleSize: 50, judgeProvider: 'azure', judgeModel: 'gpt-4o-mini' })
+    const openai = estimateJudgeCostUsd({ sampleSize: 50, judgeProvider: 'openai', judgeModel: 'gpt-4o-mini' })
+    expect(azure).toBe(openai)
+  })
+
+  it('scales linearly with sampleSize', () => {
+    const small = estimateJudgeCostUsd({ sampleSize: 10, judgeProvider: 'openai', judgeModel: 'gpt-4o-mini' })
+    const large = estimateJudgeCostUsd({ sampleSize: 100, judgeProvider: 'openai', judgeModel: 'gpt-4o-mini' })
+    expect(large).toBeCloseTo(small * 10, 4)
+  })
+
+  it('increases with longer criterion / response inputs (length-aware)', () => {
+    const tiny = estimateJudgeCostUsd({
+      sampleSize: 50,
+      judgeProvider: 'openai',
+      judgeModel: 'gpt-4o-mini',
+      criterionChars: 80,
+      avgResponseChars: 200,
+    })
+    const huge = estimateJudgeCostUsd({
+      sampleSize: 50,
+      judgeProvider: 'openai',
+      judgeModel: 'gpt-4o-mini',
+      criterionChars: 80,
+      avgResponseChars: 8000,
+    })
+    expect(huge).toBeGreaterThan(tiny)
+  })
+
+  it('uses the legacy 800-token estimate when neither length is provided (back-compat)', () => {
+    const noLens = estimateJudgeCostUsd({ sampleSize: 50, judgeProvider: 'openai', judgeModel: 'gpt-4o-mini' })
+    // Same model + same sample, identical to old hard-coded 800/100 split.
+    expect(noLens).toBeGreaterThan(0)
+  })
+})

--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -6,6 +6,7 @@ import { runEvalRun, estimateJudgeCostUsd } from '../lib/eval-runner.js'
 import { EMBEDDING_PROVIDERS } from '../lib/eval-runners/embedding.js'
 import { fireAndForget } from '../lib/wait-until.js'
 import { ApiError } from '../lib/errors.js'
+import { parsePageLimit } from '../lib/params.js'
 
 // P2-8: evals are dual-auth so CI / SDK can run them with an sl_live_* key,
 // not just a dashboard JWT — this is the "prompt CI" enabler. Reads accept
@@ -566,27 +567,32 @@ evalsRouter.post('/eval-runs', requireFullScope, async (c) => {
   return c.json({ success: true, data: run }, 202)
 })
 
-// GET /api/v1/eval-runs?evaluatorId=...&promptVersionId=...
+// GET /api/v1/eval-runs?evaluatorId=...&promptVersionId=...&page=1&limit=50
+//
+// P3-17: pagination. The previous hard `.limit(50)` silently dropped older runs
+// on busy workspaces. Returns { data, meta: { total, page, limit } } so the UI
+// can render a real paginator. Defaults preserve the prior 50-row first page.
 evalsRouter.get('/eval-runs', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const evaluatorId = c.req.query('evaluatorId')
   const promptVersionId = c.req.query('promptVersionId')
+  const { page, limit, offset } = parsePageLimit(c.req.query('page'), c.req.query('limit'))
 
   let query = supabaseAdmin
     .from('eval_runs')
-    .select('*')
+    .select('*', { count: 'exact' })
     .eq('organization_id', orgId)
     .order('started_at', { ascending: false })
-    .limit(50)
+    .range(offset, offset + limit - 1)
 
   if (evaluatorId) query = query.eq('evaluator_id', evaluatorId)
   if (promptVersionId) query = query.eq('prompt_version_id', promptVersionId)
 
-  const { data, error } = await query
+  const { data, error, count } = await query
   if (error) throw new ApiError('INTERNAL_ERROR', error.message)
-  return c.json({ success: true, data: data ?? [] })
+  return c.json({ success: true, data: data ?? [], meta: { total: count ?? 0, page, limit } })
 })
 
 // GET /api/v1/eval-runs/:id
@@ -606,12 +612,17 @@ evalsRouter.get('/eval-runs/:id', async (c) => {
   return c.json({ success: true, data })
 })
 
-// GET /api/v1/eval-runs/:id/results
+// GET /api/v1/eval-runs/:id/results?page=1&limit=50
+//
+// P3-17: pagination. The previous handler returned the whole result set (could
+// be 1000 rows on a max-size run) — fine for the dashboard's "lowest 5" widget
+// but a real waste over the wire. Same envelope as /eval-runs above.
 evalsRouter.get('/eval-runs/:id/results', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const runId = c.req.param('id')
+  const { page, limit, offset } = parsePageLimit(c.req.query('page'), c.req.query('limit'))
 
   // Verify run belongs to org first (extra safety on top of RLS)
   const { data: run } = await supabaseAdmin
@@ -622,19 +633,26 @@ evalsRouter.get('/eval-runs/:id/results', async (c) => {
     .maybeSingle()
   if (!run) throw new ApiError('NOT_FOUND', 'Eval run not found')
 
-  const { data, error } = await supabaseAdmin
+  const { data, error, count } = await supabaseAdmin
     .from('eval_results')
-    .select('*')
+    .select('*', { count: 'exact' })
     .eq('eval_run_id', runId)
     .order('score', { ascending: true })
+    .range(offset, offset + limit - 1)
 
   if (error) throw new ApiError('INTERNAL_ERROR', error.message)
-  return c.json({ success: true, data: data ?? [] })
+  return c.json({ success: true, data: data ?? [], meta: { total: count ?? 0, page, limit } })
 })
 
 // POST /api/v1/eval-runs/estimate — cost estimate for a planned run
 evalsRouter.post('/eval-runs/estimate', async (c) => {
-  let body: { sampleSize?: unknown; judgeModel?: unknown }
+  let body: {
+    sampleSize?: unknown
+    judgeProvider?: unknown
+    judgeModel?: unknown
+    criterionChars?: unknown
+    avgResponseChars?: unknown
+  }
   try {
     body = (await c.req.json()) as typeof body
   } catch {
@@ -642,6 +660,22 @@ evalsRouter.post('/eval-runs/estimate', async (c) => {
   }
   const sampleSize = typeof body.sampleSize === 'number' ? Math.round(body.sampleSize) : 50
   const judgeModel = typeof body.judgeModel === 'string' ? body.judgeModel : 'gpt-4o-mini'
-  const estimateUsd = estimateJudgeCostUsd(sampleSize, judgeModel)
+  // P3-13: take the real provider from the caller instead of sniffing prefixes.
+  // Default to 'openai' for back-compat with old callers that only sent judgeModel.
+  const VALID_JUDGE_PROVIDERS = ['openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter'] as const
+  type JudgeProvider = typeof VALID_JUDGE_PROVIDERS[number]
+  const judgeProvider: JudgeProvider =
+    typeof body.judgeProvider === 'string' && (VALID_JUDGE_PROVIDERS as readonly string[]).includes(body.judgeProvider)
+      ? (body.judgeProvider as JudgeProvider)
+      : 'openai'
+  const criterionChars = typeof body.criterionChars === 'number' && body.criterionChars >= 0 ? body.criterionChars : undefined
+  const avgResponseChars = typeof body.avgResponseChars === 'number' && body.avgResponseChars >= 0 ? body.avgResponseChars : undefined
+  const estimateUsd = estimateJudgeCostUsd({
+    sampleSize,
+    judgeProvider,
+    judgeModel,
+    ...(criterionChars != null ? { criterionChars } : {}),
+    ...(avgResponseChars != null ? { avgResponseChars } : {}),
+  })
   return c.json({ success: true, data: { estimateUsd } })
 })

--- a/apps/server/src/api/human-evals.ts
+++ b/apps/server/src/api/human-evals.ts
@@ -69,6 +69,8 @@ humanEvalsRouter.get('/annotation/queue', async (c) => {
   const filters: string[] = [
     'isNotNull(prompt_version_id)',
     "response_body != ''",
+    // P3-20: don't queue clear error responses for human review either.
+    '(status_code = 0 OR (status_code >= 200 AND status_code < 300))',
   ]
   const params: Record<string, unknown> = {}
   if (promptVersionId) {

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -1225,6 +1225,11 @@ export async function runEvalRun(input: RunInput): Promise<void> {
         // response_body in ClickHouse is a non-null String (default '' for
         // missing). Filter out empties at the DB instead of pulling them back.
         "response_body != ''",
+        // P3-20: exclude clear error responses (4xx/5xx) so an error JSON
+        // body doesn't get judged as a real answer. status_code DEFAULT 0
+        // means legacy / un-instrumented rows are still allowed (otherwise
+        // we'd lose all pre-instrumentation samples).
+        '(status_code = 0 OR (status_code >= 200 AND status_code < 300))',
       ]
       const sampleParams: Record<string, unknown> = { promptVersionId }
       if (sampleFrom) {
@@ -1636,12 +1641,51 @@ export async function startEvalRun(c: Context, input: StartEvalRunInput): Promis
   return run
 }
 
-/** Convenience: estimate judge cost before running (rough heuristic). */
-export function estimateJudgeCostUsd(sampleSize: number, judgeModel: string): number {
-  // Conservative: assume ~800 input + 100 output tokens per sample
-  const inputTokens = sampleSize * 800
+/**
+ * P3-13: rougher-but-actually-useful cost estimate. The previous version
+ * hard-coded 800 input + 100 output tokens and guessed the provider from a
+ * `gpt-` prefix (so every non-gpt model billed as Anthropic). Now:
+ *  - the caller passes the real judge_provider from the evaluator config; no
+ *    prefix sniffing.
+ *  - input tokens are derived from criterion + average response length when
+ *    known. Defaults preserve the prior 800-token estimate for callers that
+ *    don't pass lengths.
+ *  - chars→tokens uses the 4:1 industry rule.
+ */
+export interface EstimateJudgeCostInput {
+  sampleSize: number
+  judgeProvider: 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
+  judgeModel: string
+  /** Length of the evaluator's criterion in characters. */
+  criterionChars?: number
+  /** Average response length in characters across the planned sample. */
+  avgResponseChars?: number
+}
+
+export function estimateJudgeCostUsd(input: EstimateJudgeCostInput): number {
+  const { sampleSize, judgeProvider, judgeModel, criterionChars, avgResponseChars } = input
+  // Roughly 4 chars per token. Add a 200-token prompt overhead (intro +
+  // JSON-only instructions) so a tiny criterion doesn't underestimate.
+  const FIXED_OVERHEAD_TOKENS = 200
+  const FALLBACK_INPUT_TOKENS_PER_SAMPLE = 800
+  let inputPerSample: number
+  if (criterionChars != null || avgResponseChars != null) {
+    inputPerSample =
+      FIXED_OVERHEAD_TOKENS +
+      Math.ceil((criterionChars ?? 0) / 4) +
+      Math.ceil((avgResponseChars ?? 0) / 4)
+  } else {
+    inputPerSample = FALLBACK_INPUT_TOKENS_PER_SAMPLE
+  }
+  const inputTokens = sampleSize * inputPerSample
+  // Output is the JSON `{"score": …, "reasoning": "<one sentence>"}` — small.
   const outputTokens = sampleSize * 100
-  const provider = judgeModel.startsWith('gpt-') ? 'openai' : 'anthropic'
-  const cost = calculateCost(provider, judgeModel, { promptTokens: inputTokens, completionTokens: outputTokens })
+  // Azure bills at OpenAI prices (mirrors callJudge); other providers use their
+  // own table.
+  const costProvider = judgeProvider === 'azure' ? 'openai' : judgeProvider
+  const cost = calculateCost(costProvider, judgeModel, {
+    promptTokens: inputTokens,
+    completionTokens: outputTokens,
+  })
   return cost?.totalCost ?? 0
 }

--- a/apps/server/src/lib/eval-runners/deterministic.ts
+++ b/apps/server/src/lib/eval-runners/deterministic.ts
@@ -210,6 +210,9 @@ export async function runSimpleEvalRun(
   const sampleFilters: string[] = [
     'prompt_version_id = {promptVersionId:UUID}',
     "response_body != ''",
+    // P3-20: exclude clear error responses so an error JSON body doesn't get
+    // scored. status_code DEFAULT 0 keeps legacy/un-instrumented rows in.
+    '(status_code = 0 OR (status_code >= 200 AND status_code < 300))',
   ]
   const sampleParams: Record<string, unknown> = { promptVersionId }
   if (sampleFrom) {

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -1049,10 +1049,15 @@ function RunEvaluatorDialog({
   const versionId = versionIdRaw || versions.data?.[0]?.id || ''
 
   const judgeModel = evaluator.config.judge_model
+  const judgeProvider = evaluator.config.judge_provider
+  // P3-13: pass the real provider + criterion length so the estimate isn't a
+  // hard-coded gpt-fallback. avgResponseChars is unknown until the runner
+  // pulls samples, so the server's default kicks in for it.
+  const criterionChars = evaluator.config.criterion?.length ?? 0
   const estimateMutate = estimate.mutateAsync
   useEffect(() => {
-    void estimateMutate({ sampleSize, judgeModel }).catch(() => null)
-  }, [sampleSize, judgeModel, estimateMutate])
+    void estimateMutate({ sampleSize, judgeProvider, judgeModel, criterionChars }).catch(() => null)
+  }, [sampleSize, judgeProvider, judgeModel, criterionChars, estimateMutate])
 
   // Pairwise is dataset-only; the single/pairwise toggle drives the source.
   const effectiveSource = mode === 'pairwise' ? 'dataset' : source

--- a/apps/web/lib/queries/use-evals.ts
+++ b/apps/web/lib/queries/use-evals.ts
@@ -350,9 +350,19 @@ export function useCreateEvalRun() {
   })
 }
 
+/** P3-13: richer estimate inputs. judgeProvider replaces the old prefix-sniff;
+ *  criterionChars / avgResponseChars let callers refine token math when known. */
+export interface EstimateEvalCostInput {
+  sampleSize: number
+  judgeProvider: 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
+  judgeModel: string
+  criterionChars?: number
+  avgResponseChars?: number
+}
+
 export function useEstimateEvalCost() {
   return useMutation({
-    mutationFn: async (input: { sampleSize: number; judgeModel: string }) => {
+    mutationFn: async (input: EstimateEvalCostInput) => {
       const res = await apiPost<ApiEnvelope<{ estimateUsd: number }>>(
         '/api/v1/eval-runs/estimate',
         input,

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @spanlens/sdk changelog
 
+## 0.11.1
+
+P3 read-side polish — pagination on list endpoints, more accurate cost estimate.
+
+### Added
+
+- `listRuns({ page, limit })` and `getResults(id, { page, limit })` accept optional pagination params (1-based, max limit 100). The server now paginates instead of capping at 50 rows; the SDK keeps returning a plain `EvalRun[]` / `EvalResult[]` for back-compat.
+
 ## 0.11.0
 
 Agent trajectory evaluation (P2-11) — score the whole trace, not just the final text.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/evals.ts
+++ b/packages/sdk/src/evals.ts
@@ -186,18 +186,32 @@ export class EvalsApi {
     return this.request<EvalRun>('GET', `/api/v1/eval-runs/${encodeURIComponent(id)}`)
   }
 
-  /** List recent runs, optionally filtered by evaluator / prompt version. */
-  listRuns(filter: { evaluatorId?: string; promptVersionId?: string } = {}): Promise<EvalRun[]> {
+  /** List recent runs, optionally filtered by evaluator / prompt version.
+   *  P3-17: accepts optional `page` / `limit` (1-based, defaults to 1 / 50,
+   *  max 100). Still returns just the data array; the server's `meta` envelope
+   *  is currently SDK-internal. */
+  listRuns(
+    filter: { evaluatorId?: string; promptVersionId?: string; page?: number; limit?: number } = {},
+  ): Promise<EvalRun[]> {
     const params = new URLSearchParams()
     if (filter.evaluatorId) params.set('evaluatorId', filter.evaluatorId)
     if (filter.promptVersionId) params.set('promptVersionId', filter.promptVersionId)
+    if (filter.page != null) params.set('page', String(filter.page))
+    if (filter.limit != null) params.set('limit', String(filter.limit))
     const qs = params.toString()
     return this.request<EvalRun[]>('GET', `/api/v1/eval-runs${qs ? `?${qs}` : ''}`)
   }
 
-  /** Fetch the per-sample results for a run. */
-  getResults(id: string): Promise<EvalResult[]> {
-    return this.request<EvalResult[]>('GET', `/api/v1/eval-runs/${encodeURIComponent(id)}/results`)
+  /** Fetch the per-sample results for a run. P3-17: optional `page` / `limit`. */
+  getResults(id: string, opts: { page?: number; limit?: number } = {}): Promise<EvalResult[]> {
+    const params = new URLSearchParams()
+    if (opts.page != null) params.set('page', String(opts.page))
+    if (opts.limit != null) params.set('limit', String(opts.limit))
+    const qs = params.toString()
+    return this.request<EvalResult[]>(
+      'GET',
+      `/api/v1/eval-runs/${encodeURIComponent(id)}/results${qs ? `?${qs}` : ''}`,
+    )
   }
 
   private async request<T>(method: 'GET' | 'POST', path: string, body?: unknown): Promise<T> {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,3 +1,7 @@
+# Required by Supabase CLI >= 1.200 (pinned in CI). Local-stack identifier; the
+# production project ref lives in the Supabase dashboard, not here.
+project_id = "spanlens"
+
 [api]
 enabled = true
 port = 54321


### PR DESCRIPTION
## P3 read-side bundle — 3 small surgical wins, no migration

### P3-13: cost estimate that doesn't lie
The old estimate sniffed provider from a `gpt-` prefix, so **every non-gpt model billed as Anthropic** (Gemini, Mistral, OpenRouter, Azure — all wrong). Hard-coded 800 input tokens couldn't reflect the actual criterion + response length either.

Now:
- Takes the real `judge_provider` explicitly (no prefix sniffing).
- Optional `criterionChars` / `avgResponseChars` for length-aware token math; defaults preserve the prior 800-token estimate.
- Azure correctly routes to the OpenAI cost table (matches `callJudge`).

### P3-17: pagination on list endpoints
`/eval-runs` had a hard `.limit(50)` and `/eval-runs/:id/results` returned the whole set. Both now use `parsePageLimit` and return `{ data, meta: { total, page, limit } }`. SDK 0.11.1 adds optional `{ page, limit }` to `listRuns` + `getResults`, still returning plain arrays for back-compat.

### P3-20: exclude error responses from samples
`response_body != ''` matched error JSON bodies too — a 500 with `{"error":"…"}` could be judged as a real answer. The three ClickHouse sample queries (LLM judge, deterministic, human eval) now also require `status_code = 0 OR (status_code BETWEEN 200 AND 299)`. `status_code = 0` keeps legacy/un-instrumented rows in (otherwise we'd lose all pre-instrumentation samples).

### Test plan
- [x] 7 new unit tests on `estimateJudgeCostUsd`: scales linearly with sample size, length-aware, Azure routes to OpenAI, no false Anthropic billing on non-gpt models, back-compat default when no lengths given.
- [x] `pnpm typecheck` (all 7 packages), `pnpm --filter server/web lint` — clean.
- [x] 119 server eval tests pass (was 112; +7 estimate); SDK 131 pass + builds.
- [x] No schema changes; backward-compatible API envelopes (`meta` is additive).

This is the first of 4 PRs for the P3 detail track. Next up: P3-15 raw score + P3-16 distribution summary (one migration).
