### PR TITLE
feat: P3 score model — raw scores + distribution summary (P3-15 + P3-16)

### DIFF
--- a/apps/server/src/__tests__/eval-distribution.test.ts
+++ b/apps/server/src/__tests__/eval-distribution.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { computeDistribution } from '../lib/eval-runners/distribution.js'
+import type { TypedScoreConfig } from '../lib/eval-runners/judge-prompt.js'
+
+// P3-16: server-side distribution / sample summary.
+
+function sample(over: Partial<{ value_number: number | null; value_string: string | null; value_boolean: boolean | null }>) {
+  return { value_number: null, value_string: null, value_boolean: null, ...over }
+}
+
+const sc = (data_type: TypedScoreConfig['data_type'], over: Partial<TypedScoreConfig> = {}): TypedScoreConfig => ({
+  id: 'cfg',
+  data_type,
+  min_value: null,
+  max_value: null,
+  categories: null,
+  bool_true_label: null,
+  bool_false_label: null,
+  ...over,
+})
+
+describe('computeDistribution', () => {
+  it('returns null when there is no score config (NUMERIC / legacy path)', () => {
+    expect(computeDistribution([sample({ value_number: 0.8 })], null)).toBeNull()
+    expect(computeDistribution([sample({ value_number: 0.8 })], undefined)).toBeNull()
+  })
+
+  it('returns null on NUMERIC configs (avg_score + score_stddev already cover it)', () => {
+    expect(computeDistribution([sample({ value_number: 0.7 })], sc('NUMERIC'))).toBeNull()
+  })
+
+  it('counts CATEGORICAL values, ignoring null entries', () => {
+    const out = computeDistribution(
+      [
+        sample({ value_string: 'Helpful' }),
+        sample({ value_string: 'Helpful' }),
+        sample({ value_string: 'Neutral' }),
+        sample({ value_string: null }),
+        sample({ value_string: 'Helpful' }),
+      ],
+      sc('CATEGORICAL', { categories: ['Helpful', 'Neutral'] }),
+    )
+    expect(out).toEqual({ type: 'categorical', counts: { Helpful: 3, Neutral: 1 } })
+  })
+
+  it('returns an empty counts object on an empty CATEGORICAL run', () => {
+    const out = computeDistribution([], sc('CATEGORICAL'))
+    expect(out).toEqual({ type: 'categorical', counts: {} })
+  })
+
+  it('tallies BOOLEAN true / false (null is ignored)', () => {
+    const out = computeDistribution(
+      [
+        sample({ value_boolean: true }),
+        sample({ value_boolean: false }),
+        sample({ value_boolean: true }),
+        sample({ value_boolean: null }),
+      ],
+      sc('BOOLEAN'),
+    )
+    expect(out).toEqual({ type: 'boolean', counts: { true: 2, false: 1 } })
+  })
+
+  it('keeps up to 10 TEXT samples and counts the total', () => {
+    const samples = Array.from({ length: 25 }, (_, i) => sample({ value_string: `answer ${i}` }))
+    const out = computeDistribution(samples, sc('TEXT'))
+    expect(out?.type).toBe('text')
+    expect(out).toMatchObject({ count: 25 })
+    if (out?.type === 'text') {
+      expect(out.samples.length).toBe(10)
+      expect(out.samples[0]).toBe('answer 0')
+    }
+  })
+
+  it('truncates long TEXT samples to keep the summary row small', () => {
+    const long = 'x'.repeat(500)
+    const out = computeDistribution([sample({ value_string: long })], sc('TEXT'))
+    if (out?.type === 'text') {
+      // 240 chars + the ellipsis char added by the truncation branch.
+      expect(out.samples[0]!.length).toBeLessThanOrEqual(241)
+      expect(out.samples[0]!.endsWith('…')).toBe(true)
+    } else {
+      throw new Error('expected text distribution')
+    }
+  })
+
+  it('skips empty TEXT entries when picking samples', () => {
+    const out = computeDistribution(
+      [sample({ value_string: '' }), sample({ value_string: 'real' }), sample({ value_string: null })],
+      sc('TEXT'),
+    )
+    if (out?.type === 'text') {
+      expect(out.count).toBe(1)
+      expect(out.samples).toEqual(['real'])
+    } else {
+      throw new Error('expected text distribution')
+    }
+  })
+})

