### PR TITLE
feat: judge result caching (P3-18)

### DIFF
--- a/apps/server/src/__tests__/eval-judge-cache.test.ts
+++ b/apps/server/src/__tests__/eval-judge-cache.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { hashEvaluatorConfig, hashSampleInputs } from '../lib/eval-runners/judge-cache.js'
+import type { JudgeConfig } from '../lib/eval-runners/judge-prompt.js'
+
+// P3-18: judge_cache hashing — the cache key rotation logic.
+
+function cfg(over: Partial<JudgeConfig> = {}): JudgeConfig {
+  return {
+    criterion: 'Is the answer helpful?',
+    judge_provider: 'openai',
+    judge_model: 'gpt-4o-mini',
+    scale_min: 0,
+    scale_max: 1,
+    ...over,
+  }
+}
+
+describe('hashEvaluatorConfig', () => {
+  it('is deterministic for the same config', async () => {
+    const a = await hashEvaluatorConfig(cfg())
+    const b = await hashEvaluatorConfig(cfg())
+    expect(a).toBe(b)
+    // SHA-256 hex.
+    expect(a).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('rotates when the criterion changes', async () => {
+    const a = await hashEvaluatorConfig(cfg({ criterion: 'crit A' }))
+    const b = await hashEvaluatorConfig(cfg({ criterion: 'crit B' }))
+    expect(a).not.toBe(b)
+  })
+
+  it('rotates when the judge model changes', async () => {
+    const a = await hashEvaluatorConfig(cfg({ judge_model: 'gpt-4o-mini' }))
+    const b = await hashEvaluatorConfig(cfg({ judge_model: 'gpt-4o' }))
+    expect(a).not.toBe(b)
+  })
+
+  it('rotates when the rubric changes', async () => {
+    const a = await hashEvaluatorConfig(cfg({ rubric: 'old rubric' }))
+    const b = await hashEvaluatorConfig(cfg({ rubric: 'new rubric' }))
+    expect(a).not.toBe(b)
+  })
+
+  it('treats missing rubric and empty/whitespace rubric as equivalent', async () => {
+    const noRubric = await hashEvaluatorConfig(cfg())
+    const emptyRubric = await hashEvaluatorConfig(cfg({ rubric: '' }))
+    const whitespaceRubric = await hashEvaluatorConfig(cfg({ rubric: '   ' }))
+    expect(noRubric).toBe(emptyRubric)
+    expect(noRubric).toBe(whitespaceRubric)
+  })
+
+  it('rotates when anchors change', async () => {
+    const a = await hashEvaluatorConfig(cfg({ anchors: [{ response: 'good', score: 1 }] }))
+    const b = await hashEvaluatorConfig(cfg({ anchors: [{ response: 'bad', score: 0 }] }))
+    expect(a).not.toBe(b)
+  })
+
+  it('treats missing anchors array and empty anchors array as equivalent', async () => {
+    const noAnchors = await hashEvaluatorConfig(cfg())
+    const emptyAnchors = await hashEvaluatorConfig(cfg({ anchors: [] }))
+    expect(noAnchors).toBe(emptyAnchors)
+  })
+
+  it('rotates when score_config_id changes', async () => {
+    const a = await hashEvaluatorConfig(cfg({ score_config: { id: 'a', data_type: 'NUMERIC', min_value: 0, max_value: 1, categories: null, bool_true_label: null, bool_false_label: null } }))
+    const b = await hashEvaluatorConfig(cfg({ score_config: { id: 'b', data_type: 'NUMERIC', min_value: 0, max_value: 1, categories: null, bool_true_label: null, bool_false_label: null } }))
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('hashSampleInputs', () => {
+  it('is deterministic for the same inputs', async () => {
+    const a = await hashSampleInputs('Paris', null)
+    const b = await hashSampleInputs('Paris', null)
+    expect(a).toBe(b)
+  })
+
+  it('rotates when the response text changes', async () => {
+    const a = await hashSampleInputs('Paris', null)
+    const b = await hashSampleInputs('Lyon', null)
+    expect(a).not.toBe(b)
+  })
+
+  it('rotates when the golden expected_output changes', async () => {
+    const a = await hashSampleInputs('Paris', 'The capital is Paris.')
+    const b = await hashSampleInputs('Paris', 'France is in Europe.')
+    expect(a).not.toBe(b)
+  })
+
+  it('treats no expected_output as distinct from any expected_output', async () => {
+    const noGold = await hashSampleInputs('Paris', null)
+    const emptyGold = await hashSampleInputs('Paris', '')
+    // Both end up with no extra content after the separator. The null/'' case
+    // collapses to the same hash by design — both mean "no reference".
+    expect(noGold).toBe(emptyGold)
+  })
+
+  it('does not collide when response/expected boundary is ambiguous (null-byte separator)', async () => {
+    // "a b" + null vs "a" + "b" — without a null-byte separator these would
+    // both naively concat to "a b". The implementation must keep them distinct.
+    const a = await hashSampleInputs('a b', null)
+    const b = await hashSampleInputs('a', 'b')
+    expect(a).not.toBe(b)
+  })
+})

--- a/apps/server/src/__tests__/eval-runner-deterministic-columns.test.ts
+++ b/apps/server/src/__tests__/eval-runner-deterministic-columns.test.ts
@@ -28,7 +28,7 @@ let runSimpleEvalRun: typeof import('../lib/eval-runners/deterministic.js').runS
 // The update must be a subset.
 const REAL_EVAL_RUNS_COLUMNS = new Set([
   'status', 'scored_count', 'attempted_count', 'failed_count',
-  'avg_score', 'score_stddev', 'distribution',
+  'avg_score', 'score_stddev', 'distribution', 'cache_hits',
   'total_cost_usd', 'error', 'completed_at',
 ])
 

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -24,6 +24,7 @@ import { runEvaluateAlertsJob } from '../lib/cron-jobs/evaluate-alerts.js'
 import { runDetectMissingModelPricesJob } from '../lib/cron-jobs/detect-missing-model-prices.js'
 import { runSelfMonitorJob } from '../lib/cron-jobs/self-monitor.js'
 import { runDetectOrphanSpansJob } from '../lib/cron-jobs/detect-orphan-spans.js'
+import { runPruneJudgeCacheJob } from '../lib/cron-jobs/prune-judge-cache.js'
 import { runKeepWarmJob } from '../lib/cron-jobs/keep-warm.js'
 
 /**
@@ -369,6 +370,20 @@ cronRouter.get('/detect-orphan-spans', async (c) => {
   const p = result.ok
     ? logCronRun('detect-orphan-spans', 'ok', dur)
     : logCronRun('detect-orphan-spans', 'error', dur, result.error)
+  p.catch(() => undefined)
+  return c.json(result, result.ok ? 200 : 500)
+})
+
+// ── /prune-judge-cache (P3-18) — TTL-delete stale judge_cache rows ─
+cronRouter.get('/prune-judge-cache', async (c) => {
+  assertCronAuth(c.req.header('Authorization'))
+
+  const start = Date.now()
+  const result = await runPruneJudgeCacheJob()
+  const dur = Date.now() - start
+  const p = result.ok
+    ? logCronRun('prune-judge-cache', 'ok', dur)
+    : logCronRun('prune-judge-cache', 'error', dur, result.error)
   p.catch(() => undefined)
   return c.json(result, result.ok ? 200 : 500)
 })

--- a/apps/server/src/lib/cron-jobs/prune-judge-cache.ts
+++ b/apps/server/src/lib/cron-jobs/prune-judge-cache.ts
@@ -1,0 +1,44 @@
+/**
+ * /cron/prune-judge-cache (P3-18) — TTL-delete stale judge_cache rows so the
+ * cache doesn't grow unbounded.
+ *
+ * The cache memoises (org, evaluator_config_hash, response_hash) → judge
+ * outcome. A response written ~30 days ago is unlikely to be re-evaluated —
+ * the prompt version + the production sample have probably both rolled over.
+ * Keeping older rows just costs storage with no hit probability.
+ *
+ * Runs daily. Idempotent: a row stays only until its created_at + TTL.
+ */
+
+import { supabaseAdmin } from '../db.js'
+
+export interface PruneJudgeCacheResult {
+  ok: boolean
+  deleted: number
+  ttlDays: number
+  error?: string
+}
+
+/** Days a judge_cache row lives before this cron deletes it. */
+const TTL_DAYS = 30
+
+export async function runPruneJudgeCacheJob(): Promise<PruneJudgeCacheResult> {
+  const cutoff = new Date(Date.now() - TTL_DAYS * 24 * 60 * 60 * 1000).toISOString()
+  try {
+    // count: 'exact' here is cheap because the partial index on created_at
+    // covers the WHERE clause directly.
+    const { error, count } = await supabaseAdmin
+      .from('judge_cache')
+      .delete({ count: 'exact' })
+      .lt('created_at', cutoff)
+    if (error) return { ok: false, deleted: 0, ttlDays: TTL_DAYS, error: error.message }
+    return { ok: true, deleted: count ?? 0, ttlDays: TTL_DAYS }
+  } catch (err) {
+    return {
+      ok: false,
+      deleted: 0,
+      ttlDays: TTL_DAYS,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}

--- a/apps/server/src/lib/eval-runner.ts
+++ b/apps/server/src/lib/eval-runner.ts
@@ -36,6 +36,12 @@ import { startInternalTrace } from './internal-tracing.js'
 import { extractResponseText, fetchWithRetry } from './eval-runners/shared.js'
 import { sampleStdDev } from './eval-runners/stats.js'
 import { computeDistribution } from './eval-runners/distribution.js'
+import {
+  hashEvaluatorConfig,
+  hashSampleInputs,
+  lookupJudgeCache,
+  storeJudgeCache,
+} from './eval-runners/judge-cache.js'
 import { serializeTrajectory, buildTrajectoryJudgePrompt, type TrajectorySpan } from './eval-runners/trajectory.js'
 import {
   buildJudgePrompt,
@@ -104,6 +110,12 @@ interface JudgeOutcome {
   // Lets the dashboard render "4 out of 5" instead of only the derived 0.8.
   // null for non-numeric typed configs and for legacy rows.
   value_raw_number: number | null
+  // P3-18 — true when this outcome came from judge_cache. `cost` and `tokens`
+  // are 0 in that case; the original call's cost is in `cached_savings_usd`
+  // so the runner can report cumulative savings. Always false for embedding
+  // and trajectory outcomes.
+  cached: boolean
+  cached_savings_usd: number
 }
 
 // extractResponseText moved to ./eval-runners/shared.ts (imported above).
@@ -413,7 +425,14 @@ async function judgeComplete(
 }
 
 /** Calls the judge LLM once. Returns null on failure (caller skips the sample).
- * Exported for unit tests (see generateForItem note above). */
+ * Exported for unit tests (see generateForItem note above).
+ *
+ * P3-18: when `organizationId` is provided the result is memoised in
+ * judge_cache keyed by (org, config_hash, response+expected_hash). A second
+ * call with the same inputs returns the cached outcome at $0 and sets
+ * `cached: true`. Pass `organizationId: null` to bypass the cache (used by
+ * unit tests that don't want a DB round-trip).
+ */
 export async function callJudge(
   config: JudgeConfig,
   responseText: string,
@@ -424,7 +443,41 @@ export async function callJudge(
   /** Golden answer (P1-6). When present (dataset items with expected_output)
    * it is injected into the prompt as a reference for the judge. */
   expectedOutput: string | null = null,
+  /** P3-18: enables judge_cache lookup / store. Null disables caching. */
+  organizationId: string | null = null,
 ): Promise<JudgeOutcome | null> {
+  // P3-18: cache lookup. Compute both hashes up front; on hit, skip the LLM
+  // call entirely. On miss/failure, fall through to the real call. The cache
+  // helpers swallow errors so a flaky judge_cache never breaks scoring.
+  let configHash: string | null = null
+  let inputsHash: string | null = null
+  if (organizationId) {
+    try {
+      configHash = await hashEvaluatorConfig(config)
+      inputsHash = await hashSampleInputs(responseText, expectedOutput)
+      const hit = await lookupJudgeCache({ organizationId, configHash, responseHash: inputsHash })
+      if (hit) {
+        return {
+          score: hit.score,
+          value_number: hit.value_number,
+          value_string: hit.value_string,
+          value_boolean: hit.value_boolean,
+          value_raw_number: hit.value_raw_number,
+          reasoning: hit.reasoning,
+          cost: 0,
+          tokens: 0,
+          cached: true,
+          cached_savings_usd: hit.original_cost_usd,
+        }
+      }
+    } catch {
+      // Hash failures (Web Crypto unavailable in some test envs) bypass the
+      // cache silently — never block a real eval over caching plumbing.
+      configHash = null
+      inputsHash = null
+    }
+  }
+
   const prompt = buildJudgePrompt(config.criterion, responseText, {
     scale_min: config.scale_min,
     scale_max: config.scale_max,
@@ -458,13 +511,14 @@ export async function callJudge(
   // additionally preserves the clamped-but-not-normalised raw answer so the
   // dashboard can render the original scale ("4 out of 5", not only 0.8).
   const sc = config.score_config
+  let outcome: JudgeOutcome
   if (!sc || sc.data_type === 'NUMERIC') {
     const min = sc?.min_value ?? config.scale_min
     const max = sc?.max_value ?? config.scale_max
     const range = max - min || 1
     const raw = parsed.value_number ?? parsed.score ?? 0
     const normalised = (raw - min) / range
-    return {
+    outcome = {
       score: normalised,
       value_number: normalised,
       value_string: null,
@@ -473,18 +527,43 @@ export async function callJudge(
       reasoning: parsed.reasoning,
       cost: res.cost,
       tokens: res.tokens,
+      cached: false,
+      cached_savings_usd: 0,
+    }
+  } else {
+    outcome = {
+      score: null,
+      value_number: parsed.value_number,
+      value_string: parsed.value_string,
+      value_boolean: parsed.value_boolean,
+      value_raw_number: null,
+      reasoning: parsed.reasoning,
+      cost: res.cost,
+      tokens: res.tokens,
+      cached: false,
+      cached_savings_usd: 0,
     }
   }
-  return {
-    score: null,
-    value_number: parsed.value_number,
-    value_string: parsed.value_string,
-    value_boolean: parsed.value_boolean,
-    value_raw_number: null,
-    reasoning: parsed.reasoning,
-    cost: res.cost,
-    tokens: res.tokens,
+
+  // P3-18: store on cache miss (writes are best-effort, errors swallowed).
+  if (organizationId && configHash && inputsHash) {
+    void storeJudgeCache({
+      organizationId,
+      configHash,
+      responseHash: inputsHash,
+      outcome: {
+        score: outcome.score,
+        value_number: outcome.value_number,
+        value_string: outcome.value_string,
+        value_boolean: outcome.value_boolean,
+        value_raw_number: outcome.value_raw_number,
+        reasoning: outcome.reasoning,
+        original_cost_usd: outcome.cost,
+        original_tokens: outcome.tokens,
+      },
+    })
   }
+  return outcome
 }
 
 /** Outcome of one pairwise comparison (P1-7 3/3). `winner` is in PROMPT terms
@@ -1427,7 +1506,7 @@ export async function runEvalRun(input: RunInput): Promise<void> {
           }
           outcome = await scoreEmbedding(embedConfig!, sample.responseText, reference, scoringKey, scoringResourceUrl)
         } else {
-          outcome = await callJudge(config, sample.responseText, scoringKey, scoringResourceUrl, sample.expectedOutput)
+          outcome = await callJudge(config, sample.responseText, scoringKey, scoringResourceUrl, sample.expectedOutput, organizationId)
         }
         if (!outcome) {
           span.end({ status: 'error', errorMessage: isEmbedding ? 'scoreEmbedding returned null' : 'callJudge returned null' })
@@ -1509,6 +1588,11 @@ export async function runEvalRun(input: RunInput): Promise<void> {
     if (insertErr) throw new Error(`Result insert failed: ${insertErr.message}`)
 
     const totalCost = scored.reduce((sum, s) => sum + s.cost, 0)
+    // P3-18: tally cache hits + the original cost we would have paid if those
+    // hits were misses. Embedding outcomes have cached=false / savings=0 so
+    // they don't skew either count.
+    const cacheHits = scored.reduce((n, s) => n + (s.cached ? 1 : 0), 0)
+    const cacheSavingsUsd = scored.reduce((sum, s) => sum + (s.cached ? s.cached_savings_usd : 0), 0)
     // The 0..1 values that back avg_score, also reused for the P1-7
     // standard deviation / confidence interval. Empty for the typed configs
     // that don't aggregate as a mean (CATEGORICAL, TEXT) so the dashboard
@@ -1555,6 +1639,7 @@ export async function runEvalRun(input: RunInput): Promise<void> {
         score_stddev: scoreStddev,
         distribution,
         total_cost_usd: totalCost,
+        cache_hits: cacheHits,
         completed_at: new Date().toISOString(),
       })
       .eq('id', evalRunId)
@@ -1568,6 +1653,8 @@ export async function runEvalRun(input: RunInput): Promise<void> {
         avg_score: avgScore,
         score_stddev: scoreStddev,
         total_cost_usd: totalCost,
+        cache_hits: cacheHits,
+        cache_savings_usd: cacheSavingsUsd,
       },
     })
   } catch (err) {

--- a/apps/server/src/lib/eval-runners/embedding.ts
+++ b/apps/server/src/lib/eval-runners/embedding.ts
@@ -43,6 +43,10 @@ export interface EmbeddingOutcome {
   reasoning: string
   cost: number
   tokens: number
+  /** P3-18 mirror — embedding scoring is deterministic and cheap so we don't
+   *  cache it. These stay false/0 to keep the SampleOutcome union uniform. */
+  cached: boolean
+  cached_savings_usd: number
 }
 
 /** Cosine similarity of two equal-length vectors; 0 for degenerate input. */
@@ -157,5 +161,7 @@ export async function scoreEmbedding(
     reasoning: `cosine similarity ${score.toFixed(4)}${threshold != null ? ` (threshold ${threshold})` : ''}`,
     cost,
     tokens: result.tokens,
+    cached: false,
+    cached_savings_usd: 0,
   }
 }

--- a/apps/server/src/lib/eval-runners/judge-cache.ts
+++ b/apps/server/src/lib/eval-runners/judge-cache.ts
@@ -1,0 +1,139 @@
+/**
+ * P3-18: judge result cache.
+ *
+ * Memoises (organization, evaluator_config, response_text) → judge outcome so
+ * a re-evaluation of the same sample with the same evaluator doesn't re-charge
+ * the judge LLM. Cache hits return the stored score / reasoning at $0.
+ *
+ * Hashing is deterministic over a stable JSON serialisation of the relevant
+ * judge fields — editing the evaluator (criterion, model, rubric, anchors)
+ * naturally rotates the hash and invalidates entries, so there's no separate
+ * invalidation API. SHA-256 from lib/crypto.ts is used for both hashes.
+ */
+
+import { supabaseAdmin } from '../db.js'
+import { sha256Hex } from '../crypto.js'
+import type { JudgeConfig } from './judge-prompt.js'
+
+/** Cached outcome shape stored on judge_cache. Mirrors JudgeOutcome's
+ *  value columns plus the original (pre-cache) call's cost / tokens. */
+export interface CachedJudgeOutcome {
+  score: number | null
+  value_number: number | null
+  value_string: string | null
+  value_boolean: boolean | null
+  value_raw_number: number | null
+  reasoning: string
+  /** Cost of the ORIGINAL judge call. The cache hit itself bills $0; this is
+   *  kept so dashboards can report cumulative savings. */
+  original_cost_usd: number
+  original_tokens: number
+}
+
+/**
+ * Build a deterministic hash of the judge config fields that materially affect
+ * the score. Anything in this set must rotate the cache: criterion + provider
+ * + model + scale + score_config_id + rubric + anchors.
+ *
+ * Object key ordering inside JSON.stringify is browser/runtime-defined for
+ * unknown property orders, so we serialise field-by-field in a fixed order.
+ */
+export async function hashEvaluatorConfig(config: JudgeConfig): Promise<string> {
+  // Anchors: serialise each anchor in a fixed shape too. Empty array and
+  // missing field hash identically so an evaluator created without anchors
+  // and one that had its anchors deleted match the same cache rows.
+  const anchors = (config.anchors ?? []).map((a) => ({
+    response: a.response,
+    score: a.score,
+    reasoning: a.reasoning ?? null,
+  }))
+  const payload = JSON.stringify({
+    criterion: config.criterion,
+    judge_provider: config.judge_provider,
+    judge_model: config.judge_model,
+    scale_min: config.scale_min,
+    scale_max: config.scale_max,
+    score_config_id: config.score_config?.id ?? null,
+    rubric: config.rubric?.trim() ? config.rubric.trim() : null,
+    anchors,
+  })
+  return sha256Hex(payload)
+}
+
+/**
+ * Hash the sample inputs that fed the judge prompt. The expected_output
+ * (golden answer from P1-6 dataset items) is included so the same response
+ * with a different golden reference doesn't return the cached score for
+ * "criterion only".
+ */
+export function hashSampleInputs(responseText: string, expectedOutput: string | null): Promise<string> {
+  return sha256Hex(`${responseText}\x00${expectedOutput ?? ''}`)
+}
+
+/**
+ * Look up a cached judge outcome. Returns the cached row or null when the
+ * cache misses (or the lookup itself fails — caches must never break the
+ * caller's hot path).
+ */
+export async function lookupJudgeCache(args: {
+  organizationId: string
+  configHash: string
+  responseHash: string
+}): Promise<CachedJudgeOutcome | null> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('judge_cache')
+      .select('score, value_number, value_string, value_boolean, value_raw_number, reasoning, original_cost_usd, original_tokens')
+      .eq('organization_id', args.organizationId)
+      .eq('evaluator_config_hash', args.configHash)
+      .eq('response_hash', args.responseHash)
+      .maybeSingle()
+    if (error || !data) return null
+    return {
+      score: (data.score as number | null) ?? null,
+      value_number: (data.value_number as number | null) ?? null,
+      value_string: (data.value_string as string | null) ?? null,
+      value_boolean: (data.value_boolean as boolean | null) ?? null,
+      value_raw_number: (data.value_raw_number as number | null) ?? null,
+      reasoning: (data.reasoning as string | null) ?? '',
+      original_cost_usd: Number(data.original_cost_usd ?? 0),
+      original_tokens: Number(data.original_tokens ?? 0),
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Insert a fresh outcome into the cache. Uses an ON CONFLICT DO NOTHING via
+ * the natural-key unique constraint, so a race between two judge calls of the
+ * same sample doesn't double-insert. Errors are swallowed — a write failure
+ * just means the next call won't hit the cache, never a user-visible failure.
+ */
+export async function storeJudgeCache(args: {
+  organizationId: string
+  configHash: string
+  responseHash: string
+  outcome: CachedJudgeOutcome
+}): Promise<void> {
+  try {
+    await supabaseAdmin.from('judge_cache').upsert(
+      {
+        organization_id: args.organizationId,
+        evaluator_config_hash: args.configHash,
+        response_hash: args.responseHash,
+        score: args.outcome.score,
+        value_number: args.outcome.value_number,
+        value_string: args.outcome.value_string,
+        value_boolean: args.outcome.value_boolean,
+        value_raw_number: args.outcome.value_raw_number,
+        reasoning: args.outcome.reasoning,
+        original_cost_usd: args.outcome.original_cost_usd,
+        original_tokens: args.outcome.original_tokens,
+      },
+      { onConflict: 'organization_id,evaluator_config_hash,response_hash', ignoreDuplicates: true },
+    )
+  } catch {
+    // Cache writes must never break the caller. Drop and move on.
+  }
+}

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -24,6 +24,7 @@
     { "path": "/cron/detect-missing-model-prices","schedule": "0 * * * *" },
     { "path": "/cron/self-monitor",               "schedule": "31 * * * *" },
     { "path": "/cron/detect-orphan-spans",        "schedule": "17 * * * *" },
-    { "path": "/cron/keep-warm",                  "schedule": "*/5 * * * *" }
+    { "path": "/cron/keep-warm",                  "schedule": "*/5 * * * *" },
+    { "path": "/cron/prune-judge-cache",          "schedule": "0 3 * * *" }
   ]
 }

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -1518,6 +1518,16 @@ function RunDetailPanel({ runId, onClose }: { runId: string; onClose: () => void
           <div className="bg-bg-muted border border-border rounded-[5px] px-3 py-2">
             <p className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-text-faint">Cost</p>
             <p className="font-mono text-[16px] text-text font-medium">{fmtUsd(r.total_cost_usd)}</p>
+            {/* P3-18: when judge_cache returned outcomes for some samples,
+                show the hit count under the cost cell. We don't know the
+                exact saved dollar amount from this row (only the original
+                per-call cost was on the cache entry server-side), but the
+                hit count alone tells the user "this re-run was cheaper". */}
+            {r.cache_hits != null && r.cache_hits > 0 && (
+              <p className="font-mono text-[9px] text-text-faint tabular-nums mt-0.5" title="Judge calls served from cache instead of hitting the LLM">
+                {r.cache_hits} cached
+              </p>
+            )}
           </div>
         </div>
 

--- a/apps/web/lib/queries/use-evals.ts
+++ b/apps/web/lib/queries/use-evals.ts
@@ -97,6 +97,10 @@ export interface EvalRun {
    * pulling every per-sample row. NULL/absent for NUMERIC / legacy / embedding
    * runs and for pre-migration rows. */
   distribution?: RunDistribution | null
+  /** P3-18: number of judge calls served from judge_cache instead of hitting
+   * the LLM. avg_score / per-sample scores are unaffected — these are just hits
+   * that re-used a previously stored outcome at $0. 0 on pre-migration rows. */
+  cache_hits?: number
   total_cost_usd: number
   error: string | null
   created_by: string | null

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @spanlens/sdk changelog
 
+## 0.13.0
+
+Judge result caching (P3-18) — re-evaluations of the same sample with the same evaluator return $0.
+
+### Added
+
+- `EvalRun.cache_hits` — number of judge calls served from `judge_cache` instead of hitting the LLM. CI jobs can log "X cached, Y new" and reason about cost. 0 / absent on pre-migration rows.
+
+The cache is keyed by `(organization, evaluator_config_hash, response+expected_hash)`. Editing an evaluator (criterion, model, rubric, anchors) rotates the hash so old cache entries are naturally invalidated — no manual invalidation API needed. A daily TTL cron prunes rows older than 30 days.
+
 ## 0.12.0
 
 P3 score-model polish — raw judge scores + server-computed distributions.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/evals.ts
+++ b/packages/sdk/src/evals.ts
@@ -71,6 +71,9 @@ export interface EvalRun {
    * avg_score is null. Lets clients render a histogram without fetching every
    * per-sample row. NULL/absent for NUMERIC / legacy / embedding runs. */
   distribution?: RunDistribution | null
+  /** P3-18: judge calls served from cache instead of hitting the LLM. Let CI
+   * jobs log "X cached, $0 charge". 0 on pre-migration rows. */
+  cache_hits?: number
   total_cost_usd: number
   error: string | null
   started_at: string

--- a/supabase/migrations/20260615070000_judge_cache.sql
+++ b/supabase/migrations/20260615070000_judge_cache.sql
@@ -1,0 +1,51 @@
+-- P3-18: judge result cache.
+--
+-- Today the same (response_text, evaluator_config) re-evaluation re-charges
+-- every time — running the same eval twice on the same prompt version against
+-- the same production sample pays the judge LLM twice. judge_cache memoises
+-- the outcome keyed by (org, evaluator_config_hash, response_hash) so a hit
+-- returns the stored score/reasoning at $0.
+--
+-- evaluator_config_hash is a deterministic SHA-256 over the JSON-serialised
+-- judge config (criterion + provider + model + scale + score_config_id +
+-- rubric + anchors). Editing the evaluator naturally invalidates its cache
+-- entries — no manual invalidation API needed.
+--
+-- response_hash is SHA-256 over the response text being judged.
+--
+-- cache_hits on eval_runs lets the dashboard show "12 cached, $0.04 saved"
+-- and the SDK can read it in CI.
+
+CREATE TABLE IF NOT EXISTS public.judge_cache (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  evaluator_config_hash text NOT NULL,
+  response_hash text NOT NULL,
+  -- Mirror of JudgeOutcome value columns. Exactly one of score / value_string /
+  -- value_boolean is non-null per row depending on the score_config data_type.
+  score numeric,
+  value_number numeric,
+  value_string text,
+  value_boolean boolean,
+  value_raw_number numeric,
+  reasoning text,
+  -- Original (uncached) call's cost / tokens — informational, the cache hit
+  -- itself bills $0 to the org. Lets dashboards report cumulative savings.
+  original_cost_usd numeric NOT NULL DEFAULT 0,
+  original_tokens integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  -- (org, config_hash, response_hash) is the natural cache key. UNIQUE so the
+  -- lookup is a single equality on the index and the runner's "insert on
+  -- miss" path uses ON CONFLICT DO NOTHING idempotently.
+  CONSTRAINT judge_cache_key_uniq UNIQUE (organization_id, evaluator_config_hash, response_hash)
+);
+
+ALTER TABLE public.judge_cache ENABLE ROW LEVEL SECURITY;
+
+-- Index for the TTL cleanup cron (delete WHERE created_at < now() - interval '30 days').
+CREATE INDEX IF NOT EXISTS judge_cache_created_at_idx ON public.judge_cache (created_at);
+
+-- P3-18: per-run cache-hit tally. Additive NOT NULL DEFAULT 0 so existing
+-- rows are valid and the dashboard's pre-feature view shows 0 hits unchanged.
+ALTER TABLE eval_runs
+  ADD COLUMN IF NOT EXISTS cache_hits integer NOT NULL DEFAULT 0;


### PR DESCRIPTION
## P3-18: judge result caching — last P3 item

The same `(response_text, evaluator_config)` re-evaluation re-charges every time. Run the same eval twice on the same prompt version against the same production sample → pay the judge LLM twice. This memoises the outcome so repeats return at $0.

### Architecture
- **Key**: `(organization_id, evaluator_config_hash, response_hash)`
- **`evaluator_config_hash`**: deterministic SHA-256 over criterion + provider + model + scale + score_config_id + rubric + anchors. Editing the evaluator rotates the hash → entries naturally invalidate, no manual API needed.
- **`response_hash`**: SHA-256 over `response_text + \x00 + (expected_output ?? '')`. Null-byte separator prevents boundary collisions ("a b" + null vs "a" + "b").
- **Storage**: Postgres `judge_cache` table. UNIQUE on natural key + index on `created_at` for the TTL cron. RLS enabled.
- **Hit path**: bills $0, returns immediately with `cached: true` on the outcome.
- **Miss path**: real judge call, `upsert ON CONFLICT DO NOTHING` (race-safe).
- **All cache errors swallowed** — a flaky cache must never break scoring.
- **TTL**: daily 03:00 UTC cron deletes rows older than 30 days.

### User-facing changes
- **`eval_runs.cache_hits int`** (additive, NOT NULL DEFAULT 0) — per-run tally.
- **Run detail panel**: shows "N cached" under the Cost cell when hits > 0.
- **SDK 0.13.0**: `EvalRun.cache_hits` so CI jobs can log "X cached, Y new".

### Changes
- **db** (`20260615070000_judge_cache.sql`, additive + idempotent): new `judge_cache` table + `eval_runs.cache_hits`.
- **server**: `eval-runners/judge-cache.ts` pure helpers (`hashEvaluatorConfig`, `hashSampleInputs`, `lookupJudgeCache`, `storeJudgeCache`). `callJudge` takes optional `organizationId`; passes through `JudgeOutcome.cached` + `cached_savings_usd`. Embedding outcomes inherit the same shape (cached=false / savings=0). New `/cron/prune-judge-cache` registered in `vercel.json` (daily 03:00 UTC).
- **web/sdk**: `EvalRun.cache_hits` field; run detail KPI panel.

### Test plan
- [x] 13 cache hash unit tests: deterministic ✓, rotation on config/rubric/anchors/model/score_config_id changes ✓, missing-vs-empty rubric/anchors equivalence ✓, null-byte separator collision check ✓.
- [x] `pnpm typecheck` (all 7 packages), `pnpm --filter server lint`, `pnpm --filter web lint` — clean.
- [x] **154 server eval tests pass** (was 141; +13). SDK 131 pass + builds.
- [x] Backward compatible: `cache_hits` defaults to 0 on pre-migration rows; `callJudge` optional `organizationId` defaults to null (tests pass without DB round-trip).

### Deploy ordering
`deploy-server.yml` runs migrate → deploy, so the table + column exist before the runner reads/writes them. The runner reads `cached` via the optional `organizationId` path — tests pass without a real DB connection.

### What this closes
P3 detail track: **8 / 8 complete**. Eval P0-P3 trunk: **19 / 20** (only P2-12 custom JS evaluator remains, intentionally excluded — needs server sandbox).
