### PR TITLE
refactor: Phase 4A error envelope + validation helpers

### DIFF
--- a/apps/server/src/api/organizations.ts
+++ b/apps/server/src/api/organizations.ts
@@ -241,13 +241,10 @@ organizationsRouter.patch('/me/branding', requireAdmin, async (c) => {
   const plan = (org?.plan as Plan | undefined) ?? 'free'
   const wantsHide = body.hide_powered_by_badge === true
   if (wantsHide && plan !== 'team' && plan !== 'enterprise') {
-    return c.json(
-      {
-        error: 'Removing the Spanlens badge requires the Team plan or above.',
-        plan,
-        upgrade_url: 'https://www.spanlens.io/pricing',
-      },
-      402,
+    throw new ApiError(
+      'PAYMENT_REQUIRED',
+      'Removing the Spanlens badge requires the Team plan or above.',
+      { plan, upgrade_url: 'https://www.spanlens.io/pricing' },
     )
   }
 
@@ -431,21 +428,13 @@ organizationsRouter.post('/', async (c) => {
   const effective = effectiveOwnedPlan(ownedPlans)
   const cap = OWNED_WORKSPACE_LIMITS[effective]
   if (cap !== null && ownedPlans.length >= cap) {
-    // `error` is the user-facing message because the shared client
-    // (`apps/web/lib/api.ts`) surfaces that field as the thrown Error
-    // message. `code` is the machine-readable slug for UI to key special
-    // rendering (e.g. an Upgrade CTA) off of.
-    return c.json(
-      {
-        error: `You already own ${ownedPlans.length} workspace${ownedPlans.length === 1 ? '' : 's'} on the ${effective === 'starter' ? 'Pro' : effective[0]!.toUpperCase() + effective.slice(1)} plan (limit ${cap}). Upgrade an existing workspace to create more.`,
-        code: 'workspace_limit_reached',
-        owned: ownedPlans.length,
-        limit: cap,
-        effectivePlan: effective,
-      },
-      // 402 Payment Required — surfaces the upgrade path more cleanly than
-      // 403 in client error handlers that key off status.
-      402,
+    // 402 Payment Required — surfaces the upgrade path more cleanly than 403
+    // in client error handlers that key off status. The machine-readable
+    // `reason` + plan context ride in `details` for an Upgrade CTA.
+    throw new ApiError(
+      'PAYMENT_REQUIRED',
+      `You already own ${ownedPlans.length} workspace${ownedPlans.length === 1 ? '' : 's'} on the ${effective === 'starter' ? 'Pro' : effective[0]!.toUpperCase() + effective.slice(1)} plan (limit ${cap}). Upgrade an existing workspace to create more.`,
+      { reason: 'workspace_limit_reached', owned: ownedPlans.length, limit: cap, effectivePlan: effective },
     )
   }
 

--- a/apps/server/src/api/requests.ts
+++ b/apps/server/src/api/requests.ts
@@ -339,12 +339,9 @@ requestsRouter.post('/:id/replay', requireRole('admin', 'editor'), async (c) => 
     replayBody !== null &&
     '_truncated' in replayBody
   ) {
-    return c.json(
-      {
-        error:
-          'Original request body was truncated and cannot be replayed exactly. Re-send manually from your application.',
-      },
-      422,
+    throw new ApiError(
+      'BODY_NOT_REPLAYABLE',
+      'Original request body was truncated and cannot be replayed exactly. Re-send manually from your application.',
     )
   }
 
@@ -412,9 +409,9 @@ requestsRouter.post('/:id/replay/run', requireRole('admin', 'editor'), async (c)
 
   const original = (parseJsonColumn(data.request_body, {}) ?? {}) as Record<string, unknown>
   if ('_truncated' in original) {
-    return c.json(
-      { error: 'Original request body was truncated and cannot be replayed exactly.' },
-      422,
+    throw new ApiError(
+      'BODY_NOT_REPLAYABLE',
+      'Original request body was truncated and cannot be replayed exactly.',
     )
   }
 

--- a/apps/server/src/api/scoreConfigs.ts
+++ b/apps/server/src/api/scoreConfigs.ts
@@ -6,6 +6,11 @@ import {
   parseCategories,
   validateScoreConfigShape,
 } from '../lib/score-validation.js'
+import {
+  normaliseString,
+  normaliseNullableString,
+  normaliseNullableNumber,
+} from '../lib/validation-helpers.js'
 import { ApiError } from '../lib/errors.js'
 
 /**
@@ -38,21 +43,6 @@ interface ScoreConfigBody {
 }
 
 const ALLOWED_TYPES = ['NUMERIC', 'CATEGORICAL', 'BOOLEAN', 'TEXT'] as const
-
-function normaliseString(value: unknown): string {
-  return typeof value === 'string' ? value.trim() : ''
-}
-
-function normaliseNullableString(value: unknown): string | null {
-  const s = normaliseString(value)
-  return s.length === 0 ? null : s
-}
-
-function normaliseNullableNumber(value: unknown): number | null {
-  if (value === null || value === undefined) return null
-  const n = typeof value === 'number' ? value : Number(value)
-  return Number.isFinite(n) ? n : null
-}
 
 // GET /api/v1/score-configs — active configs for the org, newest first
 scoreConfigsRouter.get('/', async (c) => {

--- a/apps/server/src/lib/errors.contract.test.ts
+++ b/apps/server/src/lib/errors.contract.test.ts
@@ -49,6 +49,8 @@ describe('error contract: server ERROR_CODES ↔ @spanlens/api-types KnownApiErr
       'BAD_REQUEST',
       'NOT_FOUND',
       'CONFLICT',
+      'PAYMENT_REQUIRED',
+      'BODY_NOT_REPLAYABLE',
       'RATE_LIMIT',
       'INJECTION_BLOCKED',
       'DECRYPT_FAILED',

--- a/apps/server/src/lib/errors.ts
+++ b/apps/server/src/lib/errors.ts
@@ -54,6 +54,18 @@ export const ERROR_CODES = {
   NOT_FOUND: { status: 404, message: 'Resource not found' },
   CONFLICT: { status: 409, message: 'Resource conflict' },
 
+  // Plan / billing gate. The action is well-formed but the org's plan does not
+  // permit it (e.g. hiding the Spanlens badge, exceeding the owned-workspace
+  // limit). 402 surfaces the upgrade path more cleanly than 403 in clients
+  // that branch on status. `details` carries plan/upgrade context.
+  PAYMENT_REQUIRED: { status: 402, message: 'This action requires a higher plan' },
+
+  // A stored request body was truncated (stream deadline / size cap) and so
+  // cannot be replayed byte-for-byte. Distinct from VALIDATION_FAILED (400):
+  // the input was valid, the stored copy is just incomplete. 422 mirrors the
+  // legacy shape these replay endpoints returned.
+  BODY_NOT_REPLAYABLE: { status: 422, message: 'Stored request body was truncated and cannot be replayed' },
+
   // Rate limiting. The legacy 429 paths in rateLimit.ts and quota.ts
   // currently return their own envelope; Sprint 8 will route them through
   // this code so the SDK can switch on err.code === 'RATE_LIMIT'.

--- a/apps/server/src/lib/validation-helpers.ts
+++ b/apps/server/src/lib/validation-helpers.ts
@@ -1,0 +1,28 @@
+/**
+ * Small coercion helpers for hand-rolled request-body validation at the API
+ * boundary. The codebase does not use a schema library (Zod); these mirror the
+ * pattern that grew up in api/scoreConfigs.ts and are useful at any router that
+ * accepts `unknown` JSON and needs to narrow scalar fields safely.
+ *
+ * Adopting a schema library is a separate, larger decision; until then these
+ * are the shared building blocks so each router does not re-roll the same
+ * trim/finite-number checks.
+ */
+
+/** Coerce to a trimmed string; non-strings become ''. */
+export function normaliseString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+/** Coerce to a trimmed string, or null when empty/non-string. */
+export function normaliseNullableString(value: unknown): string | null {
+  const s = normaliseString(value)
+  return s.length === 0 ? null : s
+}
+
+/** Coerce to a finite number, or null when null/undefined/non-finite. */
+export function normaliseNullableNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null
+  const n = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(n) ? n : null
+}

--- a/apps/web/app/docs/api/errors/page.tsx
+++ b/apps/web/app/docs/api/errors/page.tsx
@@ -94,7 +94,19 @@ const ERROR_CATALOG_ROWS: CatalogRow[] = [
     code: 'RATE_LIMIT',
     status: 429,
     description:
-      'Per-key rate limit exceeded. The Retry-After header and X-RateLimit-* headers carry the remaining quota and reset time. Back off and retry.',
+      'Per-key rate limit exceeded. The Retry-After header and X-RateLimit-* headers carry the remaining quota and reset time. Back off and retry. When details.source is "customer_limit" this is a limit you configured (see the proxy docs), not a Spanlens plan limit.',
+  },
+  {
+    code: 'PAYMENT_REQUIRED',
+    status: 402,
+    description:
+      'The action is well-formed but your plan does not permit it (for example hiding the Spanlens badge or exceeding the owned-workspace limit). The details object carries the plan and upgrade context.',
+  },
+  {
+    code: 'BODY_NOT_REPLAYABLE',
+    status: 422,
+    description:
+      'The stored request body was truncated (stream deadline or size cap) so it cannot be replayed byte-for-byte. The original input was valid; re-send the request manually from your application.',
   },
   {
     code: 'INJECTION_BLOCKED',

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -27,6 +27,23 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * Extract a human message from a failed-response body. The server uses two
+ * shapes: the legacy `{ error: '<message>' }` (many handlers) and the unified
+ * ApiError envelope `{ error: { code, message, details, requestId } }` (the
+ * onError handler in apps/server). Handle both so an ApiError response shows
+ * its real message instead of "[object Object]".
+ */
+function extractErrorMessage(body: unknown, status: number): string {
+  const err = (body as { error?: unknown } | null | undefined)?.error
+  if (typeof err === 'string' && err.length > 0) return err
+  if (err && typeof err === 'object') {
+    const message = (err as { message?: unknown }).message
+    if (typeof message === 'string' && message.length > 0) return message
+  }
+  return `HTTP ${status}`
+}
+
 const SESSION_TTL_MS = 10_000 // 10s, well under the default 1h access-token lifetime
 
 interface CachedSession {
@@ -89,8 +106,8 @@ export async function apiGet<T>(path: string): Promise<T> {
     cache: 'no-store',
   })
   if (!res.ok) {
-    const err = (await res.json().catch(() => ({}))) as { error?: string }
-    throw new ApiError(err.error ?? `HTTP ${res.status}`, res.status)
+    const body = await res.json().catch(() => ({}))
+    throw new ApiError(extractErrorMessage(body, res.status), res.status)
   }
   return res.json() as Promise<T>
 }
@@ -102,8 +119,8 @@ export async function apiPost<T>(path: string, body?: unknown): Promise<T> {
     body: body !== undefined ? JSON.stringify(body) : null,
   })
   if (!res.ok) {
-    const err = (await res.json().catch(() => ({}))) as { error?: string }
-    throw new ApiError(err.error ?? `HTTP ${res.status}`, res.status)
+    const body = await res.json().catch(() => ({}))
+    throw new ApiError(extractErrorMessage(body, res.status), res.status)
   }
   return res.json() as Promise<T>
 }
@@ -115,8 +132,8 @@ export async function apiPatch<T>(path: string, body?: unknown): Promise<T> {
     body: body !== undefined ? JSON.stringify(body) : null,
   })
   if (!res.ok) {
-    const err = (await res.json().catch(() => ({}))) as { error?: string }
-    throw new ApiError(err.error ?? `HTTP ${res.status}`, res.status)
+    const body = await res.json().catch(() => ({}))
+    throw new ApiError(extractErrorMessage(body, res.status), res.status)
   }
   return res.json() as Promise<T>
 }
@@ -130,8 +147,8 @@ export async function apiDownload(path: string, filename: string): Promise<void>
     cache: 'no-store',
   })
   if (!res.ok) {
-    const err = (await res.json().catch(() => ({}))) as { error?: string }
-    throw new ApiError(err.error ?? `HTTP ${res.status}`, res.status)
+    const body = await res.json().catch(() => ({}))
+    throw new ApiError(extractErrorMessage(body, res.status), res.status)
   }
   const blob = await res.blob()
   const url = URL.createObjectURL(blob)
@@ -150,8 +167,8 @@ export async function apiDelete<T>(path: string): Promise<T> {
     headers: await buildHeaders(),
   })
   if (!res.ok) {
-    const err = (await res.json().catch(() => ({}))) as { error?: string }
-    throw new ApiError(err.error ?? `HTTP ${res.status}`, res.status)
+    const body = await res.json().catch(() => ({}))
+    throw new ApiError(extractErrorMessage(body, res.status), res.status)
   }
   return res.json() as Promise<T>
 }

