### PR TITLE
feat: activation + billing quick wins + SDK Ollama helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,16 +138,23 @@ const unregister = registerSpanlensCallbacks(Settings, { client })
 
 **More integrations**: AWS Bedrock, CrewAI, Flowise, Instructor, LlamaIndex, OpenAI Assistants, MCP server. Full setup walkthroughs at [spanlens.io/docs/integrations](https://www.spanlens.io/docs/integrations).
 
-**Ollama (local LLMs)** — Use the OpenAI-compatible client pointed at your local Ollama, then wrap with `observeOllama()` so the dashboard tags the call as Ollama instead of OpenAI.
+**Ollama (local LLMs)** — Ollama runs on your machine, so it does not go through the hosted proxy. Get a ready client with `createOllama()` and wrap each call with `observeOllama()` so the span is logged and tagged as Ollama.
 
 ```ts
-import OpenAI from 'openai'
-import { observeOllama } from '@spanlens/sdk'
+import { SpanlensClient } from '@spanlens/sdk'
+import { createOllama, observeOllama } from '@spanlens/sdk/ollama'
 
-const ollama = new OpenAI({ baseURL: 'http://localhost:11434/v1', apiKey: 'ollama' })
-await observeOllama('chat', () => ollama.chat.completions.create({
-  model: 'llama3.1', messages: [...]
-}))
+const spanlens = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+const ollama = createOllama() // points at http://localhost:11434/v1
+
+const trace = spanlens.startTrace({ name: 'chat' })
+const res = await observeOllama(trace, 'chat', (headers) =>
+  ollama.chat.completions.create(
+    { model: 'llama3.1', messages: [{ role: 'user', content: 'Hello' }] },
+    { headers },
+  ),
+)
+await trace.end({ status: 'completed' })
 ```
 
 ---

--- a/apps/web/app/(dashboard)/billing/billing-client.tsx
+++ b/apps/web/app/(dashboard)/billing/billing-client.tsx
@@ -21,6 +21,9 @@ export function BillingClient() {
   const params = useSearchParams()
   const justReturnedFromCheckout = params.get('checkout') === 'success'
   const autoOpenPtxn = params.get('_ptxn')
+  // Set by the quota upsell modal (?plan=starter|team) so the recommended
+  // card is highlighted when the user lands here from the nudge.
+  const highlightPlan = params.get('plan')
 
   const { data: subscription, isLoading } = useSubscription()
   const createCheckout = useCreateCheckout()
@@ -243,6 +246,7 @@ export function BillingClient() {
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-4">
             {PLANS.map((plan) => {
               const isCurrent = currentPlan === plan.id
+              const isRecommended = !isCurrent && plan.id === highlightPlan
               const isUpgradeInFlight =
                 createCheckout.isPending && createCheckout.variables?.plan === plan.id
 
@@ -252,15 +256,20 @@ export function BillingClient() {
                   className={cn(
                     'rounded-xl border p-5 flex flex-col min-h-[280px]',
                     isCurrent ? 'border-accent bg-accent-bg' : 'border-border bg-bg-elev',
+                    isRecommended && 'ring-2 ring-accent ring-offset-2 ring-offset-bg',
                   )}
                 >
                   <div className="flex items-start justify-between mb-3">
                     <span className="text-[15px] font-medium text-text">{plan.name}</span>
-                    {isCurrent && (
+                    {isCurrent ? (
                       <span className="font-mono text-[10px] uppercase tracking-[0.04em] px-1.5 py-0.5 rounded-full border border-accent-border bg-accent-bg text-accent">
                         Current
                       </span>
-                    )}
+                    ) : isRecommended ? (
+                      <span className="font-mono text-[10px] uppercase tracking-[0.04em] px-1.5 py-0.5 rounded-full border border-accent bg-accent text-accent-fg">
+                        Recommended
+                      </span>
+                    ) : null}
                   </div>
 
                   <div className="mb-3">

--- a/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { Skeleton } from '@/components/ui/skeleton'
 import { KpiCard } from '@/components/dashboard/kpi-card'
 import { QuotaBanner } from '@/components/dashboard/quota-banner'
+import { UpsellModal } from '@/components/dashboard/upsell-modal'
 import { Topbar, TimeRangeSelector, type CustomRange } from '@/components/layout/topbar'
 import { useStatsOverview, useStatsTimeseries, useStatsModels, useSpendForecast } from '@/lib/queries/use-stats'
 import { useAnomalies } from '@/lib/queries/use-anomalies'
@@ -690,6 +691,7 @@ export function DashboardClient() {
         <WelcomeBanner />
 
         <QuotaBanner />
+        <UpsellModal />
 
         {isError && (
           <div className="mx-[22px] mt-4 rounded-md border border-bad/30 bg-bad-bg px-4 py-3 flex items-center justify-between">

--- a/apps/web/app/(dashboard)/requests/empty-requests-hint.tsx
+++ b/apps/web/app/(dashboard)/requests/empty-requests-hint.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Copy, Check, Terminal } from 'lucide-react'
+
+/**
+ * First-run hint shown in the requests table when the account has no logged
+ * requests yet (and no filters are hiding them). Gives a copy-paste test
+ * call so a new user can confirm the proxy works without wiring code first;
+ * the request list polls on its own, so the row appears here automatically
+ * once the call lands.
+ */
+const TEST_CURL = `curl https://server.spanlens.io/proxy/openai/v1/chat/completions \\
+  -H "Authorization: Bearer $SPANLENS_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hello from Spanlens"}]}'`
+
+export function EmptyRequestsHint() {
+  const [copied, setCopied] = useState(false)
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(TEST_CURL)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-3 max-w-xl w-full">
+      <span className="text-[13px] text-text-muted">
+        No requests yet. Make your first API call through the proxy, or fire a quick test:
+      </span>
+
+      <div className="w-full rounded-md border border-border bg-[#1a1816] px-3 py-2.5 text-left">
+        <div className="flex items-center justify-between mb-1.5">
+          <span className="font-mono text-[10px] uppercase tracking-[0.05em] text-[#7c7770] flex items-center gap-1.5">
+            <Terminal className="w-3 h-3" /> Test call · curl
+          </span>
+          <button
+            type="button"
+            onClick={() => void copy()}
+            className="font-mono text-[11px] text-accent hover:opacity-80 transition-opacity flex items-center gap-1"
+          >
+            {copied ? (
+              <>
+                <Check className="w-3 h-3" /> Copied!
+              </>
+            ) : (
+              <>
+                <Copy className="w-3 h-3" /> Copy
+              </>
+            )}
+          </button>
+        </div>
+        <pre className="font-mono text-[11px] text-good leading-relaxed whitespace-pre-wrap break-words">
+          {TEST_CURL}
+        </pre>
+      </div>
+
+      <span className="font-mono text-[10.5px] text-text-faint">
+        Set <code className="text-text-muted">SPANLENS_API_KEY</code> first. New requests appear here
+        automatically.
+      </span>
+
+      <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1">
+        <Link
+          href="/projects"
+          className="font-mono text-[11.5px] text-accent hover:opacity-80 transition-opacity"
+        >
+          Add provider key →
+        </Link>
+        <Link
+          href="/docs/quick-start"
+          className="font-mono text-[11.5px] text-text-muted hover:text-text transition-colors"
+        >
+          Quick start →
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/requests/requests-client.tsx
+++ b/apps/web/app/(dashboard)/requests/requests-client.tsx
@@ -11,7 +11,10 @@ import { Topbar } from '@/components/layout/topbar'
 import {
   useRequests,
   useRequest,
+  type SavedFilterParams,
 } from '@/lib/queries/use-requests'
+import { SavedViewsBar } from './saved-views-bar'
+import { EmptyRequestsHint } from './empty-requests-hint'
 import { useProviderKeys } from '@/lib/queries/use-provider-keys'
 import { useTrace } from '@/lib/queries/use-traces'
 import { useStatsOverview, useStatsTimeseries, useTimeseriesBreakdown } from '@/lib/queries/use-stats'
@@ -1176,23 +1179,7 @@ function RequestsTable({
               {hasActiveFilters ? (
                 <span>No requests match the current filters.</span>
               ) : (
-                <>
-                  <span className="text-[13px] text-text-muted">No requests yet — make your first API call through the proxy.</span>
-                  <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1">
-                    <Link
-                      href="/projects"
-                      className="font-mono text-[11.5px] text-accent hover:opacity-80 transition-opacity"
-                    >
-                      Add provider key →
-                    </Link>
-                    <Link
-                      href="/docs/quick-start"
-                      className="font-mono text-[11.5px] text-text-muted hover:text-text transition-colors"
-                    >
-                      Quick start →
-                    </Link>
-                  </div>
-                </>
+                <EmptyRequestsHint />
               )}
             </div>
           )
@@ -1418,6 +1405,33 @@ export function RequestsClient() {
     filters.providerKeyId !== 'all' ||
     timeRange !== 'all'
 
+  // The current filter set as bare URL params — what a "saved view" stores.
+  // Only non-default values are included so equality with a saved view is exact.
+  const currentSaveParams = useMemo<SavedFilterParams>(() => {
+    const p: SavedFilterParams = {}
+    if (provider !== 'all') p.provider = provider
+    if (status !== 'all') p.status = status
+    if (filters.model.trim()) p.model = filters.model.trim()
+    if (providerKeyId !== 'all') p.providerKeyId = providerKeyId
+    if (timeRange !== 'all') p.timeRange = timeRange
+    if (sortField !== 'created_at') p.sortBy = sortField
+    if (sortDir !== 'desc') p.sortDir = sortDir
+    if (promptVersionId) p.promptVersionId = promptVersionId
+    if (userIdFilter) p.userId = userIdFilter
+    if (sessionIdFilter) p.sessionId = sessionIdFilter
+    return p
+  }, [provider, status, filters.model, providerKeyId, timeRange, sortField, sortDir, promptVersionId, userIdFilter, sessionIdFilter])
+
+  // Apply a saved view: replace the URL with exactly its params (dropping
+  // pagination + any stale filter), and re-sync the debounced model input.
+  const applySavedView = useCallback((params: SavedFilterParams) => {
+    const sp = new URLSearchParams(params)
+    router.replace(`/requests?${sp.toString()}`, { scroll: false })
+    setModelInput(params.model ?? '')
+    setPage(1)
+    setSelectedId(null)
+  }, [router])
+
   function handleSort(field: SortField) {
     const newDir = sortField === field ? (sortDir === 'desc' ? 'asc' : 'desc') : 'desc'
     applyFilter({
@@ -1608,6 +1622,13 @@ export function RequestsClient() {
           }}
         />
       </div>
+
+      {/* Saved views — name the current filter combo, one-click back into it. */}
+      <SavedViewsBar
+        current={currentSaveParams}
+        onApply={applySavedView}
+        canSave={Object.keys(currentSaveParams).length > 0}
+      />
 
       {/* Table + pagination */}
       <div className="flex flex-col flex-1">

--- a/apps/web/app/(dashboard)/requests/saved-views-bar.tsx
+++ b/apps/web/app/(dashboard)/requests/saved-views-bar.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { useState } from 'react'
+import { Bookmark, Plus, X, Check } from 'lucide-react'
+import {
+  useSavedFilters,
+  useCreateSavedFilter,
+  useDeleteSavedFilter,
+  type SavedFilterParams,
+} from '@/lib/queries/use-requests'
+import { cn } from '@/lib/utils'
+
+/**
+ * Saved views bar for the requests page. Surfaces the pre-existing
+ * `/api/v1/saved-filters` API (list / create / delete) that previously had
+ * no UI: users can name the current filter combination and one-click back
+ * into it later.
+ *
+ * `current` is the set of requests-page URL params that make up the view to
+ * save (provider, status, model, timeRange, sortBy, …). `onApply` receives a
+ * saved param map and is expected to replace the URL with exactly those.
+ */
+interface SavedViewsBarProps {
+  current: SavedFilterParams
+  onApply: (params: SavedFilterParams) => void
+  /** Whether the current filter set has anything worth saving. */
+  canSave: boolean
+}
+
+/** Stable equality on a param map, order-independent. */
+function sameParams(a: SavedFilterParams, b: SavedFilterParams): boolean {
+  const ak = Object.keys(a)
+  const bk = Object.keys(b)
+  if (ak.length !== bk.length) return false
+  return ak.every((k) => a[k] === b[k])
+}
+
+export function SavedViewsBar({ current, onApply, canSave }: SavedViewsBarProps) {
+  const { data: views } = useSavedFilters()
+  const createView = useCreateSavedFilter()
+  const deleteView = useDeleteSavedFilter()
+
+  const [naming, setNaming] = useState(false)
+  const [name, setName] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const hasViews = (views?.length ?? 0) > 0
+  // Nothing to show: no saved views and nothing to save from. Keep the row
+  // out of the layout entirely so a fresh account isn't cluttered.
+  if (!hasViews && !canSave) return null
+
+  async function save() {
+    const trimmed = name.trim()
+    if (!trimmed) {
+      setError('Enter a name')
+      return
+    }
+    try {
+      await createView.mutateAsync({ name: trimmed, filters: current })
+      setName('')
+      setNaming(false)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save')
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-1.5 px-[22px] py-[7px] border-b border-border shrink-0 flex-wrap">
+      <span className="font-mono text-[10px] uppercase tracking-[0.06em] text-text-faint inline-flex items-center gap-1 shrink-0">
+        <Bookmark className="w-3 h-3" /> Views
+      </span>
+
+      {views?.map((v) => {
+        const active = sameParams(v.filters, current)
+        return (
+          <span
+            key={v.id}
+            className={cn(
+              'group inline-flex items-center gap-1 rounded-[5px] border font-mono text-[10.5px] transition-colors',
+              active
+                ? 'border-accent-border bg-accent-bg text-accent'
+                : 'border-border bg-bg-elev text-text-muted hover:border-border-strong',
+            )}
+          >
+            <button
+              type="button"
+              onClick={() => onApply(v.filters)}
+              className="pl-[9px] py-[5px] pr-1"
+              title={`Apply "${v.name}"`}
+            >
+              {v.name}
+            </button>
+            <button
+              type="button"
+              onClick={() => deleteView.mutate(v.id)}
+              aria-label={`Delete view ${v.name}`}
+              className="pr-[7px] py-[5px] text-text-faint hover:text-bad transition-colors"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </span>
+        )
+      })}
+
+      {naming ? (
+        <span className="inline-flex items-center gap-1">
+          <input
+            autoFocus
+            type="text"
+            value={name}
+            maxLength={80}
+            placeholder="View name…"
+            onChange={(e) => {
+              setName(e.target.value)
+              if (error) setError(null)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void save()
+              if (e.key === 'Escape') {
+                setNaming(false)
+                setName('')
+                setError(null)
+              }
+            }}
+            className="font-mono text-[11px] border border-border-strong rounded-[5px] px-2 py-[5px] bg-bg text-text w-40 outline-none placeholder:text-text-faint"
+          />
+          <button
+            type="button"
+            onClick={() => void save()}
+            disabled={createView.isPending}
+            aria-label="Save view"
+            className="font-mono text-[10.5px] px-[8px] py-[5px] border border-border rounded-[5px] text-accent hover:border-border-strong disabled:opacity-40 transition-colors inline-flex items-center gap-1"
+          >
+            <Check className="w-3 h-3" /> Save
+          </button>
+          {error && <span className="font-mono text-[10.5px] text-bad">{error}</span>}
+        </span>
+      ) : (
+        canSave && (
+          <button
+            type="button"
+            onClick={() => setNaming(true)}
+            className="font-mono text-[10.5px] px-[9px] py-[5px] border border-dashed border-border rounded-[5px] text-text-faint hover:text-text hover:border-border-strong transition-colors inline-flex items-center gap-1 shrink-0"
+          >
+            <Plus className="w-3 h-3" /> Save view
+          </button>
+        )
+      )}
+    </div>
+  )
+}

--- a/apps/web/components/dashboard/upsell-modal.tsx
+++ b/apps/web/components/dashboard/upsell-modal.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { TrendingUp, Check } from 'lucide-react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { useQuota } from '@/lib/queries/use-billing'
+import { PLANS, PLAN_REQUEST_LIMITS, formatPlanLabel } from '@/lib/billing-plans'
+import type { BillingPlan } from '@/lib/queries/types'
+
+/**
+ * Quota upsell modal. When an org crosses 80% of its monthly request quota
+ * it gets a single, dismissible prompt to upgrade — with the next plan
+ * pre-selected so the billing page opens straight on the right card.
+ *
+ * This complements the always-visible {@link QuotaBanner}: the banner is
+ * passive context, the modal is the one-time nudge at the moment it matters.
+ *
+ * Show discipline:
+ *   - Only fires ≥ 80% usage, and only when there's a higher plan to sell.
+ *   - Once per browser session (so it doesn't reopen on every navigation).
+ *   - Dismissing snoozes it for the rest of the calendar month.
+ *
+ * The open decision runs in an effect (client-only) so reading storage /
+ * the current date never diverges between SSR and hydration (gotcha #22).
+ */
+
+/** Next plan up from the current one, or null if already at the top. */
+const NEXT_PLAN: Partial<Record<BillingPlan, Exclude<BillingPlan, 'free' | 'enterprise'>>> = {
+  free: 'starter',
+  starter: 'team',
+}
+
+function monthKey(plan: string): string {
+  const now = new Date() // client-only (called from effect / handler)
+  return `spanlens:upsell_dismissed:${plan}:${now.getUTCFullYear()}-${now.getUTCMonth()}`
+}
+
+export function UpsellModal() {
+  const { data: quota } = useQuota()
+  const [open, setOpen] = useState(false)
+
+  const targetId = quota ? NEXT_PLAN[quota.plan] : undefined
+
+  useEffect(() => {
+    if (!quota || quota.limit === null || !targetId) return
+    const pct = quota.limit > 0 ? quota.usedThisMonth / quota.limit : 0
+    if (pct < 0.8) return
+    try {
+      if (localStorage.getItem(monthKey(quota.plan)) === '1') return
+      if (sessionStorage.getItem('spanlens:upsell_shown') === '1') return
+      sessionStorage.setItem('spanlens:upsell_shown', '1')
+    } catch {
+      // storage blocked (private mode) — showing once is acceptable
+    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- gated on async quota arrival + storage read, no derived-state path
+    setOpen(true)
+  }, [quota, targetId])
+
+  if (!quota || quota.limit === null || !targetId) return null
+
+  const target = PLANS.find((p) => p.id === targetId)
+  if (!target) return null
+
+  const pct = quota.limit > 0 ? quota.usedThisMonth / quota.limit : 0
+  const overLimit = pct >= 1
+  const targetLimit = PLAN_REQUEST_LIMITS[targetId] ?? 0
+
+  function dismiss() {
+    try {
+      localStorage.setItem(monthKey(quota!.plan), '1')
+    } catch {
+      /* ignore */
+    }
+    setOpen(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) dismiss() }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <TrendingUp className="w-4 h-4 text-accent" />
+            {overLimit
+              ? `You've hit your ${formatPlanLabel(quota.plan)} limit`
+              : `You're approaching your ${formatPlanLabel(quota.plan)} limit`}
+          </DialogTitle>
+        </DialogHeader>
+
+        <p className="text-sm text-muted-foreground">
+          {quota.usedThisMonth.toLocaleString()} of {quota.limit.toLocaleString()} requests used
+          this month. Upgrade to{' '}
+          <span className="font-medium text-foreground">{target.name}</span> for{' '}
+          {targetLimit.toLocaleString()} requests / month and keep shipping without interruption.
+        </p>
+
+        <div className="rounded-lg border border-border p-4">
+          <div className="flex items-baseline justify-between mb-3">
+            <span className="text-sm font-semibold">{target.name}</span>
+            {target.priceUsd !== null && (
+              <span className="text-sm text-muted-foreground">
+                <span className="text-foreground font-semibold">${target.priceUsd}</span> /{' '}
+                {target.pricePeriod.replace('per ', '')}
+              </span>
+            )}
+          </div>
+          <ul className="space-y-1.5">
+            {target.features.slice(0, 4).map((f) => (
+              <li key={f} className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Check className="w-3.5 h-3.5 text-good shrink-0" />
+                {f}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={dismiss}
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors px-3 py-2"
+          >
+            Maybe later
+          </button>
+          <Link
+            href={`/billing?plan=${targetId}`}
+            onClick={() => setOpen(false)}
+            className="text-sm font-medium bg-accent text-accent-fg hover:opacity-90 transition-opacity rounded-md px-4 py-2 inline-flex items-center gap-1.5"
+          >
+            Upgrade to {target.name}
+            <span aria-hidden>→</span>
+          </Link>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/components/dashboard/welcome-banner.tsx
+++ b/apps/web/components/dashboard/welcome-banner.tsx
@@ -2,19 +2,22 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
-import { Copy, Check, X, Terminal } from 'lucide-react'
+import { Copy, Check, X, Terminal, CheckCircle2, Loader2, RefreshCw } from 'lucide-react'
 import { createClient } from '@/lib/supabase/client'
 import { consumeWelcomeStash, clearWelcomeStash } from '@/lib/welcome-stash'
+import { useProviderKeys } from '@/lib/queries/use-provider-keys'
+import { useRequests } from '@/lib/queries/use-requests'
 
 /**
  * One-time welcome banner shown right after signup. Pulls the freshly
  * created Spanlens key from sessionStorage (stashed by the onboarding
- * flow) and walks the user through the three things they need to do to
- * make their first call:
+ * flow) and walks the user through the four things they need to do to
+ * confirm their first logged call:
  *
  *   1. Save SPANLENS_API_KEY into .env.local
  *   2. Add a provider key (OpenAI / Anthropic / Gemini) at /projects
  *   3. Paste the SDK helper snippet into their code
+ *   4. Verify it worked — fire a test call and watch the first request land
  *
  * Lifecycle contract — see lib/welcome-stash.ts for the full rationale:
  *
@@ -25,6 +28,10 @@ import { consumeWelcomeStash, clearWelcomeStash } from '@/lib/welcome-stash'
  *     is silently discarded (cross-account leak protection on shared tabs).
  *   - Dismiss is now purely a UI affordance — the storage entry is
  *     already gone by the time the X button is clickable.
+ *
+ * The data-fetching (provider-key + first-request polling) lives in the
+ * inner component so those queries only mount while the banner is actually
+ * shown — existing users who never see the banner pay nothing.
  */
 
 const SNIPPET_OPENAI = `import { createOpenAI } from '@spanlens/sdk/openai'
@@ -33,14 +40,20 @@ const openai = createOpenAI()
 // Use it like a normal OpenAI SDK client:
 // await openai.chat.completions.create({ ... })`
 
+/** Copy-paste test call through the Spanlens proxy, pre-filled with the key. */
+function buildTestCurl(apiKey: string): string {
+  return `curl https://server.spanlens.io/proxy/openai/v1/chat/completions \\
+  -H "Authorization: Bearer ${apiKey}" \\
+  -H "Content-Type: application/json" \\
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hello from Spanlens"}]}'`
+}
+
 export function WelcomeBanner() {
   // Start null so the first client render matches the server (sessionStorage
   // is browser-only; the server always renders nothing here). Reading it
   // during render / via lazy useState init would diverge from SSR and trigger
   // a hydration mismatch — see gotcha #22. We resolve it after mount.
   const [apiKey, setApiKey] = useState<string | null>(null)
-  const [copiedKey, setCopiedKey] = useState(false)
-  const [copiedSnippet, setCopiedSnippet] = useState(false)
 
   useEffect(() => {
     // Resolve the current user, then consume the stash IF it was written
@@ -53,9 +66,6 @@ export function WelcomeBanner() {
         const { data, error } = await supabase.auth.getUser()
         if (cancelled) return
         if (error || !data.user) {
-          // No session — clear any stale stash defensively. A logged-out
-          // user landing on /dashboard would have been redirected by
-          // middleware anyway, but this keeps the storage tidy.
           clearWelcomeStash()
           return
         }
@@ -72,32 +82,43 @@ export function WelcomeBanner() {
 
   if (!apiKey) return null
 
-  async function copyKey() {
+  return (
+    <WelcomeBannerInner
+      apiKey={apiKey}
+      onDismiss={() => {
+        // Storage was already consumed on mount; this only drops the
+        // in-memory copy so the banner unmounts. Defensive clear in case a
+        // future change re-introduces a stashed entry mid-session.
+        clearWelcomeStash()
+        setApiKey(null)
+      }}
+    />
+  )
+}
+
+function WelcomeBannerInner({ apiKey, onDismiss }: { apiKey: string; onDismiss: () => void }) {
+  const [copiedKey, setCopiedKey] = useState(false)
+  const [copiedSnippet, setCopiedSnippet] = useState(false)
+  const [copiedCurl, setCopiedCurl] = useState(false)
+
+  // Step 2 status — flips to a checkmark once any provider key exists.
+  const providerKeys = useProviderKeys()
+  const hasProviderKey = (providerKeys.data?.length ?? 0) > 0
+
+  // Step 4 status — poll the request log (limit 1, we only need the count).
+  // useRequests already refetches every ~30s and on window focus, so the
+  // banner updates itself as soon as the first call lands.
+  const firstRequest = useRequests({ page: 1, limit: 1 })
+  const requestReceived = (firstRequest.data?.meta.total ?? 0) > 0
+
+  async function copy(text: string, mark: (v: boolean) => void) {
     try {
-      await navigator.clipboard.writeText(apiKey!)
-      setCopiedKey(true)
-      setTimeout(() => setCopiedKey(false), 1500)
+      await navigator.clipboard.writeText(text)
+      mark(true)
+      setTimeout(() => mark(false), 1500)
     } catch {
       /* ignore */
     }
-  }
-
-  async function copySnippet() {
-    try {
-      await navigator.clipboard.writeText(SNIPPET_OPENAI)
-      setCopiedSnippet(true)
-      setTimeout(() => setCopiedSnippet(false), 1500)
-    } catch {
-      /* ignore */
-    }
-  }
-
-  function dismiss() {
-    // Storage was already consumed on mount; this only drops the in-memory
-    // copy so the banner unmounts. Defensive clear in case a future change
-    // re-introduces a stashed entry mid-session.
-    clearWelcomeStash()
-    setApiKey(null)
   }
 
   return (
@@ -109,12 +130,12 @@ export function WelcomeBanner() {
               Welcome to Spanlens
             </div>
             <div className="text-[14.5px] font-medium text-text">
-              Your API key is ready. Three quick steps to your first logged request.
+              Your API key is ready. Four quick steps to your first logged request.
             </div>
           </div>
           <button
             type="button"
-            onClick={dismiss}
+            onClick={onDismiss}
             className="text-text-faint hover:text-text-muted transition-colors shrink-0 mt-0.5"
             aria-label="Dismiss welcome banner"
           >
@@ -135,7 +156,7 @@ export function WelcomeBanner() {
             <code className="flex-1 font-mono text-[12px] text-text truncate">{apiKey}</code>
             <button
               type="button"
-              onClick={() => void copyKey()}
+              onClick={() => void copy(apiKey, setCopiedKey)}
               className="font-mono text-[11px] text-text-muted hover:text-text px-2 py-[3px] rounded border border-border-strong transition-colors flex items-center gap-1.5 shrink-0"
             >
               {copiedKey ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
@@ -151,28 +172,39 @@ export function WelcomeBanner() {
           </p>
         </div>
 
-        {/* Step 2, register a provider key */}
+        {/* Step 2, register a provider key — checkmark once one exists */}
         <div className="mb-4">
-          <div className="text-[12px] font-medium text-text mb-2">
-            <span className="font-mono text-[10px] text-accent mr-1.5">2.</span>
+          <div className="text-[12px] font-medium text-text mb-2 flex items-center gap-1.5">
+            <span className="font-mono text-[10px] text-accent">2.</span>
             Register an AI provider key (OpenAI / Anthropic / Gemini)
+            {hasProviderKey && (
+              <span className="inline-flex items-center gap-1 text-good font-mono text-[10.5px]">
+                <CheckCircle2 className="w-3.5 h-3.5" /> Done
+              </span>
+            )}
           </div>
-          <p className="text-[11.5px] text-text-muted leading-relaxed">
-            Open{' '}
-            <Link
-              href="/projects"
-              className="text-accent hover:opacity-80 transition-opacity underline underline-offset-2"
-            >
-              /projects
-            </Link>
-            , find your Spanlens key, click <em>+ Add provider key</em>, and paste your AI
-            provider&apos;s API key. Spanlens stores it encrypted and uses it on your
-            behalf, your app never sees it again.
-          </p>
+          {hasProviderKey ? (
+            <p className="text-[11.5px] text-text-muted leading-relaxed">
+              Provider key registered. Spanlens stores it encrypted and uses it on your behalf.
+            </p>
+          ) : (
+            <p className="text-[11.5px] text-text-muted leading-relaxed">
+              Open{' '}
+              <Link
+                href="/projects"
+                className="text-accent hover:opacity-80 transition-opacity underline underline-offset-2"
+              >
+                /projects
+              </Link>
+              , find your Spanlens key, click <em>+ Add provider key</em>, and paste your AI
+              provider&apos;s API key. Spanlens stores it encrypted and uses it on your
+              behalf, your app never sees it again.
+            </p>
+          )}
         </div>
 
         {/* Step 3, paste the snippet */}
-        <div>
+        <div className="mb-4">
           <div className="text-[12px] font-medium text-text mb-2">
             <span className="font-mono text-[10px] text-accent mr-1.5">3.</span>
             Drop this into your code
@@ -184,7 +216,7 @@ export function WelcomeBanner() {
               </span>
               <button
                 type="button"
-                onClick={() => void copySnippet()}
+                onClick={() => void copy(SNIPPET_OPENAI, setCopiedSnippet)}
                 className="font-mono text-[11px] text-accent hover:opacity-80 transition-opacity flex items-center gap-1"
               >
                 {copiedSnippet ? (
@@ -212,6 +244,78 @@ export function WelcomeBanner() {
             </Link>{' '}
             for the matching snippet.
           </p>
+        </div>
+
+        {/* Step 4, verify it worked — live first-request detection */}
+        <div>
+          <div className="text-[12px] font-medium text-text mb-2 flex items-center gap-1.5">
+            <span className="font-mono text-[10px] text-accent">4.</span>
+            Verify it worked
+            {requestReceived && (
+              <span className="inline-flex items-center gap-1 text-good font-mono text-[10.5px]">
+                <CheckCircle2 className="w-3.5 h-3.5" /> Received
+              </span>
+            )}
+          </div>
+
+          {requestReceived ? (
+            <p className="text-[11.5px] text-text-muted leading-relaxed">
+              First request received, you&apos;re all set.{' '}
+              <Link
+                href="/requests"
+                className="text-accent hover:opacity-80 transition-opacity underline underline-offset-2"
+              >
+                View it in the request log →
+              </Link>
+            </p>
+          ) : (
+            <>
+              <p className="text-[11.5px] text-text-muted mb-2 leading-relaxed">
+                No code yet? Fire a one-off test call from your terminal (needs a provider key
+                from step 2):
+              </p>
+              <div className="rounded-md border border-border bg-[#1a1816] px-3 py-2.5">
+                <div className="flex items-center justify-between mb-1.5">
+                  <span className="font-mono text-[10px] uppercase tracking-[0.05em] text-[#7c7770] flex items-center gap-1.5">
+                    <Terminal className="w-3 h-3" /> Test call · curl
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => void copy(buildTestCurl(apiKey), setCopiedCurl)}
+                    className="font-mono text-[11px] text-accent hover:opacity-80 transition-opacity flex items-center gap-1"
+                  >
+                    {copiedCurl ? (
+                      <>
+                        <Check className="w-3 h-3" /> Copied!
+                      </>
+                    ) : (
+                      <>
+                        <Copy className="w-3 h-3" /> Copy
+                      </>
+                    )}
+                  </button>
+                </div>
+                <pre className="font-mono text-[11px] text-good leading-relaxed whitespace-pre-wrap break-words">
+                  {buildTestCurl(apiKey)}
+                </pre>
+              </div>
+              <div className="flex items-center gap-2 mt-2">
+                <span className="inline-flex items-center gap-1.5 font-mono text-[11px] text-text-faint">
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                  Waiting for your first request…
+                </span>
+                <button
+                  type="button"
+                  onClick={() => void firstRequest.refetch()}
+                  disabled={firstRequest.isFetching}
+                  className="font-mono text-[10.5px] px-[8px] py-[3px] border border-border rounded-[5px] text-text-muted hover:text-text hover:border-border-strong disabled:opacity-40 transition-colors inline-flex items-center gap-1"
+                >
+                  <RefreshCw className={firstRequest.isFetching ? 'w-3 h-3 animate-spin' : 'w-3 h-3'} />
+                  Check now
+                </button>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/lib/queries/use-requests.ts
+++ b/apps/web/lib/queries/use-requests.ts
@@ -137,10 +137,19 @@ export function useRunReplay() {
 
 // ── Saved filters ───────────────────────────────────────────────────────
 
+/**
+ * A saved filter stores the requests-page URL query params verbatim
+ * (provider, status, model, timeRange, sortBy, …) as a plain string map, so
+ * applying one is just "replace the URL with these params". This is a
+ * superset of {@link RequestsFilters} — it also carries UI-only params like
+ * `timeRange` that the page maps to `from` at query time.
+ */
+export type SavedFilterParams = Record<string, string>
+
 export interface SavedFilter {
   id: string
   name: string
-  filters: Partial<RequestsFilters>
+  filters: SavedFilterParams
   created_at: string
 }
 
@@ -160,7 +169,7 @@ export function useSavedFilters() {
 export function useCreateSavedFilter() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: async (input: { name: string; filters: Partial<RequestsFilters> }) => {
+    mutationFn: async (input: { name: string; filters: SavedFilterParams }) => {
       const res = await apiPost<ApiEnvelope<SavedFilter>>('/api/v1/saved-filters', input)
       return res.data
     },

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @spanlens/sdk changelog
 
+## 0.14.0
+
+Dedicated Ollama subpath — a one-line client factory for local models.
+
+### Added
+
+- `@spanlens/sdk/ollama` subpath exporting `createOllama(options?)`, which returns an OpenAI-compatible client already pointed at the local Ollama endpoint (`http://localhost:11434/v1`), and re-exports `observeOllama` so a single import gives you both the client and the tracer. `DEFAULT_OLLAMA_BASE_URL` is exported for self-hosted overrides.
+
+### Fixed
+
+- The README Ollama example used the wrong `observeOllama` signature (missing the trace argument and the `headers` callback), so copy-pasting it did not compile or trace. It now shows the correct `observeOllama(trace, name, (headers) => ...)` usage built on `createOllama()`.
+
 ## 0.13.0
 
 Judge result caching (P3-18) — re-evaluations of the same sample with the same evaluator return $0.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",
@@ -22,6 +22,10 @@
     "./gemini": {
       "import": "./dist/integrations/gemini.js",
       "types": "./dist/integrations/gemini.d.ts"
+    },
+    "./ollama": {
+      "import": "./dist/integrations/ollama.js",
+      "types": "./dist/integrations/ollama.d.ts"
     },
     "./langchain": {
       "import": "./dist/integrations/langchain.js",

--- a/packages/sdk/src/__tests__/ollama.test.ts
+++ b/packages/sdk/src/__tests__/ollama.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { createOllama, DEFAULT_OLLAMA_BASE_URL, observeOllama } from '../integrations/ollama.js'
+
+describe('createOllama', () => {
+  it('defaults to the local Ollama endpoint', () => {
+    const client = createOllama()
+    expect(client.baseURL).toBe(DEFAULT_OLLAMA_BASE_URL)
+  })
+
+  it('uses a throwaway apiKey by default (Ollama ignores it)', () => {
+    const client = createOllama()
+    expect(client.apiKey).toBe('ollama')
+  })
+
+  it('does not require SPANLENS_API_KEY (Ollama is local, no proxy)', () => {
+    const original = process.env.SPANLENS_API_KEY
+    delete process.env.SPANLENS_API_KEY
+    try {
+      expect(() => createOllama()).not.toThrow()
+    } finally {
+      if (original !== undefined) process.env.SPANLENS_API_KEY = original
+    }
+  })
+
+  it('accepts a baseURL override for a remote Ollama host', () => {
+    const client = createOllama({ baseURL: 'http://gpu-box.local:11434/v1' })
+    expect(client.baseURL).toBe('http://gpu-box.local:11434/v1')
+  })
+
+  it('accepts an apiKey override', () => {
+    const client = createOllama({ apiKey: 'custom' })
+    expect(client.apiKey).toBe('custom')
+  })
+
+  it('re-exports observeOllama for single-import ergonomics', () => {
+    expect(typeof observeOllama).toBe('function')
+  })
+})

--- a/packages/sdk/src/integrations/ollama.ts
+++ b/packages/sdk/src/integrations/ollama.ts
@@ -1,0 +1,72 @@
+/**
+ * Ollama client helper — a pre-configured OpenAI-compatible client pointed
+ * at a **local** Ollama server, plus the `observeOllama` tracer.
+ *
+ * Ollama runs on your own machine (`http://localhost:11434`), so unlike the
+ * hosted providers it does NOT go through the Spanlens proxy — the proxy
+ * can't reach your localhost. Observability instead comes from the SDK's
+ * client-side tracing: wrap each call with `observeOllama()` so the span is
+ * ingested and tagged `provider: 'ollama'` in the dashboard.
+ *
+ * Replaces:
+ *   import OpenAI from 'openai'
+ *   const ollama = new OpenAI({
+ *     baseURL: 'http://localhost:11434/v1',
+ *     apiKey: 'ollama',
+ *   })
+ *
+ * With:
+ *   import { createOllama } from '@spanlens/sdk/ollama'
+ *   const ollama = createOllama()
+ *
+ * `openai` is a peer dependency — install it alongside this SDK.
+ *
+ * @example  Full traced call.
+ *   import { SpanlensClient } from '@spanlens/sdk'
+ *   import { createOllama, observeOllama } from '@spanlens/sdk/ollama'
+ *
+ *   const spanlens = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+ *   const ollama = createOllama()
+ *
+ *   const trace = spanlens.startTrace({ name: 'chat' })
+ *   const res = await observeOllama(trace, 'chat', (headers) =>
+ *     ollama.chat.completions.create(
+ *       { model: 'llama3.1', messages: [{ role: 'user', content: 'Hello' }] },
+ *       { headers },
+ *     ),
+ *   )
+ *   await trace.end({ status: 'completed' })
+ */
+
+import OpenAI from 'openai'
+import type { ClientOptions } from 'openai'
+
+/** Default local Ollama OpenAI-compatible endpoint. Override for a remote host. */
+export const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434/v1'
+
+/**
+ * Build an OpenAI-compatible client pointed at a local Ollama server.
+ *
+ * No Spanlens API key is required here — Ollama is local and the client only
+ * talks to it directly. Tracing is added separately by wrapping calls with
+ * `observeOllama()` (which needs a `SpanlensClient` trace). See the module
+ * example above.
+ *
+ * @param options Forwards to `new OpenAI(options)`. `baseURL` defaults to the
+ *   local Ollama endpoint; `apiKey` defaults to the throwaway string
+ *   `'ollama'` (Ollama ignores it, but the OpenAI SDK requires a non-empty
+ *   value). Override `baseURL` to point at a remote Ollama host.
+ */
+export function createOllama(options: ClientOptions = {}): OpenAI {
+  return new OpenAI({
+    ...options,
+    // Ollama ignores the key; the OpenAI SDK just needs a non-empty string.
+    apiKey: options.apiKey ?? 'ollama',
+    baseURL: options.baseURL ?? DEFAULT_OLLAMA_BASE_URL,
+  })
+}
+
+// Re-export the tracer so a single `@spanlens/sdk/ollama` import gives users
+// both the client factory and the matching `observe` helper — mirrors how
+// `@spanlens/sdk/openai` co-locates `createOpenAI` with its header helpers.
+export { observeOllama } from '../observe.js'


### PR DESCRIPTION
## Summary

Four low-effort, high-leverage quick wins from the improvement audit, plus a small SDK fix. Most of these surface functionality the backend already had but the UI never exposed.

### Activation
- **Verify-it-worked** — the post-signup welcome banner gets a 4th step: a pre-filled test-call `curl` (real key) and live first-request detection that polls the request log and flips to a success state. The `/requests` empty state gets the same copy-paste test call.
- **Provider-key status** — welcome banner step 2 now checks `provider_keys` and shows a `✓ Done` marker once a key is registered. Data-fetching moved into an inner component so those queries only mount while the banner is shown (existing users pay nothing).

### Dashboard
- **Saved views** — wires the pre-existing `/api/v1/saved-filters` API (previously zero UI) into a new `SavedViewsBar` on the requests page: name the current filter combo, one-click apply, delete. Saved filters now store URL params.

### Billing
- **Upsell modal** — at ≥80% quota a dismissible modal recommends the next plan with pricing and deep-links to `/billing?plan=…`, which highlights the recommended card. Shown once per session, snoozes per calendar month.

### SDK
- **`createOllama()`** — new `@spanlens/sdk/ollama` subpath returning an OpenAI-compatible client pre-pointed at local Ollama, re-exporting `observeOllama`. Also fixes the README Ollama example, which used the wrong `observeOllama` signature (missing the trace arg + headers callback) and did not compile. Bumped to `0.14.0`.

## Test plan

- [x] `pnpm --filter @spanlens/sdk typecheck && test` (137 pass) `&& build`
- [x] `pnpm --filter web typecheck && lint && build && test` (57 pass)
- [x] In-browser (local stack: Supabase + ClickHouse, signup → onboarding → dashboard):
  - [x] Welcome banner: 4-step layout, test-call curl, live "waiting" state, step-2 `✓ Done` after adding a provider key
  - [x] Requests empty state: test-call hint renders
  - [x] Saved views: create → persists across reload → apply restores `?status=4xx&provider=openai`
  - [x] Upsell modal: fires at 92% quota, "Upgrade to Pro" → `/billing?plan=starter` → Pro card shows "Recommended"
  - [x] No console errors throughout

Ollama SDK is not browser-observable; covered by unit tests + build. The upsell modal's ≥80% trigger was exercised with a stubbed quota response (real 40k+ usage is infeasible locally); the component and billing highlight themselves are real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
