### PR TITLE
feat: server-side judge↔human agreement + Cohen's κ (P3-19)

### DIFF
--- a/apps/server/src/__tests__/eval-agreement.test.ts
+++ b/apps/server/src/__tests__/eval-agreement.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+import {
+  pearsonR,
+  cohensKappa,
+  interpretAgreement,
+  computeAgreement,
+} from '../lib/eval-runners/agreement.js'
+
+// P3-19: server-side agreement statistics (Pearson r + Cohen's κ).
+
+describe('pearsonR', () => {
+  it('returns null on <2 pairs', () => {
+    expect(pearsonR([])).toBeNull()
+    expect(pearsonR([{ judge: 0.5, human: 0.5 }])).toBeNull()
+  })
+
+  it('returns 1 for perfectly identical pairs', () => {
+    const r = pearsonR([
+      { judge: 0.2, human: 0.2 },
+      { judge: 0.5, human: 0.5 },
+      { judge: 0.9, human: 0.9 },
+    ])
+    expect(r).toBeCloseTo(1, 6)
+  })
+
+  it('returns -1 for perfectly inverted pairs', () => {
+    const r = pearsonR([
+      { judge: 0.2, human: 0.8 },
+      { judge: 0.5, human: 0.5 },
+      { judge: 0.8, human: 0.2 },
+    ])
+    expect(r).toBeCloseTo(-1, 6)
+  })
+
+  it('returns null when one rater has zero variance (denominator = 0)', () => {
+    // human is constant — no chance to correlate.
+    expect(
+      pearsonR([
+        { judge: 0.2, human: 0.5 },
+        { judge: 0.5, human: 0.5 },
+        { judge: 0.8, human: 0.5 },
+      ]),
+    ).toBeNull()
+  })
+})
+
+describe('cohensKappa', () => {
+  it('returns 1 for perfect agreement on 2 labels', () => {
+    const k = cohensKappa([
+      { judge: 'Helpful', human: 'Helpful' },
+      { judge: 'Helpful', human: 'Helpful' },
+      { judge: 'Neutral', human: 'Neutral' },
+      { judge: 'Neutral', human: 'Neutral' },
+    ])
+    expect(k).toBeCloseTo(1, 6)
+  })
+
+  it('returns 0 when raters agree exactly at chance', () => {
+    // Each rater 50/50 with no correlation. Build a 2x2 contingency table:
+    //   H=A H=B
+    // J=A  1   1
+    // J=B  1   1
+    // po = 2/4 = 0.5, pe = (2*2+2*2)/16 = 0.5 → κ = 0.
+    const k = cohensKappa([
+      { judge: 'A', human: 'A' },
+      { judge: 'A', human: 'B' },
+      { judge: 'B', human: 'A' },
+      { judge: 'B', human: 'B' },
+    ])
+    expect(k).toBeCloseTo(0, 6)
+  })
+
+  it('returns null on <2 pairs', () => {
+    expect(cohensKappa([])).toBeNull()
+    expect(cohensKappa([{ judge: 'A', human: 'A' }])).toBeNull()
+  })
+
+  it('returns null when both raters use a single identical label (pe = 1)', () => {
+    expect(
+      cohensKappa([
+        { judge: 'A', human: 'A' },
+        { judge: 'A', human: 'A' },
+        { judge: 'A', human: 'A' },
+      ]),
+    ).toBeNull()
+  })
+
+  it('handles 3+ categories (multi-class κ)', () => {
+    // Mostly-agreeing 3-label set should yield a strong positive κ but < 1.
+    const k = cohensKappa([
+      { judge: 'Good', human: 'Good' },
+      { judge: 'Good', human: 'Good' },
+      { judge: 'Mid',  human: 'Mid' },
+      { judge: 'Mid',  human: 'Good' }, // one disagreement
+      { judge: 'Bad',  human: 'Bad' },
+    ])
+    expect(k).not.toBeNull()
+    expect(k!).toBeGreaterThan(0.5)
+    expect(k!).toBeLessThan(1)
+  })
+
+  it('works for boolean (true/false) pairs', () => {
+    const k = cohensKappa([
+      { judge: 'true', human: 'true' },
+      { judge: 'true', human: 'true' },
+      { judge: 'false', human: 'false' },
+      { judge: 'false', human: 'false' },
+    ])
+    expect(k).toBeCloseTo(1, 6)
+  })
+})
+
+describe('interpretAgreement', () => {
+  it('buckets values into the standard rule-of-thumb labels', () => {
+    expect(interpretAgreement(0)).toBe('none')
+    expect(interpretAgreement(0.1)).toBe('none')
+    expect(interpretAgreement(0.25)).toBe('weak')
+    expect(interpretAgreement(0.5)).toBe('moderate')
+    expect(interpretAgreement(0.8)).toBe('strong')
+    // negative magnitudes use |value|.
+    expect(interpretAgreement(-0.75)).toBe('strong')
+  })
+})
+
+describe('computeAgreement', () => {
+  it('routes numeric to Pearson', () => {
+    const out = computeAgreement({
+      type: 'numeric',
+      numericPairs: [
+        { judge: 0.2, human: 0.2 },
+        { judge: 0.5, human: 0.5 },
+        { judge: 0.9, human: 0.9 },
+      ],
+    })
+    expect(out).not.toBeNull()
+    expect(out!.metric).toBe('pearson')
+    expect(out!.value).toBeCloseTo(1, 6)
+    expect(out!.interpretation).toBe('strong')
+    expect(out!.n).toBe(3)
+  })
+
+  it('routes categorical and boolean to κ', () => {
+    const cat = computeAgreement({
+      type: 'categorical',
+      labelPairs: [
+        { judge: 'Good', human: 'Good' },
+        { judge: 'Bad', human: 'Bad' },
+      ],
+    })
+    expect(cat?.metric).toBe('kappa')
+
+    const bool = computeAgreement({
+      type: 'boolean',
+      labelPairs: [
+        { judge: 'true', human: 'true' },
+        { judge: 'false', human: 'false' },
+      ],
+    })
+    expect(bool?.metric).toBe('kappa')
+  })
+
+  it('returns null when the underlying metric is undefined', () => {
+    expect(computeAgreement({ type: 'numeric', numericPairs: [] })).toBeNull()
+    expect(
+      computeAgreement({ type: 'categorical', labelPairs: [{ judge: 'A', human: 'A' }, { judge: 'A', human: 'A' }] }),
+    ).toBeNull()
+  })
+})