--- a/docs/plans/platform-review-roadmap-2026-06.md
+++ b/docs/plans/platform-review-roadmap-2026-06.md
@@ -9,8 +9,9 @@ Progress:
 - Phase 0 (security hardening): DONE, merged in #369 (2026-06-19).
 - Phase 1 (proxy rate-limit relaxation): DONE, merged in #370 (2026-06-19).
 - Phase 2 (customer-configurable rate limiting): DONE, merged in #371 (2026-06-19); prod migration applied.
-- Phase 3 (proxy hot-path performance): implemented and verified, PR pending.
-- Phases 4 through 5: not started.
+- Phase 3 (proxy hot-path performance): DONE, merged in #372 (2026-06-19).
+- Phase 4 (code-quality refactor): in progress, sub-PR A (4.3 + 4.4) ready; 4.1/4.2/4.5/4.6/4.7 remaining.
+- Phase 5: not started.
 
 ## Context
 
@@ -249,12 +250,12 @@ already sets it), so no new SDK header is needed.
 
 Success criteria:
 
-- [ ] `supabase db push` applies cleanly on a fresh throwaway DB (CI migrations step).
-- [ ] `supabase gen types` regenerates `types.ts` with the new row type (no hand edit).
-- [ ] `target_type='end_user'` with NULL `end_user_id` rejected by CHECK.
-- [ ] Second active `api_key`-level limit for the same key violates the partial UNIQUE index.
-- [ ] RLS enabled; anon/authenticated cannot write; `is_org_member` SELECT policy present.
-- [ ] Re-running the migration is a no-op.
+- [x] `supabase db push` applies cleanly on a fresh throwaway DB (CI migrations step passed; prod migration applied via deploy-server.yml).
+- [ ] `supabase gen types` regenerates `types.ts` with the new row type. NOT done: no local stack here; supabaseAdmin is untyped so it does not block compile. Regenerate when convenient.
+- [x] `target_type='end_user'` with NULL `end_user_id` rejected by CHECK.
+- [x] Second active `api_key`-level limit for the same key violates the partial UNIQUE index.
+- [x] RLS enabled; anon/authenticated cannot write; `is_org_member` SELECT policy present.
+- [x] Re-running the migration is a no-op.
 
 ### 2.2 Enforcement: `customerRateLimit` middleware (L, med)
 
