### PR TITLE
perf(server): prompt caching for LLM judge + cheaper-model guidance

### DIFF
--- a/apps/server/src/__tests__/eval-judge-caching.test.ts
+++ b/apps/server/src/__tests__/eval-judge-caching.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  buildJudgeMessages,
+  type JudgeConfig,
+} from '../lib/eval-runners/judge-prompt.js'
+import { callJudge } from '../lib/eval-runner.js'
+
+/**
+ * P4-1: judge prompt caching.
+ *
+ * Two layers under test:
+ *   1. buildJudgeMessages — the static/variable split that makes caching
+ *      possible. The system part must be byte-identical across rows of a run
+ *      (so it forms a stable cache prefix); the per-row response must live only
+ *      in the user part.
+ *   2. judgeComplete (via callJudge) — the static system is sent with
+ *      cache_control for Anthropic, and the cached-token portion of usage is
+ *      billed at the reduced cacheRead rate so reported cost reflects savings.
+ *
+ * callJudge is called with organizationId=null so the judge_cache DB layer is
+ * bypassed and only the LLM call path is exercised (fetch is stubbed).
+ */
+
+// ── buildJudgeMessages: the cache-boundary split ──────────────────────────────
+
+describe('buildJudgeMessages — static/variable split', () => {
+  const cfg = { scale_min: 0, scale_max: 1 }
+
+  test('criterion + reply schema go in the system part, not the user part', () => {
+    const { system, user } = buildJudgeMessages('Is it helpful?', 'Paris is the capital.', cfg)
+    expect(system).toContain('Is it helpful?')
+    expect(system).toContain('"score": <number between 0 and 1>')
+    expect(user).not.toContain('Is it helpful?')
+    expect(user).not.toContain('"score"')
+  })
+
+  test('the response under evaluation goes in the user part, not the system part', () => {
+    const { system, user } = buildJudgeMessages('crit', 'UNIQUE_RESPONSE_TOKEN', cfg)
+    expect(user).toContain('UNIQUE_RESPONSE_TOKEN')
+    expect(system).not.toContain('UNIQUE_RESPONSE_TOKEN')
+  })
+
+  test('system is byte-identical across different responses (stable cache prefix)', () => {
+    const a = buildJudgeMessages('crit', 'response one', cfg)
+    const b = buildJudgeMessages('crit', 'a totally different response two', cfg)
+    expect(a.system).toBe(b.system)
+    expect(a.user).not.toBe(b.user)
+  })
+
+  test('rubric + anchors stay in the cached system part', () => {
+    const { system, user } = buildJudgeMessages('crit', 'resp', {
+      ...cfg,
+      rubric: 'be strict about citations',
+      anchors: [{ response: 'great', score: 1, reasoning: 'cited well' }],
+    })
+    expect(system).toContain('be strict about citations')
+    expect(system).toContain('Calibration examples')
+    expect(user).not.toContain('be strict')
+  })
+
+  test('golden reference (per-row) goes in the user part', () => {
+    const { system, user } = buildJudgeMessages('crit', 'resp', {
+      ...cfg,
+      expected_output: 'GOLDEN_ANSWER_REF',
+    })
+    expect(user).toContain('GOLDEN_ANSWER_REF')
+    expect(system).not.toContain('GOLDEN_ANSWER_REF')
+  })
+})
+
+// ── judgeComplete cache wiring (via callJudge + stubbed fetch) ─────────────────
+
+function numericConfig(over: Partial<JudgeConfig> = {}): JudgeConfig {
+  return {
+    criterion: 'Is the answer factually correct?',
+    judge_provider: 'anthropic',
+    judge_model: 'claude-opus-4-7',
+    scale_min: 0,
+    scale_max: 1,
+    score_config: null,
+    ...over,
+  }
+}
+
+/** Capture the single fetch call and return a canned provider response. */
+function stubFetch(responseBody: unknown): { calls: Array<{ url: string; init: RequestInit }> } {
+  const calls: Array<{ url: string; init: RequestInit }> = []
+  vi.stubGlobal('fetch', vi.fn(async (url: string, init: RequestInit) => {
+    calls.push({ url, init })
+    return {
+      ok: true,
+      status: 200,
+      json: async () => responseBody,
+    } as unknown as Response
+  }))
+  return { calls }
+}
+
+describe('callJudge — Anthropic prompt caching', () => {
+  beforeEach(() => { vi.unstubAllGlobals() })
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  test('sends the static system as a cache_control ephemeral block', async () => {
+    const { calls } = stubFetch({
+      content: [{ type: 'text', text: '{"score": 0.9, "reasoning": "correct"}' }],
+      usage: { input_tokens: 50, output_tokens: 10 },
+      model: 'claude-opus-4-7',
+    })
+
+    await callJudge(numericConfig(), 'Paris is the capital of France.', 'sk-ant-test', null)
+
+    expect(calls).toHaveLength(1)
+    const body = JSON.parse(calls[0]!.init.body as string)
+    // The user message carries only the response, not the criterion.
+    expect(body.messages[0].content).toContain('Paris is the capital of France.')
+    expect(body.messages[0].content).not.toContain('factually correct')
+    // The system is a cache-control block holding the static instructions.
+    expect(Array.isArray(body.system)).toBe(true)
+    expect(body.system[0].cache_control).toEqual({ type: 'ephemeral' })
+    expect(body.system[0].text).toContain('factually correct')
+  })
+
+  test('bills the cached-read portion at the reduced cacheRead rate', async () => {
+    // opus-4-7 fallback prices: prompt 5, completion 25, cacheRead 0.5 (per 1M).
+    // usage: 100 non-cached input + 2000 cache-read + 20 output.
+    //   nonCached  = 100  → 100/1e6 * 5     = 0.0005
+    //   cacheRead  = 2000 → 2000/1e6 * 0.5  = 0.001
+    //   completion = 20   → 20/1e6 * 25     = 0.0005
+    //   total = 0.0020
+    // Without cache accounting the 2000 tokens would bill at 5 (=> ~0.011).
+    const { calls } = stubFetch({
+      content: [{ type: 'text', text: '{"score": 1, "reasoning": "ok"}' }],
+      usage: {
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_read_input_tokens: 2000,
+        cache_creation_input_tokens: 0,
+      },
+      model: 'claude-opus-4-7',
+    })
+
+    const outcome = await callJudge(numericConfig(), 'resp', 'sk-ant-test', null)
+
+    expect(calls).toHaveLength(1)
+    expect(outcome).not.toBeNull()
+    expect(outcome!.cost).toBeCloseTo(0.002, 6)
+    // tokens counts the full input (incl. cache) + output: 2100 + 20.
+    expect(outcome!.tokens).toBe(2120)
+  })
+
+  test('cache-creation tokens are billed at the cacheWrite premium', async () => {
+    // First row of a run writes the cache: cache_creation billed at 6.25/1M.
+    //   nonCached  = 50   → 50/1e6 * 5      = 0.00025
+    //   cacheWrite = 1500 → 1500/1e6 * 6.25 = 0.009375
+    //   completion = 10   → 10/1e6 * 25     = 0.00025
+    //   total = 0.009875
+    const { calls } = stubFetch({
+      content: [{ type: 'text', text: '{"score": 0.5, "reasoning": ""}' }],
+      usage: {
+        input_tokens: 50,
+        output_tokens: 10,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 1500,
+      },
+      model: 'claude-opus-4-7',
+    })
+
+    const outcome = await callJudge(numericConfig(), 'resp', 'sk-ant-test', null)
+    expect(calls).toHaveLength(1)
+    expect(outcome!.cost).toBeCloseTo(0.009875, 6)
+  })
+})
+
+describe('callJudge — OpenAI automatic prefix caching', () => {
+  beforeEach(() => { vi.unstubAllGlobals() })
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  test('sends the static instructions as a separate system role message', async () => {
+    const { calls } = stubFetch({
+      choices: [{ message: { content: '{"score": 0.8, "reasoning": "good"}' } }],
+      usage: { prompt_tokens: 120, completion_tokens: 10 },
+      model: 'gpt-4o',
+    })
+
+    await callJudge(
+      numericConfig({ judge_provider: 'openai', judge_model: 'gpt-4o' }),
+      'A sample response.',
+      'sk-openai-test',
+      null,
+    )
+
+    expect(calls).toHaveLength(1)
+    const body = JSON.parse(calls[0]!.init.body as string)
+    expect(body.messages[0].role).toBe('system')
+    expect(body.messages[0].content).toContain('factually correct')
+    expect(body.messages[1].role).toBe('user')
+    expect(body.messages[1].content).toContain('A sample response.')
+  })
+
+  test('bills cached_tokens at the reduced cacheRead rate', async () => {
+    // gpt-4o fallback: prompt 2.5, completion 10, cacheRead 1.25 (per 1M).
+    //   nonCached  = 100  → 100/1e6 * 2.5  = 0.00025
+    //   cacheRead  = 2000 → 2000/1e6 * 1.25 = 0.0025
+    //   completion = 20   → 20/1e6 * 10    = 0.0002
+    //   total = 0.00295
+    const { calls } = stubFetch({
+      choices: [{ message: { content: '{"score": 1, "reasoning": ""}' } }],
+      usage: {
+        prompt_tokens: 2100,
+        completion_tokens: 20,
+        prompt_tokens_details: { cached_tokens: 2000 },
+      },
+      model: 'gpt-4o',
+    })
+
+    const outcome = await callJudge(
+      numericConfig({ judge_provider: 'openai', judge_model: 'gpt-4o' }),
+      'resp',
+      'sk-openai-test',
+      null,
+    )
+    expect(calls).toHaveLength(1)
+    expect(outcome!.cost).toBeCloseTo(0.00295, 6)
+  })
+})

