### PR TITLE
fix(server): Phase 0 security hardening

### DIFF
--- a/apps/server/src/__tests__/anomaly-confidence.test.ts
+++ b/apps/server/src/__tests__/anomaly-confidence.test.ts
@@ -18,6 +18,18 @@ vi.mock('../lib/clickhouse.js', () => ({
   }),
 }))
 
+// detectAnomalies now resolves org + retention scope via requestsScope, which
+// internally reads the org plan from Supabase. Stub it so these unit tests
+// stay DB-free (the retention bound itself is exercised in anomaly-detect.test.ts).
+vi.mock('../lib/requests-query.js', () => ({
+  requestsScope: vi.fn(async (orgId: string) => ({
+    whereScope:
+      'organization_id = {orgId:UUID} AND created_at >= now() - INTERVAL {retentionDays:UInt32} DAY',
+    scopeParams: { orgId, retentionDays: 14 },
+    plan: 'free',
+  })),
+}))
+
 let classifyConfidence: typeof import('../lib/anomaly.js').classifyConfidence
 let detectAnomalies: typeof import('../lib/anomaly.js').detectAnomalies
 let ANOMALY_DEFAULTS: typeof import('../lib/anomaly.js').ANOMALY_DEFAULTS

--- a/apps/server/src/__tests__/anomaly-detect.test.ts
+++ b/apps/server/src/__tests__/anomaly-detect.test.ts
@@ -9,6 +9,18 @@ vi.mock('../lib/clickhouse.js', () => ({
   unscopedClickhouse: () => ({ query: mockChQuery }),
 }))
 
+// detectAnomalies resolves org + retention scope via requestsScope (which reads
+// the org plan from Supabase). Stub it so the test stays DB-free and asserts on
+// the resulting WHERE clause / params shape.
+vi.mock('../lib/requests-query.js', () => ({
+  requestsScope: vi.fn(async (orgId: string) => ({
+    whereScope:
+      'organization_id = {orgId:UUID} AND created_at >= now() - INTERVAL {retentionDays:UInt32} DAY',
+    scopeParams: { orgId, retentionDays: 14 },
+    plan: 'free',
+  })),
+}))
+
 import { detectAnomalies } from '../lib/anomaly.js'
 
 function makeRpcReturn(rows: object[]) {
@@ -165,6 +177,21 @@ describe('detectAnomalies — custom options', () => {
       expect.objectContaining({
         query: expect.stringContaining('project_id = {projectId:UUID}'),
         query_params: expect.objectContaining({ projectId: 'proj-abc' }),
+      }),
+    )
+  })
+})
+
+describe('detectAnomalies — retention scoping (gotcha #3)', () => {
+  it('applies the requestsScope retention bound and merges scopeParams', async () => {
+    mockChQuery.mockReturnValue(makeRpcReturn([]))
+    // referenceHours 720 (30d) exceeds free retention (14d); the retention
+    // bound must still clip the window via requestsScope.
+    await detectAnomalies('org-1', { referenceHours: 720 })
+    expect(mockChQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.stringContaining('INTERVAL {retentionDays:UInt32} DAY'),
+        query_params: expect.objectContaining({ orgId: 'org-1', retentionDays: 14 }),
       }),
     )
   })

--- a/apps/server/src/__tests__/frontend-errors-ratelimit.test.ts
+++ b/apps/server/src/__tests__/frontend-errors-ratelimit.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// The frontend-error sink is public and unauthenticated and is mounted BEFORE
+// apiRateLimit in app.ts, so the only thing standing between an anonymous
+// client and the structured log drain is the per-IP limiter inside the router.
+// Mock checkRateLimit so we can drive both the under-cap and over-cap paths.
+const checkRateLimitMock = vi.hoisted(() => vi.fn())
+vi.mock('../lib/rate-limit.js', () => ({ checkRateLimit: checkRateLimitMock }))
+
+import { frontendErrorsRouter } from '../api/frontendErrors.js'
+
+function post(ip: string) {
+  return frontendErrorsRouter.request('/', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-forwarded-for': ip },
+    body: JSON.stringify({ scope: 'route', message: 'boom' }),
+  })
+}
+
+beforeEach(() => {
+  checkRateLimitMock.mockReset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('frontend-errors per-IP rate limit', () => {
+  it('under the cap: logs the record and returns 204', async () => {
+    checkRateLimitMock.mockResolvedValue(true)
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const res = await post('1.2.3.4')
+
+    expect(res.status).toBe(204)
+    expect(errSpy.mock.calls.some((c) => String(c[0]).includes('[frontend-error]'))).toBe(true)
+    expect(checkRateLimitMock).toHaveBeenCalledWith('fe-err:1.2.3.4', 30)
+  })
+
+  it('over the cap: returns 204 and writes NO log line', async () => {
+    checkRateLimitMock.mockResolvedValue(false)
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const res = await post('1.2.3.4')
+
+    expect(res.status).toBe(204)
+    expect(errSpy.mock.calls.some((c) => String(c[0]).includes('[frontend-error]'))).toBe(false)
+  })
+
+  it('keys the limit on the first x-forwarded-for hop', async () => {
+    checkRateLimitMock.mockResolvedValue(true)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await frontendErrorsRouter.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-forwarded-for': '9.9.9.9, 10.0.0.1' },
+      body: JSON.stringify({ scope: 'route' }),
+    })
+
+    expect(checkRateLimitMock).toHaveBeenCalledWith('fe-err:9.9.9.9', 30)
+  })
+})

--- a/apps/server/src/__tests__/rate-limit.test.ts
+++ b/apps/server/src/__tests__/rate-limit.test.ts
@@ -173,10 +173,27 @@ describe('checkRateLimit', () => {
       expect(await checkRateLimit('proxy:any', 60)).toBe(true)
       expect(slidingWindowCalls).toHaveLength(0)
     })
