### PR TITLE
feat(server): Phase 1 proxy rate-limit relaxation

### DIFF
--- a/apps/server/src/__tests__/middleware-rate-limit.test.ts
+++ b/apps/server/src/__tests__/middleware-rate-limit.test.ts
@@ -55,7 +55,8 @@ function makeProxyApp(orgId: string | null, plan: string | null = null) {
   })
   app.use('*', proxyRateLimit as unknown as Parameters<typeof app.use>[1])
   app.get('/probe', (c) => c.json({ ok: true }))
-  // Sprint 8 hotfix — proxyRateLimit throws ApiError now.
+  // proxyRateLimit passes through on overage (no 429), but apiRateLimit still
+  // throws ApiError — installOnError keeps the shared helper consistent.
   installOnError(app)
   return app
 }
@@ -72,34 +73,40 @@ describe('proxyRateLimit', () => {
 
     const res = await makeProxyApp('org_1', 'free').request('/probe')
     expect(res.status).toBe(200)
-    expect(res.headers.get('X-RateLimit-Limit')).toBe('60')
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('600')
     expect(res.headers.get('X-RateLimit-Window')).toBe('60s')
     expect(res.headers.get('X-RateLimit-Reset')).not.toBeNull()
-    expect(checkRateLimitMock).toHaveBeenCalledWith('proxy:org_1', 60)
+    expect(checkRateLimitMock).toHaveBeenCalledWith('proxy:org_1', 600)
     // R-5: no DB SELECT for plan anymore — authApiKey caches it
     expect(fromMock).not.toHaveBeenCalled()
   })
 
