### PR TITLE
feat: customer-configurable rate limiting (Phase 2)

### DIFF
--- a/apps/server/src/__tests__/customer-rate-limit.test.ts
+++ b/apps/server/src/__tests__/customer-rate-limit.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { Hono } from 'hono'
+import { installOnError } from './helpers/install-on-error.js'
+
+// Customer-configurable rate limit enforcement (Phase 2). Mock the cached
+// config lookup and the Upstash limiter so each branch is deterministic.
+const getCustomerLimitsMock = vi.hoisted(() => vi.fn())
+const checkRateLimitMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../lib/customer-limits.js', () => ({
+  getCustomerLimits: (...args: unknown[]) => getCustomerLimitsMock(...args),
+}))
+vi.mock('../lib/rate-limit.js', () => ({
+  checkRateLimit: (...args: unknown[]) => checkRateLimitMock(...args),
+}))
+
+import { customerRateLimit } from '../middleware/customerRateLimit.js'
+
+const EMPTY = { keyLimit: null, projectLimit: null, endUserLimits: new Map(), empty: true }
+const limit = (scope: string, maxRequests: number, windowSeconds = 60) => ({ scope, maxRequests, windowSeconds })
+
+function makeApp(opts: { apiKeyId?: string | null; projectId?: string | null } = {}) {
+  const app = new Hono()
+  app.use('*', async (c, next) => {
+    c.set('apiKeyId', opts.apiKeyId === undefined ? 'key_1' : opts.apiKeyId)
+    c.set('projectId', opts.projectId === undefined ? 'proj_1' : opts.projectId)
+    c.set('organizationId', 'org_1')
+    return next()
+  })
+  app.use('*', customerRateLimit as unknown as Parameters<typeof app.use>[1])
+  app.get('/probe', (c) => c.json({ ok: true }))
+  installOnError(app)
+  return app
+}
+
+const probe = (app: Hono, headers: Record<string, string> = {}) =>
+  app.request('/probe', { headers })
+
+beforeEach(() => {
+  getCustomerLimitsMock.mockReset()
+  checkRateLimitMock.mockReset()
+})
+
+describe('customerRateLimit', () => {
+  test('no configured limits → pass-through, no Redis call', async () => {
+    getCustomerLimitsMock.mockResolvedValue(EMPTY)
+    const res = await probe(makeApp())
+    expect(res.status).toBe(200)
+    expect(checkRateLimitMock).not.toHaveBeenCalled()
+  })
+
+  test('api_key limit under cap → pass with the right Redis key + window', async () => {
+    getCustomerLimitsMock.mockResolvedValue({
+      keyLimit: limit('api_key', 100, 3600), projectLimit: null, endUserLimits: new Map(), empty: false,
+    })
+    checkRateLimitMock.mockResolvedValue(true)
+
+    const res = await probe(makeApp())
+    expect(res.status).toBe(200)
+    expect(checkRateLimitMock).toHaveBeenCalledWith('custlimit:key:key_1', 100, 3600)
+  })
+
+  test('api_key limit over cap → 429 customer_limit, no upgrade_url', async () => {
+    getCustomerLimitsMock.mockResolvedValue({
+      keyLimit: limit('api_key', 5, 60), projectLimit: null, endUserLimits: new Map(), empty: false,
+    })
+    checkRateLimitMock.mockResolvedValue(false)
+
+    const res = await probe(makeApp())
+    expect(res.status).toBe(429)
+    const body = await res.json() as { error: { code: string; details: Record<string, unknown> } }
+    expect(body.error.code).toBe('RATE_LIMIT')
+    expect(body.error.details['source']).toBe('customer_limit')
+    expect(body.error.details['scope']).toBe('api_key')
+    expect(body.error.details['limit']).toBe(5)
+    expect(body.error.details['window_seconds']).toBe(60)
+    expect(body.error.details['upgrade_url']).toBeUndefined()
+    expect(res.headers.get('Retry-After')).toBe('60')
+    expect(res.headers.get('X-Spanlens-RateLimit-Scope')).toBe('api_key')
+  })
+
+  test('end-user limits bucket per x-spanlens-user', async () => {
+    getCustomerLimitsMock.mockResolvedValue({
+      keyLimit: null, projectLimit: null,
+      endUserLimits: new Map([['u1', limit('end_user', 10)], ['u2', limit('end_user', 10)]]),
+      empty: false,
+    })
+    checkRateLimitMock.mockResolvedValue(true)
+
+    await probe(makeApp(), { 'x-spanlens-user': 'u1' })
+    await probe(makeApp(), { 'x-spanlens-user': 'u2' })
+
+    expect(checkRateLimitMock).toHaveBeenNthCalledWith(1, 'custlimit:eu:key_1:u1', 10, 60)
+    expect(checkRateLimitMock).toHaveBeenNthCalledWith(2, 'custlimit:eu:key_1:u2', 10, 60)
+  })
+
+  test('end-user over cap → 429 with end_user_id in details', async () => {
+    getCustomerLimitsMock.mockResolvedValue({
+      keyLimit: null, projectLimit: null,
+      endUserLimits: new Map([['alice', limit('end_user', 2)]]), empty: false,
+    })
+    checkRateLimitMock.mockResolvedValue(false)
+
+    const res = await probe(makeApp(), { 'x-spanlens-user': 'alice' })
+    expect(res.status).toBe(429)
+    const body = await res.json() as { error: { details: Record<string, unknown> } }
+    expect(body.error.details['scope']).toBe('end_user')
+    expect(body.error.details['end_user_id']).toBe('alice')
+  })
+
+  test('a request with no x-spanlens-user skips end-user limits', async () => {
+    getCustomerLimitsMock.mockResolvedValue({
+      keyLimit: null, projectLimit: null,
+      endUserLimits: new Map([['u1', limit('end_user', 1)]]), empty: false,
+    })
+    checkRateLimitMock.mockResolvedValue(false)
+
+    const res = await probe(makeApp()) // no header
+    expect(res.status).toBe(200) // nothing applicable to check
+    expect(checkRateLimitMock).not.toHaveBeenCalled()
+  })
+
+  test('project limit over cap → 429 scope project', async () => {
+    getCustomerLimitsMock.mockResolvedValue({
+      keyLimit: null, projectLimit: limit('project', 50, 86400), endUserLimits: new Map(), empty: false,
+    })
+    checkRateLimitMock.mockResolvedValue(false)
+
+    const res = await probe(makeApp())
+    expect(res.status).toBe(429)
+    expect(checkRateLimitMock).toHaveBeenCalledWith('custlimit:proj:proj_1', 50, 86400)
+    const body = await res.json() as { error: { details: Record<string, unknown> } }
+    expect(body.error.details['scope']).toBe('project')
+  })
+
+  test('most-specific first: end-user deny wins, key not checked', async () => {
+    getCustomerLimitsMock.mockResolvedValue({
+      keyLimit: limit('api_key', 1000), projectLimit: null,
+      endUserLimits: new Map([['u1', limit('end_user', 1)]]), empty: false,
+    })
+    checkRateLimitMock.mockResolvedValueOnce(false) // end-user check denies
+
+    const res = await probe(makeApp(), { 'x-spanlens-user': 'u1' })
+    expect(res.status).toBe(429)
+    const body = await res.json() as { error: { details: Record<string, unknown> } }
+    expect(body.error.details['scope']).toBe('end_user')
+    expect(checkRateLimitMock).toHaveBeenCalledTimes(1) // key limit never reached
+  })
+
+  test('fails open: Redis allows (true) even with a limit configured', async () => {
+    getCustomerLimitsMock.mockResolvedValue({
+      keyLimit: limit('api_key', 1), projectLimit: null, endUserLimits: new Map(), empty: false,
+    })
+    checkRateLimitMock.mockResolvedValue(true) // checkRateLimit fails open on Redis outage
+
+    const res = await probe(makeApp())
+    expect(res.status).toBe(200)
+  })
+})