+
+    it('warns exactly once across many calls (no per-request spam)', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const { checkRateLimit } = await freshRateLimit({
+        KV_REST_API_URL: undefined,
+        KV_REST_API_TOKEN: undefined,
+      })
+
+      await checkRateLimit('proxy:a', 60)
+      await checkRateLimit('proxy:b', 60)
+      await checkRateLimit('proxy:c', 60)
+
+      const backendDownWarns = warnSpy.mock.calls.filter((args) =>
+        String(args[0]).includes('RATE_LIMIT_BACKEND_DOWN'),
+      )
+      expect(backendDownWarns).toHaveLength(1)
+    })
   })
 
   describe('Redis configured but throws at runtime (KV down)', () => {
-    it('fails open with a console.error and returns true', async () => {
+    it('fails open and emits the stable RATE_LIMIT_BACKEND_DOWN code', async () => {
       const errSpy = vi
         .spyOn(console, 'error')
         .mockImplementation(() => {})
@@ -190,10 +207,10 @@ describe('checkRateLimit', () => {
       const allowed = await checkRateLimit('proxy:org-1', 60)
 
       expect(allowed).toBe(true)
-      expect(errSpy).toHaveBeenCalledWith(
-        '[rate-limit] Redis error — failing open:',
-        expect.any(Error),
-      )
+      // logError emits one structured line prefixed with the stable code so
+      // Sentry / the log drain can alert on it (was a free-form string before).
+      expect(errSpy).toHaveBeenCalledTimes(1)
+      expect(String(errSpy.mock.calls[0]![0])).toContain('RATE_LIMIT_BACKEND_DOWN')
     })
 
     it('subsequent successful calls still work after a transient error', async () => {

--- a/apps/server/src/__tests__/validate-base.test.ts
+++ b/apps/server/src/__tests__/validate-base.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { assertSafeProxyBase } from '../proxy/shared/validate-base.js'
+
+// SSRF guard for operator-supplied *_API_BASE overrides. Enforced only in
+// production (the https-only check would reject the dev/E2E http://localhost
+// mock). Defaults are trusted constants and never validated.
+describe('assertSafeProxyBase', () => {
+  const ORIGINAL_ENV = { ...process.env }
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  it('is a no-op outside production even for an internal target', () => {
+    process.env['NODE_ENV'] = 'test'
+    process.env['OPENAI_API_BASE'] = 'http://169.254.169.254'
+    expect(() =>
+      assertSafeProxyBase('OPENAI_API_BASE', 'http://169.254.169.254'),
+    ).not.toThrow()
+  })
+
+  it('is a no-op in production when the override env var is unset', () => {
+    process.env['NODE_ENV'] = 'production'
+    delete process.env['OPENAI_API_BASE']
+    expect(() =>
+      assertSafeProxyBase('OPENAI_API_BASE', 'https://api.openai.com'),
+    ).not.toThrow()
+  })
+
+  it('throws in production when the override targets an internal IP', () => {
+    process.env['NODE_ENV'] = 'production'
+    process.env['OPENAI_API_BASE'] = 'https://169.254.169.254'
+    expect(() =>
+      assertSafeProxyBase('OPENAI_API_BASE', 'https://169.254.169.254'),
+    ).toThrow(/SSRF/)
+  })
+
+  it('throws in production when the override is non-https', () => {
+    process.env['NODE_ENV'] = 'production'
+    process.env['MISTRAL_API_BASE'] = 'http://evil.example.com'
+    expect(() =>
+      assertSafeProxyBase('MISTRAL_API_BASE', 'http://evil.example.com'),
+    ).toThrow()
+  })
+
+  it('passes in production for a legitimate https override', () => {
+    process.env['NODE_ENV'] = 'production'
+    process.env['OPENROUTER_API_BASE'] = 'https://openrouter.ai/api'
+    expect(() =>
+      assertSafeProxyBase('OPENROUTER_API_BASE', 'https://openrouter.ai/api'),
+    ).not.toThrow()
+  })
+})

--- a/apps/server/src/api/frontendErrors.ts
+++ b/apps/server/src/api/frontendErrors.ts
@@ -1,13 +1,17 @@
 import { Hono } from 'hono'
+import { createMiddleware } from 'hono/factory'
+import { checkRateLimit } from '../lib/rate-limit.js'
 
 /**
  * Frontend error sink.
  *
  * Public endpoint (no auth) — we want to capture errors from logged-out
  * pages too (the login screen, public share viewer, etc). Volume-controlled
- * via per-IP rate limit on the parent /api/v1 group + a tight per-IP cap
- * here, and by accepting only known scope strings so the table doesn't
- * become a spam dumping ground.
+ * by a tight per-IP rate limit applied inside this router (the parent
+ * /api/v1 apiRateLimit does NOT cover it: this router is mounted before
+ * apiRateLimit in app.ts, and apiRateLimit fails open for tokenless
+ * requests anyway), and by accepting only known scope strings so the log
+ * stream does not become a spam dumping ground.
  *
  * The body is parsed loosely on purpose — what we get from the
  * `<ErrorBoundary>` and `app/{error,global-error}.tsx` files is whatever
@@ -43,6 +47,23 @@ function pickString(v: unknown, max = 4000): string | null {
 }
 
 export const frontendErrorsRouter = new Hono()
+
+// Tight per-IP cap. Public, no auth — IP is the only stable key. 30 errors/min
+// is generous for a genuinely broken page (a render loop fires a handful, not
+// dozens) while blocking an anonymous log-flooding loop. On limit we return
+// 204 (not 429) so a throttled sink call does not itself escalate into a
+// second client error — same fail-soft contract as the success path below.
+const FRONTEND_ERROR_RATE_LIMIT = 30
+
+frontendErrorsRouter.use('*', createMiddleware(async (c, next) => {
+  const ip =
+    c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+    c.req.header('x-real-ip') ||
+    'unknown'
+  const allowed = await checkRateLimit(`fe-err:${ip}`, FRONTEND_ERROR_RATE_LIMIT)
+  if (!allowed) return c.body(null, 204)
+  return next()
+}))
 
 frontendErrorsRouter.post('/', async (c) => {
   let body: Body

--- a/apps/server/src/lib/anomaly.ts
+++ b/apps/server/src/lib/anomaly.ts
@@ -1,4 +1,5 @@
 import { unscopedClickhouse } from './clickhouse.js'
+import { requestsScope } from './requests-query.js'
 
 /**
  * Anomaly detection over recent `requests` rows.
@@ -161,8 +162,13 @@ export async function detectAnomalies(
   const obsStart = fmtTs(new Date(now - observationHours * 3_600_000).toISOString())
   const refStart = fmtTs(new Date(now - referenceHours  * 3_600_000).toISOString())
 
+  // Org isolation + plan retention (free=14d / pro=90d / team=365d). The
+  // retention bound is enforced in addition to refStart, so a caller-supplied
+  // referenceHours larger than the org's retention can never read past it
+  // (gotcha #3 — every `requests` read must go through requestsScope).
+  const { whereScope, scopeParams } = await requestsScope(organizationId)
   const params: Record<string, unknown> = {
-    orgId: organizationId,
+    ...scopeParams,
     obsStart,
     refStart,
   }
@@ -196,7 +202,7 @@ export async function detectAnomalies(
       stddevSampIf(if(status_code >= 400, 1.0, 0.0),created_at <  parseDateTime64BestEffort({obsStart:String})) AS ref_error_stddev,
       countIf(                                       created_at <  parseDateTime64BestEffort({obsStart:String})) AS ref_all_count
     FROM requests
-    WHERE organization_id = {orgId:UUID}
+    WHERE ${whereScope}
       AND created_at >= parseDateTime64BestEffort({refStart:String})${projectClause}
     GROUP BY provider, model
     HAVING obs_all_count > 0 OR ref_all_count > 0`
@@ -353,8 +359,10 @@ export async function fetchContributingFactors(
 ): Promise<AnomalyContributingFactors | null> {
   const obsTs = fmtTs(obsStart)
   const refTs = fmtTs(refStart)
+  // Same org + retention scoping as detectAnomalies (gotcha #3).
+  const { whereScope, scopeParams } = await requestsScope(organizationId)
   const baseParams: Record<string, unknown> = {
-    orgId: organizationId,
+    ...scopeParams,
     provider,
     model,
     obsStart: obsTs,
@@ -375,7 +383,7 @@ export async function fetchContributingFactors(
       avgIf(total_tokens,      created_at >= parseDateTime64BestEffort({obsStart:String})) AS obs_total_tokens_mean,
       avgIf(total_tokens,      created_at <  parseDateTime64BestEffort({obsStart:String})) AS ref_total_tokens_mean
     FROM requests
-    WHERE organization_id = {orgId:UUID}
+    WHERE ${whereScope}
       AND provider = {provider:String}
       AND model    = {model:String}
       AND created_at >= parseDateTime64BestEffort({refStart:String})${projectClause}`
@@ -383,7 +391,7 @@ export async function fetchContributingFactors(
   const errorsSql = `
     SELECT status_code AS code, count() AS cnt
     FROM requests
-    WHERE organization_id = {orgId:UUID}
+    WHERE ${whereScope}
       AND provider = {provider:String}
       AND model    = {model:String}
       AND created_at >= parseDateTime64BestEffort({obsStart:String})

--- a/apps/server/src/lib/rate-limit.ts
+++ b/apps/server/src/lib/rate-limit.ts
@@ -1,6 +1,7 @@
 import { Redis } from '@upstash/redis'
 import { Ratelimit } from '@upstash/ratelimit'
 import type { Plan } from './quota.js'
+import { logError, logWarn } from './structured-logger.js'
 
 /**
  * Per-minute proxy ingestion limits keyed by plan.
@@ -70,6 +71,11 @@ function getLimiter(limit: number): Ratelimit | null {
 // Public API
 // ---------------------------------------------------------------------------
 
+// Module-level guard so a misconfigured prod (missing KV env vars) warns ONCE
+// rather than on every request. Reset implicitly per process / per test
+// (vi.resetModules drops this module's state).
+let _unconfiguredWarned = false
+
 /**
  * Checks whether `key` is within the sliding-window rate limit.
  *
@@ -77,9 +83,15 @@ function getLimiter(limit: number): Ratelimit | null {
  *   - the request is within the limit
  *   - Redis is not configured (fails open — transient misconfiguration
  *     should never block legitimate traffic)
- *   - any Redis error occurs (fails open with a console warning)
+ *   - any Redis error occurs (fails open)
  *
  * Returns false (deny) only when the limit is positively exceeded.
+ *
+ * Fail-open is RETAINED on both backend-down paths (a Redis outage must never
+ * block legitimate traffic), but both are now emitted with the stable,
+ * alertable `RATE_LIMIT_BACKEND_DOWN` code so a silent outage is visible in
+ * the log drain / Sentry instead of disappearing. No in-process fallback
+ * counter is added here — see docs/plans/platform-review-roadmap-2026-06.md.
  */
 export async function checkRateLimit(
   key: string,
@@ -88,7 +100,13 @@ export async function checkRateLimit(
   const limiter = getLimiter(limit)
 
   if (!limiter) {
-    // Redis not configured — fail open (dev / misconfigured prod)
+    // Redis not configured — fail open (dev / misconfigured prod). Warn once
+    // so a prod deploy missing KV_REST_API_URL/TOKEN does not silently
+    // disable ALL rate limiting with zero signal.
+    if (!_unconfiguredWarned) {
+      _unconfiguredWarned = true
+      logWarn('RATE_LIMIT_BACKEND_DOWN', { kind: 'redis_unconfigured' })
+    }
     return true
   }
 
@@ -96,7 +114,9 @@ export async function checkRateLimit(
     const { success } = await limiter.limit(key)
     return success
   } catch (err) {
-    console.error('[rate-limit] Redis error — failing open:', err)
+    // Transient Redis error — fail open, but with a stable code (was a
+    // free-form console.error before, which Sentry could not alert on).
+    logError('RATE_LIMIT_BACKEND_DOWN', { kind: 'redis_error', key }, err)
     return true
   }
 }

--- a/apps/server/src/lib/structured-logger.ts
+++ b/apps/server/src/lib/structured-logger.ts
@@ -38,6 +38,8 @@ export type LogCode =
   | 'WEBHOOK_FETCH_FAILED'
   // proxy upstream
   | 'UPSTREAM_FETCH_FAILED'
+  // rate limiting backend (Redis/Upstash) unavailable — fail-open is in effect
+  | 'RATE_LIMIT_BACKEND_DOWN'
   // Paddle billing
   | 'PADDLE_WEBHOOK_FAILED'
   | 'PADDLE_API_FAILED'

--- a/apps/server/src/proxy/mistral.ts
+++ b/apps/server/src/proxy/mistral.ts
@@ -15,6 +15,7 @@ import { runSecurityGate } from './shared/security-gate.js'
 import { fetchUpstreamWithTimeout } from './shared/upstream-fetch.js'
 import { buildLogBase } from './shared/log-base.js'
 import { runLineBufferedStreamPump } from './shared/stream-pump.js'
+import { assertSafeProxyBase } from './shared/validate-base.js'
 
 // Mistral's public API. Their chat completion endpoint is OpenAI-compatible
 // down to the request and response shape, the SSE chunk format, and the
@@ -28,6 +29,7 @@ import { runLineBufferedStreamPump } from './shared/stream-pump.js'
 const MISTRAL_BASE = (
   process.env['MISTRAL_API_BASE'] ?? 'https://api.mistral.ai'
 ).replace(/\/v1\/?$/, '')
+assertSafeProxyBase('MISTRAL_API_BASE', MISTRAL_BASE)
 
 export const mistralProxy = new Hono<ApiKeyContext>()
 

--- a/apps/server/src/proxy/openai.ts
+++ b/apps/server/src/proxy/openai.ts
@@ -15,6 +15,7 @@ import { runSecurityGate } from './shared/security-gate.js'
 import { fetchUpstreamWithTimeout } from './shared/upstream-fetch.js'
 import { buildLogBase } from './shared/log-base.js'
 import { runLineBufferedStreamPump } from './shared/stream-pump.js'
+import { assertSafeProxyBase } from './shared/validate-base.js'
 
 // Overridable so E2E (apps/web/__e2e__/smoke.spec.ts via docker-compose
 // dev mock-openai) can point this at http://localhost:4000 without hitting
@@ -25,6 +26,7 @@ import { runLineBufferedStreamPump } from './shared/stream-pump.js'
 const OPENAI_BASE = (
   process.env['OPENAI_API_BASE'] ?? 'https://api.openai.com'
 ).replace(/\/v1\/?$/, '')
+assertSafeProxyBase('OPENAI_API_BASE', OPENAI_BASE)
 
 export const openaiProxy = new Hono<ApiKeyContext>()
 

--- a/apps/server/src/proxy/openrouter.ts
+++ b/apps/server/src/proxy/openrouter.ts
@@ -15,6 +15,7 @@ import { runSecurityGate } from './shared/security-gate.js'
 import { fetchUpstreamWithTimeout } from './shared/upstream-fetch.js'
 import { buildLogBase } from './shared/log-base.js'
 import { runLineBufferedStreamPump } from './shared/stream-pump.js'
+import { assertSafeProxyBase } from './shared/validate-base.js'
 
 // OpenRouter is a meta-provider — one API key, one base URL, 100+ models from
 // 30+ providers underneath (OpenAI, Anthropic, Mistral, Meta, DeepSeek,
@@ -41,6 +42,7 @@ import { runLineBufferedStreamPump } from './shared/stream-pump.js'
 const OPENROUTER_BASE = (
   process.env['OPENROUTER_API_BASE'] ?? 'https://openrouter.ai/api'
 ).replace(/\/v1\/?$/, '')
+assertSafeProxyBase('OPENROUTER_API_BASE', OPENROUTER_BASE)
 
 /** Strip the leading `vendor/` prefix from a model id (no-op when absent). */
 function stripVendorPrefix(modelId: string): string {

--- a/apps/server/src/proxy/shared/validate-base.ts
+++ b/apps/server/src/proxy/shared/validate-base.ts
@@ -1,0 +1,33 @@
+import { validateOutboundUrlSync } from '../../lib/safe-url.js'
+
+/**
+ * SSRF guard for operator-supplied `*_API_BASE` overrides.
+ *
+ * The OpenAI / OpenRouter / Mistral proxies allow the upstream host to be
+ * overridden via an env var (so E2E can point at a local mock). That value is
+ * concatenated straight into the upstream URL and the customer's decrypted
+ * provider key is sent there, so a misconfigured or injected base
+ * (e.g. http://169.254.169.254) would exfiltrate credentials to an internal
+ * target. Validate the override at module load and fail fast instead of
+ * forwarding keys.
+ *
+ * Only enforced in production: `validateOutboundUrlSync` requires https, which
+ * would reject the documented dev/E2E mock at http://localhost:4000. Defaults
+ * (the unset case) are trusted constants and are never validated.
+ *
+ * @param envVarName the env var that may carry an override (e.g. 'OPENAI_API_BASE')
+ * @param base the resolved base URL actually used by the proxy
+ */
+export function assertSafeProxyBase(envVarName: string, base: string): void {
+  if (process.env['NODE_ENV'] !== 'production') return
+  // Only validate when the operator actually set an override; the built-in
+  // default is a known-safe constant.
+  if (!process.env[envVarName]) return
+
+  const result = validateOutboundUrlSync(base)
+  if (!result.ok) {
+    throw new Error(
+      `${envVarName} rejected by SSRF guard: ${result.message} (value: ${base})`,
+    )
+  }
+}

--- a/docs/plans/platform-review-roadmap-2026-06.md
+++ b/docs/plans/platform-review-roadmap-2026-06.md
@@ -1,0 +1,572 @@
+# Platform Review Roadmap (2026-06)
+
+Status: proposed
+Author: codebase review (2026-06-19), branch `feat/judge-prompt-caching`
+Scope: `apps/server`, `apps/web`, `supabase/`
+
+## Context
+
+This roadmap collects the actionable findings from a full codebase review into
+six phases. Every item below was verified against the working tree, so the file
+and line references are concrete starting points, not guesses. The codebase is
+healthy overall (multi-tenant isolation, `fireAndForget` drain, SWR cost cache,
+ClickHouse org + retention scoping, and `Number()` coercion are all in place),
+so this plan is about closing the remaining gaps rather than large rewrites.
+
+The two product decisions that triggered this plan:
+
+1. The per-minute proxy rate limit should be relaxed into a pure anti-runaway
+   ceiling that never hard-rejects customer LLM traffic. Monetization stays on
+   the monthly quota.
+2. Real rate limiting should become a customer-facing feature (limits the
+   customer sets on their own keys and end-users), matching the market norm
+   (Helicone, Portkey, LiteLLM).
+
+### Legend
+
+- Effort: S (under half a day), M (one to two days), L (multi-day).
+- Risk: low / med (behavioral surface area, test churn, or hot-path impact).
+
+### Verification convention (applies to every item)
+
+Per the project PR checklist, run all four and do not skip lint:
+
+- Server changes: `pnpm --filter server typecheck && pnpm --filter server lint && pnpm --filter server test`
+- Web changes: `pnpm --filter web typecheck && pnpm --filter web lint && pnpm --filter web build`
+- Migrations: `supabase db push && supabase gen types --lang typescript --local > supabase/types.ts`
+- Cross-package: `pnpm typecheck && pnpm lint`
+
+### Phase dependency graph
+
+```
+Phase 0 (security)        independent, ship first
+Phase 1 (proxy relax)     independent; shares rate-limit.ts with P0 item 2 and P2
+Phase 2 (customer limits) DB -> enforcement -> API -> UI -> docs (internal order)
+Phase 3 (hot path)        item 3.2 before 3.3 (same 6 proxy files); 3.1 independent
+Phase 4 (quality)         4.1 split BEFORE 4.2 dedup; web items independent
+Phase 5 (tests)           5.1 first (highest value); 5.2 experiment-runner after 4.2
+```
+
+---
+
+## Phase 0: Security hardening
+
+Goal: close four confirmed security gaps. All additive, low to med risk, no
+migrations. Ship first since they are independent of everything else.
+
+### 0.1 IP-rate-limit the frontend-error sink (S, low)
+
+The `/api/v1/frontend-errors` endpoint is unauthenticated AND its router is
+mounted at `app.ts:166` before `apiRateLimit` at `app.ts:171`, so the dashboard
+rate limit never runs for it. The docstring at `frontendErrors.ts:7-9` already
+promises a per-IP cap that was never implemented. An anonymous client can flood
+structured logs unbounded.
+
+- Files: `apps/server/src/api/frontendErrors.ts:45-82`, `apps/server/src/middleware/rateLimit.ts:93-95`, reference pattern `apps/server/src/api/publicShare.ts:39-55` and `badge.ts:35`.
+- Change: add a `frontendErrorsRouter.use('*', ...)` per-IP limiter using `checkRateLimit(\`fe-err:${ip}\`, 30)` from `lib/rate-limit.ts`. On limit, return `204` (not `429`) to preserve the existing always-204 fail-soft contract.
+
+Success criteria:
+
+- [ ] 31st POST from the same `x-forwarded-for` IP within 60s returns 204 and writes no `[frontend-error]` log line (verify with a `console.error` spy).
+- [ ] Requests under the cap still log and return 204.
+- [ ] `checkRateLimit` imported from `lib/rate-limit.js`, not reimplemented.
+- [ ] Server typecheck + lint + test pass.
+
+### 0.2 Make rate-limit fail-open observable (M, med)
+
+`checkRateLimit` fails open in two branches: silently when Redis env vars are
+unset (`rate-limit.ts:90-93`, no log at all) and with a raw `console.error` on
+Redis error (`rate-limit.ts:98-101`). A prod deploy missing the KV env vars
+disables all rate limiting with zero signal.
+
+- Files: `apps/server/src/lib/rate-limit.ts:84-102`, `apps/server/src/lib/structured-logger.ts:119-125`.
+- Change: replace the raw `console.error` with `logError` using a stable code (add `RATE_LIMIT_BACKEND_DOWN` to the LogCode union). Add a module-level once-guard warn in the unconfigured branch. Optional: in-process `Map` sliding-window fallback so a warm instance still caps abuse during a Redis outage (document that it is per-instance and weaker than the shared window).
+
+Success criteria:
+
+- [ ] With KV env vars unset, the first call emits exactly one structured warn with a stable code; later calls do not spam (module guard).
+- [ ] On `limiter.limit()` throw, a structured error line with a stable LogCode is emitted (err passed through `logError`).
+- [ ] If in-process fallback is implemented, the `(limit+1)`-th call in-window returns false in the same process; otherwise fail-open is explicitly retained and only logging changed.
+- [ ] New tests for the null-limiter path and the rejection path; happy-path tests still pass.
+
+### 0.3 Apply plan retention to anomaly queries (M, med)
+
+`detectAnomalies` and `fetchContributingFactors` enforce org isolation but not
+plan retention (free = 14d). The default 168h window is incidentally within
+free retention today, but `referenceHours` is caller-overridable and
+`exports.ts:358` + `anomaly-snapshot.ts:67` also call it, so a larger window
+would read past a free org's retention. Violates gotcha #3.
+
+- Files: `apps/server/src/lib/anomaly.ts:146-202`, `:346-381`, `apps/server/src/lib/requests-query.ts:118-133`.
+- Change: inject `requestsScope(organizationId)` into both queries. Merge `scopeParams` into params, replace the literal `organization_id = {orgId:UUID}` with `whereScope`, drop the now-duplicate manual orgId param.
+
+Success criteria:
+
+- [ ] Both queries include the retention bound (free=14 / pro=90 / team=365) plus org filter and refStart.
+- [ ] A free-plan org with `referenceHours` > 336h reads at most 14 days of rows (verify via mocked `unscopedClickhouse` SQL capture).
+- [ ] `anomaly-detect.test.ts` / `anomaly-confidence.test.ts` mocks updated for the new WHERE shape and still pass.
+- [ ] No duplicate-key collision in `query_params`.
+
+### 0.4 Validate proxy `*_API_BASE` env vars against SSRF (M, med)
+
+`OPENAI_API_BASE` (`openai.ts:25-27,48`), `OPENROUTER_API_BASE`
+(`openrouter.ts:41-43,68`), and `MISTRAL_API_BASE` (`mistral.ts:28-29,53`) are
+read from env and concatenated into the upstream URL with no validation. A
+misconfigured or injected base could redirect a customer's decrypted provider
+key to an internal target. `lib/safe-url.ts` already exports
+`validateOutboundUrlSync` (built for webhook SSRF). Anthropic and Gemini use
+hardcoded constants (safe); Azure uses a DB-backed per-key resource_url
+(separate surface, noted as follow-up).
+
+- Files: `apps/server/src/proxy/{openai,openrouter,mistral}.ts`, `apps/server/src/lib/safe-url.ts:176-228`.
+- Change: at module load, if the `*_API_BASE` env var is set, call `validateOutboundUrlSync` and throw on failure (fail fast). Extract a shared `proxy/shared/validate-base.ts`. Gate the throw behind `NODE_ENV === 'production'` so the documented E2E `http://localhost:4000` mock (https-only check would reject it) is not broken.
+
+Success criteria:
+
+- [ ] Setting any of the three bases to an internal/SSRF target (`http://169.254.169.254`, `https://10.0.0.1`) throws at startup in production; no request forwarded.
+- [ ] Unset env vars (prod defaults) pass; behavior unchanged.
+- [ ] The non-prod `localhost:4000` mock override still works.
+- [ ] `validateOutboundUrlSync` reused from `lib/safe-url.js` (no new IP/CIDR logic).
+
+### Phase 0 exit checklist
+
+- [ ] 0.1 through 0.4 merged.
+- [ ] `pnpm --filter server typecheck && lint && test` green.
+- [ ] Better Stack / log drain alert wired on the new `RATE_LIMIT_BACKEND_DOWN` code.
+
+---
+
+## Phase 1: Proxy rate-limit relaxation
+
+Goal: turn the per-minute proxy ceiling into an anti-runaway signal that never
+hard-rejects customer traffic. Monetization stays entirely on the monthly quota
+(`enforceQuota`), which runs right after `proxyRateLimit` on the same request.
+
+Wiring confirmed: all 6 proxies mount `authApiKey -> requireFullScope ->
+proxyRateLimit -> enforceQuota`. The two limits are independent.
+
+### 1.1 Raise `PROXY_RATE_LIMITS` to anti-runaway ceilings (S, low)
+
+Current: `{ free: 60, starter: 300, team: 1_500, enterprise: null }`
+(`rate-limit.ts:11-16`), per-org 60s sliding window.
+
+- Files: `apps/server/src/lib/rate-limit.ts:11-16`, `apps/server/src/middleware/rateLimit.ts:18-24` (doc comment), `apps/server/src/__tests__/middleware-rate-limit.test.ts:75,78,102,112-117`.
+- Change: raise roughly 10x (e.g. `free: 600, starter: 3_000, team: 15_000, enterprise: null`; finalize with product). Optionally read env overrides (e.g. `PROXY_RATE_LIMIT_FREE`) defaulting to the constants so ceilings tune without a deploy.
+
+Success criteria:
+
+- [ ] `PROXY_RATE_LIMITS` reflects new ceilings; enterprise stays null.
+- [ ] Doc comment in `rateLimit.ts` matches new numbers.
+- [ ] `middleware-rate-limit.test.ts` updated to the new free/team values and passes.
+
+### 1.2 Pass through on overage instead of throwing 429 (S, med)
+
+Current: over-ceiling throws `ApiError('RATE_LIMIT')` -> HTTP 429, hard-rejecting
+the customer's LLM request on the critical path (`rateLimit.ts:56-68`).
+
+- Files: `apps/server/src/middleware/rateLimit.ts:43-75`, `apps/server/src/__tests__/middleware-rate-limit.test.ts:83-94`.
+- Change: on `!allowed`, emit a structured `console.warn` (`event: 'proxy_rate_limit_overage'` with `organizationId`, `plan`, `limit`), set `X-Spanlens-RateLimit-Overage: true`, and `return next()`. Do not set `Retry-After`, do not throw. `enforceQuota` still runs next and remains the real gate.
+
+Success criteria:
+
+- [ ] `proxyRateLimit` never throws on the per-minute bucket; over-ceiling requests reach upstream.
+- [ ] Structured warn line emitted exactly when over the ceiling.
+- [ ] Response carries `X-Spanlens-RateLimit-Overage: true` on overage and standard `X-RateLimit-*` headers on every response.
+- [ ] `middleware-rate-limit.test.ts:83-94` rewritten: over-limit asserts pass-through + header + warn spy, not 429.
+- [ ] Monthly `enforceQuota` can still 429 (`free_limit` / `overage_disabled` / `hard_cap`) independently.
+
+### 1.3 Confirm monthly quota fully covers monetization (S, low)
+
+No code change. `MONTHLY_REQUEST_LIMITS = { free: 50_000, starter: 100_000,
+team: 1_000_000, enterprise: null }` (`quota.ts:14-19`), enforced by
+`enforceQuota` regardless of per-minute behavior.
+
+Success criteria:
+
+- [ ] Plan states that free-tier monetization is the monthly limit enforced by `enforceQuota`, not the per-minute bucket.
+- [ ] `enforceQuota` mount position (after `proxyRateLimit`) verified in all 6 proxies.
+- [ ] Existing `middleware-quota.test.ts` still passes unchanged.
+
+### 1.4 (Optional) Distinguish over-limit from Redis-error fail-open (M, low)
+
+Once 1.2 lands, an over-limit signal and a silent Redis outage both look like
+"under the limit" in metrics. Widen `checkRateLimit`'s return type so callers
+tell the cases apart and emit a distinct `proxy_rate_limit_degraded` warn.
+Connects with Phase 0 item 0.2. Upstash `Ratelimit.limit()` already returns
+`{ success, limit, remaining, reset }`, so no extra round-trip.
+
+- Files: `apps/server/src/lib/rate-limit.ts:84-102`, `apps/server/src/__tests__/rate-limit.test.ts:178-214`.
+
+Success criteria:
+
+- [ ] Return type distinguishes `over_limit` vs Redis-degraded fail-open.
+- [ ] `rate-limit.test.ts` Redis-error case asserts the degraded flag (still allows the request).
+- [ ] `proxyRateLimit` emits a separate warn for the degraded case; happy path unchanged.
+
+### Phase 1 exit checklist
+
+- [ ] 1.1 through 1.3 merged (1.4 optional, can follow).
+- [ ] No proxy path returns 429 from the per-minute bucket.
+- [ ] Overage observability confirmed in logs.
+
+---
+
+## Phase 2: Customer-configurable rate limiting (new feature)
+
+Goal: let customers set rate limits on their own keys, projects, and end-users;
+enforce them in the proxy and return 429 to the customer's end-user when hit.
+This is the desired 429 (unlike our platform limit). Internal order is strict:
+DB -> enforcement -> API -> UI -> docs.
+
+Key constraint (gotcha #24): reuse `@upstash/ratelimit` (Lua `EVAL`), never raw
+`redis.set` (silently fails on Upstash free tier). End-user identifier is the
+existing `x-spanlens-user` header (read at `log-base.ts:74`; SDK `withUser()`
+already sets it), so no new SDK header is needed.
+
+### 2.1 DB migration: `customer_rate_limits` table (M, low)
+
+- Files: `supabase/migrations/20260620000000_customer_rate_limits.sql` (NEW), mirror conventions from `20260604040000_api_keys_public_scope.sql` (CHECK + RLS) and `20260606000000_pending_deletions.sql` (deny-all + service_role); `is_org_member` helper from `20260420000000_initial_schema.sql`.
+- Change: one polymorphic table covering all three granularities.
+  - `id`, `organization_id` (NOT NULL, RLS anchor), `target_type` CHECK in (`api_key`, `project`, `end_user`), `api_key_id`, `project_id`, `end_user_id` (TEXT, the `x-spanlens-user` value), `max_requests` (CHECK > 0), `window_seconds` (CHECK in 60/3600/86400, keeps the limiter cache bounded), `is_active`, `created_at`, `updated_at`.
+  - Owner-consistency CHECK mirroring `api_keys_scope_owner_consistency`.
+  - Partial UNIQUE indexes per target type; lookup indexes on `(api_key_id, is_active)` and `(project_id, is_active)`.
+  - `ENABLE ROW LEVEL SECURITY`; SELECT `USING (is_org_member(organization_id))`; RESTRICTIVE deny-all for anon/authenticated; service_role ALL.
+  - All statements idempotent; additive columns NOT NULL + DEFAULT (gotcha #25).
+
+Success criteria:
+
+- [ ] `supabase db push` applies cleanly on a fresh throwaway DB (CI migrations step).
+- [ ] `supabase gen types` regenerates `types.ts` with the new row type (no hand edit).
+- [ ] `target_type='end_user'` with NULL `end_user_id` rejected by CHECK.
+- [ ] Second active `api_key`-level limit for the same key violates the partial UNIQUE index.
+- [ ] RLS enabled; anon/authenticated cannot write; `is_org_member` SELECT policy present.
+- [ ] Re-running the migration is a no-op.
+
+### 2.2 Enforcement: `customerRateLimit` middleware (L, med)
+
+- Files: `apps/server/src/middleware/customerRateLimit.ts` (NEW), `apps/server/src/lib/customer-limits.ts` (NEW, cached config fetch + invalidation), `apps/server/src/lib/rate-limit.ts:48-102` (extend for `windowSeconds`), all 6 `apps/server/src/proxy/*.ts` (one-line `.use` after `proxyRateLimit`), cache pattern `authApiKey.ts:84-135`.
+- Change:
+  1. Extend `getLimiter(limit, windowSeconds=60)` (cache key `${limit}:${windowSeconds}`) and `checkRateLimit(key, limit, windowSeconds=60)`. Existing callers default to 60, no behavior change.
+  2. `customer-limits.ts`: `getCustomerLimits(apiKeyId, projectId)` fetches active rows in one `supabaseAdmin` select, cached per `apiKeyId` (~30s TTL, `invalidateCustomerLimitsCache`). Cache the empty result too so the common no-limit case is a Map lookup with zero DB round-trips.
+  3. `customerRateLimit.ts` runs after `proxyRateLimit`, reads `apiKeyId`/`projectId`/`organizationId` from context and `endUserId` from the `x-spanlens-user` header. Evaluate most-specific-first (`custlimit:eu:{apiKeyId}:{endUserId}`, then `custlimit:key:{apiKeyId}`, then `custlimit:proj:{projectId}`). First deny wins. Fails open if Redis is unavailable or no config rows exist.
+
+Success criteria:
+
+- [ ] With an api_key limit of N/min, request N+1 in-window returns 429 (`RATE_LIMIT`); under N passes.
+- [ ] Two different `x-spanlens-user` values get independent buckets (distinct `custlimit:eu` keys).
+- [ ] A key/project with no configured limit incurs zero extra Redis and zero extra DB round-trips on cache hit.
+- [ ] When KV env vars unset, the middleware fails open (proxy still forwards).
+- [ ] A non-60s window (e.g. 3600) produces a separate cached limiter and a 1-hour sliding window.
+- [ ] Middleware added to all 6 proxies; unit test mirrors `middleware-rate-limit.test.ts`.
+
+### 2.3 API: CRUD endpoints (M, low)
+
+- Files: `apps/server/src/api/rateLimits.ts` (NEW), `apps/server/src/app.ts:191` (mount `/api/v1/rate-limits` next to provider-keys), copy patterns from `apiKeys.ts:35-47` and `providerKeys.ts:69-78`, `lib/audit-log.ts` (add `rate_limit.*` actions).
+- Change: `Hono<JwtContext>` router, `.use('*', authJwt)`, `requireRole('admin','editor')`. GET (list by `apiKeyId`/`projectId`), POST (validate `window_seconds` in {60,3600,86400}, `max_requests > 0`, verify target ownership, translate PG 23505 to `CONFLICT`), PATCH, DELETE (hard delete, low-risk config). Every write calls `invalidateCustomerLimitsCache` and `recordAuditEvent`. Mounted at a concrete path (no wildcard mount-order trap).
+
+Success criteria:
+
+- [ ] POST with a foreign `api_key_id` (different org) returns 403.
+- [ ] POST duplicate active limit for same target returns 409.
+- [ ] PATCH `is_active=false` stops enforcement within one cache TTL (<=30s) or immediately after invalidation.
+- [ ] All mutations appear in `audit_logs` with a `rate_limit.*` action.
+- [ ] Non-admin/editor and missing JWT rejected.
+- [ ] Reachable at `/api/v1/rate-limits`.
+
+### 2.4 UI: rate-limit config on the Projects page (M, low)
+
+- Files: `apps/web/app/(dashboard)/projects/projects-client.tsx`, `apps/web/app/(dashboard)/projects/page.tsx`, `apps/web/lib/queries/types.ts`.
+- Change: a "Rate limits" control per Spanlens key row (per-key cap + optional per-end-user caps), and a project-level limit in the project settings panel. All reads/writes via `fetch('/api/v1/rate-limits...')` with TanStack Query mutation + invalidation. Read-only for viewer role.
+
+Success criteria:
+
+- [ ] Admin can create/edit/delete a per-key limit from the Projects page and see it reflected after mutation.
+- [ ] Per-end-user limits can be added under a key and listed.
+- [ ] Viewer sees limits read-only.
+- [ ] All requests go through `/api/v1/rate-limits` (no direct Supabase from web).
+- [ ] No hydration warnings (time formatting via `apps/web/lib/utils.ts`, gotcha #22).
+
+### 2.5 429 response behavior to the end-user (S, low)
+
+- Files: `apps/server/src/middleware/customerRateLimit.ts`, `apps/server/src/lib/errors.ts:60` (reuse `RATE_LIMIT`).
+- Change: on a positively-exceeded customer limit, `throw new ApiError('RATE_LIMIT', msg, { source: 'customer_limit', scope, limit, window_seconds, end_user_id? })`. No `upgrade_url` / Spanlens pricing link (distinct from the platform 429). Set `Retry-After = window_seconds` and `X-Spanlens-RateLimit-Scope`.
+
+Success criteria:
+
+- [ ] Exceeding a customer limit returns 429 with `code: RATE_LIMIT` and `details.source = 'customer_limit'`.
+- [ ] `Retry-After` equals `window_seconds`; `X-Spanlens-RateLimit-Scope` identifies which limit fired.
+- [ ] No Spanlens `upgrade_url` in the body (distinguishable from the platform 429).
+- [ ] The end-user receives the 429 body unmodified through the proxy.
+
+### 2.6 SDK + docs (S, low)
+
+- Files: `apps/web/app/docs/proxy/page.tsx`, `apps/web/app/docs/sdk/page.tsx`. No new SDK helper (`withUser()` already exists at `packages/sdk/src/integrations/openai.ts:104-126`).
+- Change: document the feature, the 429 envelope, the `X-Spanlens-RateLimit-*` headers, and that per-end-user limits require sending `x-spanlens-user`. Cross-link `withUser()` from `/docs/sdk`.
+
+Success criteria:
+
+- [ ] `/docs/proxy` documents the 429 shape and the `X-Spanlens-RateLimit-*` headers.
+- [ ] `/docs/sdk` links `withUser()` to per-end-user limits with an example.
+- [ ] No new SDK header introduced; existing SDK tests unchanged.
+- [ ] `pnpm --filter web build` passes.
+
+### Phase 2 exit checklist
+
+- [ ] 2.1 through 2.6 merged in dependency order.
+- [ ] End-to-end: configure a per-key limit in the dashboard, exceed it via the proxy, observe 429 to the caller.
+- [ ] Follow-ups filed: token/cost-based limits (needs a rolling-spend counter in the log path), per-end-user limit-hit events on the `/users` dashboard.
+
+---
+
+## Phase 3: Proxy hot-path performance
+
+Goal: remove per-request blocking work from the proxy critical path. Sequence
+3.2 before 3.3 (same 6 files); 3.1 is independent.
+
+### 3.1 Cache `checkMonthlyQuota` and static-import the policy (M, med)
+
+`enforceQuota` runs `checkMonthlyQuota(orgId)` on every `/proxy/*` request,
+uncached: a Supabase `organizations` SELECT, a full-month ClickHouse `count()`
+scan that grows with volume, and a gratuitous dynamic `import('./quota-policy.js')`.
+
+- Files: `apps/server/src/lib/quota.ts:198-250,201-205,224-239,232`, `apps/server/src/middleware/quota.ts:22-69`, mirror `apps/server/src/lib/requests-query.ts:23-79` (getOrgPlan cache), increment hook `apps/server/src/lib/logger.ts` (~line 287, after the CH insert).
+- Change: (A) static-import `evaluateQuotaPolicy` (it is pure, already imported by `middleware/quota.ts:4`). (B) `getOrgQuotaSettings(orgId)` cache mirroring `getOrgPlan` (TTL Map + in-flight coalescing + reset hook). (C) in-memory month counter seeded by one `countMonthlyRequests` on cold/expired/rollover, incremented per successful logged request via `incrementMonthUsage(orgId)`, re-synced from CH on TTL expiry. Billing accuracy unaffected (Paddle/overage use `countMonthlyRequests` directly).
+
+Success criteria:
+
+- [ ] A warm-cache `/proxy/*` request issues zero Supabase `organizations` SELECTs and zero ClickHouse `count()` from the quota path (verify with spies).
+- [ ] `await import('./quota-policy.js')` no longer appears in `quota.ts`.
+- [ ] `middleware-quota.test.ts` still passes (mocks `checkMonthlyQuota`).
+- [ ] New test: cold call hits CH once; N logged requests increment in-memory without further `count()`; after TTL re-syncs from CH; UTC month rollover resets.
+- [ ] Free org crossing 50,000 still blocked with `free_limit` within one TTL window.
+- [ ] `api/billing.ts` quota numbers stay correct (same cache or <=60s staleness).
+
+### 3.2 Parallelize provider-key decrypt and body parse (S, low)
+
+In each of the 6 proxies, `assertProviderKey` (DB + AES decrypt) and
+`parseProxyRequestBody` run serially before `runSecurityGate`. They share no
+inputs. `runSecurityGate` consumes `parsed.reqBodyJson`, so it stays after.
+
+- Files: `apps/server/src/proxy/{openai,anthropic,gemini,azure,mistral,openrouter}.ts`, helpers `proxy/shared/provider-key.ts:36-49`, `proxy/shared/request-body.ts:29-51`.
+- Change: `const [providerKey, parsed] = await Promise.all([assertProviderKey(...), parseProxyRequestBody(c, {...})])`, then `runSecurityGate`. Carry each file's existing parse options (openai+azure pass `injectOpenAIStreamOptions: true`). For azure, move the resource_url guard after the `Promise.all`.
+
+Success criteria:
+
+- [ ] All 6 proxies use a single `Promise.all` before `runSecurityGate`.
+- [ ] `runSecurityGate` still runs after the `Promise.all`.
+- [ ] Azure resource_url guard still throws `INTERNAL_ERROR` when empty.
+- [ ] Missing provider key still yields `NO_PROVIDER_KEY` (rejection propagates out of `Promise.all`).
+- [ ] `proxy_overhead_ms` observably drops by roughly the smaller await duration.
+- [ ] Existing proxy tests unchanged.
+
+### 3.3 Move prompt-version resolution off the streaming path (M, med)
+
+`buildLogBase` is async only because it awaits `resolvePromptVersion`, and in
+the streaming path it is awaited before the stream Response is returned. On a
+cold prompt cache that is 1-2 Supabase queries delaying time-to-first-token. The
+resolved id only lands on the log row.
+
+- Files: `apps/server/src/proxy/shared/log-base.ts:52-79`, all 6 proxies' `buildLogBase` call sites and log continuations, `apps/server/src/proxy/stream-logger.ts:54-58`, `apps/server/src/lib/resolve-prompt-version.ts:45-157`, `apps/server/src/lib/logger.ts:52`.
+- Change: make `buildLogBase` synchronous (capture the raw header, drop the resolve call). Resolve the prompt version inside the log continuation that already runs after the response starts: `fireAndForget(logRequestAsync(...))` (non-streaming) and the `onComplete` callback (streaming). Apply to all 6 proxies.
+
+Success criteria:
+
+- [ ] `buildLogBase` is no longer async and contains no `resolvePromptVersion` call; callers no longer await it.
+- [ ] On a streaming request with a cold prompt cache, the resolve queries run after the stream pump starts (assert ordering with spies).
+- [ ] The logged row still carries the correct `prompt_version_id`; A/B routing still works.
+- [ ] Non-streaming path resolves inside `fireAndForget`.
+- [ ] All 6 proxies updated consistently.
+
+### Phase 3 exit checklist
+
+- [ ] 3.1 through 3.3 merged (3.2 first, then 3.3, 3.1 any time).
+- [ ] `proxy_overhead_ms` p95 measured before/after, improvement recorded.
+
+---
+
+## Phase 4: Code-quality refactor
+
+Goal: bring oversized files under the 800-line ceiling and remove the eval /
+experiment runner duplication that makes provider additions error-prone.
+Sequence: 4.1 (split) before 4.2 (dedup). Web items (4.5 through 4.7) are
+independent of each other and of the server work.
+
+### 4.1 Split `lib/eval-runner.ts` (1870 lines) (L, med)
+
+The file already imports 8 helpers from `lib/eval-runners/` and re-exports for
+back-compat. Still inline: judge transport, judge calls, generate, pool,
+provider-key resolve, and the monolithic `runEvalRun` (824-1747) with trajectory
+/ pairwise / single paths inlined.
+
+- Files: `apps/server/src/lib/eval-runner.ts` (ranges 307-492, 503-714, 717-734, 824-1747, 905-1062, 1069-1254, 1555-1732), consumers `api/evals.ts`, `api/prompts.ts`, ~16 test files.
+- Change: keep `eval-runner.ts` a thin dispatcher + re-export barrel (target under 400 lines). Extract `judge-transport.ts`, `judge-calls.ts`, `generate.ts`, `pool.ts`, `provider-key.ts`, `run-trajectory.ts`, `run-pairwise.ts`, `run-single.ts`, `estimate.ts` under `eval-runners/`. Re-export every previously-exported symbol so import sites and tests are untouched.
+
+Success criteria:
+
+- [ ] `eval-runner.ts` <= ~400 lines.
+- [ ] All previously exported symbols still re-exported (full list in source review).
+- [ ] Server typecheck passes.
+- [ ] Server test passes with zero changes to the ~16 existing eval test files.
+- [ ] Each new file under ~400 lines; no behavior change.
+
+### 4.2 Consolidate experiment-runner duplication (M, med)
+
+`experiment-runner.ts` reimplements `pool` (byte-identical), a local
+`JudgeConfig`, simpler `buildJudgePrompt`/`parseJudgeReply` clones, and a 167-line
+`callJudge` that duplicates the judge transport. The header comments admit the
+duplication was to avoid circular imports, which 4.1 removes.
+
+- Files: `apps/server/src/lib/experiment-runner.ts:27-33,228-245,247-262,264-430,434-451`, leaf modules from 4.1, `lib/eval-runners/judge-prompt.ts:208-322`.
+- Change: after 4.1 lands leaf modules, replace local `pool`, `JudgeConfig`, `buildJudgePrompt`/`parseJudgeReply`, and `callJudge` with imports from the shared modules. Net removal ~210 lines.
+
+Success criteria:
+
+- [ ] `experiment-runner.ts` no longer defines `pool`, `JudgeConfig`, `buildJudgePrompt`, `parseJudgeReply`, or `callJudge`.
+- [ ] Drops by ~200+ lines.
+- [ ] No circular import (madge / tsc clean).
+- [ ] A/B scoring output (`score_a`/`score_b`, costs) unchanged on a fixture run.
+
+### 4.3 Route bare `c.json` errors through `ApiError` (S, low)
+
+`errors.ts` has no `PAYMENT_REQUIRED` and no generic upstream-error code.
+Confirmed bare sites: `requests.ts:342,415,496`; `organizations.ts:244,438`
+(both HTTP 402). Note: `anomalies.ts` is already compliant (it throws
+`ApiError` at `:171`); no change there.
+
+- Files: `apps/server/src/lib/errors.ts:27-91`, `api/requests.ts`, `api/organizations.ts`.
+- Change: add `PAYMENT_REQUIRED` (402) and an upstream-error code. Convert both 402 sites in `organizations.ts` and the truncated-body sites in `requests.ts` to `ApiError`, preserving the details payloads. The `requests.ts:496` dynamic-status passthrough is either documented as intentional or wrapped.
+
+Success criteria:
+
+- [ ] `ERROR_CODES` contains `PAYMENT_REQUIRED` (402) and an upstream-error code.
+- [ ] `organizations.ts` has zero bare `c.json({error})`; both 402 paths use `ApiError` and keep their details.
+- [ ] `requests.ts` truncated-body sites use `ApiError`; the 496 passthrough documented or wrapped.
+- [ ] ErrorCode union still compiles; existing envelope tests green.
+
+### 4.4 Promote validation helpers to `lib/validation-helpers.ts` (S, low)
+
+`scoreConfigs.ts:42-55` has three private `normalise*` coercion helpers useful
+at any boundary. No Zod (a schema library is a separate, larger decision).
+
+- Files: `apps/server/src/api/scoreConfigs.ts:42-55`, `apps/server/src/lib/validation-helpers.ts` (NEW).
+- Change: move the three helpers verbatim (explicit return types), re-import in `scoreConfigs.ts`. Migrate other boundary files opportunistically.
+
+Success criteria:
+
+- [ ] `lib/validation-helpers.ts` exports the 3 helpers with explicit return types.
+- [ ] `scoreConfigs.ts` imports them, no local copies.
+- [ ] No new package added.
+
+### 4.5 Extract `settings-client.tsx` (2464 lines) (M, low)
+
+Already partitioned into ~25 named tab components dispatched by `TabContent`.
+
+- Files: `apps/web/app/(dashboard)/settings/settings-client.tsx`.
+- Change: `_components/` for shared primitives (NativeInput, Toggle, MonoPill, Hint, TabHeader, CopyButton) and `_tabs/` one file per tab (general, members, security, system, billing, profile, notifications, webhooks, integrations, destinations). Keep `SettingsClient` + `TabContent` in the entry file. Preserve `'use client'` and hydration-safe helpers.
+
+Success criteria:
+
+- [ ] `settings-client.tsx` <= ~300 lines (dispatcher + shell).
+- [ ] Each extracted tab under ~400 lines.
+- [ ] Web typecheck + lint pass.
+- [ ] All tabs render with no hydration regression (manual smoke).
+
+### 4.6 Extract `evals-client.tsx` (2390 lines) (M, low)
+
+- Files: `apps/web/app/(dashboard)/evals/evals-client.tsx`.
+- Change: `_components/` with `new-evaluator-dialog.tsx` (157-968), `run-evaluator-dialog.tsx` (969-1378), `run-detail-panel.tsx`, `evaluator-row.tsx`, `correlation-card.tsx`, `runs-view.tsx`, `status-badge.tsx`. `EvalsClient` stays in the entry file.
+
+Success criteria:
+
+- [ ] `evals-client.tsx` <= ~500 lines.
+- [ ] Both dialogs isolated into single-responsibility files.
+- [ ] Web typecheck + lint pass.
+- [ ] Create evaluator, run evaluator, run-detail flows work (manual smoke).
+
+### 4.7 Extract `requests-client.tsx` (1704 lines) (M, low)
+
+- Files: `apps/web/app/(dashboard)/requests/requests-client.tsx`.
+- Change: `_lib/format.ts` (pure helpers), `stat-strip.tsx`, `traffic-bars.tsx` (wrap recharts in `dynamic({ ssr: false })`, gotcha #22), `request-drawer.tsx`, `requests-table.tsx`. Hoist the duplicated `CopyButton` into `apps/web/components` (shared with settings).
+
+Success criteria:
+
+- [ ] `requests-client.tsx` <= ~500 lines.
+- [ ] TrafficBars guarded against SSR hydration mismatch.
+- [ ] `CopyButton` defined once, reused by requests and settings.
+- [ ] Web typecheck + lint pass; list/filters/drawer/chart work (manual smoke).
+
+### Phase 4 exit checklist
+
+- [ ] 4.1 before 4.2; both merged.
+- [ ] 4.3, 4.4 merged.
+- [ ] 4.5 through 4.7 merged.
+- [ ] No file over 800 lines among the targets; full `pnpm typecheck && lint` green.
+
+---
+
+## Phase 5: Test coverage
+
+Goal: cover the high-value untested modules. 5.1 first (customer-facing
+verdicts, pure functions, lowest effort). The experiment-runner part of 5.2 is
+easier after the 4.2 dedup makes its dependencies mockable.
+
+### 5.1 Test `prompt-experiment-stats.ts` (M, low) HIGHEST VALUE
+
+114 lines of significance math (`errorRateTest` two-proportion z-test,
+`welchTest` Welch t-test, `normalCdf`, `tPValue`) with zero tests, feeding the
+customer-visible A/B winner verdict at `prompt-experiments.ts:245-272`. A wrong
+p-value silently mislabels a winner.
+
+- Files: `apps/server/src/lib/prompt-experiment-stats.ts:18-114`, `apps/server/src/lib/__tests__/prompt-experiment-stats.test.ts` (NEW).
+- Change: cover both functions across insufficient-sample, significant,
+  not-significant, zero-variance, and `relativeLift`-null branches. Validate at
+  least two p-values against an external reference (R/SciPy) within ~1e-3.
+
+Success criteria:
+
+- [ ] >= 12 cases covering both functions' branches.
+- [ ] >= 2 p-value assertions checked against an external reference within documented tolerance.
+- [ ] Line + branch coverage >= 90%.
+- [ ] Server test green.
+
+### 5.2 Test `experiment-runner.ts`, `admin-emails.ts`, `stats-queries.ts` (M, low)
+
+- Files: `apps/server/src/lib/experiment-runner.ts`, `admin-emails.ts:14-40`, `stats-queries.ts`.
+- Change:
+  - `admin-emails` (do first): empty array when no admins, opted-out admin excluded, no-prefs-row admin included, missing-address skipped.
+  - `stats-queries`: table-test each builder for org-isolation filter presence and `Number()` coercion (gotcha #19), no `ilike` (gotcha #20), DateTime handling.
+  - `experiment-runner` (after 4.2): aggregate math, `bothErrored` span status, no-items / missing-key error paths.
+
+Success criteria:
+
+- [ ] `admin-emails.ts`: opt-out + missing-email + no-admin branches, >= 90% coverage.
+- [ ] `stats-queries.ts`: each builder asserts org filter + numeric coercion; key builders >= 80%.
+- [ ] `experiment-runner.ts`: aggregate math + error paths covered after shared imports are mockable.
+- [ ] All new tests pass.
+
+### Phase 5 exit checklist
+
+- [ ] 5.1 merged first.
+- [ ] 5.2 merged (experiment-runner part after 4.2).
+- [ ] Coverage report shows the four modules above their targets.
+
+---
+
+## Branch note: `feat/judge-prompt-caching`
+
+The current branch (Anthropic prompt caching for the LLM judge) is mergeable.
+Split logic and cost accounting are correct. Two caveats to record, not blockers:
+
+- Caching only helps when the judge system prefix exceeds the per-model minimum
+  (1024 tokens for Sonnet/Opus, 2048 for Haiku) and rows in the same run land
+  within the 5-minute TTL. Short judge prompts see little or no saving (the code
+  correctly treats this as safe, since the API ignores `cache_control` below the
+  minimum).
+- The caching test asserts the request body shape but not the response usage
+  (`cache_read_input_tokens`), so it does not prove a live cache hit. A
+  follow-up integration assertion on usage would close that gap.
+
+(Note: an early review flagged a missing `anthropic-beta` header as a blocker.
+That is not required for the GA models used as judges; `cache_control` is
+honored without it.)
+```


### PR DESCRIPTION
## Summary

Phase 0 of the platform review roadmap (`docs/plans/platform-review-roadmap-2026-06.md`). Closes four confirmed, independent security gaps. All additive, no migrations, no behavior change for legitimate traffic.

| # | Gap | Fix |
|---|-----|-----|
| 0.1 | `/api/v1/frontend-errors` is public, mounted before `apiRateLimit`, and `apiRateLimit` fails open for tokenless requests, so any anonymous client could flood the structured log drain unbounded | Per-IP rate limit (30/min) inside the router, reusing `checkRateLimit`. Over the cap returns `204` without logging (preserves the fail-soft contract) |
| 0.2 | `checkRateLimit` fails open silently when KV is unconfigured (no log) and with a free-form `console.error` on Redis error, so a silent outage disables all rate limiting with no signal | Emit the stable `RATE_LIMIT_BACKEND_DOWN` code via `logError` (Redis error) and a once-guarded `logWarn` (unconfigured). Fail-open behavior itself is retained and documented |
| 0.3 | `detectAnomalies` / `fetchContributingFactors` enforced org isolation but not plan retention; a caller-supplied `referenceHours` could read past a free org's 14d window (gotcha #3) | Route both through `requestsScope()` so org + retention scoping is applied to all three queries |
| 0.4 | `OPENAI`/`OPENROUTER`/`MISTRAL` `_API_BASE` env overrides were concatenated into the upstream URL unvalidated, so a misconfigured/injected base could exfiltrate the decrypted provider key (SSRF) | New `proxy/shared/validate-base.ts` validates overrides via `validateOutboundUrlSync` at module load, production-only (so the dev/E2E `localhost` mock is unaffected). Fails fast on an internal target |

## Test plan

- [x] `pnpm --filter server typecheck`
- [x] `pnpm --filter server lint`
- [x] `pnpm --filter server test` — 110 files / 1310 tests green
- [x] New test suites: rate-limit warn-once + stable code, anomaly retention scoping, frontend-errors per-IP limit, validate-base SSRF matrix

## Notes

- Branched from `main` (independent of `feat/judge-prompt-caching`).
- Follow-up (ops, not code): wire a Better Stack / log-drain alert on the `RATE_LIMIT_BACKEND_DOWN` code.