### PR TITLE
perf(server): Phase 3 proxy hot-path optimizations

### DIFF
--- a/apps/server/src/__tests__/quota-cache.test.ts
+++ b/apps/server/src/__tests__/quota-cache.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+// P3.1: checkMonthlyQuota runs on every /proxy/* request and must not hit
+// Supabase + ClickHouse each time. These tests pin the caching: org settings
+// and the month count are fetched once per org per TTL window.
+const fromMock = vi.fn()
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: { from: (...args: unknown[]) => fromMock(...args) },
+}))
+
+const chQueryMock = vi.fn()
+vi.mock('../lib/clickhouse.js', () => ({
+  unscopedClickhouse: () => ({ query: chQueryMock }),
+}))
+
+import { checkMonthlyQuota, resetQuotaCaches } from '../lib/quota.js'
+
+function setOrgPlan(plan: string, allowOverage = true, capMultiplier = 5) {
+  fromMock.mockReturnValue({
+    select: () => ({
+      eq: () => ({
+        single: async () => ({ data: { plan, allow_overage: allowOverage, overage_cap_multiplier: capMultiplier } }),
+      }),
+    }),
+  })
+}
+
+function setCount(n: number) {
+  chQueryMock.mockResolvedValue({ json: async () => [{ n: String(n) }] })
+}
+
+beforeEach(() => {
+  resetQuotaCaches()
+  fromMock.mockReset()
+  chQueryMock.mockReset()
+})
+
+describe('checkMonthlyQuota caching (P3.1)', () => {
+  test('warm cache: a second call within TTL hits neither Supabase nor ClickHouse', async () => {
+    setOrgPlan('free')
+    setCount(10)
+
+    const first = await checkMonthlyQuota('org_1')
+    const second = await checkMonthlyQuota('org_1')
+
+    expect(first.usedThisMonth).toBe(10)
+    expect(second.usedThisMonth).toBe(10)
+    expect(fromMock).toHaveBeenCalledTimes(1) // org settings cached
+    expect(chQueryMock).toHaveBeenCalledTimes(1) // month count cached
+  })
+
+  test('concurrent cold calls coalesce into one of each query', async () => {
+    setOrgPlan('starter')
+    setCount(50)
+
+    await Promise.all([
+      checkMonthlyQuota('org_2'),
+      checkMonthlyQuota('org_2'),
+      checkMonthlyQuota('org_2'),
+    ])
+
+    expect(fromMock).toHaveBeenCalledTimes(1)
+    expect(chQueryMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('enterprise (unlimited) skips the count query entirely', async () => {
+    setOrgPlan('enterprise')
+
+    const res = await checkMonthlyQuota('org_3')
+
+    expect(res.allowed).toBe(true)
+    expect(res.limit).toBeNull()
+    expect(chQueryMock).not.toHaveBeenCalled()
+  })
+
+  test('resetQuotaCaches forces a refetch', async () => {
+    setOrgPlan('free')
+    setCount(10)
+
+    await checkMonthlyQuota('org_4')
+    resetQuotaCaches()
+    await checkMonthlyQuota('org_4')
+
+    expect(fromMock).toHaveBeenCalledTimes(2)
+    expect(chQueryMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('separate orgs do not share cache entries', async () => {
+    setOrgPlan('free')
+    setCount(10)
+
+    await checkMonthlyQuota('org_a')
+    await checkMonthlyQuota('org_b')
+
+    expect(fromMock).toHaveBeenCalledTimes(2)
+    expect(chQueryMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/server/src/lib/events-writer.ts
+++ b/apps/server/src/lib/events-writer.ts
@@ -84,6 +84,8 @@ interface RequestRowLike {
   response_flags?: string
   has_security_flags?: boolean
   truncated?: number
+  /** Resolved in logger.ts (from promptVersionId or the raw header), threaded through. */
+  prompt_version_id?: string | null
 }
 
 /**
@@ -158,7 +160,7 @@ export async function writeRequestAsEvent(
     metadata,
     user_id: data.userId ?? null,
     session_id: data.sessionId ?? null,
-    prompt_version_id: data.promptVersionId ?? null,
+    prompt_version_id: requestRow.prompt_version_id ?? data.promptVersionId ?? null,
     provider_key_id: data.providerKeyId ?? null,
     flags: flagsValue,
     response_flags: responseFlagsValue,

--- a/apps/server/src/lib/logger.ts
+++ b/apps/server/src/lib/logger.ts
@@ -7,6 +7,7 @@ import { sendEmail, renderSecurityAlertEmail } from './resend.js'
 import { emitWebhookEvent } from './webhook-emit.js'
 import { writeRequestAsEvent } from './events-writer.js'
 import { logError } from './structured-logger.js'
+import { resolvePromptVersion } from './resolve-prompt-version.js'
 
 /**
  * Customer-controlled body logging mode (sent via the `x-spanlens-log-body`
@@ -50,6 +51,13 @@ export interface RequestLogData {
   traceId: string | null
   spanId: string | null
   promptVersionId?: string | null
+  /**
+   * Raw X-Spanlens-Prompt-Version header. When promptVersionId is not already
+   * set, logRequestAsync resolves this to an id here, off the response-critical
+   * path (the proxy hot path no longer resolves it before returning the
+   * response). Ignored when promptVersionId is provided directly.
+   */
+  promptVersionHeader?: string | null
   providerKeyId?: string | null
   /** Customer-supplied end-user ID (x-spanlens-user header). */
   userId?: string | null
@@ -238,6 +246,21 @@ export async function logRequestAsync(data: RequestLogData): Promise<void> {
   const userId = dropIdentifiers ? null : (data.userId ?? null)
   const sessionId = dropIdentifiers ? null : (data.sessionId ?? null)
 
+  // Resolve the prompt version here rather than in the proxy hot path: on a
+  // cold cache this is 1-2 Supabase queries, and logRequestAsync already runs
+  // after the response has been handed off (fireAndForget / stream onComplete),
+  // so it no longer delays time-to-first-token. Callers that pass a concrete
+  // promptVersionId (evals, replays) keep it as-is.
+  let promptVersionId = data.promptVersionId ?? null
+  if (promptVersionId == null && data.promptVersionHeader) {
+    const resolved = await resolvePromptVersion(
+      data.organizationId,
+      data.promptVersionHeader,
+      data.traceId,
+    )
+    promptVersionId = resolved?.versionId ?? null
+  }
+
   const clickhouseRow = {
     id: randomUUID(),
     organization_id: data.organizationId,
@@ -259,7 +282,7 @@ export async function logRequestAsync(data: RequestLogData): Promise<void> {
     error_message: errorMessage,
     trace_id: data.traceId,
     span_id: data.spanId,
-    prompt_version_id: data.promptVersionId ?? null,
+    prompt_version_id: promptVersionId,
     provider_key_id: data.providerKeyId ?? null,
     user_id: userId,
     session_id: sessionId,

--- a/apps/server/src/lib/quota.ts
+++ b/apps/server/src/lib/quota.ts
@@ -1,5 +1,6 @@
 import { supabaseAdmin } from './db.js'
 import { unscopedClickhouse } from './clickhouse.js'
+import { evaluateQuotaPolicy } from './quota-policy.js'
 
 /**
  * Monthly request quota per plan tier. Checked in the proxy middleware
@@ -184,6 +185,102 @@ export interface QuotaCheckResult {
   capMultiplier: number
 }
 
+// ---------------------------------------------------------------------------
+// Hot-path caches (P3.1). enforceQuota runs checkMonthlyQuota on EVERY /proxy/*
+// request; uncached it cost one Supabase SELECT + one full-month ClickHouse
+// count() scan per request. Both are now cached per org with a short TTL +
+// in-flight coalescing (same pattern as getOrgPlan in requests-query.ts).
+//
+// Trade-off: the monthly count can lag real traffic by up to COUNT_TTL_MS. The
+// quota band tolerates this — the free-tier block is a soft monetization gate,
+// not a security boundary, and BYOK means overage past the boundary costs us
+// nothing. Billing/overage accounting uses countMonthlyRequests directly
+// (paddle-usage.ts, quota-warnings.ts), NOT this cache, so it is unaffected.
+// A future refinement (an in-memory counter incremented from logRequestAsync)
+// could make the cached count exact between refreshes; deferred as higher-risk.
+// ---------------------------------------------------------------------------
+
+interface CachedQuotaSettings {
+  plan: Plan
+  allowOverage: boolean
+  capMultiplier: number
+  expiresAt: number
+}
+const SETTINGS_TTL_MS = 30 * 1000
+const settingsCache = new Map<string, CachedQuotaSettings>()
+const settingsInflight = new Map<string, Promise<CachedQuotaSettings>>()
+
+async function getOrgQuotaSettings(organizationId: string): Promise<CachedQuotaSettings> {
+  const cached = settingsCache.get(organizationId)
+  if (cached && cached.expiresAt > Date.now()) return cached
+  const existing = settingsInflight.get(organizationId)
+  if (existing) return existing
+
+  const fetchPromise = (async (): Promise<CachedQuotaSettings> => {
+    try {
+      const { data: org } = await supabaseAdmin
+        .from('organizations')
+        .select('plan, allow_overage, overage_cap_multiplier')
+        .eq('id', organizationId)
+        .single()
+      const settings: CachedQuotaSettings = {
+        plan: ((org?.plan as Plan) ?? 'free') as Plan,
+        allowOverage: (org?.allow_overage as boolean | undefined) ?? true,
+        capMultiplier: (org?.overage_cap_multiplier as number | undefined) ?? 5,
+        expiresAt: Date.now() + SETTINGS_TTL_MS,
+      }
+      settingsCache.set(organizationId, settings)
+      return settings
+    } finally {
+      settingsInflight.delete(organizationId)
+    }
+  })()
+  settingsInflight.set(organizationId, fetchPromise)
+  return fetchPromise
+}
+
+interface CachedMonthCount {
+  count: number
+  monthKey: string
+  expiresAt: number
+}
+const COUNT_TTL_MS = 10 * 1000
+const countCache = new Map<string, CachedMonthCount>()
+const countInflight = new Map<string, Promise<number>>()
+
+async function getCachedMonthlyCount(
+  organizationId: string,
+  monthStart: Date,
+): Promise<number> {
+  const monthKey = monthStart.toISOString().slice(0, 7) // YYYY-MM
+  const cached = countCache.get(organizationId)
+  if (cached && cached.monthKey === monthKey && cached.expiresAt > Date.now()) {
+    return cached.count
+  }
+  const existing = countInflight.get(organizationId)
+  if (existing) return existing
+
+  const fetchPromise = (async (): Promise<number> => {
+    try {
+      const count = await countMonthlyRequests(organizationId, monthStart)
+      countCache.set(organizationId, { count, monthKey, expiresAt: Date.now() + COUNT_TTL_MS })
+      return count
+    } finally {
+      countInflight.delete(organizationId)
+    }
+  })()
+  countInflight.set(organizationId, fetchPromise)
+  return fetchPromise
+}
+
+/** Test/escape hatch — flush the quota hot-path caches. */
+export function resetQuotaCaches(): void {
+  settingsCache.clear()
+  settingsInflight.clear()
+  countCache.clear()
+  countInflight.clear()
+}
+
 /**
  * Counts this org's requests in the current UTC calendar month and applies
  * the Pattern C quota policy (see lib/quota-policy.ts).
@@ -193,20 +290,14 @@ export interface QuotaCheckResult {
  *   - api/billing.ts            — exposes current quota state to the dashboard
  *   - lib/quota-warnings.ts     — iterates active orgs to send 80/100% emails
  *
- * Falls back to 'free' + conservative defaults on any lookup failure.
+ * Org settings + the month count are cached per org (short TTL) so the proxy
+ * hot path does not hit Supabase + ClickHouse on every request. Falls back to
+ * 'free' + conservative defaults on any lookup failure.
  */
 export async function checkMonthlyQuota(
   organizationId: string,
 ): Promise<QuotaCheckResult> {
-  const { data: org } = await supabaseAdmin
-    .from('organizations')
-    .select('plan, allow_overage, overage_cap_multiplier')
-    .eq('id', organizationId)
-    .single()
-
-  const plan = ((org?.plan as Plan) ?? 'free') as Plan
-  const allowOverage = (org?.allow_overage as boolean | undefined) ?? true
-  const capMultiplier = (org?.overage_cap_multiplier as number | undefined) ?? 5
+  const { plan, allowOverage, capMultiplier } = await getOrgQuotaSettings(organizationId)
 
   const limit = MONTHLY_REQUEST_LIMITS[plan]
   if (limit === null) {
@@ -226,10 +317,9 @@ export async function checkMonthlyQuota(
 
   // Billing accuracy: count the full UTC month, bypassing plan retention.
   // Free's 14-day window would otherwise undercount usage past day 14.
-  const used = await countMonthlyRequests(organizationId, monthStart)
+  const used = await getCachedMonthlyCount(organizationId, monthStart)
 
   // Apply Pattern C policy
-  const { evaluateQuotaPolicy } = await import('./quota-policy.js')
   const decision = evaluateQuotaPolicy({
     used,
     limit,

--- a/apps/server/src/proxy/anthropic.ts
+++ b/apps/server/src/proxy/anthropic.ts
@@ -34,9 +34,12 @@ anthropicProxy.all('/*', async (c) => {
   const projectId = c.get('projectId') as string
   const apiKeyId = c.get('apiKeyId')
 
-  const providerKey = await assertProviderKey(apiKeyId, 'anthropic')
-  // Anthropic stream usage is in message_delta — no stream_options injection needed.
-  const parsed = await parseProxyRequestBody(c)
+  // Provider-key lookup and body parse are independent — run concurrently.
+  const [providerKey, parsed] = await Promise.all([
+    assertProviderKey(apiKeyId, 'anthropic'),
+    // Anthropic stream usage is in message_delta — no stream_options injection needed.
+    parseProxyRequestBody(c),
+  ])
   const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
 
   const upstreamUrl = `${ANTHROPIC_BASE}${c.req.path.replace(/^\/proxy\/anthropic/, '')}`
@@ -58,7 +61,7 @@ anthropicProxy.all('/*', async (c) => {
     handlerStartMs,
   })
 
-  const logBase = await buildLogBase({
+  const logBase = buildLogBase({
     c, provider: 'anthropic',
     organizationId, projectId, apiKeyId,
     providerKey,

--- a/apps/server/src/proxy/azure.ts
+++ b/apps/server/src/proxy/azure.ts
@@ -44,7 +44,12 @@ azureProxy.all('/*', async (c) => {
   const projectId = c.get('projectId') as string
   const apiKeyId = c.get('apiKeyId')
 
-  const providerKey = await assertProviderKey(apiKeyId, 'azure')
+  // Provider-key lookup and body parse are independent — run concurrently.
+  // The resource_url guard reads providerKey.metadata, so it runs after.
+  const [providerKey, parsed] = await Promise.all([
+    assertProviderKey(apiKeyId, 'azure'),
+    parseProxyRequestBody(c, { injectOpenAIStreamOptions: true }),
+  ])
 
   // resource_url is enforced NOT NULL at the DB layer for 'azure' rows
   // (provider_keys_azure_requires_resource_url CHECK constraint).
@@ -57,7 +62,6 @@ azureProxy.all('/*', async (c) => {
     throw new ApiError('INTERNAL_ERROR', 'Azure provider key is missing resource_url — re-register it')
   }
 
-  const parsed = await parseProxyRequestBody(c, { injectOpenAIStreamOptions: true })
   const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
 
   const upstreamUrl = `${resourceUrl}/openai/v1${c.req.path.replace(/^\/proxy\/azure/, '')}`
@@ -78,7 +82,7 @@ azureProxy.all('/*', async (c) => {
     handlerStartMs,
   })
 
-  const logBase = await buildLogBase({
+  const logBase = buildLogBase({
     c, provider: 'azure',
     organizationId, projectId, apiKeyId,
     providerKey,

--- a/apps/server/src/proxy/gemini.ts
+++ b/apps/server/src/proxy/gemini.ts
@@ -34,10 +34,13 @@ geminiProxy.all('/*', async (c) => {
   const projectId = c.get('projectId') as string
   const apiKeyId = c.get('apiKeyId')
 
-  const providerKey = await assertProviderKey(apiKeyId, 'gemini')
-  // Gemini's body stays untransformed; isStreaming is decided by the URL
-  // path (`:streamGenerateContent`), not the body's `stream` flag.
-  const parsed = await parseProxyRequestBody(c)
+  // Provider-key lookup and body parse are independent — run concurrently.
+  const [providerKey, parsed] = await Promise.all([
+    assertProviderKey(apiKeyId, 'gemini'),
+    // Gemini's body stays untransformed; isStreaming is decided by the URL
+    // path (`:streamGenerateContent`), not the body's `stream` flag.
+    parseProxyRequestBody(c),
+  ])
 
   // Build the upstream URL with our decrypted key in `?key=` (the caller's
   // ?key= is OVERWRITTEN — a customer can't smuggle their own credential).
@@ -72,7 +75,7 @@ geminiProxy.all('/*', async (c) => {
   const modelMatch = /\/models\/([^/:]+)/.exec(originalPath)
   const isStreaming = /:streamGenerateContent/.test(originalPath)
 
-  const logBase = await buildLogBase({
+  const logBase = buildLogBase({
     c, provider: 'gemini',
     organizationId, projectId, apiKeyId,
     providerKey,

--- a/apps/server/src/proxy/mistral.ts
+++ b/apps/server/src/proxy/mistral.ts
@@ -48,10 +48,13 @@ mistralProxy.all('/*', async (c) => {
   const projectId = c.get('projectId') as string
   const apiKeyId = c.get('apiKeyId')
 
-  const providerKey = await assertProviderKey(apiKeyId, 'mistral')
-  // stream_options.include_usage is OpenAI-only — Mistral always emits usage
-  // in the final SSE chunk regardless of any flag, so no injection needed.
-  const parsed = await parseProxyRequestBody(c)
+  // Provider-key lookup and body parse are independent — run concurrently.
+  const [providerKey, parsed] = await Promise.all([
+    assertProviderKey(apiKeyId, 'mistral'),
+    // stream_options.include_usage is OpenAI-only — Mistral always emits usage
+    // in the final SSE chunk regardless of any flag, so no injection needed.
+    parseProxyRequestBody(c),
+  ])
   const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
 
   const upstreamUrl = `${MISTRAL_BASE}${c.req.path.replace(/^\/proxy\/mistral/, '')}`
@@ -69,7 +72,7 @@ mistralProxy.all('/*', async (c) => {
     handlerStartMs,
   })
 
-  const logBase = await buildLogBase({
+  const logBase = buildLogBase({
     c, provider: 'mistral',
     organizationId, projectId, apiKeyId,
     providerKey,

--- a/apps/server/src/proxy/openai.ts
+++ b/apps/server/src/proxy/openai.ts
@@ -45,8 +45,13 @@ openaiProxy.all('/*', async (c) => {
   const projectId = c.get('projectId') as string
   const apiKeyId = c.get('apiKeyId')
 
-  const providerKey = await assertProviderKey(apiKeyId, 'openai')
-  const parsed = await parseProxyRequestBody(c, { injectOpenAIStreamOptions: true })
+  // The provider-key lookup (DB + decrypt) and the body read/parse are
+  // independent — run them concurrently to shave one round-trip off the
+  // pre-fetch critical path. runSecurityGate depends on parsed, so it stays after.
+  const [providerKey, parsed] = await Promise.all([
+    assertProviderKey(apiKeyId, 'openai'),
+    parseProxyRequestBody(c, { injectOpenAIStreamOptions: true }),
+  ])
   const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
 
   const upstreamUrl = `${OPENAI_BASE}${c.req.path.replace(/^\/proxy\/openai/, '')}`
@@ -64,7 +69,7 @@ openaiProxy.all('/*', async (c) => {
     handlerStartMs,
   })
 
-  const logBase = await buildLogBase({
+  const logBase = buildLogBase({
     c, provider: 'openai',
     organizationId, projectId, apiKeyId,
     providerKey,

--- a/apps/server/src/proxy/openrouter.ts
+++ b/apps/server/src/proxy/openrouter.ts
@@ -65,8 +65,11 @@ openrouterProxy.all('/*', async (c) => {
   const projectId = c.get('projectId') as string
   const apiKeyId = c.get('apiKeyId')
 
-  const providerKey = await assertProviderKey(apiKeyId, 'openrouter')
-  const parsed = await parseProxyRequestBody(c)
+  // Provider-key lookup and body parse are independent — run concurrently.
+  const [providerKey, parsed] = await Promise.all([
+    assertProviderKey(apiKeyId, 'openrouter'),
+    parseProxyRequestBody(c),
+  ])
   const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
 
   const upstreamUrl = `${OPENROUTER_BASE}${c.req.path.replace(/^\/proxy\/openrouter/, '')}`
@@ -88,7 +91,7 @@ openrouterProxy.all('/*', async (c) => {
     handlerStartMs,
   })
 
-  const logBase = await buildLogBase({
+  const logBase = buildLogBase({
     c, provider: 'openrouter',
     organizationId, projectId, apiKeyId,
     providerKey,

--- a/apps/server/src/proxy/shared/log-base.ts
+++ b/apps/server/src/proxy/shared/log-base.ts
@@ -9,7 +9,6 @@
 
 import type { Context } from 'hono'
 import { parseLogBodyMode } from '../../lib/logger.js'
-import { resolvePromptVersion } from '../../lib/resolve-prompt-version.js'
 import type { SecurityFlag } from '../../lib/security-scan.js'
 import type { ResolvedProviderKey } from '../utils.js'
 import type { ProxyProvider } from './provider-key.js'
@@ -28,6 +27,14 @@ export interface ProxyLogBase {
   traceId: string | null
   spanId: string | null
   promptVersionId: string | null
+  /**
+   * Raw X-Spanlens-Prompt-Version header, resolved to promptVersionId later
+   * inside logRequestAsync (off the response-critical path). buildLogBase no
+   * longer resolves it: on a cold prompt cache the resolve does 1-2 Supabase
+   * queries, and doing that here delayed time-to-first-token on streaming
+   * requests even though the id is only needed for the deferred log write.
+   */
+  promptVersionHeader: string | null
   providerKeyId: string
   userId: string | null
   sessionId: string | null
@@ -49,13 +56,8 @@ export interface BuildLogBaseInput {
   statusCode: number
 }
 
-export async function buildLogBase(input: BuildLogBaseInput): Promise<ProxyLogBase> {
+export function buildLogBase(input: BuildLogBaseInput): ProxyLogBase {
   const traceId = input.c.req.header('x-trace-id') ?? null
-  const resolved = await resolvePromptVersion(
-    input.organizationId,
-    input.c.req.header('x-spanlens-prompt-version') ?? null,
-    traceId,
-  )
   return {
     organizationId: input.organizationId,
     projectId: input.projectId,
@@ -69,7 +71,8 @@ export async function buildLogBase(input: BuildLogBaseInput): Promise<ProxyLogBa
     errorMessage: null,
     traceId,
     spanId: input.c.req.header('x-span-id') ?? null,
-    promptVersionId: resolved?.versionId ?? null,
+    promptVersionId: null,
+    promptVersionHeader: input.c.req.header('x-spanlens-prompt-version') ?? null,
     providerKeyId: input.providerKey.id,
     userId: input.c.req.header('x-spanlens-user') ?? null,
     sessionId: input.c.req.header('x-spanlens-session') ?? null,

--- a/docs/plans/platform-review-roadmap-2026-06.md
+++ b/docs/plans/platform-review-roadmap-2026-06.md
@@ -8,8 +8,9 @@ Progress:
 
 - Phase 0 (security hardening): DONE, merged in #369 (2026-06-19).
 - Phase 1 (proxy rate-limit relaxation): DONE, merged in #370 (2026-06-19).
-- Phase 2 (customer-configurable rate limiting): implemented and verified, PR pending.
-- Phases 3 through 5: not started.
+- Phase 2 (customer-configurable rate limiting): DONE, merged in #371 (2026-06-19); prod migration applied.
+- Phase 3 (proxy hot-path performance): implemented and verified, PR pending.
+- Phases 4 through 5: not started.
 
 ## Context
 
@@ -223,8 +224,8 @@ Success criteria:
 
 ## Phase 2: Customer-configurable rate limiting (new feature)
 
-Status: implemented and verified (server typecheck + lint + 1309 tests, web
-typecheck + lint + build). All six items (2.1 through 2.6) done; PR pending.
+Status: DONE, merged in #371 (2026-06-19). Prod migration applied via
+deploy-server.yml. All six items (2.1 through 2.6) shipped.
 
 Goal: let customers set rate limits on their own keys, projects, and end-users;
 enforce them in the proxy and return 429 to the customer's end-user when hit.
@@ -333,6 +334,11 @@ Success criteria:
 
 ## Phase 3: Proxy hot-path performance
 
+Status: implemented and verified (server typecheck + lint + 1314 tests). All
+three items done; PR pending. Deviation: 3.1 shipped the lower-risk variant
+(short-TTL count cache + coalescing, no logger.ts increment hook). The in-memory
+increment refinement is deferred as higher-risk and not needed for the core win.
+
 Goal: remove per-request blocking work from the proxy critical path. Sequence
 3.2 before 3.3 (same 6 files); 3.1 is independent.
 
@@ -392,8 +398,11 @@ Success criteria:
 
 ### Phase 3 exit checklist
 
-- [ ] 3.1 through 3.3 merged (3.2 first, then 3.3, 3.1 any time).
-- [ ] `proxy_overhead_ms` p95 measured before/after, improvement recorded.
+- [x] 3.1 through 3.3 implemented and verified (typecheck + lint + 1314 tests). PR pending.
+- [x] 3.2 (parallel pre-fetch) all 6 proxies use one `Promise.all` before `runSecurityGate`; azure resource_url guard relocated after it.
+- [x] 3.3 (prompt-version deferral) `buildLogBase` is sync; resolution moved into `logRequestAsync` (runs after response handoff). New test asserts the logged row still carries the resolved id.
+- [x] 3.1 (quota cache) warm-cache `/proxy/*` issues zero Supabase SELECT + zero ClickHouse count() from the quota path; dynamic import removed; `middleware-quota.test.ts` + `overage-charge-flow.test.ts` unchanged and green.
+- [ ] `proxy_overhead_ms` p95 measured before/after in prod, improvement recorded (post-merge).
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 3 of the platform review roadmap (`docs/plans/platform-review-roadmap-2026-06.md`). Removes per-request blocking work from the proxy critical path. Server-only, no migrations, no API contract change.

| # | Change | Effect |
|---|--------|--------|
| 3.2 | **Parallelize pre-fetch** in all 6 proxies: `assertProviderKey` (DB + AES decrypt) and `parseProxyRequestBody` now run in one `Promise.all` before `runSecurityGate` (which consumes the parsed body and stays after). Azure's `resource_url` guard moved after the `Promise.all`. | Removes one serial round-trip per request |
| 3.3 | **Defer prompt-version resolution**: `buildLogBase` is now synchronous and carries the raw `X-Spanlens-Prompt-Version` header instead of resolving it. `logRequestAsync` resolves it (1-2 Supabase queries on a cold cache) after the response is handed off (fireAndForget / stream `onComplete`). `events-writer` threads the resolved id through `requestRow`. | Removes a cold-cache DB round-trip from time-to-first-token |
| 3.1 | **Cache the monthly quota check**: `enforceQuota` ran a Supabase SELECT + a full-month ClickHouse `count()` on every request. Org settings (30s) and the month count (10s) are now cached per org with in-flight coalescing (mirrors `getOrgPlan`); the gratuitous `await import('./quota-policy.js')` is now a static import. | Removes the single largest proxy-overhead contributor |

### 3.1 scope note

Shipped the lower-risk variant: a short-TTL count cache + coalescing, **not** the in-memory counter + `logRequestAsync` increment hook from the roadmap. The core win (no per-request SELECT / count scan) is achieved; the increment refinement touches billing-adjacent counting across modules and is deferred as higher-risk. The cached count can lag real traffic by up to 10s, which the soft monetization gate tolerates (BYOK, so overage at the boundary costs us nothing). Billing/overage accounting uses `countMonthlyRequests` directly and is unaffected.

## Test plan

- [x] `pnpm --filter server typecheck && lint && test` (1314 tests)
- [x] New `quota-cache.test.ts`: warm cache hits neither Supabase nor ClickHouse; concurrent cold calls coalesce; enterprise skips the count; reset forces refetch; orgs isolated
- [x] Proxy + logger regression (74 tests) unchanged; `middleware-quota.test.ts` + `overage-charge-flow.test.ts` unchanged and green
- [ ] `proxy_overhead_ms` p95 measured before/after in prod (post-merge)

## Notes

- Branched from `main` (independent of #369 / #370 / #371, all merged).
- All logging still funnels through `logRequestAsync`, so the prompt-version resolution moved in one place rather than per-proxy.