--- a/apps/server/src/__tests__/customer-rate-limit.test.ts
+++ b/apps/server/src/__tests__/customer-rate-limit.test.ts
@@ -20,7 +20,9 @@ const EMPTY = { keyLimit: null, projectLimit: null, endUserLimits: new Map(), em
 const limit = (scope: string, maxRequests: number, windowSeconds = 60) => ({ scope, maxRequests, windowSeconds })
 
 function makeApp(opts: { apiKeyId?: string | null; projectId?: string | null } = {}) {
-  const app = new Hono()
+  const app = new Hono<{
+    Variables: { apiKeyId: string | null; projectId: string | null; organizationId: string | null }
+  }>()
   app.use('*', async (c, next) => {
     c.set('apiKeyId', opts.apiKeyId === undefined ? 'key_1' : opts.apiKeyId)
     c.set('projectId', opts.projectId === undefined ? 'proj_1' : opts.projectId)
@@ -33,7 +35,7 @@ function makeApp(opts: { apiKeyId?: string | null; projectId?: string | null } =
   return app
 }
 
-const probe = (app: Hono, headers: Record<string, string> = {}) =>
+const probe = (app: ReturnType<typeof makeApp>, headers: Record<string, string> = {}) =>
   app.request('/probe', { headers })
 
 beforeEach(() => {

--- a/apps/server/src/api/rateLimits.ts
+++ b/apps/server/src/api/rateLimits.ts
@@ -1,0 +1,288 @@
+import { Hono } from 'hono'
+import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { requireRole } from '../middleware/requireRole.js'
+import { supabaseAdmin } from '../lib/db.js'
+import { recordAuditEvent } from '../lib/audit-log.js'
+import {
+  invalidateCustomerLimitsCache,
+  resetCustomerLimitsCache,
+} from '../lib/customer-limits.js'
+import { ApiError } from '../lib/errors.js'
+
+/**
+ * Customer-configurable rate limits (Phase 2). Dashboard CRUD for the limits a
+ * customer sets on their own Spanlens keys / projects / end-users. Enforcement
+ * lives in middleware/customerRateLimit.ts; config rows are in the
+ * `customer_rate_limits` table (migration 20260619000000).
+ *
+ * Auth mirrors apiKeysRouter / providerKeysRouter: authJwt for all routes,
+ * requireRole('admin','editor') on writes. Every target is verified to belong
+ * to the caller's org before any read or write.
+ */
+
+export const rateLimitsRouter = new Hono<JwtContext>()
+
+rateLimitsRouter.use('*', authJwt)
+
+const requireEdit = requireRole('admin', 'editor')
+
+const VALID_WINDOWS = new Set([60, 3600, 86400])
+const SELECT_COLUMNS =
+  'id, target_type, api_key_id, project_id, end_user_id, max_requests, window_seconds, is_active, created_at, updated_at'
+
+/** Verify the Spanlens key belongs to a project owned by `orgId`. */
+async function assertApiKeyInOrg(apiKeyId: string, orgId: string): Promise<boolean> {
+  const { data } = await supabaseAdmin
+    .from('api_keys')
+    .select('id, projects!inner(organization_id)')
+    .eq('id', apiKeyId)
+    .maybeSingle()
+  if (!data) return false
+  const project = data.projects as unknown as { organization_id: string } | null
+  return project?.organization_id === orgId
+}
+
+/** Verify the project belongs to `orgId`. */
+async function assertProjectInOrg(projectId: string, orgId: string): Promise<boolean> {
+  const { data } = await supabaseAdmin
+    .from('projects')
+    .select('id')
+    .eq('id', projectId)
+    .eq('organization_id', orgId)
+    .maybeSingle()
+  return Boolean(data)
+}
+
+interface CreateBody {
+  target_type?: unknown
+  api_key_id?: unknown
+  project_id?: unknown
+  end_user_id?: unknown
+  max_requests?: unknown
+  window_seconds?: unknown
+}
+
+function validateMaxRequests(v: unknown): number {
+  const n = typeof v === 'number' ? v : Number(v)
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new ApiError('VALIDATION_FAILED', 'max_requests must be a positive integer')
+  }
+  return n
+}
+
+function validateWindow(v: unknown): number {
+  const n = typeof v === 'number' ? v : Number(v)
+  if (!VALID_WINDOWS.has(n)) {
+    throw new ApiError('VALIDATION_FAILED', 'window_seconds must be one of 60, 3600, 86400')
+  }
+  return n
+}
+
+// GET /api/v1/rate-limits?apiKeyId=xxx | ?projectId=xxx
+// Lists configured limits for a key (key-level + its end-user limits) or a
+// project. Requires one of the two filters so we never leak the whole org.
+rateLimitsRouter.get('/', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+
+  const apiKeyId = c.req.query('apiKeyId')
+  const projectId = c.req.query('projectId')
+
+  let query = supabaseAdmin
+    .from('customer_rate_limits')
+    .select(SELECT_COLUMNS)
+    .eq('organization_id', orgId)
+
+  if (apiKeyId) {
+    if (!(await assertApiKeyInOrg(apiKeyId, orgId))) {
+      throw new ApiError('FORBIDDEN', 'apiKeyId does not belong to this organization')
+    }
+    query = query.eq('api_key_id', apiKeyId)
+  } else if (projectId) {
+    if (!(await assertProjectInOrg(projectId, orgId))) {
+      throw new ApiError('FORBIDDEN', 'projectId does not belong to this organization')
+    }
+    query = query.eq('project_id', projectId).eq('target_type', 'project')
+  } else {
+    throw new ApiError('VALIDATION_FAILED', 'apiKeyId or projectId query param is required')
+  }
+
+  const { data, error } = await query.order('created_at', { ascending: true })
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to load rate limits')
+  return c.json({ success: true, data: data ?? [] })
+})
+
+// POST /api/v1/rate-limits — create a limit.
+rateLimitsRouter.post('/', requireEdit, async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+
+  let body: CreateBody
+  try {
+    body = (await c.req.json()) as CreateBody
+  } catch {
+    throw new ApiError('INVALID_JSON_BODY', 'Request body must be valid JSON')
+  }
+
+  const targetType = body.target_type
+  if (targetType !== 'api_key' && targetType !== 'project' && targetType !== 'end_user') {
+    throw new ApiError('VALIDATION_FAILED', "target_type must be 'api_key', 'project', or 'end_user'")
+  }
+
+  const maxRequests = validateMaxRequests(body.max_requests)
+  const windowSeconds = validateWindow(body.window_seconds)
+
+  // Resolve + verify ownership of the target, and shape the row to satisfy the
+  // DB owner-consistency CHECK.
+  const row: Record<string, unknown> = {
+    organization_id: orgId,
+    target_type: targetType,
+    max_requests: maxRequests,
+    window_seconds: windowSeconds,
+    api_key_id: null,
+    project_id: null,
+    end_user_id: null,
+  }
+
+  let invalidateKeyId: string | null = null
+
+  if (targetType === 'api_key') {
+    const apiKeyId = body.api_key_id
+    if (typeof apiKeyId !== 'string' || !(await assertApiKeyInOrg(apiKeyId, orgId))) {
+      throw new ApiError('FORBIDDEN', 'api_key_id does not belong to this organization')
+    }
+    row['api_key_id'] = apiKeyId
+    invalidateKeyId = apiKeyId
+  } else if (targetType === 'project') {
+    const projectId = body.project_id
+    if (typeof projectId !== 'string' || !(await assertProjectInOrg(projectId, orgId))) {
+      throw new ApiError('FORBIDDEN', 'project_id does not belong to this organization')
+    }
+    row['project_id'] = projectId
+  } else {
+    // end_user: requires the scoping api_key_id + the end-user identifier
+    const apiKeyId = body.api_key_id
+    const endUserId = body.end_user_id
+    if (typeof apiKeyId !== 'string' || !(await assertApiKeyInOrg(apiKeyId, orgId))) {
+      throw new ApiError('FORBIDDEN', 'api_key_id does not belong to this organization')
+    }
+    if (typeof endUserId !== 'string' || endUserId.trim().length === 0) {
+      throw new ApiError('VALIDATION_FAILED', 'end_user_id is required for an end_user limit')
+    }
+    row['api_key_id'] = apiKeyId
+    row['end_user_id'] = endUserId.trim()
+    invalidateKeyId = apiKeyId
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('customer_rate_limits')
+    .insert(row)
+    .select(SELECT_COLUMNS)
+    .single()
+
+  if (error || !data) {
+    if (error?.code === '23505') {
+      throw new ApiError('CONFLICT', 'A rate limit already exists for this target')
+    }
+    throw new ApiError('INTERNAL_ERROR', 'Failed to create rate limit')
+  }
+
+  if (invalidateKeyId) invalidateCustomerLimitsCache(invalidateKeyId)
+  else resetCustomerLimitsCache()
+
+  void recordAuditEvent(c, {
+    action: 'rate_limit.create',
+    resourceType: 'customer_rate_limits',
+    resourceId: data.id as string,
+    metadata: { target_type: targetType, max_requests: maxRequests, window_seconds: windowSeconds },
+  })
+
+  return c.json({ success: true, data }, 201)
+})
+
+interface PatchBody {
+  max_requests?: unknown
+  window_seconds?: unknown
+  is_active?: unknown
+}
+
+// PATCH /api/v1/rate-limits/:id — update max_requests / window_seconds / is_active.
+rateLimitsRouter.patch('/:id', requireEdit, async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+  const id = c.req.param('id')
+
+  let body: PatchBody
+  try {
+    body = (await c.req.json()) as PatchBody
+  } catch {
+    throw new ApiError('INVALID_JSON_BODY', 'Request body must be valid JSON')
+  }
+
+  const updates: Record<string, unknown> = {}
+  if (body.max_requests !== undefined) updates['max_requests'] = validateMaxRequests(body.max_requests)
+  if (body.window_seconds !== undefined) updates['window_seconds'] = validateWindow(body.window_seconds)
+  if (body.is_active !== undefined) {
+    if (typeof body.is_active !== 'boolean') {
+      throw new ApiError('VALIDATION_FAILED', 'is_active must be a boolean')
+    }
+    updates['is_active'] = body.is_active
+  }
+  if (Object.keys(updates).length === 0) {
+    throw new ApiError('VALIDATION_FAILED', 'No updatable fields provided')
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('customer_rate_limits')
+    .update(updates)
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .select(SELECT_COLUMNS)
+    .maybeSingle()
+
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to update rate limit')
+  if (!data) throw new ApiError('NOT_FOUND', 'Rate limit not found')
+
+  const keyId = data.api_key_id as string | null
+  if (keyId) invalidateCustomerLimitsCache(keyId)
+  else resetCustomerLimitsCache()
+
+  void recordAuditEvent(c, {
+    action: 'rate_limit.update',
+    resourceType: 'customer_rate_limits',
+    resourceId: id,
+    metadata: { fields: Object.keys(updates) },
+  })
+
+  return c.json({ success: true, data })
+})
+
+// DELETE /api/v1/rate-limits/:id — hard delete (low-risk config, not a secret).
+rateLimitsRouter.delete('/:id', requireEdit, async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+  const id = c.req.param('id')
+
+  const { data, error } = await supabaseAdmin
+    .from('customer_rate_limits')
+    .delete()
+    .eq('id', id)
+    .eq('organization_id', orgId)
+    .select('id, api_key_id')
+    .maybeSingle()
+
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to delete rate limit')
+  if (!data) throw new ApiError('NOT_FOUND', 'Rate limit not found')
+
+  const keyId = data.api_key_id as string | null
+  if (keyId) invalidateCustomerLimitsCache(keyId)
+  else resetCustomerLimitsCache()
+
+  void recordAuditEvent(c, {
+    action: 'rate_limit.delete',
+    resourceType: 'customer_rate_limits',
+    resourceId: id,
+  })
+
+  return c.json({ success: true })
+})

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -53,6 +53,7 @@ import { webhooksRouter }      from './api/webhooks.js'
 import { exportsRouter }       from './api/exports.js'
 import { openapiRouter }       from './api/openapi.js'
 import { providerKeysRouter }  from './api/providerKeys.js'
+import { rateLimitsRouter }    from './api/rateLimits.js'
 import { frontendErrorsRouter } from './api/frontendErrors.js'
 import { meRouter }            from './api/me.js'
 import { meRoleRouter }        from './api/meRole.js'
@@ -189,6 +190,7 @@ app.route('/api/v1/organizations',  organizationsRouter)
 app.route('/api/v1/projects',       projectsRouter)
 app.route('/api/v1/api-keys',       apiKeysRouter)
 app.route('/api/v1/provider-keys',  providerKeysRouter)
+app.route('/api/v1/rate-limits',    rateLimitsRouter)
 app.route('/api/v1/requests',       requestsRouter)
 app.route('/api/v1/users',          usersRouter)
 app.route('/api/v1/sessions',       sessionsRouter)

--- a/apps/server/src/lib/customer-limits.ts
+++ b/apps/server/src/lib/customer-limits.ts
@@ -1,0 +1,141 @@
+import { supabaseAdmin } from './db.js'
+
+/**
+ * Customer-configured rate limits (Phase 2). Read on the proxy hot path, so the
+ * lookup is cached per Spanlens key with a short TTL + request coalescing,
+ * mirroring the plan cache in requests-query.ts and the auth cache in
+ * authApiKey.ts. The common case (a key with NO configured limit) caches the
+ * empty result too, so it costs one Map lookup and zero DB round-trips.
+ *
+ * Config rows live in the `customer_rate_limits` table (migration
+ * 20260619000000). Enforcement is in middleware/customerRateLimit.ts.
+ */
+
+export type CustomerLimitScope = 'api_key' | 'project' | 'end_user'
+
+export interface CustomerLimit {
+  readonly scope: CustomerLimitScope
+  readonly maxRequests: number
+  readonly windowSeconds: number
+}
+
+export interface ResolvedCustomerLimits {
+  /** Cap on all traffic through this Spanlens key. */
+  readonly keyLimit: CustomerLimit | null
+  /** Cap across every key in the key's project. */
+  readonly projectLimit: CustomerLimit | null
+  /** Per-end-user caps for this key, keyed by the x-spanlens-user value. */
+  readonly endUserLimits: ReadonlyMap<string, CustomerLimit>
+  /** True when nothing is configured — lets the middleware short-circuit. */
+  readonly empty: boolean
+}
+
+interface CachedLimits extends ResolvedCustomerLimits {
+  expiresAt: number
+}
+
+const TTL_MS = 30 * 1000 // 30s — matches getOrgPlan; downgrades apply quickly
+const cache = new Map<string, CachedLimits>()
+const inflight = new Map<string, Promise<CachedLimits>>()
+
+const EMPTY: ResolvedCustomerLimits = {
+  keyLimit: null,
+  projectLimit: null,
+  endUserLimits: new Map(),
+  empty: true,
+}
+
+interface LimitRow {
+  target_type: CustomerLimitScope
+  end_user_id: string | null
+  max_requests: number | string
+  window_seconds: number | string
+}
+
+/**
+ * Resolves all active limits relevant to a request: the key-level limit and
+ * the key's end-user limits (both keyed on api_key_id), plus the project-level
+ * limit (keyed on project_id). Cached per apiKeyId.
+ *
+ * Falls back to the empty set on any lookup error — a config-read blip must
+ * never break the customer's proxy traffic.
+ */
+export async function getCustomerLimits(
+  apiKeyId: string,
+  projectId: string | null,
+): Promise<ResolvedCustomerLimits> {
+  const cached = cache.get(apiKeyId)
+  if (cached && cached.expiresAt > Date.now()) return cached
+
+  const existing = inflight.get(apiKeyId)
+  if (existing) return existing
+
+  const fetchPromise = (async (): Promise<CachedLimits> => {
+    try {
+      let query = supabaseAdmin
+        .from('customer_rate_limits')
+        .select('target_type, end_user_id, max_requests, window_seconds')
+        .eq('is_active', true)
+      query = projectId
+        ? query.or(`api_key_id.eq.${apiKeyId},project_id.eq.${projectId}`)
+        : query.eq('api_key_id', apiKeyId)
+
+      const { data, error } = await query
+      if (error) throw error
+
+      const rows = (data ?? []) as LimitRow[]
+      let keyLimit: CustomerLimit | null = null
+      let projectLimit: CustomerLimit | null = null
+      const endUserLimits = new Map<string, CustomerLimit>()
+
+      for (const r of rows) {
+        const limit: CustomerLimit = {
+          scope: r.target_type,
+          maxRequests: Number(r.max_requests),
+          windowSeconds: Number(r.window_seconds),
+        }
+        if (r.target_type === 'api_key') keyLimit = limit
+        else if (r.target_type === 'project') projectLimit = limit
+        else if (r.target_type === 'end_user' && r.end_user_id) {
+          endUserLimits.set(r.end_user_id, limit)
+        }
+      }
+
+      const resolved: CachedLimits = {
+        keyLimit,
+        projectLimit,
+        endUserLimits,
+        empty: !keyLimit && !projectLimit && endUserLimits.size === 0,
+        expiresAt: Date.now() + TTL_MS,
+      }
+      cache.set(apiKeyId, resolved)
+      return resolved
+    } catch {
+      // Fail open: cache an empty set briefly so a transient error does not
+      // hammer the DB on every request, and never block proxy traffic.
+      const fallback: CachedLimits = { ...EMPTY, endUserLimits: new Map(), expiresAt: Date.now() + TTL_MS }
+      cache.set(apiKeyId, fallback)
+      return fallback
+    } finally {
+      inflight.delete(apiKeyId)
+    }
+  })()
+
+  inflight.set(apiKeyId, fetchPromise)
+  return fetchPromise
+}
+
+/** Invalidate the cache for one key after a CRUD write touching it. */
+export function invalidateCustomerLimitsCache(apiKeyId: string): void {
+  cache.delete(apiKeyId)
+  inflight.delete(apiKeyId)
+}
+
+/**
+ * Flush the whole cache. Used after a project-level write (which affects every
+ * key under the project — we don't track that mapping in-process) and by tests.
+ */
+export function resetCustomerLimitsCache(): void {
+  cache.clear()
+  inflight.clear()
+}

--- a/apps/server/src/lib/rate-limit.ts
+++ b/apps/server/src/lib/rate-limit.ts
@@ -58,28 +58,31 @@ function getRedis(): Redis | null {
 }
 
 // ---------------------------------------------------------------------------
-// Ratelimit instances — one per unique limit value (free/starter/team/api)
+// Ratelimit instances — one per unique (limit, windowSeconds) pair. Platform
+// limits all use the default 60s window; customer-configurable limits (Phase 2)
+// also use 3600s / 86400s, so the cache is keyed by both.
 // ---------------------------------------------------------------------------
 
-const _limiters = new Map<number, Ratelimit>()
+const _limiters = new Map<string, Ratelimit>()
 
-function getLimiter(limit: number): Ratelimit | null {
+function getLimiter(limit: number, windowSeconds = 60): Ratelimit | null {
   const redis = getRedis()
   if (!redis) return null
 
-  if (!_limiters.has(limit)) {
+  const cacheKey = `${limit}:${windowSeconds}`
+  if (!_limiters.has(cacheKey)) {
     _limiters.set(
-      limit,
+      cacheKey,
       new Ratelimit({
         redis,
-        limiter: Ratelimit.slidingWindow(limit, '60 s'),
+        limiter: Ratelimit.slidingWindow(limit, `${windowSeconds} s`),
         // Prefix all keys so they don't collide with other Redis data
         prefix: 'spanlens:rl',
       }),
     )
   }
 
-  return _limiters.get(limit)!
+  return _limiters.get(cacheKey)!
 }
 
 // ---------------------------------------------------------------------------
@@ -111,8 +114,9 @@ let _unconfiguredWarned = false
 export async function checkRateLimit(
   key: string,
   limit: number,
+  windowSeconds = 60,
 ): Promise<boolean> {
-  const limiter = getLimiter(limit)
+  const limiter = getLimiter(limit, windowSeconds)
 
   if (!limiter) {
     // Redis not configured — fail open (dev / misconfigured prod). Warn once

--- a/apps/server/src/middleware/customerRateLimit.ts
+++ b/apps/server/src/middleware/customerRateLimit.ts
@@ -1,0 +1,70 @@
+import { createMiddleware } from 'hono/factory'
+import type { ApiKeyContext } from './authApiKey.js'
+import { getCustomerLimits, type CustomerLimit, type CustomerLimitScope } from '../lib/customer-limits.js'
+import { checkRateLimit } from '../lib/rate-limit.js'
+import { ApiError } from '../lib/errors.js'
+
+/**
+ * Customer-configurable rate limiting (Phase 2).
+ *
+ * Mounted AFTER proxyRateLimit + enforceQuota in every proxy, so our platform
+ * ceiling and the monthly monetization gate run first. This enforces limits the
+ * CUSTOMER set on their own key / project / end-users.
+ *
+ * Unlike proxyRateLimit (Phase 1, pass-through anti-runaway), exceeding a
+ * customer-set limit DOES return 429 to the end-user — the customer configured
+ * it precisely to throttle their own traffic. The 429 carries
+ * details.source='customer_limit' and no Spanlens upgrade_url, so it is
+ * distinguishable from a platform/plan limit.
+ *
+ * Hot path: a key with no configured limit short-circuits after one cached Map
+ * lookup (zero Redis, zero DB). Keys with limits do 1-3 Redis calls. Fails open
+ * if Redis is unavailable (checkRateLimit) — a customer throttle is best-effort,
+ * not a hard security boundary, and an outage must not break their traffic.
+ */
+export const customerRateLimit = createMiddleware<ApiKeyContext>(async (c, next) => {
+  const apiKeyId = c.get('apiKeyId')
+  // Defensive: authApiKey always sets apiKeyId before this runs.
+  if (!apiKeyId) return next()
+
+  const projectId = c.get('projectId') ?? null
+  const limits = await getCustomerLimits(apiKeyId, projectId)
+  if (limits.empty) return next()
+
+  const endUserId = c.req.header('x-spanlens-user') || null
+
+  // Most-specific first; the first DENY wins (all applicable limits must pass).
+  const checks: Array<{ scope: CustomerLimitScope; key: string; limit: CustomerLimit }> = []
+  if (endUserId) {
+    const eu = limits.endUserLimits.get(endUserId)
+    if (eu) checks.push({ scope: 'end_user', key: `custlimit:eu:${apiKeyId}:${endUserId}`, limit: eu })
+  }
+  if (limits.keyLimit) {
+    checks.push({ scope: 'api_key', key: `custlimit:key:${apiKeyId}`, limit: limits.keyLimit })
+  }
+  if (limits.projectLimit && projectId) {
+    checks.push({ scope: 'project', key: `custlimit:proj:${projectId}`, limit: limits.projectLimit })
+  }
+
+  for (const { scope, key, limit } of checks) {
+    const allowed = await checkRateLimit(key, limit.maxRequests, limit.windowSeconds)
+    if (!allowed) {
+      c.header('Retry-After', String(limit.windowSeconds))
+      c.header('X-Spanlens-RateLimit-Scope', scope)
+      c.header('X-Spanlens-RateLimit-Remaining', '0')
+      throw new ApiError(
+        'RATE_LIMIT',
+        `Customer-configured rate limit exceeded (${scope}): ${limit.maxRequests} requests per ${limit.windowSeconds}s.`,
+        {
+          source: 'customer_limit',
+          scope,
+          limit: limit.maxRequests,
+          window_seconds: limit.windowSeconds,
+          ...(scope === 'end_user' && endUserId ? { end_user_id: endUserId } : {}),
+        },
+      )
+    }
+  }
+
+  return next()
+})

--- a/apps/server/src/proxy/anthropic.ts
+++ b/apps/server/src/proxy/anthropic.ts
@@ -3,6 +3,7 @@ import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
 import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
+import { customerRateLimit } from '../middleware/customerRateLimit.js'
 import { calculateCost } from '../lib/cost.js'
 import { logRequestAsync } from '../lib/logger.js'
 import { fireAndForget } from '../lib/wait-until.js'
@@ -25,6 +26,7 @@ anthropicProxy.use('*', authApiKey)
 anthropicProxy.use('*', requireFullScope)
 anthropicProxy.use('*', proxyRateLimit)
 anthropicProxy.use('*', enforceQuota)
+anthropicProxy.use('*', customerRateLimit)
 
 anthropicProxy.all('/*', async (c) => {
   const handlerStartMs = Date.now()

--- a/apps/server/src/proxy/azure.ts
+++ b/apps/server/src/proxy/azure.ts
@@ -3,6 +3,7 @@ import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
 import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
+import { customerRateLimit } from '../middleware/customerRateLimit.js'
 import { calculateCost } from '../lib/cost.js'
 import { logRequestAsync } from '../lib/logger.js'
 import { fireAndForget } from '../lib/wait-until.js'
@@ -35,6 +36,7 @@ azureProxy.use('*', authApiKey)
 azureProxy.use('*', requireFullScope)
 azureProxy.use('*', proxyRateLimit)
 azureProxy.use('*', enforceQuota)
+azureProxy.use('*', customerRateLimit)
 
 azureProxy.all('/*', async (c) => {
   const handlerStartMs = Date.now()

--- a/apps/server/src/proxy/gemini.ts
+++ b/apps/server/src/proxy/gemini.ts
@@ -3,6 +3,7 @@ import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
 import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
+import { customerRateLimit } from '../middleware/customerRateLimit.js'
 import { calculateCost } from '../lib/cost.js'
 import { logRequestAsync } from '../lib/logger.js'
 import { fireAndForget } from '../lib/wait-until.js'
@@ -25,6 +26,7 @@ geminiProxy.use('*', authApiKey)
 geminiProxy.use('*', requireFullScope)
 geminiProxy.use('*', proxyRateLimit)
 geminiProxy.use('*', enforceQuota)
+geminiProxy.use('*', customerRateLimit)
 
 geminiProxy.all('/*', async (c) => {
   const handlerStartMs = Date.now()

--- a/apps/server/src/proxy/mistral.ts
+++ b/apps/server/src/proxy/mistral.ts
@@ -3,6 +3,7 @@ import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
 import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
+import { customerRateLimit } from '../middleware/customerRateLimit.js'
 import { calculateCost } from '../lib/cost.js'
 import { logRequestAsync } from '../lib/logger.js'
 import { fireAndForget } from '../lib/wait-until.js'
@@ -37,6 +38,7 @@ mistralProxy.use('*', authApiKey)
 mistralProxy.use('*', requireFullScope)
 mistralProxy.use('*', proxyRateLimit)
 mistralProxy.use('*', enforceQuota)
+mistralProxy.use('*', customerRateLimit)
 
 mistralProxy.all('/*', async (c) => {
   const handlerStartMs = Date.now()

--- a/apps/server/src/proxy/openai.ts
+++ b/apps/server/src/proxy/openai.ts
@@ -3,6 +3,7 @@ import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
 import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
+import { customerRateLimit } from '../middleware/customerRateLimit.js'
 import { calculateCost } from '../lib/cost.js'
 import { logRequestAsync } from '../lib/logger.js'
 import { fireAndForget } from '../lib/wait-until.js'
@@ -34,6 +35,7 @@ openaiProxy.use('*', authApiKey)
 openaiProxy.use('*', requireFullScope)
 openaiProxy.use('*', proxyRateLimit)
 openaiProxy.use('*', enforceQuota)
+openaiProxy.use('*', customerRateLimit)
 
 openaiProxy.all('/*', async (c) => {
   const handlerStartMs = Date.now()

--- a/apps/server/src/proxy/openrouter.ts
+++ b/apps/server/src/proxy/openrouter.ts
@@ -3,6 +3,7 @@ import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
 import { requireFullScope } from '../middleware/requireFullScope.js'
 import { enforceQuota } from '../middleware/quota.js'
 import { proxyRateLimit } from '../middleware/rateLimit.js'
+import { customerRateLimit } from '../middleware/customerRateLimit.js'
 import { calculateCost } from '../lib/cost.js'
 import { logRequestAsync } from '../lib/logger.js'
 import { fireAndForget } from '../lib/wait-until.js'
@@ -56,6 +57,7 @@ openrouterProxy.use('*', authApiKey)
 openrouterProxy.use('*', requireFullScope)
 openrouterProxy.use('*', proxyRateLimit)
 openrouterProxy.use('*', enforceQuota)
+openrouterProxy.use('*', customerRateLimit)
 
 openrouterProxy.all('/*', async (c) => {
   const handlerStartMs = Date.now()

--- a/apps/web/app/(dashboard)/projects/_components/rate-limits-dialog.tsx
+++ b/apps/web/app/(dashboard)/projects/_components/rate-limits-dialog.tsx
@@ -1,0 +1,252 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { GhostBtn, PrimaryBtn } from '@/components/ui/primitives'
+import { PermissionGate } from '@/components/permission-gate'
+import {
+  useRateLimits,
+  useCreateRateLimit,
+  useUpdateRateLimit,
+  useDeleteRateLimit,
+} from '@/lib/queries/use-rate-limits'
+import type { CustomerRateLimit } from '@/lib/queries/types'
+
+const WINDOWS = [
+  { value: 60, label: 'per minute' },
+  { value: 3600, label: 'per hour' },
+  { value: 86400, label: 'per day' },
+] as const
+
+function windowLabel(seconds: number): string {
+  return WINDOWS.find((w) => w.value === seconds)?.label ?? `per ${seconds}s`
+}
+
+const inputCls =
+  'w-full h-9 px-3 rounded-[6px] border border-border bg-bg text-[13px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong transition-colors'
+
+interface Props {
+  apiKeyId: string | null
+  apiKeyName: string
+  open: boolean
+  onClose: () => void
+}
+
+/**
+ * Per-Spanlens-key rate-limit manager (Phase 2). Lets an admin/editor set a
+ * key-level cap and per-end-user caps (keyed on the x-spanlens-user header).
+ * All reads/writes go through /api/v1/rate-limits — no direct Supabase access.
+ */
+export function RateLimitsDialog({ apiKeyId, apiKeyName, open, onClose }: Props) {
+  const { data: limits, isLoading } = useRateLimits(open ? apiKeyId : null)
+  const createMut = useCreateRateLimit()
+  const updateMut = useUpdateRateLimit()
+  const deleteMut = useDeleteRateLimit()
+
+  const keyLimit = useMemo(
+    () => limits?.find((l) => l.target_type === 'api_key') ?? null,
+    [limits],
+  )
+  const endUserLimits = useMemo(
+    () => (limits ?? []).filter((l) => l.target_type === 'end_user'),
+    [limits],
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Rate limits</DialogTitle>
+        </DialogHeader>
+        <DialogDescription className="text-[12.5px] text-text-muted mt-1">
+          Throttle traffic through <span className="font-mono">{apiKeyName}</span>. A request over
+          a configured limit gets a 429. Per-end-user limits bucket on the{' '}
+          <code>x-spanlens-user</code> header.
+        </DialogDescription>
+
+        {isLoading ? (
+          <p className="text-[12.5px] text-text-faint mt-4">Loading…</p>
+        ) : (
+          <div className="mt-3 space-y-6">
+            {/* ── Key-level limit ───────────────────────────────────────── */}
+            <section className="space-y-2">
+              <h3 className="text-[12.5px] font-medium text-text">Key limit</h3>
+              {keyLimit ? (
+                <LimitRow
+                  limit={keyLimit}
+                  label={`${keyLimit.max_requests} requests ${windowLabel(keyLimit.window_seconds)}`}
+                  onToggle={(active) => updateMut.mutate({ id: keyLimit.id, is_active: active })}
+                  onDelete={() => deleteMut.mutate(keyLimit.id)}
+                  busy={updateMut.isPending || deleteMut.isPending}
+                />
+              ) : (
+                <PermissionGate need="edit">
+                  <AddLimitForm
+                    busy={createMut.isPending}
+                    onSubmit={(max, win) =>
+                      createMut.mutate({
+                        target_type: 'api_key',
+                        api_key_id: apiKeyId as string,
+                        max_requests: max,
+                        window_seconds: win,
+                      })
+                    }
+                  />
+                </PermissionGate>
+              )}
+            </section>
+
+            {/* ── Per-end-user limits ───────────────────────────────────── */}
+            <section className="space-y-2">
+              <h3 className="text-[12.5px] font-medium text-text">Per end-user limits</h3>
+              {endUserLimits.length === 0 && (
+                <p className="text-[11.5px] text-text-faint">
+                  None yet. Add a cap for a specific end-user identifier.
+                </p>
+              )}
+              {endUserLimits.map((l) => (
+                <LimitRow
+                  key={l.id}
+                  limit={l}
+                  label={`${l.end_user_id}: ${l.max_requests} ${windowLabel(l.window_seconds)}`}
+                  onToggle={(active) => updateMut.mutate({ id: l.id, is_active: active })}
+                  onDelete={() => deleteMut.mutate(l.id)}
+                  busy={updateMut.isPending || deleteMut.isPending}
+                />
+              ))}
+              <PermissionGate need="edit">
+                <AddEndUserForm
+                  busy={createMut.isPending}
+                  onSubmit={(endUser, max, win) =>
+                    createMut.mutate({
+                      target_type: 'end_user',
+                      api_key_id: apiKeyId as string,
+                      end_user_id: endUser,
+                      max_requests: max,
+                      window_seconds: win,
+                    })
+                  }
+                />
+              </PermissionGate>
+            </section>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function LimitRow({
+  limit,
+  label,
+  onToggle,
+  onDelete,
+  busy,
+}: {
+  limit: CustomerRateLimit
+  label: string
+  onToggle: (active: boolean) => void
+  onDelete: () => void
+  busy: boolean
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-[6px] border border-border bg-bg-elev px-3 py-2">
+      <span className={`text-[12.5px] ${limit.is_active ? 'text-text' : 'text-text-faint line-through'}`}>
+        {label}
+      </span>
+      <PermissionGate need="edit">
+        <div className="flex items-center gap-2 shrink-0">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => onToggle(!limit.is_active)}
+            className="font-mono text-[11px] text-text-faint hover:text-text transition-colors disabled:opacity-50"
+          >
+            {limit.is_active ? 'Disable' : 'Enable'}
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onDelete}
+            className="font-mono text-[11px] text-bad/70 hover:text-bad transition-colors disabled:opacity-50"
+          >
+            Delete
+          </button>
+        </div>
+      </PermissionGate>
+    </div>
+  )
+}
+
+function WindowSelect({ value, onChange }: { value: number; onChange: (v: number) => void }) {
+  return (
+    <Select value={String(value)} onValueChange={(v) => onChange(Number(v))}>
+      <SelectTrigger className="w-[130px]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {WINDOWS.map((w) => (
+          <SelectItem key={w.value} value={String(w.value)}>{w.label}</SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+function AddLimitForm({ busy, onSubmit }: { busy: boolean; onSubmit: (max: number, win: number) => void }) {
+  const [max, setMax] = useState('')
+  const [win, setWin] = useState(60)
+  const valid = Number.isInteger(Number(max)) && Number(max) > 0
+  return (
+    <form
+      className="flex items-center gap-2"
+      onSubmit={(e) => { e.preventDefault(); if (valid) onSubmit(Number(max), win) }}
+    >
+      <input
+        value={max}
+        onChange={(e) => setMax(e.target.value)}
+        inputMode="numeric"
+        placeholder="max requests"
+        className={inputCls}
+      />
+      <WindowSelect value={win} onChange={setWin} />
+      <PrimaryBtn type="submit" disabled={!valid || busy}>{busy ? '…' : 'Add'}</PrimaryBtn>
+    </form>
+  )
+}
+
+function AddEndUserForm({
+  busy,
+  onSubmit,
+}: {
+  busy: boolean
+  onSubmit: (endUser: string, max: number, win: number) => void
+}) {
+  const [endUser, setEndUser] = useState('')
+  const [max, setMax] = useState('')
+  const [win, setWin] = useState(60)
+  const valid = endUser.trim().length > 0 && Number.isInteger(Number(max)) && Number(max) > 0
+  return (
+    <form
+      className="flex items-center gap-2 flex-wrap"
+      onSubmit={(e) => { e.preventDefault(); if (valid) { onSubmit(endUser.trim(), Number(max), win); setEndUser(''); setMax('') } }}
+    >
+      <input
+        value={endUser}
+        onChange={(e) => setEndUser(e.target.value)}
+        placeholder="end-user id"
+        className={`${inputCls} flex-1 min-w-[120px] font-mono`}
+      />
+      <input
+        value={max}
+        onChange={(e) => setMax(e.target.value)}
+        inputMode="numeric"
+        placeholder="max"
+        className={`${inputCls} w-[90px]`}
+      />
+      <WindowSelect value={win} onChange={setWin} />
+      <PrimaryBtn type="submit" disabled={!valid || busy}>{busy ? '…' : 'Add'}</PrimaryBtn>
+    </form>
+  )
+}

--- a/apps/web/app/(dashboard)/projects/projects-client.tsx
+++ b/apps/web/app/(dashboard)/projects/projects-client.tsx
@@ -12,6 +12,7 @@ import {
   Search,
   Trash2,
   Key as KeyIcon,
+  Gauge,
 } from 'lucide-react'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
@@ -43,6 +44,7 @@ import {
 import { cn } from '@/lib/utils'
 import { formatLastUsed } from '@/lib/api-key-staleness'
 import { StaleBadge } from '@/components/ui/stale-badge'
+import { RateLimitsDialog } from './_components/rate-limits-dialog'
 
 // Hydration-safe mounted gate, same pattern as the other overhauled pages.
 const subscribeNoop = () => () => {}
@@ -167,6 +169,8 @@ export function ProjectsClient() {
 
   // Banner shown once after a Spanlens key is created
   const [newKey, setNewKey] = useState<string | null>(null)
+  // Rate-limits dialog target (Spanlens key). null = closed.
+  const [rateLimitsKey, setRateLimitsKey] = useState<{ id: string; name: string } | null>(null)
   const [cmdCopied, setCmdCopied] = useState(false)
   const [keyCopied, setKeyCopied] = useState(false)
 
@@ -867,6 +871,13 @@ export function ProjectsClient() {
                                     </span>
                                   </div>
                                 </div>
+                                <GhostBtn
+                                  className="flex items-center gap-1.5 text-[12px] px-3 py-[5px] h-[28px] shrink-0"
+                                  onClick={() => setRateLimitsKey({ id: key.id, name: key.name })}
+                                  title="Configure rate limits for this key"
+                                >
+                                  <Gauge className="h-3.5 w-3.5" /> Rate limits
+                                </GhostBtn>
                                 <PermissionGate need="edit">
                                   <GhostBtn
                                     className="flex items-center gap-1.5 text-[12px] px-3 py-[5px] h-[28px] shrink-0"
@@ -1125,6 +1136,14 @@ export function ProjectsClient() {
           </form>
         </DialogContent>
       </Dialog>
+
+      {/* Rate limits dialog (per Spanlens key) */}
+      <RateLimitsDialog
+        apiKeyId={rateLimitsKey?.id ?? null}
+        apiKeyName={rateLimitsKey?.name ?? ''}
+        open={rateLimitsKey !== null}
+        onClose={() => setRateLimitsKey(null)}
+      />
 
       {/* Add provider key dialog */}
       <Dialog

--- a/apps/web/app/docs/proxy/page.tsx
+++ b/apps/web/app/docs/proxy/page.tsx
@@ -355,22 +355,24 @@ res, _ := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
 
       <h2>Rate limits and response headers</h2>
       <p>
-        Every <code>/proxy/*</code> response, including the rare <code>429</code>, carries
-        four standard rate limit headers so your client can back off without guessing.
+        Spanlens applies a high per-organization per-minute ceiling on{' '}
+        <code>/proxy/*</code> purely to stop a runaway loop, not to throttle normal
+        production traffic. Going over it does <strong>not</strong> reject your request:
+        the call passes through to your provider and the response carries{' '}
+        <code>X-Spanlens-RateLimit-Overage: true</code> so you can spot the spike. Your
+        plan&apos;s monthly request quota is the limit that actually gates usage.
+      </p>
+      <p>
+        Every <code>/proxy/*</code> response carries the standard rate limit headers so a
+        client can read the current window without guessing.
       </p>
       <ul>
-        <li>
-          <code>X-RateLimit-Limit</code>, requests allowed in the current window. Default
-          is 120 per minute per Spanlens key; team and enterprise plans get higher caps.
-        </li>
-        <li>
-          <code>X-RateLimit-Remaining</code>, requests left in the current window. Drops to
-          0 right before the next 429.
-        </li>
+        <li><code>X-RateLimit-Limit</code>, requests allowed in the current window for your plan.</li>
+        <li><code>X-RateLimit-Remaining</code>, requests left in the current window.</li>
         <li>
           <code>X-RateLimit-Reset</code>, unix epoch second at which the window rolls over.
-          Use this directly in a sleep until the next minute boundary; do not parse the
-          server clock from <code>Date</code> since clock skew costs you retries.
+          Use this directly rather than parsing the server clock from <code>Date</code>,
+          since clock skew costs you retries.
         </li>
         <li>
           <code>X-RateLimit-Window</code>, the window length in seconds. Currently always{' '}
@@ -378,12 +380,36 @@ res, _ := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
           clients that read it.
         </li>
       </ul>
+
+      <h3>Customer-configured rate limits</h3>
       <p>
-        On a <code>429</code> the response also includes <code>Retry-After: 60</code>,
-        matching the window length so a naive retry-after-sleep client still works
-        correctly. The same headers ship from <code>/api/v1/*</code> dashboard endpoints
-        with a higher per-token cap, so an SDK that mirrors the proxy logic against your
-        own API works without special casing.
+        You can set your own limits on a Spanlens key, a project, or an individual
+        end-user from the <a href="/projects">Projects</a> page. Unlike the platform
+        ceiling above, exceeding one of your own limits <strong>does</strong> return a{' '}
+        <code>429</code> to the caller, because you configured it precisely to throttle
+        that traffic. The error body identifies which limit fired:
+      </p>
+      <CodeBlock>{`{
+  "error": {
+    "code": "RATE_LIMIT",
+    "message": "Customer-configured rate limit exceeded (end_user): 60 requests per 60s.",
+    "details": {
+      "source": "customer_limit",
+      "scope": "end_user",
+      "limit": 60,
+      "window_seconds": 60,
+      "end_user_id": "user_123"
+    }
+  }
+}`}</CodeBlock>
+      <p>
+        The response also carries <code>Retry-After</code> (the window length in seconds)
+        and <code>X-Spanlens-RateLimit-Scope</code> (<code>api_key</code>,{' '}
+        <code>project</code>, or <code>end_user</code>). A <code>customer_limit</code> 429
+        never includes an upgrade link, which is how you tell it apart from a platform or
+        plan limit. Per-end-user limits bucket on the{' '}
+        <code>X-Spanlens-User</code> header, so send it (the SDK{' '}
+        <a href="/docs/sdk">withUser()</a> helper does this) for those limits to apply.
       </p>
 
       <h2>Self-hosting</h2>

--- a/apps/web/app/docs/sdk/page.tsx
+++ b/apps/web/app/docs/sdk/page.tsx
@@ -202,6 +202,12 @@ res = client.chat.completions.create(
         the <a href="/docs/features/requests">/requests</a> page via{' '}
         <code>?userId=</code> / <code>?sessionId=</code>.
       </p>
+      <p>
+        The same end-user ID is what{' '}
+        <a href="/docs/proxy">per-end-user rate limits</a> bucket on. Set a per-end-user
+        cap from the <a href="/projects">Projects</a> page and send{' '}
+        <code>withUser(id)</code> on each call for it to apply.
+      </p>
       <LangTabs
         ts={`import {
   createOpenAI,

--- a/apps/web/lib/queries/types.ts
+++ b/apps/web/lib/queries/types.ts
@@ -88,6 +88,22 @@ export interface ProviderKey {
   last_scan_result?: 'clean' | 'leaked' | 'error' | null
 }
 
+/** Customer-configured rate limit (Phase 2). One per target. */
+export interface CustomerRateLimit {
+  id: string
+  target_type: 'api_key' | 'project' | 'end_user'
+  api_key_id: string | null
+  project_id: string | null
+  /** The x-spanlens-user value, for target_type='end_user'. */
+  end_user_id: string | null
+  max_requests: number
+  /** 60 (per minute), 3600 (per hour), or 86400 (per day). */
+  window_seconds: number
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
 export interface RequestRow {
   id: string
   provider: string

--- a/apps/web/lib/queries/use-rate-limits.ts
+++ b/apps/web/lib/queries/use-rate-limits.ts
@@ -1,0 +1,75 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiDelete, apiGet, apiPatch, apiPost } from '@/lib/api'
+import type { ApiEnvelope, CustomerRateLimit } from './types'
+
+export const rateLimitsQueryKey = ['rate-limits'] as const
+
+/** List customer-configured rate limits for a Spanlens key (key-level + its end-user limits). */
+export function useRateLimits(apiKeyId: string | null) {
+  return useQuery({
+    queryKey: [...rateLimitsQueryKey, { apiKeyId }] as const,
+    enabled: Boolean(apiKeyId),
+    queryFn: async () => {
+      const res = await apiGet<ApiEnvelope<CustomerRateLimit[]>>(
+        `/api/v1/rate-limits?apiKeyId=${encodeURIComponent(apiKeyId as string)}`,
+      )
+      return res.data
+    },
+  })
+}
+
+export interface CreateRateLimitInput {
+  target_type: 'api_key' | 'project' | 'end_user'
+  api_key_id?: string
+  project_id?: string
+  end_user_id?: string
+  max_requests: number
+  window_seconds: number
+}
+
+export function useCreateRateLimit() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: CreateRateLimitInput) => {
+      const res = await apiPost<ApiEnvelope<CustomerRateLimit>>('/api/v1/rate-limits', input)
+      return res.data
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: rateLimitsQueryKey })
+    },
+  })
+}
+
+export function useUpdateRateLimit() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async ({
+      id,
+      ...patch
+    }: {
+      id: string
+      max_requests?: number
+      window_seconds?: number
+      is_active?: boolean
+    }) => {
+      await apiPatch(`/api/v1/rate-limits/${id}`, patch)
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: rateLimitsQueryKey })
+    },
+  })
+}
+
+export function useDeleteRateLimit() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await apiDelete(`/api/v1/rate-limits/${id}`)
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: rateLimitsQueryKey })
+    },
+  })
+}

--- a/docs/plans/platform-review-roadmap-2026-06.md
+++ b/docs/plans/platform-review-roadmap-2026-06.md
@@ -7,8 +7,9 @@ Scope: `apps/server`, `apps/web`, `supabase/`
 Progress:
 
 - Phase 0 (security hardening): DONE, merged in #369 (2026-06-19).
-- Phase 1 (proxy rate-limit relaxation): implemented and verified, PR pending.
-- Phases 2 through 5: not started.
+- Phase 1 (proxy rate-limit relaxation): DONE, merged in #370 (2026-06-19).
+- Phase 2 (customer-configurable rate limiting): implemented and verified, PR pending.
+- Phases 3 through 5: not started.
 
 ## Context
 
@@ -222,6 +223,9 @@ Success criteria:
 
 ## Phase 2: Customer-configurable rate limiting (new feature)
 
+Status: implemented and verified (server typecheck + lint + 1309 tests, web
+typecheck + lint + build). All six items (2.1 through 2.6) done; PR pending.
+
 Goal: let customers set rate limits on their own keys, projects, and end-users;
 enforce them in the proxy and return 429 to the customer's end-user when hit.
 This is the desired 429 (unlike our platform limit). Internal order is strict:
@@ -321,8 +325,8 @@ Success criteria:
 
 ### Phase 2 exit checklist
 
-- [ ] 2.1 through 2.6 merged in dependency order.
-- [ ] End-to-end: configure a per-key limit in the dashboard, exceed it via the proxy, observe 429 to the caller.
+- [x] 2.1 through 2.6 implemented and verified (server: typecheck + lint + 1309 tests; web: typecheck + lint + build). PR pending.
+- [ ] End-to-end against prod after merge: configure a per-key limit in the dashboard, exceed it via the proxy, observe 429 to the caller (needs the migration applied via deploy-server.yml).
 - [ ] Follow-ups filed: token/cost-based limits (needs a rolling-spend counter in the log path), per-end-user limit-hit events on the `/users` dashboard.
 
 ---

--- a/supabase/migrations/20260619000000_customer_rate_limits.sql
+++ b/supabase/migrations/20260619000000_customer_rate_limits.sql
@@ -1,0 +1,113 @@
+-- 20260619000000_customer_rate_limits.sql
+--
+-- Phase 2 of the platform review roadmap: customer-configurable rate limiting.
+--
+-- Unlike the platform per-minute ceiling (PROXY_RATE_LIMITS, anti-runaway only,
+-- pass-through on overage) and the monthly quota (monetization), these are
+-- limits the CUSTOMER sets on their own keys / projects / end-users. When one
+-- is exceeded we DO return 429 to the customer's end-user, because the customer
+-- configured it to throttle their own traffic (matches Helicone/Portkey/LiteLLM).
+--
+-- One polymorphic table covers all three granularities so the restore UI,
+-- the proxy lookup, and the CRUD API stay in one place:
+--   • api_key   — a cap on one Spanlens key (all traffic through that key)
+--   • project   — a cap across every key in a project
+--   • end_user  — a cap per end-user identifier (the x-spanlens-user header),
+--                 scoped to a specific Spanlens key
+--
+-- organization_id is always set (tenant isolation + RLS anchor) regardless of
+-- which target the limit points at. Enforcement lives in
+-- apps/server/src/middleware/customerRateLimit.ts (mounted after proxyRateLimit)
+-- and reuses the Upstash sliding-window limiter via lib/rate-limit.ts.
+
+CREATE TABLE IF NOT EXISTS customer_rate_limits (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+
+  target_type TEXT NOT NULL CHECK (
+    target_type IN ('api_key', 'project', 'end_user')
+  ),
+
+  -- Set for target_type='api_key' AND target_type='end_user' (the key the
+  -- end-user limit is scoped to). NULL for target_type='project'.
+  api_key_id UUID REFERENCES api_keys(id) ON DELETE CASCADE,
+  -- Set only for target_type='project'.
+  project_id UUID REFERENCES projects(id) ON DELETE CASCADE,
+  -- The x-spanlens-user value. Set only for target_type='end_user'.
+  end_user_id TEXT,
+
+  max_requests INTEGER NOT NULL CHECK (max_requests > 0),
+  -- Restricted set keeps the @upstash/ratelimit limiter cache bounded
+  -- (one limiter instance per distinct (limit, window) pair).
+  window_seconds INTEGER NOT NULL DEFAULT 60 CHECK (
+    window_seconds IN (60, 3600, 86400)
+  ),
+
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- Enforce that the target columns match the discriminator at the DB level so
+  -- an app-layer bug can never create an inconsistent row (mirrors the
+  -- api_keys_scope_owner_consistency pattern in 20260604040000).
+  CONSTRAINT customer_rate_limits_target_consistency CHECK (
+    (target_type = 'api_key'
+      AND api_key_id IS NOT NULL AND project_id IS NULL AND end_user_id IS NULL)
+    OR (target_type = 'project'
+      AND project_id IS NOT NULL AND api_key_id IS NULL AND end_user_id IS NULL)
+    OR (target_type = 'end_user'
+      AND api_key_id IS NOT NULL AND end_user_id IS NOT NULL AND project_id IS NULL)
+  )
+);
+
+-- One limit row per target. The CRUD API toggles is_active in place rather than
+-- creating a second row, and translates the unique violation (23505) to a 409.
+CREATE UNIQUE INDEX IF NOT EXISTS customer_rate_limits_api_key_uniq
+  ON customer_rate_limits (api_key_id)
+  WHERE target_type = 'api_key';
+
+CREATE UNIQUE INDEX IF NOT EXISTS customer_rate_limits_project_uniq
+  ON customer_rate_limits (project_id)
+  WHERE target_type = 'project';
+
+CREATE UNIQUE INDEX IF NOT EXISTS customer_rate_limits_end_user_uniq
+  ON customer_rate_limits (api_key_id, end_user_id)
+  WHERE target_type = 'end_user';
+
+-- Proxy hot-path lookup: all active limits for a key (key-level + its end-user
+-- limits) and a project's limit, fetched in one select per request (cached).
+CREATE INDEX IF NOT EXISTS customer_rate_limits_api_key_active_idx
+  ON customer_rate_limits (api_key_id, is_active);
+
+CREATE INDEX IF NOT EXISTS customer_rate_limits_project_active_idx
+  ON customer_rate_limits (project_id, is_active);
+
+-- Keep updated_at fresh on UPDATE (shared trigger fn from 20260420000000).
+CREATE OR REPLACE TRIGGER customer_rate_limits_updated_at
+  BEFORE UPDATE ON customer_rate_limits
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+ALTER TABLE customer_rate_limits ENABLE ROW LEVEL SECURITY;
+
+-- Members of the org can list. Writes go through the server with service_role.
+CREATE POLICY customer_rate_limits_select ON customer_rate_limits
+  FOR SELECT USING (is_org_member(organization_id));
+
+-- Explicit deny-all for anon + authenticated on write paths. The server uses
+-- supabaseAdmin (service_role) which bypasses RLS.
+CREATE POLICY customer_rate_limits_deny_writes ON customer_rate_limits
+  AS RESTRICTIVE
+  FOR ALL
+  TO anon, authenticated
+  USING (false)
+  WITH CHECK (false);
+
+-- Allow service_role writes explicitly so the restrictive policy above does
+-- not block legitimate server writes when RLS is forced on.
+CREATE POLICY customer_rate_limits_service_role_all ON customer_rate_limits
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary

Phase 2 of the platform review roadmap (`docs/plans/platform-review-roadmap-2026-06.md`). Lets customers set rate limits on their own Spanlens keys / projects / end-users, enforced in the proxy. This is the market norm (Helicone / Portkey / LiteLLM): a limit you configure to throttle your own traffic, distinct from the platform anti-runaway ceiling (Phase 1, pass-through).

Unlike the platform limit, exceeding a customer-set limit returns 429 to the end-user, because the customer configured it precisely to throttle that traffic.

### Changes

| Item | Where | What |
|------|-------|------|
| 2.1 DB | `supabase/migrations/20260619000000_customer_rate_limits.sql` | Polymorphic table (api_key / project / end_user), DB-level owner-consistency CHECK, partial UNIQUE per target, RLS (is_org_member SELECT + service_role writes), `window_seconds` in {60, 3600, 86400}, idempotent |
| 2.2 Enforce | `middleware/customerRateLimit.ts`, `lib/customer-limits.ts`, `lib/rate-limit.ts` | Mounted after `enforceQuota` in all 6 proxies. Evaluates end_user → api_key → project (first deny wins). Cached per-key config (30s TTL + coalescing; empty result cached so a no-limit key costs one Map lookup, zero DB). Reuses the Upstash Lua sliding window (gotcha #24); `getLimiter`/`checkRateLimit` gained an optional `windowSeconds`. Fails open if Redis is down |
| 2.3 API | `api/rateLimits.ts` → `/api/v1/rate-limits` | CRUD with authJwt + requireRole('admin','editor'), org-ownership checks, 23505 → CONFLICT, audit + cache invalidation on writes |
| 2.5 429 | (middleware) | `details.source='customer_limit'`, no upgrade_url, `X-Spanlens-RateLimit-Scope` + `Retry-After` |
| 2.4 UI | `/projects` key row "Rate limits" button → `_components/rate-limits-dialog.tsx` | Per-key + per-end-user caps (window per minute/hour/day). Reads/writes via `/api/v1/rate-limits` (no direct Supabase). Edit controls gated by `PermissionGate need="edit"`; viewers read-only. Kept in its own file so `projects-client.tsx` does not grow |
| 2.6 Docs | `/docs/proxy`, `/docs/sdk` | Document the feature, 429 envelope, `X-Spanlens-RateLimit-*` headers, `x-spanlens-user` requirement; cross-link `withUser()`. Also corrected the now-stale Phase 1 per-minute section to reflect pass-through |

### Deferred follow-ups (filed, not in this PR)

- Token / cost-based limits (needs a rolling-spend counter in the log path).
- Per-end-user limit-hit events on the `/users` dashboard.

## Test plan

- [x] `pnpm --filter server typecheck && lint && test` (1309 tests; new `customer-rate-limit.test.ts` covers empty/under/over, per-end-user bucketing, scope precedence, fail-open)
- [x] `pnpm --filter web typecheck && lint && build`
- [ ] Live E2E after merge (needs the migration applied via deploy-server.yml): set a per-key limit in the dashboard, exceed it, observe 429 to the caller

## Notes

- Branched from `main` (independent of Phase 0 #369 / Phase 1 #370, both merged).
- The migration applies before the server deploys via `deploy-server.yml` (`supabase db push --linked` → Vercel), preserving the schema-first ordering (gotcha #25).
- `supabase/types.ts` was not regenerated (no local stack here). `supabaseAdmin` is untyped (no Database generic) so server compiles regardless, and web talks only to the API. If a CI types-diff check exists, regenerate after the migration applies.