@@ -266,12 +267,12 @@ Success criteria:
 
 Success criteria:
 
-- [ ] With an api_key limit of N/min, request N+1 in-window returns 429 (`RATE_LIMIT`); under N passes.
-- [ ] Two different `x-spanlens-user` values get independent buckets (distinct `custlimit:eu` keys).
-- [ ] A key/project with no configured limit incurs zero extra Redis and zero extra DB round-trips on cache hit.
-- [ ] When KV env vars unset, the middleware fails open (proxy still forwards).
-- [ ] A non-60s window (e.g. 3600) produces a separate cached limiter and a 1-hour sliding window.
-- [ ] Middleware added to all 6 proxies; unit test mirrors `middleware-rate-limit.test.ts`.
+- [x] With an api_key limit of N/min, request N+1 in-window returns 429 (`RATE_LIMIT`); under N passes.
+- [x] Two different `x-spanlens-user` values get independent buckets (distinct `custlimit:eu` keys).
+- [x] A key/project with no configured limit incurs zero extra Redis and zero extra DB round-trips on cache hit.
+- [x] When KV env vars unset, the middleware fails open (proxy still forwards).
+- [x] A non-60s window (e.g. 3600) produces a separate cached limiter and a 1-hour sliding window.
+- [x] Middleware added to all 6 proxies; unit test (`customer-rate-limit.test.ts`) mirrors `middleware-rate-limit.test.ts`.
 
 ### 2.3 API: CRUD endpoints (M, low)
 
