### PR TITLE
perf(web): hover prefetch on Go to dashboard CTAs (PT-3)

### DIFF
--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link'
 import { Button } from '@/components/ui/button'
+import { DashboardCTALink } from '@/components/layout/dashboard-cta-link'
 
 export default function NotFound() {
   return (
@@ -9,9 +9,9 @@ export default function NotFound() {
       <p className="text-muted-foreground mb-8">
         The page you&apos;re looking for doesn&apos;t exist.
       </p>
-      <Link href="/dashboard">
+      <DashboardCTALink>
         <Button>Go to dashboard</Button>
-      </Link>
+      </DashboardCTALink>
     </div>
   )
 }

--- a/apps/web/components/layout/auth-nav-buttons.tsx
+++ b/apps/web/components/layout/auth-nav-buttons.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { ArrowRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { createClient } from '@/lib/supabase/server'
+import { DashboardCTALink } from '@/components/layout/dashboard-cta-link'
 
 interface AuthNavButtonsProps {
   /** Label for the signup CTA when logged out. Defaults to "Start free". */
@@ -45,12 +46,12 @@ export async function AuthNavButtons({ signupLabel = 'Start free' }: AuthNavButt
             Live demo
           </Button>
         </Link>
-        <Link href="/dashboard">
+        <DashboardCTALink>
           <Button size="sm" className="gap-1.5">
             Go to dashboard
             <ArrowRight className="h-3.5 w-3.5" />
           </Button>
-        </Link>
+        </DashboardCTALink>
       </>
     )
   }

--- a/apps/web/components/layout/dashboard-cta-link.tsx
+++ b/apps/web/components/layout/dashboard-cta-link.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useCallback, useRef } from 'react'
+
+/**
+ * PT-3: marketing-page CTA that warms the dashboard route on hover/focus.
+ *
+ * Next.js Link in the App Router prefetches the destination on viewport entry,
+ * which warms the loading.tsx + RSC tree but doesn't always force the full
+ * async data load (depends on the `prefetch` setting + production vs. dev).
+ * We add an onMouseEnter / onFocus → router.prefetch('/dashboard') so the
+ * cold-start sidebarSpecs prefetchAll batch fires the moment the user shows
+ * intent to click. Combined with PT-1's non-blocking layout, this makes the
+ * transition feel instant.
+ *
+ * Idempotent: we only fire the prefetch once per mount; router.prefetch is
+ * also internally deduped by Next.js, but skipping the second call avoids
+ * a no-op render cycle.
+ */
+export function DashboardCTALink({ children, className }: { children: React.ReactNode; className?: string }) {
+  const router = useRouter()
+  const firedRef = useRef(false)
+
+  const warm = useCallback(() => {
+    if (firedRef.current) return
+    firedRef.current = true
+    router.prefetch('/dashboard')
+  }, [router])
+
+  return (
+    <Link
+      href="/dashboard"
+      onMouseEnter={warm}
+      onFocus={warm}
+      onTouchStart={warm}
+      {...(className ? { className } : {})}
+    >
+      {children}
+    </Link>
+  )
+}


### PR DESCRIPTION
## PT-3: hover prefetch on /dashboard CTAs

### Why
Marketing-page CTAs targeting `/dashboard` are a high-intent entry point for returning logged-in users. Default Next.js Link prefetch warms on viewport entry but doesn't guarantee full RSC tree fetch (depends on prefetch setting + dev vs production). Hover/focus prefetch fires the moment the user shows click intent so by the time the click lands, the layout's `prefetchAll(sidebarSpecs)` batch is already warmed.

### What
New client component `DashboardCTALink` wraps Link with `onMouseEnter` / `onFocus` / `onTouchStart` → `router.prefetch('/dashboard')`. Dedupes via a ref so multi-pixel hover doesn't refire.

Applied to:
- `apps/web/components/layout/auth-nav-buttons.tsx` (header CTA when logged in, on marketing pages)
- `apps/web/app/not-found.tsx` (404 "Go to dashboard" button)

### With PT-1
PT-1 made the layout non-blocking (skeleton renders ~50ms after click). PT-3 warms the actual data so by the time skeleton swaps to real content, the prefetch batch has finished. The combination targets perceived-instant navigation.

### Test plan
- [x] React props inspection in dev preview confirms onMouseEnter/onFocus/onTouchStart wired
- [x] typecheck + lint clean
- Note: `router.prefetch` is dev-mode no-op per Next.js docs — production-only verification. Watch Vercel preview for warmed RSC fetches on `/dashboard` after deploy.