-  test('free plan over limit → 429 with structured error + Retry-After', async () => {
+  test('over the ceiling → pass-through (NOT 429) with overage header + warn', async () => {
     checkRateLimitMock.mockResolvedValue(false)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const res = await makeProxyApp('org_1', 'free').request('/probe')
-    expect(res.status).toBe(429)
-    const body = await res.json() as Record<string, unknown>
-    expect((body['error'] as { details: { limit: number } }).details.limit).toBe(60)
-    expect((body['error'] as { details: Record<string, unknown> }).details['window']).toBe('60s')
-    expect((body['error'] as { details: Record<string, unknown> }).details['upgrade_url']).toBe('https://www.spanlens.io/pricing')
-    expect(res.headers.get('Retry-After')).toBe('60')
+
+    // Critical: the customer's LLM request still goes through.
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Spanlens-RateLimit-Overage')).toBe('true')
     expect(res.headers.get('X-RateLimit-Remaining')).toBe('0')
+    // No 429 means no Retry-After and no upgrade_url leakage.
+    expect(res.headers.get('Retry-After')).toBeNull()
+    // Overage is surfaced for observability via the stable warn code.
+    const overageWarns = warnSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('PROXY_RATE_LIMIT_OVERAGE'),
+    )
+    expect(overageWarns).toHaveLength(1)
   })
 
-  test('missing plan falls back to free (60 req/min)', async () => {
+  test('missing plan falls back to free (600 req/min)', async () => {
     // The cached lookup didn't set plan → middleware defaults to 'free'
     checkRateLimitMock.mockResolvedValue(true)
 
     const res = await makeProxyApp('org_1', null).request('/probe')
     expect(res.status).toBe(200)
-    expect(res.headers.get('X-RateLimit-Limit')).toBe('60')
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('600')
   })
 
   test('enterprise plan (limit=null) → unlimited, no rate-limit headers set', async () => {
@@ -109,11 +116,11 @@ describe('proxyRateLimit', () => {
     expect(checkRateLimitMock).not.toHaveBeenCalled()
   })
 
-  test('team plan limit is 1500 req/min', async () => {
+  test('team plan ceiling is 15000 req/min', async () => {
     checkRateLimitMock.mockResolvedValue(true)
 
     await makeProxyApp('org_1', 'team').request('/probe')
-    expect(checkRateLimitMock).toHaveBeenCalledWith('proxy:org_1', 1500)
+    expect(checkRateLimitMock).toHaveBeenCalledWith('proxy:org_1', 15000)
   })
 })
 

--- a/apps/server/src/lib/rate-limit.ts
+++ b/apps/server/src/lib/rate-limit.ts
@@ -4,15 +4,30 @@ import type { Plan } from './quota.js'
 import { logError, logWarn } from './structured-logger.js'
 
 /**
- * Per-minute proxy ingestion limits keyed by plan.
+ * Per-minute proxy ceilings keyed by plan.
  *
  * Applied per organization (all API keys in the same org share the bucket).
  * Enterprise is unlimited (null).
+ *
+ * These are pure anti-runaway ceilings, NOT a monetization lever — monetization
+ * lives entirely in the monthly quota (enforceQuota, which runs right after
+ * proxyRateLimit on every proxy request). BYOK means we bear no LLM cost on
+ * overage, and the proxy is the customer's critical path, so the ceilings are
+ * set ~10x a realistic sustained rate and overage no longer hard-rejects
+ * (see proxyRateLimit in middleware/rateLimit.ts). Each is env-overridable so
+ * the ceiling can be tuned without a deploy.
  */
+function ceilingFromEnv(envVar: string, fallback: number): number {
+  const raw = process.env[envVar]
+  if (raw == null || raw === '') return fallback
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? n : fallback
+}
+
 export const PROXY_RATE_LIMITS: Record<Plan, number | null> = {
-  free:       60,
-  starter:    300,
-  team:       1_500,
+  free:       ceilingFromEnv('PROXY_RATE_LIMIT_FREE',    600),
+  starter:    ceilingFromEnv('PROXY_RATE_LIMIT_STARTER', 3_000),
+  team:       ceilingFromEnv('PROXY_RATE_LIMIT_TEAM',    15_000),
   enterprise: null,
 }
 

--- a/apps/server/src/lib/structured-logger.ts
+++ b/apps/server/src/lib/structured-logger.ts
@@ -40,6 +40,8 @@ export type LogCode =
   | 'UPSTREAM_FETCH_FAILED'
   // rate limiting backend (Redis/Upstash) unavailable — fail-open is in effect
   | 'RATE_LIMIT_BACKEND_DOWN'
+  // per-minute proxy ceiling exceeded — pass-through anti-runaway signal (not a block)
+  | 'PROXY_RATE_LIMIT_OVERAGE'
   // Paddle billing
   | 'PADDLE_WEBHOOK_FAILED'
   | 'PADDLE_API_FAILED'

--- a/apps/server/src/middleware/rateLimit.ts
+++ b/apps/server/src/middleware/rateLimit.ts
@@ -4,6 +4,7 @@ import { checkRateLimit, PROXY_RATE_LIMITS, API_RATE_LIMIT } from '../lib/rate-l
 import type { ApiKeyContext } from './authApiKey.js'
 import type { JwtContext } from './authJwt.js'
 import { ApiError } from '../lib/errors.js'
+import { logWarn } from '../lib/structured-logger.js'
 
 /**
  * Per-minute rate limit for proxy routes (plan-aware).
@@ -15,10 +16,19 @@ import { ApiError } from '../lib/errors.js'
  * Pre-R-5 every proxy request was 2 round-trips (api_keys + plan);
  * post-R-5 it's 1 round-trip (cached) or 0 (cache hit).
  *
- *   free       →    60 req/min
- *   starter    →   300 req/min
- *   team       → 1,500 req/min
+ * Default ceilings (env-overridable, see PROXY_RATE_LIMITS):
+ *   free       →    600 req/min
+ *   starter    →  3,000 req/min
+ *   team       → 15,000 req/min
  *   enterprise → unlimited
+ *
+ * These are pure anti-runaway ceilings, NOT a monetization lever. On overage
+ * we do NOT 429 the customer's LLM request — that would hard-reject production
+ * traffic on the critical path, and BYOK means we bear no LLM cost on overage.
+ * Instead we PASS THROUGH and emit a structured warn (PROXY_RATE_LIMIT_OVERAGE)
+ * plus an X-Spanlens-RateLimit-Overage response header for observability. The
+ * monthly quota (enforceQuota, mounted right after this) remains the real
+ * monetization / abuse gate.
  *
  * All API keys within the same organization share one bucket, so a team
  * that issues multiple keys cannot multiply its quota.
@@ -54,17 +64,15 @@ export const proxyRateLimit = createMiddleware<ApiKeyContext>(async (c, next) =>
   c.header('X-RateLimit-Reset', String(resetAt))
 
   if (!allowed) {
+    // Pass-through, NOT a 429. Over the per-minute ceiling is an anti-runaway
+    // signal only — surface it for observability and let the request proceed
+    // to enforceQuota (the monetization gate) and upstream. A Redis outage
+    // also lands here as allowed=true (fail-open), so this branch fires only
+    // on a genuine, positive overage.
+    logWarn('PROXY_RATE_LIMIT_OVERAGE', { organizationId, plan, limit, window: '60s' })
     c.header('X-RateLimit-Remaining', '0')
-    c.header('Retry-After', '60')
-    throw new ApiError(
-      'RATE_LIMIT',
-      `Rate limit exceeded: ${limit} requests/min on the ${plan} plan. Upgrade or retry after 60 seconds.`,
-      {
-        limit,
-        window: '60s',
-        upgrade_url: 'https://www.spanlens.io/pricing',
-      },
-    )
+    c.header('X-Spanlens-RateLimit-Overage', 'true')
+    return next()
   }
 
   // For successful requests we don't know the exact remaining count

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -163,7 +163,6 @@ const PLANS = [
     description: 'For personal projects and exploration',
     features: [
       '50K requests / month',
-      '60 req/min rate limit',
       '1 seat',
       '1 workspace',
       'Unlimited projects',
@@ -183,7 +182,6 @@ const PLANS = [
     description: 'For solo developers shipping to production',
     features: [
       '100K requests / month',
-      '300 req/min rate limit',
       '3 seats',
       '2 workspaces',
       'Unlimited projects',
@@ -204,7 +202,6 @@ const PLANS = [
     description: 'For teams that need full visibility',
     features: [
       '1M requests / month',
-      '1,500 req/min rate limit',
       '10 seats',
       '5 workspaces',
       'Unlimited projects',
@@ -226,7 +223,6 @@ const PLANS = [
     description: 'For large teams with advanced needs',
     features: [
       'Custom requests / month',
-      'Custom rate limit',
       'Unlimited seats',
       'Unlimited workspaces',
       'Unlimited projects',

--- a/docs/plans/platform-review-roadmap-2026-06.md
+++ b/docs/plans/platform-review-roadmap-2026-06.md
@@ -1,8 +1,14 @@
 # Platform Review Roadmap (2026-06)
 
-Status: proposed
+Status: in progress
 Author: codebase review (2026-06-19), branch `feat/judge-prompt-caching`
 Scope: `apps/server`, `apps/web`, `supabase/`
+
+Progress:
+
+- Phase 0 (security hardening): DONE, merged in #369 (2026-06-19).
+- Phase 1 (proxy rate-limit relaxation): implemented and verified, PR pending.
+- Phases 2 through 5: not started.
 
 ## Context
 
@@ -51,6 +57,9 @@ Phase 5 (tests)           5.1 first (highest value); 5.2 experiment-runner after
 
 ## Phase 0: Security hardening
 
+Status: DONE, merged in #369 (2026-06-19). Verified with
+`pnpm --filter server typecheck && lint && test` (1310 tests green).
+
 Goal: close four confirmed security gaps. All additive, low to med risk, no
 migrations. Ship first since they are independent of everything else.
 
@@ -67,10 +76,10 @@ structured logs unbounded.
 
 Success criteria:
 
-- [ ] 31st POST from the same `x-forwarded-for` IP within 60s returns 204 and writes no `[frontend-error]` log line (verify with a `console.error` spy).
-- [ ] Requests under the cap still log and return 204.
-- [ ] `checkRateLimit` imported from `lib/rate-limit.js`, not reimplemented.
-- [ ] Server typecheck + lint + test pass.
+- [x] 31st POST from the same `x-forwarded-for` IP within 60s returns 204 and writes no `[frontend-error]` log line (verify with a `console.error` spy).
+- [x] Requests under the cap still log and return 204.
+- [x] `checkRateLimit` imported from `lib/rate-limit.js`, not reimplemented.
+- [x] Server typecheck + lint + test pass.
 
 ### 0.2 Make rate-limit fail-open observable (M, med)
 
@@ -84,10 +93,10 @@ disables all rate limiting with zero signal.
 
 Success criteria:
 
-- [ ] With KV env vars unset, the first call emits exactly one structured warn with a stable code; later calls do not spam (module guard).
-- [ ] On `limiter.limit()` throw, a structured error line with a stable LogCode is emitted (err passed through `logError`).
-- [ ] If in-process fallback is implemented, the `(limit+1)`-th call in-window returns false in the same process; otherwise fail-open is explicitly retained and only logging changed.
-- [ ] New tests for the null-limiter path and the rejection path; happy-path tests still pass.
+- [x] With KV env vars unset, the first call emits exactly one structured warn with a stable code; later calls do not spam (module guard).
+- [x] On `limiter.limit()` throw, a structured error line with a stable LogCode is emitted (err passed through `logError`).
+- [x] In-process fallback NOT implemented; fail-open is explicitly retained and documented, only logging changed.
+- [x] New tests for the null-limiter (warn-once) path and the rejection path; happy-path tests still pass.
 
 ### 0.3 Apply plan retention to anomaly queries (M, med)
 
@@ -102,10 +111,10 @@ would read past a free org's retention. Violates gotcha #3.
 
 Success criteria:
 
-- [ ] Both queries include the retention bound (free=14 / pro=90 / team=365) plus org filter and refStart.
-- [ ] A free-plan org with `referenceHours` > 336h reads at most 14 days of rows (verify via mocked `unscopedClickhouse` SQL capture).
-- [ ] `anomaly-detect.test.ts` / `anomaly-confidence.test.ts` mocks updated for the new WHERE shape and still pass.
-- [ ] No duplicate-key collision in `query_params`.
+- [x] Both queries include the retention bound (free=14 / pro=90 / team=365) plus org filter and refStart.
+- [x] A free-plan org with `referenceHours` > 336h reads at most 14 days of rows (verify via mocked `unscopedClickhouse` SQL capture).
+- [x] `anomaly-detect.test.ts` / `anomaly-confidence.test.ts` mocks updated for the new WHERE shape and still pass.
+- [x] No duplicate-key collision in `query_params`.
 
 ### 0.4 Validate proxy `*_API_BASE` env vars against SSRF (M, med)
 
@@ -123,16 +132,16 @@ hardcoded constants (safe); Azure uses a DB-backed per-key resource_url
 
 Success criteria:
 
-- [ ] Setting any of the three bases to an internal/SSRF target (`http://169.254.169.254`, `https://10.0.0.1`) throws at startup in production; no request forwarded.
-- [ ] Unset env vars (prod defaults) pass; behavior unchanged.
-- [ ] The non-prod `localhost:4000` mock override still works.
-- [ ] `validateOutboundUrlSync` reused from `lib/safe-url.js` (no new IP/CIDR logic).
+- [x] Setting any of the three bases to an internal/SSRF target (`http://169.254.169.254`, `https://10.0.0.1`) throws at startup in production; no request forwarded.
+- [x] Unset env vars (prod defaults) pass; behavior unchanged.
+- [x] The non-prod `localhost:4000` mock override still works.
+- [x] `validateOutboundUrlSync` reused from `lib/safe-url.js` (no new IP/CIDR logic).
 
 ### Phase 0 exit checklist
 
-- [ ] 0.1 through 0.4 merged.
-- [ ] `pnpm --filter server typecheck && lint && test` green.
-- [ ] Better Stack / log drain alert wired on the new `RATE_LIMIT_BACKEND_DOWN` code.
+- [x] 0.1 through 0.4 merged (#369).
+- [x] `pnpm --filter server typecheck && lint && test` green (1310 tests).
+- [ ] Better Stack / log drain alert wired on the new `RATE_LIMIT_BACKEND_DOWN` code. (ops follow-up, not code)
 
 ---
 
@@ -155,9 +164,9 @@ Current: `{ free: 60, starter: 300, team: 1_500, enterprise: null }`
 
 Success criteria:
 
-- [ ] `PROXY_RATE_LIMITS` reflects new ceilings; enterprise stays null.
-- [ ] Doc comment in `rateLimit.ts` matches new numbers.
-- [ ] `middleware-rate-limit.test.ts` updated to the new free/team values and passes.
+- [x] `PROXY_RATE_LIMITS` reflects new ceilings (free 600 / starter 3000 / team 15000, env-overridable); enterprise stays null.
+- [x] Doc comment in `rateLimit.ts` matches new numbers.
+- [x] `middleware-rate-limit.test.ts` updated to the new free/team values and passes.
 
 ### 1.2 Pass through on overage instead of throwing 429 (S, med)
 
@@ -169,11 +178,11 @@ the customer's LLM request on the critical path (`rateLimit.ts:56-68`).
 
 Success criteria:
 
-- [ ] `proxyRateLimit` never throws on the per-minute bucket; over-ceiling requests reach upstream.
-- [ ] Structured warn line emitted exactly when over the ceiling.
-- [ ] Response carries `X-Spanlens-RateLimit-Overage: true` on overage and standard `X-RateLimit-*` headers on every response.
-- [ ] `middleware-rate-limit.test.ts:83-94` rewritten: over-limit asserts pass-through + header + warn spy, not 429.
-- [ ] Monthly `enforceQuota` can still 429 (`free_limit` / `overage_disabled` / `hard_cap`) independently.
+- [x] `proxyRateLimit` never throws on the per-minute bucket; over-ceiling requests reach upstream.
+- [x] Structured warn line (`PROXY_RATE_LIMIT_OVERAGE`) emitted exactly when over the ceiling.
+- [x] Response carries `X-Spanlens-RateLimit-Overage: true` on overage and standard `X-RateLimit-*` headers on every response.
+- [x] `middleware-rate-limit.test.ts` over-limit test rewritten: asserts pass-through (200) + header + warn spy, not 429.
+- [x] Monthly `enforceQuota` can still 429 (`free_limit` / `overage_disabled` / `hard_cap`) independently (middleware-quota.test.ts unchanged, still green).
 
 ### 1.3 Confirm monthly quota fully covers monetization (S, low)
 
@@ -183,9 +192,9 @@ team: 1_000_000, enterprise: null }` (`quota.ts:14-19`), enforced by
 
 Success criteria:
 
-- [ ] Plan states that free-tier monetization is the monthly limit enforced by `enforceQuota`, not the per-minute bucket.
-- [ ] `enforceQuota` mount position (after `proxyRateLimit`) verified in all 6 proxies.
-- [ ] Existing `middleware-quota.test.ts` still passes unchanged.
+- [x] Plan states that free-tier monetization is the monthly limit enforced by `enforceQuota`, not the per-minute bucket (documented in `rate-limit.ts` + `middleware/rateLimit.ts`).
+- [x] `enforceQuota` mount position (after `proxyRateLimit`) verified in all 6 proxies.
+- [x] Existing `middleware-quota.test.ts` still passes unchanged.
 
 ### 1.4 (Optional) Distinguish over-limit from Redis-error fail-open (M, low)
 
@@ -205,9 +214,9 @@ Success criteria:
 
 ### Phase 1 exit checklist
 
-- [ ] 1.1 through 1.3 merged (1.4 optional, can follow).
-- [ ] No proxy path returns 429 from the per-minute bucket.
-- [ ] Overage observability confirmed in logs.
+- [x] 1.1 through 1.3 implemented and verified (typecheck + lint + 1300 tests green); 1.4 deferred as optional follow-up.
+- [x] No proxy path returns 429 from the per-minute bucket.
+- [x] Overage observability via `PROXY_RATE_LIMIT_OVERAGE` warn + `X-Spanlens-RateLimit-Overage` header.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 1 of the platform review roadmap (`docs/plans/platform-review-roadmap-2026-06.md`). The per-minute proxy rate limit becomes a pure anti-runaway ceiling that never hard-rejects customer LLM traffic. Monetization stays entirely on the monthly quota (`enforceQuota`), which runs right after `proxyRateLimit` on every proxy request.

### Why

We sit on the customer's critical path and operate BYOK (the customer pays their own provider). Hard-rejecting a production LLM call with a 429 at a per-minute threshold is a worse failure than a brief over-rate, and we bear no LLM cost on overage. The per-minute number was never the monetization lever (the monthly quota is), so it should not behave like one.

### Changes

| # | Item | Detail |
|---|------|--------|
| 1.1 | Raise ceilings ~10x | `PROXY_RATE_LIMITS`: free 60→600, starter 300→3000, team 1,500→15,000 (enterprise still unlimited). Each is env-overridable (`PROXY_RATE_LIMIT_FREE/STARTER/TEAM`) so ceilings tune without a deploy |
| 1.2 | Pass-through on overage | `proxyRateLimit` no longer throws 429. It passes through to `enforceQuota` + upstream, emits a structured `PROXY_RATE_LIMIT_OVERAGE` warn, and sets an `X-Spanlens-RateLimit-Overage` response header |
| 1.3 | Monetization unchanged | Monthly quota (`enforceQuota`) remains the sole free-tier gate / billing path; documented, no code change. Dashboard `apiRateLimit` (120/min) is untouched and still 429s |
| - | Pricing page | Removed the now-stale, misleading "X req/min rate limit" bullet from all four tiers (the per-minute ceiling is no longer a hard cap or a tier differentiator; monthly requests already differentiate tiers) |

### Deferred

1.4 (widen `checkRateLimit` return type to distinguish genuine over-limit from a Redis-error fail-open) is an optional follow-up, not included here.

## Test plan

- [x] `pnpm --filter server typecheck && lint && test` (1300 tests green)
- [x] `middleware-rate-limit.test.ts`: over-limit test rewritten to assert pass-through (200) + `X-Spanlens-RateLimit-Overage` header + `PROXY_RATE_LIMIT_OVERAGE` warn spy, not 429; free/team ceiling assertions updated to 600/15000
- [x] `middleware-quota.test.ts` unchanged and still green (monetization gate intact)
- [x] `pnpm --filter web typecheck && lint`; rendered `/pricing` confirmed to contain no rate-limit text

## Notes

- Branched from `main` (independent of Phase 0 #369, already merged).
- `X-Spanlens-RateLimit-Overage` is a response header; the upstream x-spanlens-* strip policy applies to request headers only, so it is unaffected.