--- a/apps/server/src/__tests__/eval-runner-deterministic-columns.test.ts
+++ b/apps/server/src/__tests__/eval-runner-deterministic-columns.test.ts
@@ -28,7 +28,8 @@ let runSimpleEvalRun: typeof import('../lib/eval-runners/deterministic.js').runS
 // The update must be a subset.
 const REAL_EVAL_RUNS_COLUMNS = new Set([
   'status', 'scored_count', 'attempted_count', 'failed_count',
-  'avg_score', 'score_stddev', 'total_cost_usd', 'error', 'completed_at',
+  'avg_score', 'score_stddev', 'distribution',
+  'total_cost_usd', 'error', 'completed_at',
 ])
 
 let lastUpdatePayload: Record<string, unknown> | null = null
@@ -40,7 +41,7 @@ let lastEvalResultsRows: Array<Record<string, unknown>> | null = null
 const REAL_EVAL_RESULTS_COLUMNS = new Set([
   'organization_id', 'eval_run_id', 'request_id', 'dataset_item_id',
   'score', 'reasoning', 'judge_cost_usd', 'judge_tokens', 'score_config_id',
-  'value_number', 'value_string', 'value_boolean',
+  'value_number', 'value_string', 'value_boolean', 'value_raw_number',
 ])
 
 beforeEach(async () => {

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -35,6 +35,7 @@ import { startInternalTrace } from './internal-tracing.js'
 // (`from '../lib/eval-runner.js'`) keep working unchanged.
 import { extractResponseText, fetchWithRetry } from './eval-runners/shared.js'
 import { sampleStdDev } from './eval-runners/stats.js'
+import { computeDistribution } from './eval-runners/distribution.js'
 import { serializeTrajectory, buildTrajectoryJudgePrompt, type TrajectorySpan } from './eval-runners/trajectory.js'
 import {
   buildJudgePrompt,
@@ -99,6 +100,10 @@ interface JudgeOutcome {
   value_number: number | null
   value_string: string | null
   value_boolean: boolean | null
+  // P3-15 — the judge's RAW numeric answer before clamp/normalisation.
+  // Lets the dashboard render "4 out of 5" instead of only the derived 0.8.
+  // null for non-numeric typed configs and for legacy rows.
+  value_raw_number: number | null
 }
 
 // extractResponseText moved to ./eval-runners/shared.ts (imported above).
@@ -449,7 +454,9 @@ export async function callJudge(
 
   // Turn the parsed reply into the stored JudgeOutcome. NUMERIC / legacy
   // normalise into 0..1 so the `score` column stays consistent with pre-4B.1c
-  // rows; typed paths carry the value_* columns straight through.
+  // rows; typed paths carry the value_* columns straight through. P3-15
+  // additionally preserves the clamped-but-not-normalised raw answer so the
+  // dashboard can render the original scale ("4 out of 5", not only 0.8).
   const sc = config.score_config
   if (!sc || sc.data_type === 'NUMERIC') {
     const min = sc?.min_value ?? config.scale_min
@@ -462,6 +469,7 @@ export async function callJudge(
       value_number: normalised,
       value_string: null,
       value_boolean: null,
+      value_raw_number: raw,
       reasoning: parsed.reasoning,
       cost: res.cost,
       tokens: res.tokens,
@@ -472,6 +480,7 @@ export async function callJudge(
     value_number: parsed.value_number,
     value_string: parsed.value_string,
     value_boolean: parsed.value_boolean,
+    value_raw_number: null,
     reasoning: parsed.reasoning,
     cost: res.cost,
     tokens: res.tokens,
@@ -1489,6 +1498,8 @@ export async function runEvalRun(input: RunInput): Promise<void> {
       value_number: s.value_number,
       value_string: s.value_string,
       value_boolean: s.value_boolean,
+      // P3-15: judge's raw answer pre-normalisation (NUMERIC path only).
+      value_raw_number: s.value_raw_number,
     }))
 
     const { error: insertErr } = await supabaseAdmin
@@ -1526,6 +1537,12 @@ export async function runEvalRun(input: RunInput): Promise<void> {
     // P1-7: sample stddev backs the 95% CI rendered next to avg_score. NULL
     // when there are <2 numeric points or the type has no mean.
     const scoreStddev = sampleStdDev(scoreValues)
+    // P3-16: precompute the distribution / sample summary for typed configs
+    // whose avg_score is null (CATEGORICAL, TEXT, BOOLEAN). The UI reads this
+    // jsonb in one shot instead of pulling every per-sample row to histogram
+    // client-side. Returns null for NUMERIC / legacy / embedding — their
+    // avg_score + score_stddev already say everything useful.
+    const distribution = computeDistribution(scored, config.score_config ?? null)
 
     await supabaseAdmin
       .from('eval_runs')
@@ -1536,6 +1553,7 @@ export async function runEvalRun(input: RunInput): Promise<void> {
         failed_count: preparedSamples.length - scored.length,
         avg_score: avgScore,
         score_stddev: scoreStddev,
+        distribution,
         total_cost_usd: totalCost,
         completed_at: new Date().toISOString(),
       })

--- a/apps/server/src/lib/eval-runners/distribution.ts
+++ b/apps/server/src/lib/eval-runners/distribution.ts
@@ -1,0 +1,86 @@
+/**
+ * P3-16: compute a server-side distribution / sample summary at run completion.
+ *
+ * For typed configs that don't aggregate as a mean (CATEGORICAL, TEXT) the
+ * dashboard had to either pull every per-sample row to build a histogram
+ * client-side or show nothing. This helper produces a small jsonb the UI
+ * reads in one shot. NUMERIC / legacy / embedding return null — their
+ * avg_score + score_stddev already carry the summary.
+ *
+ * Pure + sync + dependency-free so it's trivially unit-testable.
+ */
+
+import type { TypedScoreConfig } from './judge-prompt.js'
+
+/** A minimal projection of the scored sample shape the runner already has. */
+export interface ScoredSampleForDistribution {
+  value_number: number | null
+  value_string: string | null
+  value_boolean: boolean | null
+}
+
+/** Distribution shapes per data_type. The discriminant matches data_type
+ *  one-for-one so the UI can switch on it without consulting the score_config. */
+export type RunDistribution =
+  | { type: 'categorical'; counts: Record<string, number> }
+  | { type: 'boolean'; counts: { true: number; false: number } }
+  | { type: 'text'; count: number; samples: string[] }
+
+/** Max number of text samples kept on the run row. The full set is still in
+ *  eval_results — this is just for an at-a-glance summary. */
+const TEXT_SAMPLE_LIMIT = 10
+/** Per-sample text truncation so a few long answers don't bloat the row. */
+const TEXT_SAMPLE_MAX_CHARS = 240
+
+/**
+ * Build the distribution summary for a run. Returns null on score types that
+ * are already summarised by avg_score (NUMERIC + legacy + embedding) so the
+ * caller can simply pass it through to `eval_runs.distribution`.
+ */
+export function computeDistribution(
+  scored: ScoredSampleForDistribution[],
+  scoreConfig: TypedScoreConfig | null | undefined,
+): RunDistribution | null {
+  if (!scoreConfig) return null
+
+  if (scoreConfig.data_type === 'CATEGORICAL') {
+    // Counts keyed by the category string. Unknown / null are ignored —
+    // parseJudgeReply already rejected anything not in the allow-list.
+    const counts: Record<string, number> = {}
+    for (const s of scored) {
+      const v = s.value_string
+      if (v == null) continue
+      counts[v] = (counts[v] ?? 0) + 1
+    }
+    return { type: 'categorical', counts }
+  }
+
+  if (scoreConfig.data_type === 'BOOLEAN') {
+    let t = 0
+    let f = 0
+    for (const s of scored) {
+      if (s.value_boolean === true) t++
+      else if (s.value_boolean === false) f++
+    }
+    return { type: 'boolean', counts: { true: t, false: f } }
+  }
+
+  if (scoreConfig.data_type === 'TEXT') {
+    // Keep the first N non-empty samples, truncated, so the dashboard can show
+    // representative answers without fetching the whole result set.
+    const samples: string[] = []
+    let count = 0
+    for (const s of scored) {
+      const v = s.value_string
+      if (v == null || v.length === 0) continue
+      count++
+      if (samples.length < TEXT_SAMPLE_LIMIT) {
+        samples.push(v.length > TEXT_SAMPLE_MAX_CHARS ? v.slice(0, TEXT_SAMPLE_MAX_CHARS) + '…' : v)
+      }
+    }
+    return { type: 'text', count, samples }
+  }
+
+  // NUMERIC and unknown future types: avg_score + score_stddev already cover it.
+  return null
+}

--- a/apps/server/src/lib/eval-runners/embedding.ts
+++ b/apps/server/src/lib/eval-runners/embedding.ts
@@ -37,6 +37,9 @@ export interface EmbeddingOutcome {
   value_number: number
   value_string: null
   value_boolean: boolean | null
+  /** P3-15 mirror — embeddings have no separate "raw" scale (cosine similarity
+   *  is already in 0..1 and the same as `value_number`), so this stays null. */
+  value_raw_number: null
   reasoning: string
   cost: number
   tokens: number
@@ -150,6 +153,7 @@ export async function scoreEmbedding(
     value_number: score,
     value_string: null,
     value_boolean: threshold != null ? score >= threshold : null,
+    value_raw_number: null,
     reasoning: `cosine similarity ${score.toFixed(4)}${threshold != null ? ` (threshold ${threshold})` : ''}`,
     cost,
     tokens: result.tokens,

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -1376,7 +1376,16 @@ function RunEvaluatorDialog({
 function LowestScoreRow({
   res,
 }: {
-  res: { id: string; score: number; reasoning: string | null; judge_cost_usd: number; request_id: string | null; dataset_item_id: string | null }
+  res: {
+    id: string
+    score: number
+    reasoning: string | null
+    judge_cost_usd: number
+    request_id: string | null
+    dataset_item_id: string | null
+    /** P3-15: judge's raw answer (NUMERIC path); null/undefined for non-numeric. */
+    value_raw_number?: number | null
+  }
 }) {
   const [open, setOpen] = useState(false)
   return (
@@ -1395,6 +1404,12 @@ function LowestScoreRow({
       <div className="flex justify-between items-center mb-1">
         <span className="font-mono text-[12px] text-text font-medium">
           {fmtScore(res.score)}
+          {/* P3-15: judge's raw answer ("4" out of 5, not just normalised 0.8). */}
+          {res.value_raw_number != null && (
+            <span className="ml-1.5 text-text-faint text-[10px] font-normal tabular-nums">
+              (raw {res.value_raw_number})
+            </span>
+          )}
         </span>
         <span className="font-mono text-[10px] text-text-faint">
           {fmtUsd(res.judge_cost_usd)}
@@ -1546,8 +1561,50 @@ function RunDetailPanel({ runId, onClose }: { runId: string; onClose: () => void
           </div>
         )}
 
-        {/* Histogram */}
-        {r.status === 'completed' && results.data && results.data.length > 0 && (
+        {/* P3-16: typed-config distribution summary. For CATEGORICAL / BOOLEAN
+            it shows the count bars; for TEXT it shows up to 10 sample answers.
+            Renders ONLY when the server precomputed the summary (typed configs);
+            NUMERIC / legacy runs still get the per-sample histogram below. */}
+        {r.status === 'completed' && r.distribution && (
+          <div>
+            <p className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-2">
+              {r.distribution.type === 'text' ? 'Sample answers' : 'Distribution'}
+            </p>
+            {(r.distribution.type === 'categorical' || r.distribution.type === 'boolean') && (() => {
+              const counts: Record<string, number> = r.distribution.type === 'boolean'
+                ? { true: r.distribution.counts.true, false: r.distribution.counts.false }
+                : r.distribution.counts
+              const entries = Object.entries(counts)
+              const max = Math.max(1, ...entries.map(([, n]) => n))
+              return (
+                <div className="space-y-1">
+                  {entries.map(([k, n]) => (
+                    <div key={k} className="flex items-center gap-2 font-mono text-[11px]">
+                      <span className="w-[100px] truncate text-text-muted" title={k}>{k}</span>
+                      <div className="flex-1 h-4 bg-bg-elev rounded-[2px] overflow-hidden">
+                        <div className="h-full bg-text/70" style={{ width: `${(n / max) * 100}%` }} />
+                      </div>
+                      <span className="w-[40px] text-right tabular-nums text-text-faint">{n}</span>
+                    </div>
+                  ))}
+                </div>
+              )
+            })()}
+            {r.distribution.type === 'text' && (
+              <div className="space-y-1.5">
+                <p className="font-mono text-[10.5px] text-text-faint">
+                  Showing {r.distribution.samples.length} of {r.distribution.count} scored.
+                </p>
+                {r.distribution.samples.map((s, i) => (
+                  <div key={i} className="font-mono text-[11px] text-text-muted bg-bg-elev rounded-[3px] px-2 py-1.5 line-clamp-3">{s}</div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Histogram — NUMERIC / legacy path. distribution wins for typed configs. */}
+        {r.status === 'completed' && !r.distribution && results.data && results.data.length > 0 && (
           <>
             <div>
               <p className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint mb-2">

--- a/apps/web/lib/queries/use-evals.ts
+++ b/apps/web/lib/queries/use-evals.ts
@@ -50,6 +50,14 @@ export interface Evaluator {
 
 export type EvalRunStatus = 'pending' | 'running' | 'completed' | 'failed'
 
+/** P3-16 — distribution shape stored on eval_runs.distribution (jsonb). The
+ *  `type` field mirrors the score_config's data_type so the UI can switch
+ *  without looking the config up. */
+export type RunDistribution =
+  | { type: 'categorical'; counts: Record<string, number> }
+  | { type: 'boolean'; counts: { true: number; false: number } }
+  | { type: 'text'; count: number; samples: string[] }
+
 export interface EvalRun {
   id: string
   organization_id: string
@@ -84,6 +92,11 @@ export interface EvalRun {
    * 95% CI shown next to the average. null for runs with <2 numeric samples or
    * non-mean evaluator types (CATEGORICAL / TEXT), and for pre-migration rows. */
   score_stddev: number | null
+  /** P3-16: precomputed distribution / sample summary for typed configs whose
+   * avg_score is null. Lets the UI render a histogram in one read instead of
+   * pulling every per-sample row. NULL/absent for NUMERIC / legacy / embedding
+   * runs and for pre-migration rows. */
+  distribution?: RunDistribution | null
   total_cost_usd: number
   error: string | null
   created_by: string | null
@@ -103,6 +116,10 @@ export interface EvalResult {
   judge_cost_usd: number
   judge_tokens: number
   created_at: string
+  /** P3-15: the judge's raw answer before clamp/normalisation (NUMERIC path).
+   *  Lets the dashboard render "4 out of 5" instead of only the derived 0.8.
+   *  null for non-numeric typed configs and for pre-migration rows. */
+  value_raw_number?: number | null
   /** P1-7 (3/3): pairwise winner ('a' | 'b' | 'tie'); null for single-mode results. */
   winner?: 'a' | 'b' | 'tie' | null
   /** P2-11 — for trajectory results: the evaluated trace id. */

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @spanlens/sdk changelog
 
+## 0.12.0
+
+P3 score-model polish — raw judge scores + server-computed distributions.
+
+### Added
+
+- `EvalResult.value_raw_number` (P3-15) — the judge's raw answer before clamp/normalisation. The dashboard can render "4 out of 5" instead of only the derived 0.8. `null` for non-numeric typed configs and pre-migration rows.
+- `EvalRun.distribution` (P3-16) — a precomputed summary for typed configs whose `avg_score` is null. Discriminated union with `type: 'categorical' | 'boolean' | 'text'`. Lets clients render a histogram in one shot instead of pulling every per-sample row. `null`/absent for NUMERIC / legacy / embedding runs.
+- `RunDistribution` type export.
+
 ## 0.11.1
 
 P3 read-side polish — pagination on list endpoints, more accurate cost estimate.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/evals.ts
+++ b/packages/sdk/src/evals.ts
@@ -26,6 +26,13 @@ const DEFAULT_TIMEOUT_MS = 300_000
 
 export type EvalRunStatus = 'pending' | 'running' | 'completed' | 'failed'
 
+/** P3-16 — server-precomputed distribution stored on EvalRun.distribution. The
+ *  `type` discriminant mirrors the score_config's data_type one-for-one. */
+export type RunDistribution =
+  | { type: 'categorical'; counts: Record<string, number> }
+  | { type: 'boolean'; counts: { true: number; false: number } }
+  | { type: 'text'; count: number; samples: string[] }
+
 /** An eval run as returned by the API (snake_case, 1:1 with the REST shape). */
 export interface EvalRun {
   id: string
@@ -60,6 +67,10 @@ export interface EvalRun {
    * 95% confidence interval (see {@link scoreConfidenceInterval}). null when
    * the run has <2 numeric samples or the evaluator has no mean. */
   score_stddev: number | null
+  /** P3-16: precomputed distribution / sample summary for typed configs whose
+   * avg_score is null. Lets clients render a histogram without fetching every
+   * per-sample row. NULL/absent for NUMERIC / legacy / embedding runs. */
+  distribution?: RunDistribution | null
   total_cost_usd: number
   error: string | null
   started_at: string
@@ -73,6 +84,9 @@ export interface EvalResult {
   dataset_item_id: string | null
   score: number | null
   reasoning: string | null
+  /** P3-15: judge's raw answer before clamp/normalisation (NUMERIC path).
+   *  Lets clients render the original scale. null for non-numeric / legacy. */
+  value_raw_number?: number | null
   value_number: number | null
   value_string: string | null
   value_boolean: boolean | null

--- a/supabase/migrations/20260615060000_eval_raw_and_distribution.sql
+++ b/supabase/migrations/20260615060000_eval_raw_and_distribution.sql
@@ -1,0 +1,22 @@
+-- P3-15: keep the judge's RAW numeric answer alongside the normalised 0..1.
+-- Today eval_results.value_number stores (raw - scale_min)/(scale_max - scale_min)
+-- only, so "the judge said 4 out of 5" is unrecoverable from the row — you can
+-- only show 0.8. Store the pre-normalisation number too so the dashboard can
+-- render the original scale and downstream stats keep their full precision.
+--
+-- P3-16: precompute the distribution / sample summary for typed runs that have
+-- no avg_score (CATEGORICAL, TEXT, and BOOLEAN where the dashboard wants the
+-- raw true/false tally next to the pass-rate). Today the UI either re-fetches
+-- every per-sample row to build the histogram client-side, or shows nothing.
+-- A jsonb summary on eval_runs collapses that to one cheap read.
+--
+-- Additive + nullable (gotcha #25). value_raw_number stays NULL for pre-
+-- migration rows and for non-numeric typed configs (BOOLEAN / CATEGORICAL /
+-- TEXT). distribution stays NULL for NUMERIC/legacy runs where avg_score +
+-- score_stddev already say everything useful.
+
+ALTER TABLE eval_results
+  ADD COLUMN IF NOT EXISTS value_raw_number numeric;
+
+ALTER TABLE eval_runs
+  ADD COLUMN IF NOT EXISTS distribution jsonb;


### PR DESCRIPTION
## P3 score-model bundle — 2 items, 1 additive migration

### P3-15: keep the judge's raw answer
`eval_results.value_number` stored the normalised `(raw - min)/(max - min)` only — "the judge said 4 out of 5" was unrecoverable, you could only show `0.8`. New `eval_results.value_raw_number` holds the clamped-but-not-normalised number. The dashboard's lowest-score list now renders `<normalised> (raw N)` when present. NULL for non-numeric typed configs (BOOLEAN/CATEGORICAL/TEXT) and for pre-migration rows.

### P3-16: server-precomputed distribution for typed configs
CATEGORICAL / TEXT runs ended with `avg_score = null` and the UI either refetched every per-sample row to histogram client-side, or showed nothing. New `eval_runs.distribution jsonb` carries a discriminated union:

```ts
type RunDistribution =
  | { type: 'categorical'; counts: Record<string, number> }
  | { type: 'boolean'; counts: { true: number; false: number } }
  | { type: 'text'; count: number; samples: string[] /* up to 10, truncated */ }
```

Returns `null` for NUMERIC / legacy / embedding — `avg_score` + `score_stddev` already cover those. The detail panel renders bars (CATEGORICAL/BOOLEAN) or sample answers (TEXT) when the field is set; the existing numeric histogram still kicks in otherwise.

### Changes
- **db** (`20260615060000_eval_raw_and_distribution.sql`, additive + idempotent): `eval_results.value_raw_number numeric` + `eval_runs.distribution jsonb`.
- **server**: new pure helper `computeDistribution()` in `eval-runners/distribution.ts`; `JudgeOutcome` / `EmbeddingOutcome` carry `value_raw_number`; runner writes both at completion.
- **web/sdk** (0.12.0): `RunDistribution` discriminated-union type export; result panel renders the new shapes.
- **tests**: 8 distribution cases (categorical counts, boolean tally, text truncation, empty samples, null types); deterministic-columns guard now permits the new columns.

### Test plan
- [x] `pnpm typecheck` (all 7 packages), `pnpm --filter server lint`, `pnpm --filter web lint` — clean.
- [x] 13 server eval test files, **127 tests pass** (was 119; +8 distribution); SDK 131 pass + builds.
- [x] Backward compatible: both new fields nullable + optional in TS types; demo data uses NUMERIC runs which still get the existing histogram.

### Deploy ordering
`deploy-server.yml` runs migrate → deploy, so the columns exist before the runner writes them. Additive only — old rows render the legacy histogram via the `!r.distribution` fallback.
