### PR TITLE
docs(web): changelog entry for customer-configurable rate limits

### DIFF
--- a/apps/web/lib/changelog/entries.ts
+++ b/apps/web/lib/changelog/entries.ts
@@ -39,6 +39,16 @@ export type ChangelogTag =
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-06-19',
+    slug: 'customer-rate-limits',
+    title: 'Set your own rate limits, per key and per end-user',
+    tags: ['feature', 'improvement'],
+    body: [
+      'You can now set rate limits on your own Spanlens keys, projects, and end-users from the Projects page. Cap a key at N requests per minute, hour, or day, or cap an individual end-user (the value you pass via withUser or the x-spanlens-user header) so one customer cannot exhaust your budget. When a configured limit is hit the proxy returns a 429 to that caller, tagged with the scope that fired, while the rest of your traffic flows normally. It is the same per-key, per-end-user control you would otherwise build in front of a provider, available with one dashboard setting.',
+      'At the same time, our own platform throttle stopped getting in your way. The per-minute proxy ceiling is now a pure anti-runaway safeguard: going over it no longer rejects your production calls, it lets them through and flags the spike for us instead. Your plan is gated by its monthly request quota, not by a per-minute cap, so a burst of legitimate traffic will not start returning 429s. See [Proxy docs](/docs/proxy).',
+    ].join('\n\n'),
+  },
+  {
     date: '2026-06-16',
     slug: 'evals-methodology-rigor',
     title: 'Evaluations get statistical rigor and agent trajectory scoring',


### PR DESCRIPTION
## Summary

Adds a changelog entry (2026-06-19) announcing the rate-limiting work shipped this week:

- **Customer-configurable rate limits** (Phase 2, [#371](https://github.com/spanlens/Spanlens/pull/371)): set per-key / per-project / per-end-user caps from the Projects page; the proxy 429s the caller with the scope that fired.
- **Platform throttle relaxed** (Phase 1, [#370](https://github.com/spanlens/Spanlens/pull/370)): the per-minute proxy ceiling is now a pass-through anti-runaway safeguard, not a hard 429; monthly quota gates the plan instead.

Tagged `feature` + `improvement`. Follows the house style (plain prose, no em-dash).

## Verified in production before publishing

Drove the dashboard via the browser + the proxy via direct calls on `server.spanlens.io`:

1. Set a per-key limit of 2/min on a test key via the Projects → Rate limits dialog (POST 200).
2. Called the proxy repeatedly → got `429 { error.code: RATE_LIMIT, details.source: 'customer_limit', scope: 'api_key', limit: 2, window_seconds: 60 }`, no upgrade_url.
3. Deleted the test limit (DELETE 200), key restored.

## Test plan

- [x] `pnpm --filter web typecheck && lint && build` (/changelog + feed.xml generate)