### PR TITLE
perf(web): non-blocking dashboard layout (PT-1)

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -1,9 +1,11 @@
+import { Suspense } from 'react'
 import { cookies, headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { HydrationBoundary } from '@tanstack/react-query'
 import { Sidebar } from '@/components/layout/sidebar'
 import { SidebarShowToggle } from '@/components/layout/sidebar-show-toggle'
 import { DashboardContent } from '@/components/layout/dashboard-content'
+import { DashboardShellSkeleton } from '@/components/layout/sidebar-skeleton'
 import { PendingInvitationsBanner } from '@/components/layout/pending-invitations-banner'
 import { WorkspaceSwitchOverlay } from '@/components/layout/workspace-switch-overlay'
 import { SidebarProvider } from '@/lib/sidebar-context'
@@ -55,7 +57,34 @@ import { sidebarSpecs } from '@/lib/server/queries/sidebar'
  * HydrationBoundary only scopes the page subtree — Sidebar lives in the
  * layout, OUTSIDE that boundary, so the prefetched cache was never visible
  * to the components that needed it. The boundary MUST wrap the consumers.
+ *
+ * PT-1 (2026-06-15): instead of blocking the whole layout on that prefetch,
+ * the prefetch + the HydrationBoundary now live in a `<PrefetchedShell>`
+ * sub-component wrapped in `<Suspense fallback={<DashboardShellSkeleton/>}>`.
+ * The auth headers + cookie reads (cheap) still run synchronously in the
+ * layout. Result: the browser sees the shell skeleton within ~50ms of the
+ * click instead of waiting for the 1-3s prefetch.
+ *
+ * Why this avoids the #425 race that killed 16d83e6's streaming attempt:
+ * that revert had TWO sibling HydrationBoundaries on the same QueryClient
+ * (one resolved synchronously, one streamed via Suspense). Here we have a
+ * single boundary inside the Suspended sub-component, with the page-level
+ * boundary nested below it. Nested boundaries hydrate in tree order within
+ * one reconciliation pass — no sibling race.
  */
+
+/** Async data layer: awaits sidebarSpecs, wraps the layout interior in a
+ *  HydrationBoundary so the Sidebar / PendingInvitationsBanner hooks find
+ *  their cache on mount. Streamed in via the layout's Suspense. */
+async function PrefetchedShell({ children }: { children: React.ReactNode }) {
+  const sidebarState = await prefetchAll(sidebarSpecs())
+  return (
+    <HydrationBoundary state={sidebarState}>
+      {children}
+    </HydrationBoundary>
+  )
+}
+
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   const h = await headers()
   const userId = h.get('x-spanlens-user-id')
@@ -65,10 +94,8 @@ export default async function DashboardLayout({ children }: { children: React.Re
   if (!userId) redirect('/login')
   if (!orgId || !onboarded) redirect('/onboarding')
 
-  const sidebarState = await prefetchAll(sidebarSpecs())
-
-  // Seed the desktop collapse state from the cookie so SSR renders the right
-  // layout on first paint (no flash of the sidebar before hydration).
+  // Cheap synchronous read — seeds the SidebarProvider so SSR renders the
+  // right desktop collapse state on first paint (no flash before hydration).
   const cookieStore = await cookies()
   const initialCollapsed = cookieStore.get(SIDEBAR_COLLAPSED_COOKIE)?.value === '1'
 
@@ -80,36 +107,42 @@ export default async function DashboardLayout({ children }: { children: React.Re
     <OverlayContainerProvider>
       <CommandPaletteProvider>
         <SidebarProvider initialCollapsed={initialCollapsed}>
-          <HydrationBoundary state={sidebarState}>
-            {/* Dashboard renders at 125% scale (zoom) for a roomier default
-                view. Height is divided by the SAME factor so the zoomed
-                container still resolves to exactly one viewport height — without
-                the correction, 100vh * 1.25 would overflow and add a stray
-                scrollbar. The zoom factor and the height divisor must always
-                match. Scoped to the dashboard only; landing/docs/demo keep
-                their 100% scale. */}
-            <div className="flex h-[calc(100vh/1.25)] overflow-hidden bg-bg [zoom:1.25]">
-              <Sidebar />
-              {/* Brings the sidebar back when it's collapsed to zero width.
-                  Renders nothing while the sidebar is visible. */}
-              <SidebarShowToggle />
-              <main className="flex-1 overflow-y-auto min-w-0">
-                {/* Pending workspace invitations surface here: any dashboard
-                    page renders this banner at the top, so a user who never
-                    clicked the email link still sees the invite waiting for
-                    them. Self-hides when there are none / after dismissal. */}
-                <PendingInvitationsBanner />
-                <DashboardContent>{children}</DashboardContent>
-              </main>
-              {/* Portal target for dialogs / command palette — inside the zoom
-                  wrapper so overlays render at the same 125% scale. */}
-              <OverlayContainerTarget />
-              {/* Workspace-switch loading UI. Self-mounted because the sidebar
-                  uses hard reload; this listens on a window event and renders
-                  during the SSR round-trip. */}
-              <WorkspaceSwitchOverlay />
-            </div>
-          </HydrationBoundary>
+          {/* PT-1: shell + sidebar/page render inside Suspense so the layout
+              returns its HTML the moment the auth + cookie reads complete.
+              The skeleton is shape-matched to the real Sidebar geometry so
+              the swap is visually stable. */}
+          <Suspense fallback={<DashboardShellSkeleton initialCollapsed={initialCollapsed} />}>
+            <PrefetchedShell>
+              {/* Dashboard renders at 125% scale (zoom) for a roomier default
+                  view. Height is divided by the SAME factor so the zoomed
+                  container still resolves to exactly one viewport height — without
+                  the correction, 100vh * 1.25 would overflow and add a stray
+                  scrollbar. The zoom factor and the height divisor must always
+                  match. Scoped to the dashboard only; landing/docs/demo keep
+                  their 100% scale. */}
+              <div className="flex h-[calc(100vh/1.25)] overflow-hidden bg-bg [zoom:1.25]">
+                <Sidebar />
+                {/* Brings the sidebar back when it's collapsed to zero width.
+                    Renders nothing while the sidebar is visible. */}
+                <SidebarShowToggle />
+                <main className="flex-1 overflow-y-auto min-w-0">
+                  {/* Pending workspace invitations surface here: any dashboard
+                      page renders this banner at the top, so a user who never
+                      clicked the email link still sees the invite waiting for
+                      them. Self-hides when there are none / after dismissal. */}
+                  <PendingInvitationsBanner />
+                  <DashboardContent>{children}</DashboardContent>
+                </main>
+                {/* Portal target for dialogs / command palette — inside the zoom
+                    wrapper so overlays render at the same 125% scale. */}
+                <OverlayContainerTarget />
+                {/* Workspace-switch loading UI. Self-mounted because the sidebar
+                    uses hard reload; this listens on a window event and renders
+                    during the SSR round-trip. */}
+                <WorkspaceSwitchOverlay />
+              </div>
+            </PrefetchedShell>
+          </Suspense>
         </SidebarProvider>
       </CommandPaletteProvider>
     </OverlayContainerProvider>

--- a/apps/web/components/layout/sidebar-skeleton.tsx
+++ b/apps/web/components/layout/sidebar-skeleton.tsx
@@ -1,0 +1,63 @@
+/**
+ * PT-1: shell skeleton for the dashboard layout.
+ *
+ * Shown as the Suspense fallback while the layout's prefetchAll(sidebarSpecs)
+ * is running, so the browser sees the shell within ~50ms of the click instead
+ * of waiting for 1-3s of server-side prefetch. The skeleton mirrors the
+ * real Sidebar / main split so the swap to the real layout is visually
+ * stable (no jump).
+ *
+ * Pure presentational, no client state — safe to render server-side.
+ */
+import { cn } from '@/lib/utils'
+
+interface DashboardShellSkeletonProps {
+  /** Mirrors the SidebarProvider's initial cookie-seeded collapse state so
+   *  the skeleton matches the resolved Sidebar's geometry. Desktop only —
+   *  the sidebar is a slide-in drawer on mobile and shows zero width by
+   *  default there. */
+  initialCollapsed: boolean
+}
+
+export function DashboardShellSkeleton({ initialCollapsed }: DashboardShellSkeletonProps) {
+  return (
+    <div className="flex h-[calc(100vh/1.25)] overflow-hidden bg-bg [zoom:1.25]">
+      {/* Sidebar skeleton — desktop only. Mobile renders a closed drawer so
+          there's nothing to skeletonise; the real Sidebar will mount with
+          the topbar's menu button. */}
+      <aside
+        className={cn(
+          'hidden md:flex flex-col shrink-0 border-r border-border bg-bg',
+          initialCollapsed ? 'w-0' : 'w-[272px]',
+        )}
+      >
+        {!initialCollapsed && (
+          <div className="flex-1 flex flex-col gap-3 px-[14px] py-[16px]">
+            {/* Logo / workspace switcher row */}
+            <div className="h-7 w-[180px] bg-bg-elev rounded-[5px] animate-pulse" />
+            <div className="h-7 w-full bg-bg-elev rounded-[5px] animate-pulse" />
+            {/* Nav block — match the real sidebar's group of ~6 items */}
+            <div className="mt-3 space-y-1.5">
+              {[0, 1, 2, 3, 4, 5].map((i) => (
+                <div key={i} className="h-6 w-full bg-bg-elev rounded-[4px] animate-pulse opacity-80" />
+              ))}
+            </div>
+            {/* Second group */}
+            <div className="mt-3 space-y-1.5">
+              {[0, 1, 2].map((i) => (
+                <div key={i} className="h-6 w-full bg-bg-elev rounded-[4px] animate-pulse opacity-70" />
+              ))}
+            </div>
+            {/* Bottom quota card */}
+            <div className="mt-auto h-[68px] w-full bg-bg-elev rounded-[6px] animate-pulse" />
+          </div>
+        )}
+      </aside>
+
+      {/* Main area — keep empty/blank so the page's own loading.tsx
+          skeleton owns the content space when it mounts. Even an empty
+          main signals "page content is loading" to the user. */}
+      <main className="flex-1 overflow-y-auto min-w-0" />
+    </div>
+  )
+}


### PR DESCRIPTION
## PT-1: dashboard layout non-blocking

### Problem
The `(dashboard)` layout used to `await prefetchAll(sidebarSpecs())` before returning any HTML. Cold visits paid **2-5s** of blank screen; warm visits paid **1-2s**. The page's own `loading.tsx` couldn't help — it only renders AFTER the layout's awaits complete.

Layout comment (kept for context):
> Sidebar / banner data is NOT prefetched here. The components that read it live in the (dashboard) layout — outside this page's HydrationBoundary scope.

### Fix
Move the prefetch into a `<PrefetchedShell>` async sub-component wrapped in `<Suspense fallback={<DashboardShellSkeleton />}>`. The layout itself only does the cheap auth header + cookie reads synchronously. Browser sees the shell skeleton within ~50ms of the click. The real sidebar + page stream in when prefetch resolves.

The skeleton is shape-matched to the real Sidebar geometry (272px desktop, 0px when `initialCollapsed` from cookie) so the swap is visually stable.

### Why this avoids the #425 race
Earlier streaming attempt (revert 16d83e6) had TWO sibling `HydrationBoundary`s on the same QueryClient — one synchronous (above-fold) + one streamed via Suspense (below-fold). The deferred one's `hydrate()` raced with the synchronous one's `hydrate()`.

PT-1 has a **single** boundary inside the Suspended sub-component; the page-level boundary nests inside. Nested boundaries hydrate in tree order within one reconciliation pass — no sibling race.

### Test plan
- [x] `pnpm --filter web typecheck`, `pnpm --filter web lint` — clean
- [x] `pnpm --filter web build` — production build succeeds
- [x] Auth/cookie reads + redirect path stays synchronous (verified by /dashboard still redirecting to /login)
- Note: full visual frame check requires a logged-in dashboard session — not easily reproducible in PR review. Watch Vercel preview for any `Application error` after deploy.