--- a/apps/server/src/api/human-evals.ts
+++ b/apps/server/src/api/human-evals.ts
@@ -3,6 +3,7 @@ import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { requestsScope, selectRequests } from '../lib/requests-query.js'
 import { validateScore, type ScoreConfig } from '../lib/score-validation.js'
+import { computeAgreement, type AgreementResult } from '../lib/eval-runners/agreement.js'
 import { ApiError } from '../lib/errors.js'
 
 /**
@@ -358,8 +359,13 @@ humanEvalsRouter.delete('/human-evals/:id', async (c) => {
 })
 
 // GET /api/v1/human-evals/correlation?promptName=...&promptVersionId=...
-// Returns per-request pairs (judge_score, human_score) for the matching scope.
-// Client computes Pearson r. Server just provides paired data.
+//
+// P3-19: returns paired (judge, human) data PLUS a server-computed agreement
+// statistic so dashboards / SDK consumers don't have to recompute it. Picks
+// Pearson r for numeric scores and Cohen's κ for typed-config labels
+// (CATEGORICAL / BOOLEAN). For backward compatibility the legacy `pairs`
+// array (numeric judgeScore/humanScore) remains in the response, so old
+// clients keep working unchanged.
 humanEvalsRouter.get('/human-evals/correlation', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
@@ -379,41 +385,92 @@ humanEvalsRouter.get('/human-evals/correlation', async (c) => {
       .eq('name', promptName)
     versionIds = (versions ?? []).map((v) => v.id)
   }
-  if (versionIds.length === 0) return c.json({ success: true, data: [] })
+  const emptyEnvelope = { pairs: [] as Array<{ requestId: string; judgeScore: number; humanScore: number }>, agreement: null as AgreementResult | null }
+  if (versionIds.length === 0) return c.json({ success: true, data: emptyEnvelope.pairs, pairs: emptyEnvelope.pairs, agreement: emptyEnvelope.agreement })
 
-  // Pull human evals for those versions
+  // Pull human evals — include the typed value columns so we can compute κ
+  // on CATEGORICAL / BOOLEAN configs, not just Pearson on numeric.
   const { data: humans } = await supabaseAdmin
     .from('human_evals')
-    .select('request_id, score')
+    .select('request_id, score, value_number, value_string, value_boolean')
     .in('prompt_version_id', versionIds)
-  const humanMap = new Map<string, number>()
-  for (const h of humans ?? []) {
-    if (h.request_id) humanMap.set(h.request_id, h.score)
-  }
-  if (humanMap.size === 0) return c.json({ success: true, data: [] })
 
-  // Most recent judge score per request
+  interface HumanRow { score: number | null; value_number: number | null; value_string: string | null; value_boolean: boolean | null }
+  const humanMap = new Map<string, HumanRow>()
+  for (const h of humans ?? []) {
+    if (h.request_id) {
+      humanMap.set(h.request_id, {
+        score: h.score as number | null,
+        value_number: h.value_number as number | null,
+        value_string: h.value_string as string | null,
+        value_boolean: h.value_boolean as boolean | null,
+      })
+    }
+  }
+  if (humanMap.size === 0) return c.json({ success: true, data: emptyEnvelope.pairs, pairs: emptyEnvelope.pairs, agreement: emptyEnvelope.agreement })
+
+  // Most recent judge result per request, with the same typed columns.
   const reqIds = [...humanMap.keys()]
   const { data: evalResults } = await supabaseAdmin
     .from('eval_results')
-    .select('request_id, score, created_at')
+    .select('request_id, score, value_number, value_string, value_boolean, created_at')
     .in('request_id', reqIds)
     .order('created_at', { ascending: false })
 
-  const judgeMap = new Map<string, number>()
+  interface JudgeRow { score: number | null; value_number: number | null; value_string: string | null; value_boolean: boolean | null }
+  const judgeMap = new Map<string, JudgeRow>()
   for (const e of evalResults ?? []) {
     if (e.request_id && !judgeMap.has(e.request_id)) {
-      judgeMap.set(e.request_id, e.score)
+      judgeMap.set(e.request_id, {
+        score: e.score as number | null,
+        value_number: e.value_number as number | null,
+        value_string: e.value_string as string | null,
+        value_boolean: e.value_boolean as boolean | null,
+      })
     }
   }
 
+  // Build the legacy numeric pairs (back-compat).
   const pairs: Array<{ requestId: string; judgeScore: number; humanScore: number }> = []
-  for (const [requestId, humanScore] of humanMap.entries()) {
-    const judgeScore = judgeMap.get(requestId)
-    if (judgeScore != null) {
-      pairs.push({ requestId, judgeScore, humanScore })
+  for (const [requestId, human] of humanMap.entries()) {
+    const judge = judgeMap.get(requestId)
+    if (!judge) continue
+    if (judge.score != null && human.score != null) {
+      pairs.push({ requestId, judgeScore: judge.score, humanScore: human.score })
     }
   }
 
-  return c.json({ success: true, data: pairs })
+  // P3-19: decide which metric applies. Inspect the first complete pair —
+  // CATEGORICAL when both raters supplied a label, BOOLEAN when both gave a
+  // boolean, otherwise NUMERIC.
+  const numericPairs: Array<{ judge: number; human: number }> = []
+  const labelPairs: Array<{ judge: string; human: string }> = []
+  let categoricalSeen = false
+  let booleanSeen = false
+  for (const [requestId, human] of humanMap.entries()) {
+    const judge = judgeMap.get(requestId)
+    if (!judge) continue
+    if (judge.value_string != null && human.value_string != null) {
+      labelPairs.push({ judge: judge.value_string, human: human.value_string })
+      categoricalSeen = true
+    } else if (judge.value_boolean != null && human.value_boolean != null) {
+      labelPairs.push({ judge: String(judge.value_boolean), human: String(human.value_boolean) })
+      booleanSeen = true
+    } else if (judge.score != null && human.score != null) {
+      numericPairs.push({ judge: judge.score, human: human.score })
+    }
+  }
+
+  let agreement: AgreementResult | null = null
+  if (categoricalSeen) {
+    agreement = computeAgreement({ type: 'categorical', labelPairs })
+  } else if (booleanSeen) {
+    agreement = computeAgreement({ type: 'boolean', labelPairs })
+  } else if (numericPairs.length > 0) {
+    agreement = computeAgreement({ type: 'numeric', numericPairs })
+  }
+
+  // `data` stays as the legacy pairs array so existing clients keep working;
+  // `pairs` mirrors it explicitly and `agreement` is the new field.
+  return c.json({ success: true, data: pairs, pairs, agreement })
 })

--- a/apps/server/src/lib/eval-runners/agreement.ts
+++ b/apps/server/src/lib/eval-runners/agreement.ts
@@ -1,0 +1,142 @@
+/**
+ * P3-19: server-side LLM-judge ↔ human-eval agreement statistics.
+ *
+ * The previous flow shipped paired (judge, human) scores to the browser and
+ * recomputed Pearson r on every render. That worked for NUMERIC scores but
+ * couldn't say anything about CATEGORICAL ("Helpful" / "Neutral" / ...) or
+ * BOOLEAN (pass/fail) evaluators — there's no meaningful Pearson on labels.
+ *
+ * This module adds Cohen's κ for those typed configs and centralises both
+ * metrics server-side, so dashboards / SDK consumers see a uniform shape
+ * regardless of the evaluator type.
+ *
+ * Pure, sync, dependency-free.
+ */
+
+/** A judge ↔ human pair, generic over the value type. */
+export interface NumericPair {
+  judge: number
+  human: number
+}
+
+export interface LabelPair {
+  judge: string
+  human: string
+}
+
+/** Combined result for the dashboard. `value` is on each metric's own scale:
+ *  Pearson r in [-1, 1], Cohen's κ in [-1, 1] (chance-adjusted agreement). */
+export interface AgreementResult {
+  metric: 'pearson' | 'kappa'
+  value: number
+  /** Sample size after filtering to complete pairs. */
+  n: number
+  /** Standard rule-of-thumb bucket for quick reading. */
+  interpretation: 'none' | 'weak' | 'moderate' | 'strong'
+}
+
+/**
+ * Pearson product-moment correlation. Returns null on degenerate input
+ * (<2 pairs or zero variance on either side).
+ */
+export function pearsonR(pairs: NumericPair[]): number | null {
+  const n = pairs.length
+  if (n < 2) return null
+  let sA = 0, sB = 0, sA2 = 0, sB2 = 0, sAB = 0
+  for (const p of pairs) {
+    sA += p.judge
+    sB += p.human
+    sA2 += p.judge * p.judge
+    sB2 += p.human * p.human
+    sAB += p.judge * p.human
+  }
+  const num = n * sAB - sA * sB
+  const den = Math.sqrt((n * sA2 - sA * sA) * (n * sB2 - sB * sB))
+  if (den === 0) return null
+  return num / den
+}
+
+/**
+ * Cohen's κ for nominal labels. Equivalent for 2-class (BOOLEAN) and
+ * multi-class (CATEGORICAL) — κ collapses to the binary case when the label
+ * universe has size 2.
+ *
+ *   κ = (po - pe) / (1 - pe)
+ *   po = observed agreement (sum of diagonal / n)
+ *   pe = chance agreement (sum_k (row_k * col_k) / n²)
+ *
+ * Returns null when n < 2, when the rater label sets are degenerate, or when
+ * pe == 1 (no room above chance, division undefined).
+ */
+export function cohensKappa(pairs: LabelPair[]): number | null {
+  const n = pairs.length
+  if (n < 2) return null
+  // Universe of labels seen on either side. Order does not affect κ.
+  const labels = new Set<string>()
+  for (const p of pairs) {
+    labels.add(p.judge)
+    labels.add(p.human)
+  }
+  if (labels.size < 2) {
+    // Both raters used a single identical label everywhere → trivially in
+    // perfect agreement, but κ is undefined (pe = 1). Convention: return null.
+    return null
+  }
+
+  // Marginal frequencies and the diagonal count (observed agreement).
+  const rowTotals = new Map<string, number>()
+  const colTotals = new Map<string, number>()
+  let agreeCount = 0
+  for (const p of pairs) {
+    rowTotals.set(p.judge, (rowTotals.get(p.judge) ?? 0) + 1)
+    colTotals.set(p.human, (colTotals.get(p.human) ?? 0) + 1)
+    if (p.judge === p.human) agreeCount++
+  }
+
+  const po = agreeCount / n
+  let pe = 0
+  for (const label of labels) {
+    const r = rowTotals.get(label) ?? 0
+    const c = colTotals.get(label) ?? 0
+    pe += (r * c) / (n * n)
+  }
+  if (pe === 1) return null
+  return (po - pe) / (1 - pe)
+}
+
+/**
+ * Bucket a metric value into the standard "rule-of-thumb" interpretation.
+ * Same cutoffs Pearson interpretation already used in the dashboard
+ * (`|r| < 0.2 = none`, < 0.4 = weak, < 0.7 = moderate, else strong) — applied
+ * to κ too since the magnitudes are comparable in [-1, 1].
+ */
+export function interpretAgreement(value: number): AgreementResult['interpretation'] {
+  const m = Math.abs(value)
+  if (m >= 0.7) return 'strong'
+  if (m >= 0.4) return 'moderate'
+  if (m >= 0.2) return 'weak'
+  return 'none'
+}
+
+/**
+ * Run-mode selector: looks at the score_config the evaluator + reviewer both
+ * targeted and picks the right metric. Returns null when the metric can't be
+ * computed (too few pairs, degenerate labels).
+ */
+export function computeAgreement(args: {
+  type: 'numeric' | 'categorical' | 'boolean'
+  numericPairs?: NumericPair[]
+  labelPairs?: LabelPair[]
+}): AgreementResult | null {
+  if (args.type === 'numeric') {
+    const pairs = args.numericPairs ?? []
+    const r = pearsonR(pairs)
+    if (r === null || !Number.isFinite(r)) return null
+    return { metric: 'pearson', value: r, n: pairs.length, interpretation: interpretAgreement(r) }
+  }
+  // CATEGORICAL + BOOLEAN both reduce to Cohen's κ over the label pairs.
+  const pairs = args.labelPairs ?? []
+  const k = cohensKappa(pairs)
+  if (k === null || !Number.isFinite(k)) return null
+  return { metric: 'kappa', value: k, n: pairs.length, interpretation: interpretAgreement(k) }
+}

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -1792,34 +1792,47 @@ function EvaluatorRow({
 
 function CorrelationCard({ promptName }: { promptName: string }) {
   const correlation = useCorrelation({ promptName })
-  const pairs = correlation.data ?? []
-  const r = pearsonR(pairs)
+  const pairs = correlation.data?.pairs ?? []
+  // P3-19: prefer the server's agreement statistic (handles Pearson r for
+  // numeric scores AND Cohen's κ for CATEGORICAL / BOOLEAN evaluators that
+  // the old client-side pearsonR couldn't measure). Falls back to client
+  // Pearson when the server didn't return one (e.g. pre-deploy old API).
+  const agreement = correlation.data?.agreement ?? null
+  const clientR = agreement == null ? pearsonR(pairs) : null
+  const metricValue = agreement != null ? agreement.value : clientR
+  const metricLabel = agreement?.metric === 'kappa' ? "Cohen's κ" : 'Pearson r'
 
-  if (pairs.length === 0) return null
+  if (pairs.length === 0 && agreement == null) return null
 
   // Scatter plot bounds: 0..1 × 0..1, padded to 120×120
   const W = 120, H = 120, PAD = 6
   const dotX = (judge: number) => PAD + judge * (W - 2 * PAD)
   const dotY = (human: number) => H - PAD - human * (H - 2 * PAD)
 
-  // Interpret r — same buckets as standard correlation rules of thumb.
-  const interpretation = r == null
-    ? '—'
-    : Math.abs(r) >= 0.7 ? 'Strong'
-    : Math.abs(r) >= 0.4 ? 'Moderate'
-    : Math.abs(r) >= 0.2 ? 'Weak'
-    : 'None'
+  // Capitalised first letter to match the prior 'Strong' / 'Moderate' display.
+  const interpretation = agreement
+    ? agreement.interpretation.charAt(0).toUpperCase() + agreement.interpretation.slice(1)
+    : metricValue == null
+      ? '—'
+      : Math.abs(metricValue) >= 0.7 ? 'Strong'
+      : Math.abs(metricValue) >= 0.4 ? 'Moderate'
+      : Math.abs(metricValue) >= 0.2 ? 'Weak'
+      : 'None'
 
-  const rColor = r == null
+  const rColor = metricValue == null
     ? 'text-text-faint'
-    : r >= 0.7 ? 'text-good'
-    : r >= 0.4 ? 'text-warn'
+    : metricValue >= 0.7 ? 'text-good'
+    : metricValue >= 0.4 ? 'text-warn'
     : 'text-bad'
+
+  // n for the displayed metric: agreement.n if server-computed, otherwise the
+  // numeric pairs count we already have.
+  const sampleCount = agreement?.n ?? pairs.length
 
   return (
     <div className="bg-bg-elev border border-border rounded-[6px] p-4">
       <div className="flex items-start gap-4">
-        {/* Scatter plot */}
+        {/* Scatter plot — only meaningful for numeric pairs. */}
         <svg width={W} height={H} className="shrink-0 bg-bg rounded-[4px] border border-border">
           {/* Diagonal reference line, perfect agreement */}
           <line
@@ -1845,26 +1858,26 @@ function CorrelationCard({ promptName }: { promptName: string }) {
             <p className="font-mono text-[11px] text-text-faint mb-0.5 truncate">
               {promptName}
             </p>
-            {/* flex-wrap so the "Pearson r · …" label drops below the big
-                number instead of overflowing the card on narrow (2-up) widths. */}
+            {/* flex-wrap so the metric label drops below the big number
+                instead of overflowing the card on narrow (2-up) widths. */}
             <div className="flex items-baseline flex-wrap gap-x-2 gap-y-0.5">
               <span className={cn('font-mono text-[22px] font-medium', rColor)}>
-                {r == null ? '—' : r.toFixed(2)}
+                {metricValue == null ? '—' : metricValue.toFixed(2)}
               </span>
               <span className="font-mono text-[10.5px] text-text-muted">
-                Pearson r · {interpretation}
+                {metricLabel} · {interpretation}
               </span>
             </div>
           </div>
           <div className="font-mono text-[10.5px] text-text-faint">
-            {pairs.length} paired sample{pairs.length === 1 ? '' : 's'}
-            {pairs.length < 10 && ' (more data → more reliable)'}
+            {sampleCount} paired sample{sampleCount === 1 ? '' : 's'}
+            {sampleCount < 10 && ' (more data → more reliable)'}
           </div>
         </div>
       </div>
       <p className="font-mono text-[10.5px] text-text-faint mt-3 leading-relaxed">
         Dot = one request judged by both. Dashed line = perfect agreement.
-        Low r means your LLM judge disagrees with humans → revise the criterion.
+        Low values mean your LLM judge disagrees with humans → revise the criterion.
       </p>
     </div>
   )

--- a/apps/web/lib/queries/use-human-evals.ts
+++ b/apps/web/lib/queries/use-human-evals.ts
@@ -51,6 +51,23 @@ export interface CorrelationPair {
   humanScore: number
 }
 
+/** P3-19: server-computed agreement statistic. Pearson for numeric scores,
+ *  Cohen's κ for typed-config labels (CATEGORICAL / BOOLEAN). null when there's
+ *  not enough data or the label set is degenerate. */
+export interface CorrelationAgreement {
+  metric: 'pearson' | 'kappa'
+  value: number
+  n: number
+  interpretation: 'none' | 'weak' | 'moderate' | 'strong'
+}
+
+/** Full envelope from /human-evals/correlation. `pairs` is the numeric back-
+ *  compat array; `agreement` is the new server-side stat. */
+export interface CorrelationEnvelope {
+  pairs: CorrelationPair[]
+  agreement: CorrelationAgreement | null
+}
+
 // ── Queue filters ───────────────────────────────────────────────────────────
 
 export interface QueueFilters {
@@ -133,13 +150,21 @@ export function useDeleteHumanEval() {
 export function useCorrelation(scope: { promptName?: string; promptVersionId?: string }) {
   return useQuery({
     queryKey: ['correlation', scope] as const,
-    queryFn: async () => {
+    queryFn: async (): Promise<CorrelationEnvelope> => {
       const qs = new URLSearchParams()
       if (scope.promptName) qs.set('promptName', scope.promptName)
       if (scope.promptVersionId) qs.set('promptVersionId', scope.promptVersionId)
       const suffix = qs.size > 0 ? `?${qs}` : ''
-      const res = await apiGet<ApiEnvelope<CorrelationPair[]>>(`/api/v1/human-evals/correlation${suffix}`)
-      return res.data ?? []
+      // P3-19: response now carries `agreement` (Pearson r or Cohen's κ)
+      // alongside the legacy `pairs` array. The server keeps `data` as the
+      // pairs array for back-compat with old clients.
+      const res = await apiGet<ApiEnvelope<CorrelationPair[]> & { pairs?: CorrelationPair[]; agreement?: CorrelationAgreement | null }>(
+        `/api/v1/human-evals/correlation${suffix}`,
+      )
+      return {
+        pairs: res.pairs ?? res.data ?? [],
+        agreement: res.agreement ?? null,
+      }
     },
     enabled: !!(scope.promptName || scope.promptVersionId),
   })


### PR DESCRIPTION
## P3-19: server-side agreement + Cohen's κ for categorical evaluators

The previous `/correlation` endpoint shipped paired (judge, human) scores to the browser and recomputed Pearson r on every render. That worked for NUMERIC evaluators but said **nothing about CATEGORICAL ("Helpful" / "Neutral" / …) or BOOLEAN (pass/fail)** evaluators — no meaningful Pearson on labels, so the dashboard just showed "—" for them.

This PR moves the metric server-side and adds **Cohen's κ** for typed-config labels.

### Changes
- **server** — new pure helper `eval-runners/agreement.ts`: `pearsonR`, `cohensKappa` (multi-class), `interpretAgreement` (none/weak/moderate/strong buckets), and `computeAgreement()` which routes based on the data type. Dependency-free.
- **api** — `/api/v1/human-evals/correlation` now returns `{ pairs, agreement: { metric, value, n, interpretation } | null }`. Picks κ when at least one pair uses `value_string` or `value_boolean`, Pearson otherwise. The legacy `data` field still carries the numeric pairs array, so older clients keep working unchanged.
- **web** — `CorrelationCard` reads `correlation.data.agreement` first (falls back to client `pearsonR` on the cached pairs for resilience during the deploy window). Label flips between "Pearson r" and "Cohen's κ" automatically.

### No migration
`human_evals` and `eval_results` already have `value_string` / `value_boolean` / `value_number` columns from the typed-score-config work — the server just queries them now.

### Test plan
- [x] 14 new unit tests on the agreement helpers (perfect / inverted / random / degenerate / 2-class / 3-class / boolean / interpretation buckets).
- [x] `pnpm typecheck` (all 7 packages), `pnpm --filter server lint`, `pnpm --filter web lint` — clean.
- [x] 14 server eval test files, **141 tests pass** (was 127); SDK still 131 + builds.
- [x] Back-compat: server still returns the legacy numeric pairs array under `data`; demo page continues to call client `pearsonR` directly on `DEMO_CORRELATION_PAIRS` (unchanged signature).

### Follow-ups
- P3-18 (judge result caching) — the last P3 item, the most complex (cache table + evaluator-config hashing). Next PR.