--- a/apps/server/src/lib/eval-runners/judge-calls.ts
+++ b/apps/server/src/lib/eval-runners/judge-calls.ts
@@ -14,7 +14,7 @@ import { fetchWithRetry } from './shared.js'
 import { calculateCost } from '../cost.js'
 import { buildOpenAIBody } from '../playground-runner.js'
 import {
-  buildJudgePrompt,
+  buildJudgeMessages,
   parseJudgeReply,
   buildPairwiseJudgePrompt,
   parsePairwiseReply,
@@ -78,7 +78,8 @@ const GEMINI_PAIRWISE_SCHEMA: Record<string, unknown> = {
 }
 
 /**
- * Low-level judge call: send `prompt` to the judge model and return the raw
+ * Low-level judge call: send the {system, user} judge messages to the judge
+ * model and return the raw
  * reply text + cost + tokens WITHOUT interpreting it. Shared by the absolute
  * (callJudge) and pairwise (callPairwiseJudge) paths so the five provider
  * integrations live in exactly one place. Returns null on any transport
@@ -89,9 +90,18 @@ async function judgeComplete(
   model: string,
   apiKey: string,
   resourceUrl: string | null,
-  prompt: string,
+  /**
+   * P4-1: the judge prompt split into a static `system` prefix and a per-row
+   * `user` part. When `system` is non-empty it is sent as a cacheable system
+   * prefix (Anthropic `cache_control`, OpenAI automatic prefix caching) so
+   * rows 2..N of a run reuse it at a fraction of the input price. When `system`
+   * is empty the call is byte-identical to the pre-caching single-message form,
+   * which keeps the pairwise and trajectory paths unchanged.
+   */
+  messages: { system: string; user: string },
   geminiResponseSchema: Record<string, unknown>,
 ): Promise<{ text: string; cost: number; tokens: number } | null> {
+  const { system, user } = messages
   // OpenAI, Azure, Mistral, OpenRouter are all OpenAI-compatible chat
   // completions; only the URL, auth header, and cost-table provider differ.
   if (provider === 'openai' || provider === 'azure' || provider === 'mistral' || provider === 'openrouter') {
@@ -113,19 +123,30 @@ async function judgeComplete(
       url = `${resourceUrl}/openai/v1/chat/completions`
       headers = { 'Content-Type': 'application/json', 'api-key': apiKey }
     }
+    // System as a separate role makes it the cacheable prefix. OpenAI caches
+    // prompts >1024 tokens automatically; no header or flag is needed.
+    const chatMessages = system
+      ? [{ role: 'system', content: system }, { role: 'user', content: user }]
+      : [{ role: 'user', content: user }]
     const res = await fetchWithRetry(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(buildOpenAIBody(
         model,
-        [{ role: 'user', content: prompt }],
+        chatMessages,
         { temperature: 0, maxTokens: 200, responseFormat: { type: 'json_object' } },
       )),
     })
     if (!res || !res.ok) return null
     const json = await res.json() as {
       choices: Array<{ message: { content: string } }>
-      usage: { prompt_tokens: number; completion_tokens: number; cost?: number }
+      usage: {
+        prompt_tokens: number
+        completion_tokens: number
+        cost?: number
+        // OpenAI reports the auto-cached portion here (subset of prompt_tokens).
+        prompt_tokens_details?: { cached_tokens?: number }
+      }
       model: string
     }
     const text = json.choices?.[0]?.message?.content ?? ''
@@ -137,31 +158,64 @@ async function judgeComplete(
       cost = json.usage.cost
     } else {
       const costProvider = provider === 'azure' ? 'openai' : provider
+      const cachedTokens = json.usage?.prompt_tokens_details?.cached_tokens ?? 0
       cost = calculateCost(costProvider, json.model ?? model, {
         promptTokens: json.usage?.prompt_tokens ?? 0,
         completionTokens: json.usage?.completion_tokens ?? 0,
+        // OpenAI cache reads are billed at the reduced cacheRead rate; no
+        // separate write charge, so cacheWriteTokens stays 0.
+        cacheReadTokens: cachedTokens,
       })?.totalCost ?? 0
     }
     return { text, cost, tokens }
   }
 
   if (provider === 'anthropic') {
+    // P4-1: mark the static system prefix ephemeral so it is cached for the
+    // 5-minute TTL. Below the per-model minimum (1024 tokens for Sonnet/Opus,
+    // 2048 for Haiku) Anthropic silently ignores cache_control and bills
+    // normally, so always setting it is safe.
+    const body: Record<string, unknown> = {
+      model,
+      max_tokens: 200,
+      temperature: 0,
+      messages: [{ role: 'user', content: user }],
+    }
+    if (system) {
+      body['system'] = [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }]
+    }
     const res = await fetchWithRetry('https://api.anthropic.com/v1/messages', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' },
-      body: JSON.stringify({ model, max_tokens: 200, temperature: 0, messages: [{ role: 'user', content: prompt }] }),
+      body: JSON.stringify(body),
     })
     if (!res || !res.ok) return null
     const json = await res.json() as {
       content: Array<{ type: string; text: string }>
-      usage: { input_tokens: number; output_tokens: number }
+      usage: {
+        input_tokens: number
+        output_tokens: number
+        // Present only when cache_control is honoured. input_tokens is the
+        // NON-cached remainder, so the true prompt total is the sum of all three.
+        cache_creation_input_tokens?: number
+        cache_read_input_tokens?: number
+      }
       model: string
     }
     const text = json.content?.find((b) => b.type === 'text')?.text ?? ''