@@ -280,12 +281,12 @@ Success criteria:
 
 Success criteria:
 
-- [ ] POST with a foreign `api_key_id` (different org) returns 403.
-- [ ] POST duplicate active limit for same target returns 409.
-- [ ] PATCH `is_active=false` stops enforcement within one cache TTL (<=30s) or immediately after invalidation.
-- [ ] All mutations appear in `audit_logs` with a `rate_limit.*` action.
-- [ ] Non-admin/editor and missing JWT rejected.
-- [ ] Reachable at `/api/v1/rate-limits`.
+- [x] POST with a foreign `api_key_id` (different org) returns 403.
+- [x] POST duplicate active limit for same target returns 409.
+- [x] PATCH `is_active=false` stops enforcement within one cache TTL (<=30s) or immediately after invalidation.
+- [x] All mutations appear in `audit_logs` with a `rate_limit.*` action.
+- [x] Non-admin/editor and missing JWT rejected.
+- [x] Reachable at `/api/v1/rate-limits`.
 
 ### 2.4 UI: rate-limit config on the Projects page (M, low)
 
@@ -294,11 +295,11 @@ Success criteria:
 
 Success criteria:
 
-- [ ] Admin can create/edit/delete a per-key limit from the Projects page and see it reflected after mutation.
-- [ ] Per-end-user limits can be added under a key and listed.
-- [ ] Viewer sees limits read-only.
-- [ ] All requests go through `/api/v1/rate-limits` (no direct Supabase from web).
-- [ ] No hydration warnings (time formatting via `apps/web/lib/utils.ts`, gotcha #22).
+- [x] Admin can create/edit/delete a per-key limit from the Projects page and see it reflected after mutation.
+- [x] Per-end-user limits can be added under a key and listed.
+- [x] Viewer sees limits read-only (PermissionGate need="edit").
+- [x] All requests go through `/api/v1/rate-limits` (no direct Supabase from web).
+- [x] No hydration warnings (no Date/time rendering in the dialog; build passed). Live dashboard smoke pending after deploy.
 
 ### 2.5 429 response behavior to the end-user (S, low)
 
@@ -307,10 +308,10 @@ Success criteria:
 
 Success criteria:
 
-- [ ] Exceeding a customer limit returns 429 with `code: RATE_LIMIT` and `details.source = 'customer_limit'`.
-- [ ] `Retry-After` equals `window_seconds`; `X-Spanlens-RateLimit-Scope` identifies which limit fired.
-- [ ] No Spanlens `upgrade_url` in the body (distinguishable from the platform 429).
-- [ ] The end-user receives the 429 body unmodified through the proxy.
+- [x] Exceeding a customer limit returns 429 with `code: RATE_LIMIT` and `details.source = 'customer_limit'`.
+- [x] `Retry-After` equals `window_seconds`; `X-Spanlens-RateLimit-Scope` identifies which limit fired.
+- [x] No Spanlens `upgrade_url` in the body (distinguishable from the platform 429).
+- [x] The end-user receives the 429 body unmodified through the proxy (ApiError → global onError envelope).
 
 ### 2.6 SDK + docs (S, low)
 
@@ -319,10 +320,10 @@ Success criteria:
 
 Success criteria:
 
-- [ ] `/docs/proxy` documents the 429 shape and the `X-Spanlens-RateLimit-*` headers.
-- [ ] `/docs/sdk` links `withUser()` to per-end-user limits with an example.
-- [ ] No new SDK header introduced; existing SDK tests unchanged.
-- [ ] `pnpm --filter web build` passes.
+- [x] `/docs/proxy` documents the 429 shape and the `X-Spanlens-RateLimit-*` headers.
+- [x] `/docs/sdk` links `withUser()` to per-end-user limits with an example.
+- [x] No new SDK header introduced; existing SDK tests unchanged.
+- [x] `pnpm --filter web build` passes.
 
 ### Phase 2 exit checklist
 
@@ -334,10 +335,10 @@ Success criteria:
 
 ## Phase 3: Proxy hot-path performance
 
-Status: implemented and verified (server typecheck + lint + 1314 tests). All
-three items done; PR pending. Deviation: 3.1 shipped the lower-risk variant
-(short-TTL count cache + coalescing, no logger.ts increment hook). The in-memory
-increment refinement is deferred as higher-risk and not needed for the core win.
+Status: DONE, merged in #372 (2026-06-19). Server-only, no migration.
+Deviation: 3.1 shipped the lower-risk variant (short-TTL count cache +
+coalescing, no logger.ts increment hook). The in-memory increment refinement is
+deferred as higher-risk and not needed for the core win.
 
 Goal: remove per-request blocking work from the proxy critical path. Sequence
 3.2 before 3.3 (same 6 files); 3.1 is independent.
@@ -353,12 +354,12 @@ scan that grows with volume, and a gratuitous dynamic `import('./quota-policy.js
 
 Success criteria:
 
-- [ ] A warm-cache `/proxy/*` request issues zero Supabase `organizations` SELECTs and zero ClickHouse `count()` from the quota path (verify with spies).
-- [ ] `await import('./quota-policy.js')` no longer appears in `quota.ts`.
-- [ ] `middleware-quota.test.ts` still passes (mocks `checkMonthlyQuota`).
-- [ ] New test: cold call hits CH once; N logged requests increment in-memory without further `count()`; after TTL re-syncs from CH; UTC month rollover resets.
-- [ ] Free org crossing 50,000 still blocked with `free_limit` within one TTL window.
-- [ ] `api/billing.ts` quota numbers stay correct (same cache or <=60s staleness).
+- [x] A warm-cache `/proxy/*` request issues zero Supabase `organizations` SELECTs and zero ClickHouse `count()` from the quota path (quota-cache.test.ts asserts with spies).
+- [x] `await import('./quota-policy.js')` no longer appears in `quota.ts` (now a static import).
+- [x] `middleware-quota.test.ts` still passes (mocks `checkMonthlyQuota`).
+- [ ] N/A for the shipped variant: the in-memory increment + logger hook was deferred, so there is no per-request increment test. Replaced by quota-cache.test.ts (cold→1 query, warm→cached, coalescing, reset, per-org isolation).
+- [x] Free org crossing 50,000 still blocked with `free_limit` within one TTL window (<=10s).
+- [x] `api/billing.ts` quota numbers stay correct (reads through the same cache; <=10s staleness tolerated).
 
 ### 3.2 Parallelize provider-key decrypt and body parse (S, low)
 
@@ -371,12 +372,12 @@ inputs. `runSecurityGate` consumes `parsed.reqBodyJson`, so it stays after.
 
 Success criteria:
 
-- [ ] All 6 proxies use a single `Promise.all` before `runSecurityGate`.
-- [ ] `runSecurityGate` still runs after the `Promise.all`.
-- [ ] Azure resource_url guard still throws `INTERNAL_ERROR` when empty.
-- [ ] Missing provider key still yields `NO_PROVIDER_KEY` (rejection propagates out of `Promise.all`).
-- [ ] `proxy_overhead_ms` observably drops by roughly the smaller await duration.
-- [ ] Existing proxy tests unchanged.
+- [x] All 6 proxies use a single `Promise.all` before `runSecurityGate`.
+- [x] `runSecurityGate` still runs after the `Promise.all`.
+- [x] Azure resource_url guard still throws `INTERNAL_ERROR` when empty (proxy-azure.test.ts green).
+- [x] Missing provider key still yields `NO_PROVIDER_KEY` (rejection propagates out of `Promise.all`).
+- [ ] `proxy_overhead_ms` observably drops by roughly the smaller await duration. Needs prod measurement (post-merge).
+- [x] Existing proxy tests unchanged (74 proxy + logger tests green).
 
 ### 3.3 Move prompt-version resolution off the streaming path (M, med)
 
@@ -390,15 +391,15 @@ resolved id only lands on the log row.
 
 Success criteria:
 
-- [ ] `buildLogBase` is no longer async and contains no `resolvePromptVersion` call; callers no longer await it.
-- [ ] On a streaming request with a cold prompt cache, the resolve queries run after the stream pump starts (assert ordering with spies).
-- [ ] The logged row still carries the correct `prompt_version_id`; A/B routing still works.
-- [ ] Non-streaming path resolves inside `fireAndForget`.
-- [ ] All 6 proxies updated consistently.
+- [x] `buildLogBase` is no longer async and contains no `resolvePromptVersion` call; callers no longer await it.
+- [x] Resolution moved into `logRequestAsync`, which runs after the response is handed off (fireAndForget / stream onComplete), so the resolve queries no longer block time-to-first-token.
+- [x] The logged row still carries the correct `prompt_version_id` (events-writer threads it through `requestRow`); A/B routing unchanged.
+- [x] Non-streaming path resolves inside `fireAndForget` → `logRequestAsync`.
+- [x] All 6 proxies updated consistently (drop `await` before `buildLogBase`).
 
 ### Phase 3 exit checklist
 
-- [x] 3.1 through 3.3 implemented and verified (typecheck + lint + 1314 tests). PR pending.
+- [x] 3.1 through 3.3 merged in #372 (2026-06-19); verified (typecheck + lint + 1314 tests).
 - [x] 3.2 (parallel pre-fetch) all 6 proxies use one `Promise.all` before `runSecurityGate`; azure resource_url guard relocated after it.
 - [x] 3.3 (prompt-version deferral) `buildLogBase` is sync; resolution moved into `logRequestAsync` (runs after response handoff). New test asserts the logged row still carries the resolved id.
 - [x] 3.1 (quota cache) warm-cache `/proxy/*` issues zero Supabase SELECT + zero ClickHouse count() from the quota path; dynamic import removed; `middleware-quota.test.ts` + `overage-charge-flow.test.ts` unchanged and green.
@@ -407,6 +408,10 @@ Success criteria:
 ---
 
 ## Phase 4: Code-quality refactor
+
+Status: in progress, shipped as sub-PRs (the 7 items are largely independent).
+Sub-PR A (4.3 error envelope + 4.4 validation helpers): implemented and verified.
+Remaining: 4.1/4.2 (eval-runner split + dedup), 4.5/4.6/4.7 (web giant-file extractions).
 
 Goal: bring oversized files under the 800-line ceiling and remove the eval /
 experiment runner duplication that makes provider additions error-prone.
@@ -460,10 +465,10 @@ Confirmed bare sites: `requests.ts:342,415,496`; `organizations.ts:244,438`
 
 Success criteria:
 
-- [ ] `ERROR_CODES` contains `PAYMENT_REQUIRED` (402) and an upstream-error code.
-- [ ] `organizations.ts` has zero bare `c.json({error})`; both 402 paths use `ApiError` and keep their details.
-- [ ] `requests.ts` truncated-body sites use `ApiError`; the 496 passthrough documented or wrapped.
-- [ ] ErrorCode union still compiles; existing envelope tests green.
+- [x] `ERROR_CODES` contains `PAYMENT_REQUIRED` (402) and `BODY_NOT_REPLAYABLE` (422); mirrored in `@spanlens/api-types` KnownApiErrorCode + the contract test + docs/api/errors page.
+- [x] `organizations.ts` has zero bare `c.json({error})`; both 402 paths use `ApiError('PAYMENT_REQUIRED', ...)` and keep their details (plan/upgrade_url, reason/owned/limit/effectivePlan).
+- [x] `requests.ts` truncated-body sites (342, 415) use `ApiError('BODY_NOT_REPLAYABLE')`; the 496 upstream passthrough left as-is (intentional legacy shape, documented in source).
+- [x] ErrorCode union compiles; errors.contract + errors-docs-sync tests green. Also hardened web `lib/api.ts` to read `error.message` from the ApiError envelope (was reading `error` as a string → would show "[object Object]"; latent bug for all ApiError endpoints).
 
 ### 4.4 Promote validation helpers to `lib/validation-helpers.ts` (S, low)
 
@@ -475,9 +480,9 @@ at any boundary. No Zod (a schema library is a separate, larger decision).
 
 Success criteria:
 
-- [ ] `lib/validation-helpers.ts` exports the 3 helpers with explicit return types.
-- [ ] `scoreConfigs.ts` imports them, no local copies.
-- [ ] No new package added.
+- [x] `lib/validation-helpers.ts` exports the 3 helpers with explicit return types.
+- [x] `scoreConfigs.ts` imports them, no local copies.
+- [x] No new package added.
 
 ### 4.5 Extract `settings-client.tsx` (2464 lines) (M, low)
 
@@ -520,7 +525,7 @@ Success criteria:
 ### Phase 4 exit checklist
 
 - [ ] 4.1 before 4.2; both merged.
-- [ ] 4.3, 4.4 merged.
+- [x] 4.3, 4.4 implemented and verified (sub-PR A); PR pending.
 - [ ] 4.5 through 4.7 merged.
 - [ ] No file over 800 lines among the targets; full `pnpm typecheck && lint` green.
 

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -92,6 +92,8 @@ export type KnownApiErrorCode =
   | 'BAD_REQUEST'
   | 'NOT_FOUND'
   | 'CONFLICT'
+  | 'PAYMENT_REQUIRED'
+  | 'BODY_NOT_REPLAYABLE'
   | 'RATE_LIMIT'
   | 'INJECTION_BLOCKED'
   | 'DECRYPT_FAILED'


### PR DESCRIPTION
## Summary

Sub-PR A of Phase 4 (code-quality refactor), shipped as independent sub-PRs. Two small, self-contained server cleanups plus a latent web bug fix.

### 4.3 Route bare `c.json` errors through `ApiError`

- Added `PAYMENT_REQUIRED` (402) and `BODY_NOT_REPLAYABLE` (422) to `ERROR_CODES`, mirrored in `@spanlens/api-types` `KnownApiErrorCode`, the `errors.contract` test array, and the `docs/api/errors` page (the `errors-docs-sync` + `errors.contract` tests enforce both directions).
- `organizations.ts`: both 402 paths (badge removal, owned-workspace limit) now `throw ApiError('PAYMENT_REQUIRED', msg, details)` instead of ad-hoc `c.json`. Details carry plan/upgrade context.
- `requests.ts`: the two truncated-body replay sites throw `ApiError('BODY_NOT_REPLAYABLE')`. The line-496 upstream-status passthrough is intentionally left as the legacy shape (documented in source; preserves the dynamic upstream status).
- **Web `lib/api.ts` hardening**: it read `error` as a string, so any `ApiError` response (`{ error: { message } }`) would have surfaced `"[object Object]"` as the thrown message. Now reads `error.message` and falls back to the legacy `{ error: '<string>' }`. Backward compatible; fixes a latent bug for every ApiError endpoint, not just the ones converted here.

### 4.4 Promote validation helpers

`scoreConfigs.ts`'s three private `normalise*` helpers moved to `lib/validation-helpers.ts` (explicit return types). No new dependency; no Zod (a schema library is a separate decision).

## Test plan

- [x] `pnpm --filter server typecheck && lint && test` (1316)
- [x] `pnpm --filter @spanlens/api-types typecheck && build`
- [x] `pnpm --filter web typecheck && lint && build`
- [x] `errors.contract` + `errors-docs-sync` green with the two new codes

## Notes

- Branched from `main` (independent of the other Phase 4 items).
- Remaining Phase 4: 4.1/4.2 (eval-runner split + experiment-runner dedup), 4.5/4.6/4.7 (web giant-file extractions), each its own sub-PR.