### PR TITLE
feat(web): add Blog link to marketing nav and footer

### DIFF
--- a/apps/web/components/layout/footer.tsx
+++ b/apps/web/components/layout/footer.tsx
@@ -45,6 +45,7 @@ export function Footer() {
               <Link href="/pricing" className="hover:text-text transition-colors">Pricing</Link>
               <Link href="/docs/quick-start" className="hover:text-text transition-colors">Quick start</Link>
               <Link href="/changelog" className="hover:text-text transition-colors">Changelog</Link>
+              <a href="https://blog.spanlens.io" className="hover:text-text transition-colors">Blog</a>
               <a href="https://status.spanlens.io" target="_blank" rel="noopener noreferrer" className="hover:text-text transition-colors">Status</a>
             </div>
           </div>

--- a/apps/web/components/layout/marketing-nav.tsx
+++ b/apps/web/components/layout/marketing-nav.tsx
@@ -34,6 +34,7 @@ export function MarketingNav({ signupLabel = 'Start free →', subtitle }: Marke
           <Link href="/docs" className="hover:text-text transition-colors">Docs</Link>
           <Link href="/pricing" className="hover:text-text transition-colors">Pricing</Link>
           <Link href="/changelog" className="hover:text-text transition-colors">Changelog</Link>
+          <a href="https://blog.spanlens.io" className="hover:text-text transition-colors">Blog</a>
           <a
             href="https://github.com/spanlens/Spanlens"
             target="_blank"


### PR DESCRIPTION
## Summary
Surface `blog.spanlens.io` in both shared marketing components so the blog has a discovery path. Previously there were zero entry points from the main site.

- **marketing-nav.tsx**: top nav, between Changelog and GitHub
- **footer.tsx**: footer Product group, between Changelog and Status

Both apply to all marketing pages (home, pricing, docs, legal, etc.) since these are the shared components.

## Implementation notes
- External subdomain, so uses a plain `<a href>` (not Next.js `<Link>`)
- Opens in the same tab like other owned content (Docs, Changelog); only separate external services (GitHub, Status) open in a new tab

## Test plan
- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint`
- [x] Browser preview: Blog renders in both nav and footer, `href` resolves to `https://blog.spanlens.io`