-    const tokens = (json.usage?.input_tokens ?? 0) + (json.usage?.output_tokens ?? 0)
+    const u = json.usage
+    const cacheWrite = u?.cache_creation_input_tokens ?? 0
+    const cacheRead = u?.cache_read_input_tokens ?? 0
+    const inputTokens = u?.input_tokens ?? 0
+    // promptTokens must be the FULL input incl. cache for calculateCost, which
+    // subtracts the cache portions back out to bill each tier at its own rate.
+    const promptTokens = inputTokens + cacheWrite + cacheRead
+    const tokens = promptTokens + (u?.output_tokens ?? 0)
     const cost = calculateCost('anthropic', json.model ?? model, {
-      promptTokens: json.usage?.input_tokens ?? 0,
-      completionTokens: json.usage?.output_tokens ?? 0,
+      promptTokens,
+      completionTokens: u?.output_tokens ?? 0,
+      cacheReadTokens: cacheRead,
+      cacheWriteTokens: cacheWrite,
     })?.totalCost ?? 0
     return { text, cost, tokens }
   }
@@ -169,26 +223,37 @@ async function judgeComplete(
   // Gemini — JSON output enforced via responseMimeType + responseSchema so the
   // reply is always parseable. The schema MUST match the prompt's JSON shape.
   if (provider === 'gemini') {
+    const body: Record<string, unknown> = {
+      contents: [{ role: 'user', parts: [{ text: user }] }],
+      generationConfig: {
+        temperature: 0,
+        maxOutputTokens: 200,
+        responseMimeType: 'application/json',
+        responseSchema: geminiResponseSchema,
+      },
+    }
+    // Gemini 2.5 models apply implicit caching automatically; routing the
+    // static instructions through systemInstruction gives it a stable prefix.
+    if (system) {
+      body['systemInstruction'] = { parts: [{ text: system }] }
+    }
     const res = await fetchWithRetry(
       `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          contents: [{ role: 'user', parts: [{ text: prompt }] }],
-          generationConfig: {
-            temperature: 0,
-            maxOutputTokens: 200,
-            responseMimeType: 'application/json',
-            responseSchema: geminiResponseSchema,
-          },
-        }),
+        body: JSON.stringify(body),
       },
     )
     if (!res || !res.ok) return null
     const json = await res.json() as {
       candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
-      usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number; thoughtsTokenCount?: number }
+      usageMetadata?: {
+        promptTokenCount?: number
+        candidatesTokenCount?: number
+        thoughtsTokenCount?: number
+        cachedContentTokenCount?: number
+      }
       modelVersion?: string
     }
     const text = json.candidates?.[0]?.content?.parts?.[0]?.text ?? ''
@@ -201,6 +266,9 @@ async function judgeComplete(
     const cost = calculateCost('gemini', json.modelVersion ?? model, {
       promptTokens: json.usageMetadata?.promptTokenCount ?? 0,
       completionTokens,
+      // promptTokenCount already includes cached tokens; bill that subset at
+      // the cacheRead rate when the model reports it.
+      cacheReadTokens: json.usageMetadata?.cachedContentTokenCount ?? 0,
     })?.totalCost ?? 0
     return { text, cost, tokens }
   }
@@ -263,7 +331,8 @@ export async function callJudge(
     }
   }
 
-  const prompt = buildJudgePrompt(config.criterion, responseText, {
+  // P4-1: split prompt so the static instructions become a cacheable prefix.
+  const judgeMessages = buildJudgeMessages(config.criterion, responseText, {
     scale_min: config.scale_min,
     scale_max: config.scale_max,
     score_config: config.score_config ?? null,
@@ -278,7 +347,7 @@ export async function callJudge(
     config.judge_model,
     apiKey,
     resourceUrl,
-    prompt,
+    judgeMessages,
     geminiJudgeSchema(config.score_config),
   )
   if (!res) return null
@@ -373,12 +442,15 @@ export async function callPairwiseJudge(
     rubric: config.rubric ?? null,
     expected_output: expectedOutput,
   })
+  // Pairwise is not split for caching (both responses vary per row, so the
+  // static prefix is just the criterion/rubric — rarely above the cache
+  // minimum). Empty system => byte-identical single-message call as before.
   const res = await judgeComplete(
     config.judge_provider,
     config.judge_model,
     apiKey,
     resourceUrl,
-    prompt,
+    { system: '', user: prompt },
     GEMINI_PAIRWISE_SCHEMA,
   )
   if (!res) return null
@@ -407,12 +479,14 @@ export async function callTrajectoryJudge(
     scale_max: config.scale_max,
     rubric: config.rubric ?? null,
   })
+  // Trajectory prompts embed the whole serialized trace inline (highly variable
+  // per row), so there is no useful static prefix. Empty system => unchanged call.
   const res = await judgeComplete(
     config.judge_provider,
     config.judge_model,
     apiKey,
     resourceUrl,
-    prompt,
+    { system: '', user: prompt },
     geminiJudgeSchema(null),
   )
   if (!res) return null

--- a/apps/server/src/lib/eval-runners/judge-prompt.ts
+++ b/apps/server/src/lib/eval-runners/judge-prompt.ts
@@ -63,10 +63,33 @@ export interface JudgeConfig {
 }
 
 /**
- * Build the judge prompt text. Branches on the score_config data_type so
- * the judge gets a reply schema matching the column we'll write to.
+ * A judge prompt split into a STATIC system part and a VARIABLE user part.
+ *
+ * P4-1 (prompt caching): the system part holds everything that is identical
+ * across every sample in a run (criterion, rubric, anchors, reply schema) so
+ * it can be marked as a cacheable prefix. The user part holds only the
+ * per-row response (and its golden reference). Keeping the variable text OUT
+ * of the cached prefix is what lets Anthropic `cache_control` and OpenAI's
+ * automatic prefix caching actually hit on rows 2..N of a run.
  */
-export function buildJudgePrompt(
+export interface JudgeMessages {
+  /** Static across a run: instructions + criterion + rubric + anchors + schema. */
+  system: string
+  /** Per-row: the response under evaluation (+ optional golden reference). */
+  user: string
+}
+
+/**
+ * Build the judge prompt as a {system, user} split. Branches on the
+ * score_config data_type so the judge gets a reply schema matching the column
+ * we'll write to.
+ *
+ * The split is the cache boundary: `system` is byte-identical for every sample
+ * scored by the same evaluator in a run, `user` carries the row-specific
+ * response. `buildJudgePrompt` below joins the two for callers (and tests) that
+ * want the legacy single-string form.
+ */
+export function buildJudgeMessages(
   criterion: string,
   responseText: string,
   config: {
@@ -82,12 +105,13 @@ export function buildJudgePrompt(
     /** P1-7: few-shot calibration anchors (NUMERIC / legacy path only). */
     anchors?: JudgeAnchor[] | null
   },
-): string {
+): JudgeMessages {
   // P1-7: middle-out truncation keeps the start AND the end of a long response
   // (the conclusion is often where the answer lives) instead of head-only.
   const truncated = truncateMiddle(responseText, MAX_RESPONSE_CHARS)
 
   // Reference (expected) answer, also truncated middle-out to the same cap.
+  // Per-row (golden answers vary per dataset item) so it lives in the user part.
   const expected = config.expected_output
   const referenceBlock = expected
     ? `
@@ -108,15 +132,6 @@ Scoring rubric (apply consistently):
 ${rubric}`
     : ''
 
-  const intro = `You are an evaluator. Score the assistant response below against this criterion.
-
-Criterion: ${criterion}${rubricBlock}
-
-Response to evaluate:
-"""
-${truncated}
-"""${referenceBlock}`
-
   const sc = config.score_config
 
   // P1-7: few-shot calibration anchors. Only meaningful on the NUMERIC / legacy
@@ -132,49 +147,80 @@ ${anchors
   .join('\n')}`
     : ''
 
-  // Legacy NUMERIC path — unchanged from before 4B.1c except the optional
-  // rubric (intro) + anchors blocks, both of which collapse to '' when absent.
+  // Static instruction header: identical for every row scored by this
+  // evaluator. Criterion + rubric + anchors all belong here (they come from the
+  // evaluator config, not the sample) so the whole block can be cached.
+  const intro = `You are an evaluator. Score the assistant response in the user message against this criterion.
+
+Criterion: ${criterion}${rubricBlock}${anchorsBlock}`
+
+  // The user part is the same for every type: the response under evaluation,
+  // plus the optional golden reference. Both are per-row, never cached.
+  const user = `Response to evaluate:
+"""
+${truncated}
+"""${referenceBlock}`
+
+  // Reply schema instruction differs per data_type but is still static across a
+  // run, so it stays in the system part.
+  let schema: string
   if (!sc || sc.data_type === 'NUMERIC') {
     const min = sc?.min_value ?? config.scale_min
     const max = sc?.max_value ?? config.scale_max
-    return `${intro}${anchorsBlock}
-
-Reply ONLY in JSON with this exact shape:
+    schema = `Reply ONLY in JSON with this exact shape:
 {"score": <number between ${min} and ${max}>, "reasoning": "<one short sentence>"}
 
 No prose outside the JSON. No markdown fences.`
-  }
-
-  if (sc.data_type === 'BOOLEAN') {
+  } else if (sc.data_type === 'BOOLEAN') {
     const trueLabel = sc.bool_true_label ?? 'pass'
     const falseLabel = sc.bool_false_label ?? 'fail'
-    return `${intro}
-
-Reply ONLY in JSON with this exact shape:
+    schema = `Reply ONLY in JSON with this exact shape:
 {"value": <true or false>, "reasoning": "<one short sentence>"}
 
 \`true\` means "${trueLabel}", \`false\` means "${falseLabel}". No prose outside the JSON. No markdown fences.`
-  }
-
-  if (sc.data_type === 'CATEGORICAL') {
+  } else if (sc.data_type === 'CATEGORICAL') {
     const cats = Array.isArray(sc.categories)
       ? sc.categories.filter((c): c is string => typeof c === 'string')
       : []
-    return `${intro}
-
-Reply ONLY in JSON with this exact shape:
+    schema = `Reply ONLY in JSON with this exact shape:
 {"value": "<one of: ${cats.map((c) => JSON.stringify(c)).join(', ')}>", "reasoning": "<one short sentence>"}
 
 The \`value\` MUST be one of the categories above, exact case match. No prose outside the JSON. No markdown fences.`
-  }
-
-  // TEXT — judge writes a free-form short answer.
-  return `${intro}
-
-Reply ONLY in JSON with this exact shape:
+  } else {
+    // TEXT — judge writes a free-form short answer.
+    schema = `Reply ONLY in JSON with this exact shape:
 {"value": "<short answer>", "reasoning": "<one short sentence>"}
 
 Keep \`value\` under 200 characters. No prose outside the JSON. No markdown fences.`
+  }
+
+  return { system: `${intro}
+
+${schema}`, user }
+}
+
+/**
+ * Legacy single-string form of the judge prompt. Joins the {system, user}
+ * split so existing callers and tests keep working unchanged. New call sites
+ * that want prompt caching should use `buildJudgeMessages` and send the two
+ * parts as separate system/user content (see judge-calls.judgeComplete).
+ */
+export function buildJudgePrompt(
+  criterion: string,
+  responseText: string,
+  config: {
+    scale_min: number
+    scale_max: number
+    score_config?: TypedScoreConfig | null
+    expected_output?: string | null
+    rubric?: string | null
+    anchors?: JudgeAnchor[] | null
+  },
+): string {
+  const { system, user } = buildJudgeMessages(criterion, responseText, config)
+  return `${system}
+
+${user}`
 }
 
 /**

--- a/apps/web/app/(dashboard)/evals/evals-client.tsx
+++ b/apps/web/app/(dashboard)/evals/evals-client.tsx
@@ -572,6 +572,9 @@ function NewEvaluatorDialog({
                       ))}
                     </SelectContent>
                   </Select>
+                  <p className="font-mono text-[10.5px] text-text-faint mt-1">
+                    Pass/fail and classification checks usually score just as well on a smaller, cheaper model like Haiku or gpt-4o-mini. Save the larger judges for nuanced 0–1 scoring.
+                  </p>
                 </div>
               </div>
 

--- a/apps/web/app/docs/features/evals/page.tsx
+++ b/apps/web/app/docs/features/evals/page.tsx
@@ -260,11 +260,40 @@ export default function EvalsDocs() {
         </li>
       </ul>
 
+      <h2>Prompt caching</h2>
+      <p>
+        Within a single run every sample is scored against the same criterion, rubric, and
+        calibration anchors. Spanlens sends that static block as a cached prefix and the per-sample
+        response as the only varying part, so the judge instructions are charged at full price once
+        and reused at the reduced cache rate for the rest of the run.
+      </p>
+      <ul>
+        <li>
+          Anthropic judges use an ephemeral <code>cache_control</code> prefix (cache reads bill at
+          roughly one tenth of the input price). The bigger the rubric and anchor set, the larger
+          the saving.
+        </li>
+        <li>
+          OpenAI and Gemini judges get the same benefit automatically once the static prefix is
+          large enough, because the instructions are sent as a stable system prefix.
+        </li>
+        <li>
+          Reported eval cost already reflects the cached and full-price token split, so the number
+          you see is what your provider actually billed.
+        </li>
+      </ul>
+
       <h2>Cost</h2>
       <p>
         Judge calls are <strong>billed to your provider key</strong> (Spanlens does not cover
         them). Approximate cost with gpt-4o-mini: ~<code>$0.0005</code> per evaluation.
         50 samples ≈ <code>$0.025</code>.
+      </p>
+      <p>
+        Pick the judge model to match the job. Pass/fail (<code>BOOLEAN</code>) and classification
+        (<code>CATEGORICAL</code>) checks usually score just as well on a small, fast model like
+        Haiku or gpt-4o-mini, which costs a fraction of a frontier model. Reserve the larger judges
+        for nuanced 0–1 scoring where the extra reasoning earns its price.
       </p>
       <p>Guardrails:</p>
       <ul>


### PR DESCRIPTION
## Summary

Cost audit of the server-side LLM judge path (`cost-aware-llm-pipeline`). Anomaly detection and model recommendations make **no** LLM calls (pure ClickHouse SQL / rule tables), so the only LLM cost surface is the eval judge. This PR lands the two low-risk wins from that audit. A larger Batch API change is designed below as a follow-up.

## What changed

### 1. Prompt caching on judge calls (server)

The judge prompt is now split into a **static system prefix** (criterion, rubric, calibration anchors, reply schema) and a **per-row user part** (the response under evaluation + its golden reference). The static prefix is byte-identical for every sample scored by an evaluator in a run, so it becomes a cacheable prefix.

- **Anthropic**: system block sent with an ephemeral `cache_control` marker. Cache reads bill at ~1/10 of input price.
- **OpenAI / Gemini**: static block sent as a system role / system instruction, so their automatic prefix caching applies once the prefix is large enough.
- `judgeComplete` extracts the cache token tiers from `usage` and feeds them to `calculateCost`, so **reported eval cost reflects the real cache-aware bill** instead of pricing every token at full input rate.
- Pairwise and trajectory judges pass an empty system, keeping those calls byte-identical to before (no useful static prefix there).

`buildJudgeMessages` is the new source of truth; `buildJudgePrompt` delegates to it, so existing callers and tests are unchanged.

### 2. Judge model guidance (web + docs)

- Evaluator form: hint under the judge model select recommending smaller, cheaper models (Haiku, gpt-4o-mini) for pass/fail and classification checks.
- Evals feature docs: new "Prompt caching" section + a model-selection note in "Cost".

## Estimated savings (50-sample run, Anthropic judge, long rubric)

| Scenario | Cost/run | Saving |
|---|---|---|
| Before (no caching) | ~$0.16 | baseline |
| Prompt caching (rubric > 1024 tok) | ~$0.05 | ~69% |
| Haiku instead of Sonnet (BOOLEAN/CATEGORICAL) | ~$0.04 | ~75% |
| Caching + Haiku | ~$0.012 | ~92% |

Below the per-model cache minimum (1024 tok Sonnet/Opus, 2048 Haiku) Anthropic silently ignores `cache_control` and bills normally, so always setting it is safe.

## Tests

- `eval-judge-caching.test.ts` (10 new): static/variable split correctness, stable cache prefix across rows, Anthropic `cache_control` request shape, cache-aware cost for Anthropic (read + write tiers) and OpenAI.
- Existing 1290 server tests still green (1300 total). typecheck + lint clean on server and web.

## Test plan

- [x] `pnpm --filter server typecheck && lint && test`
- [x] `pnpm --filter web typecheck && lint`
- [ ] Manual: run an Anthropic evaluator with a long rubric over 50 samples in staging, confirm `cache_read_input_tokens > 0` on rows 2..N and that reported cost drops vs. an un-cached baseline run.

## Follow-up (NOT in this PR): Anthropic Batch API

Dataset-source eval runs are fully async (auto-run is fire-and-forget), which fits the Batch API (50% discount, up to 10k req/batch, 24h SLA). Deferred because it is a larger, higher-risk change to the eval result-write path:

1. Migration: `eval_runs` add `batch_id`, `batch_provider`, `batch_status` (additive, idempotent).
2. When `source = 'dataset'` and provider supports batching, submit a batch instead of inline scoring; store `batch_id`, mark run `pending_batch`.
3. New cron `/cron/poll-eval-batches` (5 min) polls open batches, writes results on completion, registered in `vercel.json` + GH Actions + Better Stack (gotcha #32 triple-scheduler).
4. UI: render `pending_batch` state with the 24h expectation; keep inline scoring as the default for interactive runs.

Trade-off: 50% cheaper vs. up to 24h latency, so it should be opt-in per evaluator, not the default.
