### PR TITLE
docs: quick wins 7-11 (SDK error/sampling/parity docs, troubleshooting + backup pages, pricing copy)

### DIFF
--- a/apps/web/app/docs/_components/sidebar.tsx
+++ b/apps/web/app/docs/_components/sidebar.tsx
@@ -128,12 +128,14 @@ const NAV: NavGroup[] = [
       { title: 'Direct proxy (any language)', href: '/docs/proxy' },
       { title: 'REST API reference', href: '/docs/api' },
       { title: 'Error codes', href: '/docs/api/errors' },
+      { title: 'Troubleshooting', href: '/docs/troubleshooting' },
     ],
   },
   {
     title: 'Self-hosting',
     items: [
       { title: 'Docker', href: '/docs/self-host' },
+      { title: 'Backup & restore', href: '/docs/self-host/backup' },
     ],
   },
 ]

--- a/apps/web/app/docs/self-host/backup/page.tsx
+++ b/apps/web/app/docs/self-host/backup/page.tsx
@@ -1,0 +1,303 @@
+export const metadata = {
+  alternates: { canonical: '/docs/self-host/backup' },
+  title: 'Backup & restore · Spanlens Docs',
+  description:
+    'Backup and restore runbook for self-hosted Spanlens: pg_dump the Supabase Postgres, dump the ClickHouse requests log, snapshot the Docker volumes, and back up ENCRYPTION_KEY separately.',
+}
+
+export default function SelfHostBackupPage() {
+  return (
+    <div>
+      <h1>Backup &amp; restore</h1>
+      <p className="lead">
+        A self-hosted Spanlens deployment keeps its data in two places. This page is the
+        operator runbook for backing both of them up, restoring from those backups, and the
+        one secret that lives outside every database and must be backed up on its own.
+      </p>
+
+      <h2>Two datastores, two backup strategies</h2>
+      <p>
+        Spanlens splits its data across two stores on purpose (see{' '}
+        <a href="/docs/self-host">Self-hosting</a> and{' '}
+        <a href="/docs/concepts/data-model">Data model</a>). Both must be backed up.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Store</th>
+            <th>What lives there</th>
+            <th>If you lose it</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <strong>Supabase Postgres</strong>
+            </td>
+            <td>
+              Organizations, projects, API keys, encrypted provider keys, traces, spans,
+              prompts, evals, subscriptions/billing. The transactional source of truth.
+            </td>
+            <td>Catastrophic. Accounts, keys, and configuration are gone.</td>
+          </tr>
+          <tr>
+            <td>
+              <strong>ClickHouse</strong>
+            </td>
+            <td>
+              The <code>requests</code> log only (every proxied LLM call: tokens, cost,
+              latency, bodies). Append-only observability telemetry.
+            </td>
+            <td>
+              Recoverable in spirit. You lose historical dashboards and analytics, not
+              accounts or keys.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Note the split in the bundled <code>docker-compose.yml</code>: it runs three services,{' '}
+        <code>web</code>, <code>server</code>, and <code>clickhouse</code>.{' '}
+        <strong>There is no Postgres container.</strong> Postgres is your Supabase project,
+        managed separately, so its backup runs against the Supabase connection string rather
+        than a local container.
+      </p>
+
+      <h2 id="postgres">Postgres (Supabase)</h2>
+      <p>
+        Managed Supabase projects have their own automated backups (Project Settings &rarr;
+        Database &rarr; Backups). Take your own logical dumps on top of that so you hold a copy
+        outside the provider and can restore into any Postgres 17 target.
+      </p>
+
+      <h3>Back up with pg_dump</h3>
+      <p>
+        Grab the connection string from <strong>Project Settings &rarr; Database</strong> (use
+        the direct connection, port <code>5432</code>). The custom format (<code>-Fc</code>)
+        restores selectively and compresses well.
+      </p>
+      <pre>{`# Full logical dump, custom format
+pg_dump \\
+  "postgresql://postgres:<password>@db.<ref>.supabase.co:5432/postgres" \\
+  --format=custom --no-owner --no-privileges \\
+  --file=spanlens-pg-$(date +%F).dump
+
+# Plain SQL alternative (human-readable, larger)
+pg_dump "postgresql://postgres:<password>@db.<ref>.supabase.co:5432/postgres" \\
+  --no-owner --no-privileges \\
+  > spanlens-pg-$(date +%F).sql`}</pre>
+      <p className="text-sm text-muted-foreground">
+        <code>--no-owner --no-privileges</code> keeps the dump portable across projects (the
+        Supabase-managed roles differ per project). If you self-host Postgres elsewhere, dump
+        with <code>docker exec &lt;your-postgres-container&gt; pg_dump ...</code> instead. The
+        bundled compose file does not ship a Postgres container.
+      </p>
+
+      <h3 id="restore-postgres">Restore Postgres</h3>
+      <p>
+        Restore a custom-format dump with <code>pg_restore</code>; restore a plain SQL dump
+        with <code>psql</code>. Point at a fresh Supabase project (or any empty Postgres 17
+        database).
+      </p>
+      <pre>{`# Restore a custom-format (.dump) backup
+pg_restore \\
+  --dbname="postgresql://postgres:<password>@db.<new-ref>.supabase.co:5432/postgres" \\
+  --no-owner --no-privileges --clean --if-exists \\
+  spanlens-pg-2026-07-01.dump
+
+# Restore a plain SQL (.sql) backup
+psql "postgresql://postgres:<password>@db.<new-ref>.supabase.co:5432/postgres" \\
+  -f spanlens-pg-2026-07-01.sql`}</pre>
+      <p>
+        After restoring into a brand-new project, re-run{' '}
+        <a
+          href="https://raw.githubusercontent.com/spanlens/Spanlens/main/supabase/init.sql"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          supabase/init.sql
+        </a>{' '}
+        first if the schema is not already present (all statements are{' '}
+        <code>CREATE IF NOT EXISTS</code> / <code>ALTER IF NOT EXISTS</code>, so re-running is
+        safe), then restore the data dump on top.
+      </p>
+
+      <h3 id="encryption-key">The ENCRYPTION_KEY is not in the dump you can rely on</h3>
+      <p>
+        Provider keys (your real OpenAI / Anthropic / Gemini keys) are stored encrypted with
+        AES-256-GCM under <code>ENCRYPTION_KEY</code>. The encrypted ciphertext travels inside
+        the Postgres dump, but it is <strong>useless without the exact same{' '}
+        <code>ENCRYPTION_KEY</code></strong> that encrypted it. Restore the database with a
+        different key and every provider key silently decrypts to garbage (an empty string),
+        surfacing later as &ldquo;wrong API key&rdquo; errors from the upstream provider.
+      </p>
+      <ul>
+        <li>
+          Back up <code>ENCRYPTION_KEY</code> <strong>separately and securely</strong> in a
+          secret manager (AWS Secrets Manager, GCP Secret Manager, HashiCorp Vault), never
+          alongside the database dump.
+        </li>
+        <li>
+          A restore is only complete when the restored database is paired with the matching
+          <code>ENCRYPTION_KEY</code>. Treat them as one unit.
+        </li>
+        <li>
+          Lose the key and the encrypted provider keys are unrecoverable; users must re-enter
+          them. Everything else in the dump (orgs, projects, traces) restores fine.
+        </li>
+      </ul>
+
+      <h2 id="clickhouse">ClickHouse (request logs)</h2>
+      <p>
+        In the bundled stack the ClickHouse service is named <code>clickhouse</code>, listens
+        on <code>8123</code> (HTTP) and <code>9000</code> (native), and defaults to user{' '}
+        <code>spanlens</code> / database <code>spanlens</code>. All backup commands below run
+        against that service. On ClickHouse Cloud, use the automatic backups it provides and
+        swap the host/credentials for your managed endpoint.
+      </p>
+
+      <h3>Native BACKUP (recommended)</h3>
+      <p>
+        ClickHouse&apos;s built-in <code>BACKUP</code> statement writes a consistent snapshot
+        of the <code>requests</code> table (and its schema). Run it through{' '}
+        <code>clickhouse-client</code> inside the container.
+      </p>
+      <pre>{`# Back up the requests table to a local directory backup
+docker compose exec clickhouse clickhouse-client \\
+  --user spanlens --password "$CLICKHOUSE_PASSWORD" --database spanlens \\
+  --query "BACKUP TABLE spanlens.requests TO Disk('backups', 'requests-$(date +%F).zip')"
+
+# Back up straight to S3-compatible storage
+docker compose exec clickhouse clickhouse-client \\
+  --user spanlens --password "$CLICKHOUSE_PASSWORD" --database spanlens \\
+  --query "BACKUP TABLE spanlens.requests TO S3('https://<bucket>.s3.amazonaws.com/spanlens/requests-$(date +%F)', '<access-key>', '<secret-key>')"`}</pre>
+      <p className="text-sm text-muted-foreground">
+        The <code>Disk(&apos;backups&apos;, ...)</code> target requires a{' '}
+        <code>backups</code> disk configured in the ClickHouse server config; the S3 target
+        works out of the box. For an operator-friendly wrapper with rotation and incremental
+        support, <code>clickhouse-backup</code> is a common third-party tool.
+      </p>
+
+      <h3>Portable dump with SELECT INTO OUTFILE</h3>
+      <p>
+        For a plain, portable dump with no disk/S3 config, stream the table out as compressed
+        native or CSV data.
+      </p>
+      <pre>{`# Native format, gzip-compressed (round-trips fastest)
+docker compose exec -T clickhouse clickhouse-client \\
+  --user spanlens --password "$CLICKHOUSE_PASSWORD" --database spanlens \\
+  --query "SELECT * FROM spanlens.requests FORMAT Native" \\
+  | gzip > requests-$(date +%F).native.gz`}</pre>
+
+      <h3 id="restore-clickhouse">Restore ClickHouse</h3>
+      <p>
+        Restore is the inverse of whichever backup you took. Point at a fresh{' '}
+        <code>clickhouse</code> container (or Cloud service) and re-create the schema first if
+        it is empty.
+      </p>
+      <pre>{`# From a native BACKUP
+docker compose exec clickhouse clickhouse-client \\
+  --user spanlens --password "$CLICKHOUSE_PASSWORD" --database spanlens \\
+  --query "RESTORE TABLE spanlens.requests FROM Disk('backups', 'requests-2026-07-01.zip')"
+
+# From a SELECT ... INTO OUTFILE native dump
+gunzip -c requests-2026-07-01.native.gz \\
+  | docker compose exec -T clickhouse clickhouse-client \\
+      --user spanlens --password "$CLICKHOUSE_PASSWORD" --database spanlens \\
+      --query "INSERT INTO spanlens.requests FORMAT Native"`}</pre>
+      <p>
+        <strong>Re-run the migrations after any ClickHouse restore.</strong> The migrations
+        are idempotent (every statement is <code>CREATE ... IF NOT EXISTS</code> /{' '}
+        <code>ALTER ... ADD COLUMN IF NOT EXISTS</code>), so this is safe whether the restored
+        data already has the latest schema or a slightly older one. It fills in any columns or
+        views added since the backup was taken.
+      </p>
+      <pre>{`# From a clone of the repo (loads apps/server/.env if present)
+pnpm ch:migrate
+
+# Or standalone, pointed at your ClickHouse
+CLICKHOUSE_URL=http://localhost:8123 \\
+CLICKHOUSE_USER=spanlens CLICKHOUSE_PASSWORD=<password> CLICKHOUSE_DB=spanlens \\
+  npx -y tsx clickhouse/apply.ts`}</pre>
+
+      <h2 id="volumes">Coarse alternative: snapshot the Docker volumes</h2>
+      <p>
+        If you want a blunt, filesystem-level backup of the whole ClickHouse container instead
+        of a logical dump, snapshot its named volumes directly. The bundled{' '}
+        <code>docker-compose.yml</code> declares exactly two named volumes,{' '}
+        <code>clickhouse_data</code> (the data directory,{' '}
+        <code>/var/lib/clickhouse</code>) and <code>clickhouse_logs</code> (server logs,{' '}
+        <code>/var/log/clickhouse-server</code>). Only <code>clickhouse_data</code> holds your
+        <code>requests</code> rows; <code>clickhouse_logs</code> is optional.
+      </p>
+      <p className="text-sm text-muted-foreground">
+        Compose prefixes volume names with the project name (usually the directory name), so
+        the real volume is often <code>&lt;project&gt;_clickhouse_data</code>. Run{' '}
+        <code>docker volume ls</code> to see the exact names.
+      </p>
+      <pre>{`# Stop the container first for a consistent, crash-safe snapshot
+docker compose stop clickhouse
+
+# Tar the data volume into the current directory
+docker run --rm \\
+  -v spanlens_clickhouse_data:/data:ro \\
+  -v "$PWD":/backup \\
+  busybox tar czf /backup/clickhouse_data-$(date +%F).tar.gz -C /data .
+
+# Restart
+docker compose start clickhouse`}</pre>
+      <p>Restore into a fresh, empty volume:</p>
+      <pre>{`docker run --rm \\
+  -v spanlens_clickhouse_data:/data \\
+  -v "$PWD":/backup \\
+  busybox sh -c "cd /data && tar xzf /backup/clickhouse_data-2026-07-01.tar.gz"
+
+docker compose up -d clickhouse
+pnpm ch:migrate   # top up the schema, idempotent`}</pre>
+      <p className="text-sm text-muted-foreground">
+        A volume snapshot is a full-container image, not a portable table dump: restore it into
+        the same ClickHouse major version (<code>clickhouse/clickhouse-server:24.10-alpine</code>{' '}
+        in the bundled compose file) to avoid on-disk format surprises. Prefer the logical{' '}
+        <code>BACKUP</code> / <code>SELECT</code> dumps above when you need portability.
+      </p>
+
+      <h2 id="schedule">Retention, scheduling, and restore drills</h2>
+      <ul>
+        <li>
+          <strong>Automate it.</strong> Wrap the Postgres and ClickHouse dumps in one script
+          and run it from cron (or a systemd timer). A daily dump with a{' '}
+          <code>$(date +%F)</code> filename gives you point-in-time recovery per day.
+        </li>
+        <li>
+          <strong>Rotate.</strong> Push dumps to off-box storage (S3, a backup host) and prune
+          old ones, for example keep 7 daily + 4 weekly. A simple{' '}
+          <code>find backups/ -name &apos;*.dump&apos; -mtime +7 -delete</code> caps local disk.
+        </li>
+        <li>
+          <strong>Match retention to value.</strong> Postgres holds the crown jewels, keep
+          those dumps long. ClickHouse is observability, so a shorter horizon is fine, and{' '}
+          <a href="/docs/features/billing">plan retention</a> already caps how far back the
+          server reads the <code>requests</code> log anyway.
+        </li>
+        <li>
+          <strong>Store the key with the backups&apos; provenance, not the backups.</strong>{' '}
+          Keep the current <code>ENCRYPTION_KEY</code> in your secret manager and document
+          which key each Postgres dump was taken under.
+        </li>
+        <li>
+          <strong>Run a restore drill.</strong> A backup you have never restored is a guess.
+          Periodically restore both stores into a throwaway stack, pair them with the matching{' '}
+          <code>ENCRYPTION_KEY</code>, run <code>pnpm ch:migrate</code>, and confirm the
+          dashboard loads and a stored provider key still decrypts by making one proxied call.
+        </li>
+      </ul>
+
+      <hr />
+      <p className="text-sm text-muted-foreground">
+        Related: <a href="/docs/self-host">Self-hosting</a> (stack layout and env vars),{' '}
+        <a href="/docs/features/settings">Keys &amp; encryption</a> (how provider keys are
+        encrypted), <a href="/docs/features/export">Data export</a> (per-workspace exports).
+      </p>
+    </div>
+  )
+}

--- a/apps/web/app/docs/troubleshooting/page.tsx
+++ b/apps/web/app/docs/troubleshooting/page.tsx
@@ -1,0 +1,394 @@
+export const metadata = {
+  alternates: { canonical: '/docs/troubleshooting' },
+  title: 'Troubleshooting · Spanlens Docs',
+  description:
+    'Symptom-first fixes for the most common Spanlens problems: 401/403 auth, 429 rate limits, 502/503/504 upstream errors, missing requests, empty traces, and truncated streaming responses.',
+}
+
+/**
+ * Symptom-oriented companion to /docs/api/errors.
+ *
+ * The error-codes page is organized by error.code (given a code, what does it
+ * mean). This page is organized by observable symptom (given what you see, what
+ * is the likely cause and fix) and links back to the matching code. Kept a
+ * zero-JS static server component like errors/page.tsx: no 'use client', no
+ * imports, plain prose + <pre> + <table>. The layout wraps this in .prose.
+ *
+ * Every claim here is grounded in the server behavior documented in CLAUDE.md
+ * 'Known Gotchas' and the proxy / quick-start docs. When server behavior
+ * changes, update the matching row here and in /docs/api/errors.
+ */
+
+interface SymptomRow {
+  status: string
+  cause: string
+  fix: string
+}
+
+const STATUS_ROWS: SymptomRow[] = [
+  {
+    status: '401 UNAUTHORIZED',
+    cause:
+      'Missing, malformed, or wrong auth header. The runtime has no SPANLENS_API_KEY, or the upstream client is still pointed at the provider with the provider key.',
+    fix: 'Send your Spanlens key (sl_live_…), not the provider key. OpenAI/Azure clients use Authorization: Bearer sl_live_…; Anthropic uses x-api-key: sl_live_…; Gemini uses x-goog-api-key: sl_live_…. Confirm SPANLENS_API_KEY is set in the runtime.',
+  },
+  {
+    status: '403 PUBLIC_KEY_WRITE_FORBIDDEN',
+    cause:
+      'A public-scope key (sl_live_pub_…) was used on a write endpoint. Public keys are read-only by design and are rejected on /proxy/*, /ingest/*, and OTLP /v1/traces.',
+    fix: 'Use a full-scope key (sl_live_… without the pub_ segment) for proxying and ingest. Keep public keys for MCP servers, BI tools, and read embeds only.',
+  },
+  {
+    status: '429 RATE_LIMIT',
+    cause:
+      'A rate limit fired. Two distinct kinds: (1) a limit you configured on a key/project/end-user, or (2) your Spanlens plan monthly request quota.',
+    fix: 'Read details.source. "customer_limit" is one you set, so back off using Retry-After, or raise it on the Projects page. A plan/quota 429 includes an upgrade link; upgrade or wait for the window to reset.',
+  },
+  {
+    status: '400 NO_PROVIDER_KEY',
+    cause:
+      'The Spanlens key has no active provider key registered for the provider you called (inferred from the URL path).',
+    fix: 'Open /projects, expand the Spanlens key, click Add provider key, pick the matching provider (OpenAI / Anthropic / Gemini / …), and paste your real AI key.',
+  },
+  {
+    status: '502 UPSTREAM_FAILED',
+    cause:
+      'The upstream provider returned an error or the network to it failed. details.provider names which one.',
+    fix: 'Usually a provider-side incident or a bad request the provider rejected. Check the provider status page, inspect the row in /requests for the upstream error body, then retry.',
+  },
+  {
+    status: '503 DECRYPT_FAILED',
+    cause:
+      'The stored provider key could not be decrypted. Operator-side configuration drift: ENCRYPTION_KEY no longer matches the key used when the provider key was saved.',
+    fix: 'Self-host only. The operator must restore the original ENCRYPTION_KEY, or re-enter every provider key under the new one. See the empty-decryption section below.',
+  },
+  {
+    status: '504 UPSTREAM_TIMEOUT',
+    cause:
+      'A non-streaming upstream call did not return headers within the timeout (UPSTREAM_TIMEOUT_MS, 35s). The provider was slow or the generation was very long.',
+    fix: 'Safe to retry. For long generations, switch to streaming (stream: true) so the first byte arrives in ~200 ms and you use the 290s stream budget instead of the 35s header timeout.',
+  },
+]
+
+export default function TroubleshootingPage() {
+  return (
+    <div>
+      <h1>Troubleshooting</h1>
+      <p className="lead">
+        Start from the symptom you are seeing. Each section gives the likely cause and the
+        fix. This page is organized by what you observe; the{' '}
+        <a href="/docs/api/errors">error-codes reference</a> is organized by the stable{' '}
+        <code>error.code</code> value, so branch your client logic there and use this page to
+        diagnose.
+      </p>
+
+      <h2 id="status-quick-reference">HTTP status quick reference</h2>
+      <p>
+        Every 4xx / 5xx response carries the standard envelope (
+        <code>error.code</code>, <code>error.message</code>, <code>error.details</code>,{' '}
+        <code>error.requestId</code>). Match the status you got, then jump to the section
+        below for the full walkthrough.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Status &amp; code</th>
+            <th>Likely cause</th>
+            <th>Fix</th>
+          </tr>
+        </thead>
+        <tbody>
+          {STATUS_ROWS.map((row) => (
+            <tr key={row.status}>
+              <td>
+                <code>{row.status}</code>
+              </td>
+              <td>{row.cause}</td>
+              <td>{row.fix}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h2 id="auth">Authentication and scope (401 / 403)</h2>
+      <p>
+        A <code>401 UNAUTHORIZED</code> means the server could not authenticate the request at
+        all; a <code>403</code> means it authenticated you but the key is not allowed to do
+        what you asked.
+      </p>
+
+      <h3>Send the Spanlens key on the header your provider SDK uses</h3>
+      <p>
+        You authenticate with your <em>Spanlens</em> key (<code>sl_live_…</code>), never the
+        raw provider key. Each provider SDK puts the key on a different header, and the proxy
+        accepts whichever one arrives:
+      </p>
+      <pre>{`OpenAI / Azure   Authorization: Bearer sl_live_...
+Anthropic        x-api-key: sl_live_...
+Gemini           x-goog-api-key: sl_live_...`}</pre>
+      <p>
+        If you use an official provider SDK, you do not set these by hand: pass the Spanlens
+        key as the SDK&apos;s <code>api_key</code> and point <code>base_url</code> at the matching{' '}
+        <a href="/docs/proxy">proxy URL</a>. A stray <code>401 &quot;Incorrect API key&quot;</code>
+        almost always means one of: <code>SPANLENS_API_KEY</code> is missing in the runtime,
+        the value has a typo or trailing whitespace, or the client is still constructed with
+        the upstream <code>baseURL</code> so the request never reaches Spanlens.
+      </p>
+
+      <h3>403 PUBLIC_KEY_WRITE_FORBIDDEN (wrong key scope)</h3>
+      <p>
+        Spanlens keys come in two scopes. A <strong>full</strong> key (
+        <code>sl_live_…</code>) can proxy, ingest, and read. A <strong>public</strong> key (
+        <code>sl_live_pub_…</code>) is read-only and is deliberately rejected on every write
+        path (<code>/proxy/*</code>, <code>/ingest/*</code>, and OTLP{' '}
+        <code>/v1/traces</code>) with:
+      </p>
+      <pre>{`HTTP/1.1 403 Forbidden
+
+{
+  "error": {
+    "code": "PUBLIC_KEY_WRITE_FORBIDDEN",
+    "message": "Public scope keys cannot use proxy, ingest, or OTLP endpoints",
+    "details": { "scope": "public" }
+  }
+}`}</pre>
+      <p>
+        Fix: use a full-scope key for proxying and ingest. Public keys are meant for places
+        where the key is exposed in plaintext (MCP servers, BI dashboards, read-only embeds),
+        so they can only call the read APIs. You issue full keys per project and public keys
+        per workspace on the <a href="/projects">Projects</a> page.
+      </p>
+
+      <h2 id="rate-limits">Which rate limit fired (429)</h2>
+      <p>
+        A <code>429 RATE_LIMIT</code> can come from two very different places. Read{' '}
+        <code>error.details.source</code> to tell them apart before you change anything.
+      </p>
+
+      <h3>Customer-configured limit (details.source = &quot;customer_limit&quot;)</h3>
+      <p>
+        This is a limit <em>you</em> set on a Spanlens key, a project, or an individual
+        end-user from the <a href="/projects">Projects</a> page. It exists precisely to
+        throttle that traffic, so exceeding it does reject the call. The body tells you which
+        limit fired:
+      </p>
+      <pre>{`{
+  "error": {
+    "code": "RATE_LIMIT",
+    "message": "Customer-configured rate limit exceeded (end_user): 60 requests per 60s.",
+    "details": {
+      "source": "customer_limit",
+      "scope": "end_user",
+      "limit": 60,
+      "window_seconds": 60,
+      "end_user_id": "user_123"
+    }
+  }
+}`}</pre>
+      <p>
+        The response also carries <code>Retry-After</code> (window length in seconds) and{' '}
+        <code>X-Spanlens-RateLimit-Scope</code> (<code>api_key</code>, <code>project</code>,
+        or <code>end_user</code>). A <code>customer_limit</code> 429 never includes an upgrade
+        link, which is how you distinguish it from a plan limit. Per-end-user limits bucket on
+        the <code>X-Spanlens-User</code> header, so send it for those limits to apply. Fix:
+        back off until <code>Retry-After</code>, or raise the limit on the Projects page.
+      </p>
+
+      <h3>Spanlens plan quota</h3>
+      <p>
+        Separate from your own limits, your plan has a monthly request quota. When that is the
+        limit that fired, the error includes plan and upgrade context. Fix: upgrade the plan
+        or wait for the quota window to reset. See{' '}
+        <a href="/docs/features/billing">billing &amp; quotas</a>.
+      </p>
+      <p>
+        There is also a high platform ceiling on <code>/proxy/*</code> that only exists to
+        stop a runaway loop. Going over it does <strong>not</strong> reject the request: the
+        call still passes through and the response carries{' '}
+        <code>X-Spanlens-RateLimit-Overage: true</code> so you can spot the spike. Every
+        proxy response also carries <code>X-RateLimit-Limit</code>,{' '}
+        <code>X-RateLimit-Remaining</code>, <code>X-RateLimit-Reset</code> (unix epoch
+        second), and <code>X-RateLimit-Window</code>; read <code>X-RateLimit-Reset</code>
+        directly instead of parsing your own clock to avoid skew. Details in{' '}
+        <a href="/docs/proxy#rate-limits">the proxy docs</a>.
+      </p>
+
+      <h2 id="upstream">Upstream and provider-key errors (502 / 503 / 504)</h2>
+      <p>
+        These are the failures that happen after your request is authenticated but before (or
+        during) the call to the real provider.
+      </p>
+      <ul>
+        <li>
+          <code>502 UPSTREAM_FAILED</code> means the provider returned an error or the network to
+          it failed. <code>details.provider</code> names which provider. Check the provider
+          status page and the row in <a href="/requests">/requests</a> for the upstream error
+          body, then retry.
+        </li>
+        <li>
+          <code>504 UPSTREAM_TIMEOUT</code> means a non-streaming call did not return headers
+          within the ~35s header timeout. The provider was slow or the generation was long.
+          Safe to retry; better yet switch to streaming (see{' '}
+          <a href="#truncated">truncated responses</a> below).
+        </li>
+        <li>
+          <code>503 DECRYPT_FAILED</code> means the stored provider key could not be decrypted.
+          This is operator-side configuration drift, not a client bug. See the next section.
+        </li>
+      </ul>
+
+      <h2 id="no-requests">Requests are not appearing in the dashboard</h2>
+      <p>
+        You are making LLM calls but <a href="/requests">/requests</a> stays empty. Work
+        through these in order; each is a real cause we have seen in the field.
+      </p>
+      <ol>
+        <li>
+          <strong>The Spanlens key is not set in the deployed environment.</strong> Setting{' '}
+          <code>SPANLENS_API_KEY</code> in <code>.env.local</code> covers local dev only. Add
+          it to your production environment (Vercel / Railway / Fly) as well, then{' '}
+          <strong>redeploy</strong>, because new env values do not apply to existing deployments.
+        </li>
+        <li>
+          <strong>The request is still going to the provider directly.</strong> In your
+          Network tab the call should hit{' '}
+          <code>server.spanlens.io/proxy/*</code>, not <code>api.openai.com</code> (or the
+          equivalent). If it is not, the client is constructed with the upstream{' '}
+          <code>baseURL</code>; use the SDK helper or set <code>base_url</code> to the proxy.
+        </li>
+        <li>
+          <strong>No provider key is registered</strong> → the call returns{' '}
+          <code>400 NO_PROVIDER_KEY</code> instead of logging. Add one under the Spanlens key
+          on <a href="/projects">/projects</a>.
+        </li>
+        <li>
+          <strong>Your app is silently in mock mode.</strong> Some apps return a canned 200
+          &quot;mock&quot; response when an API key env var is missing, so the AI looks like
+          it works but no real call is ever made and nothing reaches Spanlens. After adding
+          env vars, confirm a real row lands in <a href="/requests">/requests</a> rather than
+          trusting the app response.
+        </li>
+      </ol>
+      <h3>Verify with one curl call</h3>
+      <p>
+        The fastest way to isolate app config from Spanlens config is to bypass your app
+        entirely and hit the proxy directly. A row should appear in{' '}
+        <a href="/requests">/requests</a> within a few seconds:
+      </p>
+      <pre>{`curl https://server.spanlens.io/proxy/openai/v1/chat/completions \\
+  -H "Authorization: Bearer $SPANLENS_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "gpt-4o-mini",
+    "messages": [{"role": "user", "content": "ping"}]
+  }'`}</pre>
+      <ul>
+        <li>
+          Get a <code>200</code> and a row appears → Spanlens is configured correctly; the
+          gap is in your application (env not loaded, wrong base URL, or mock mode).
+        </li>
+        <li>
+          Get a <code>401</code> → the key is wrong or not exported in this shell.
+        </li>
+        <li>
+          Get a <code>400 NO_PROVIDER_KEY</code> → register a provider key (step 3 above).
+        </li>
+      </ul>
+
+      <h2 id="empty-traces">Traces show Spans: 0 / Tokens: 0</h2>
+      <p>
+        A trace exists in <a href="/traces">/traces</a> but shows zero spans and zero tokens.
+        This is the signature of an <strong>outdated SDK</strong>. Older SDK versions fired
+        the trace and its child-span ingest POSTs concurrently, so a span could arrive before
+        the trace row was committed and be silently dropped; a late <code>end()</code> patch
+        then found no row to update. Short traces happened to pass, which is why it slips
+        through in dev.
+      </p>
+      <p>
+        Fix: upgrade the SDK. The ingest ordering race was fixed by chaining child POSTs
+        after the parent creation promise; make sure you are on a current release:
+      </p>
+      <pre>{`pnpm add @spanlens/sdk@latest
+# or: npm install @spanlens/sdk@latest`}</pre>
+      <p>
+        If you built a custom ingest client instead of using the SDK, replicate the same
+        rule: do not POST a child span until the parent trace create has resolved, and do not
+        send an <code>end()</code> patch until the span create has resolved. See the{' '}
+        <a href="/docs/sdk">SDK reference</a>.
+      </p>
+
+      <h2 id="truncated">Response cut off or shows a &quot;truncated&quot; badge</h2>
+      <p>
+        A streaming response stops early and the row in <a href="/requests">/requests</a>
+        carries a <code>truncated</code> badge. The proxy runs on Vercel Pro with a 300-second
+        hard ceiling and gracefully closes streams at <strong>290 seconds</strong> to leave
+        room to flush the log. A generation that runs past that budget is cut off, the
+        partial output is logged with <code>truncated: true</code>, and your client sees the
+        stream end before <code>[DONE]</code> / <code>message_stop</code>.
+      </p>
+      <p>Options, in order of preference:</p>
+      <ul>
+        <li>
+          <strong>Lower the work per call.</strong> Reduce <code>max_tokens</code> or split
+          the task so a single generation finishes well inside 290 seconds.
+        </li>
+        <li>
+          <strong>Use streaming with chunked accumulation.</strong> For large{' '}
+          <code>max_tokens</code> or JSON mode with big outputs, set{' '}
+          <code>stream: true</code> and accumulate chunks, and the first byte arrives in ~200 ms
+          and you get partial output even if the deadline is hit.
+        </li>
+        <li>
+          <strong>Self-hosting?</strong> The deadline is tunable with the{' '}
+          <code>STREAM_DEADLINE_MS</code> env var (default <code>290000</code>). On a Vercel
+          Hobby plan, whose function ceiling is 60s, set it to about <code>50000</code>.
+        </li>
+      </ul>
+      <p>
+        Note: a non-streaming call that exceeds the header timeout returns{' '}
+        <code>504 UPSTREAM_TIMEOUT</code> instead of a truncated row, which is the same
+        underlying &quot;too slow&quot; problem, which is why streaming is the fix for both.
+        More detail in <a href="/docs/proxy">the proxy docs</a>.
+      </p>
+
+      <h2 id="empty-decryption">Provider key decryption returns empty (self-host)</h2>
+      <p>
+        On a self-hosted instance, provider keys are stored encrypted with AES-256-GCM under
+        your <code>ENCRYPTION_KEY</code>. If that key does not match the one in use when a
+        provider key was saved, decryption can fail quietly and yield an empty string rather
+        than an error, so the upstream call goes out with no credential and the provider
+        rejects it. When the failure surfaces as a typed error it is{' '}
+        <code>503 DECRYPT_FAILED</code>.
+      </p>
+      <p>Checklist for the operator:</p>
+      <ul>
+        <li>
+          <code>ENCRYPTION_KEY</code> must be a 32-byte base64 value and must be{' '}
+          <em>identical</em> across every instance and deploy that reads the same database.
+        </li>
+        <li>
+          If the key was rotated, the old provider-key rows can no longer be decrypted.
+          Restore the original <code>ENCRYPTION_KEY</code>, or re-enter every provider key on{' '}
+          the <a href="/projects">Projects</a> page so they are re-encrypted under the new
+          value.
+        </li>
+        <li>
+          Watch for calls that reach the provider with no credential (upstream 401): an empty
+          decryption result is the usual cause. See{' '}
+          <a href="/docs/self-host">self-hosting</a> for environment setup.
+        </li>
+      </ul>
+
+      <hr />
+      <p className="text-sm text-muted-foreground">
+        Still stuck? Look up the exact code in the{' '}
+        <a href="/docs/api/errors">error-codes reference</a>, review the{' '}
+        <a href="/docs/proxy">proxy docs</a> for headers and the stream deadline, or open an
+        issue at{' '}
+        <a href="https://github.com/spanlens/Spanlens/issues">github.com/spanlens/Spanlens/issues</a>{' '}
+        with the <code>error.requestId</code> from the response so the operator can pull the
+        matching logs.
+      </p>
+    </div>
+  )
+}

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -162,7 +162,7 @@ const PLANS = [
     price: '$0',
     description: 'For personal projects and exploration',
     features: [
-      '50K requests / month',
+      '50K requests / month, then a hard 429',
       '1 seat',
       '1 workspace',
       'Unlimited projects',
@@ -235,8 +235,8 @@ const PLANS = [
       'Dedicated support + SLA',
     ],
     overage: null,
-    cta: 'Contact us',
-    href: 'mailto:hi@spanlens.io',
+    cta: 'Talk to sales',
+    href: 'mailto:hi@spanlens.io?subject=Spanlens%20Enterprise%20inquiry&body=Hi%20Spanlens%20team%2C%0A%0AWe%27re%20interested%20in%20the%20Enterprise%20plan.%0A%0ACompany%3A%20%0AExpected%20monthly%20request%20volume%3A%20%0AWhat%20we%20need%20(SSO%2C%20on-prem%2C%20custom%20SLA%2C%20etc.)%3A%20%0A',
     highlight: false,
   },
 ]
@@ -366,6 +366,11 @@ export default function PricingPage() {
           ))}
         </div>
 
+        {/* Tax note — Paddle is merchant of record and adds VAT/GST at checkout */}
+        <p className="mt-6 text-center text-[12px] text-text-faint">
+          Prices in USD, exclusive of applicable taxes. VAT/GST is added at checkout by Paddle.
+        </p>
+
         {/* Overage policy */}
         <div className="mt-16 rounded-xl border border-border bg-bg-elev p-6 max-w-3xl mx-auto">
           <h3 className="font-semibold text-[15px] text-text mb-3">What happens if I go over my quota?</h3>
@@ -392,7 +397,7 @@ export default function PricingPage() {
             </div>
             <div className="grid grid-cols-[140px_1fr] gap-x-4">
               <dt className="font-semibold text-text">Free plan</dt>
-              <dd>Proxy keeps working past 50K, but logging pauses (we don&apos;t want to break your app). Upgrade to Pro to resume logging plus overage.</dd>
+              <dd>No overage. At <span className="font-mono">50K</span> requests/month the proxy returns a hard <span className="font-mono">429</span> so a runaway dev loop can&apos;t quietly cost you money. Upgrade to Pro for a soft limit with authorized overage.</dd>
             </div>
           </dl>
           <Link

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -299,6 +299,35 @@ For short-lived scripts, call `client.close()` before exit (or use
 
 ---
 
+## SDK versions & feature parity
+
+> **On version numbers.** The Python (`spanlens`) and TypeScript (`@spanlens/sdk`) SDKs are versioned **completely independently**. A version number in one says nothing about the other, and the gap between them is not a signal of maturity or maintenance. Both are pre-1.0 and both are actively maintained; features land in each on its own release cadence.
+
+The table below is the honest, file-level comparison of what each package ships today. Use it to check whether a capability you rely on exists in the SDK for your language before you build on it.
+
+| Capability | Python (`spanlens`) | TypeScript (`@spanlens/sdk`) |
+| --- | :---: | :---: |
+| Core tracing (client / trace / span / `observe`) | ✓ | ✓ |
+| Sampling (head-based, configurable rate) | ✓ | ✓ |
+| OpenAI auto-instrument helper | ✓ `observe_openai` | ✓ `observeOpenAI` |
+| Anthropic auto-instrument helper | ✓ `observe_anthropic` | ✓ `observeAnthropic` |
+| Gemini auto-instrument helper | ✓ `observe_gemini` | ✓ `observeGemini` |
+| Ollama auto-instrument helper (local LLMs) | ✓ `observe_ollama` | ✓ `observeOllama` |
+| Proxy client factory (OpenAI) | ✓ `create_openai` | ✓ `createOpenAI` |
+| Proxy client factory (Anthropic) | ✓ `create_anthropic` | ✓ `createAnthropic` |
+| Proxy client factory (Gemini) | ✓ `create_gemini` | ✓ `createGemini` |
+| Proxy client factory (Ollama) | ✗ (use a raw OpenAI client at `localhost:11434`) | ✓ `createOllama` (`@spanlens/sdk/ollama`) |
+| LangChain integration | ✓ | ✓ |
+| LangGraph integration | ✓ (via the LangChain handler) | ✓ (via the LangChain handler) |
+| LlamaIndex integration | ✓ | ✓ |
+| Vercel AI SDK integration | ✗ (Vercel AI is JS-only) | ✓ |
+| Evals API (script-driven prompt CI) | ✗ (not yet) | ✓ `EvalsApi` |
+| CLI (`init` wizard) | ✓ (bundled `spanlens` command) | ✓ (separate [`@spanlens/cli`](https://www.npmjs.com/package/@spanlens/cli) package) |
+
+`partial` is not used above because every current capability is either fully present or absent in a given SDK. If you need a capability marked ✗ in your language, open an issue. Parity gaps are tracked and prioritized.
+
+---
+
 ## Self-hosting
 
 Point the SDK and proxy helpers at your own deployment:

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -354,12 +354,134 @@ process.exit(0)
 
 `flush()` resolves even if some requests failed. It uses `Promise.allSettled` internally so a network error won't hang the process.
 
+## Error handling
+
+Instrumentation is fire-and-forget by design, so **tracing never crashes your app**. Every ingest call is governed by two `SpanlensConfig` options:
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `silent` | `boolean` | `true` | When `true`, ingest failures are swallowed (the call resolves to `null`) so your hot path is never interrupted. When `false`, the failure is **re-thrown** so you can surface it in tests or fail-fast environments. |
+| `onError` | `(err, context) => void` | (none) | Called on **every** ingest failure, regardless of `silent`. `context` is the failing route, e.g. `"POST /ingest/traces"`. Use it to forward errors to your monitoring stack. |
+
+Even with the default `silent: true`, `onError` still fires, so you get full visibility without the risk of an unhandled rejection taking down a request.
+
+### `SpanlensApiError`
+
+When the Spanlens server rejects a call with its standard error envelope (a `4xx`), the SDK surfaces a typed `SpanlensApiError` instead of a bare `Error`. This lets you branch on a stable `code` rather than string-matching a message. It reaches you either through `onError` (always) or as a thrown value (when `silent: false`).
+
+```ts
+import { SpanlensApiError } from '@spanlens/sdk'
+
+class SpanlensApiError extends Error {
+  code: string                              // stable machine code, e.g. 'PUBLIC_KEY_WRITE_FORBIDDEN'
+  status: number                            // HTTP status (4xx)
+  details?: Record<string, unknown>         // optional structured context
+  requestId: string | null                  // server request id for support
+}
+```
+
+### Automatic retries
+
+The transport retries **transient** failures on its own, so a brief network blip or a `429` doesn't lose a span:
+
+- **Retried** (up to `3` attempts total) with exponential back-off `200 ms → 400 ms → 800 ms`: network errors, request timeouts (default `3000 ms`), `429`, and `5xx`.
+- **Not retried**: `4xx` client errors. These are your bug (bad key, missing scope, malformed body), so retrying wastes time. They go straight to `onError` (and throw when `silent: false`).
+
+Because every trace and span carries a **client-generated UUID**, retries are idempotent: the same UUID delivered twice is a no-op on the server.
+
+### Forwarding to Sentry
+
+```ts
+import * as Sentry from '@sentry/node'
+import { SpanlensClient, SpanlensApiError } from '@spanlens/sdk'
+
+const client = new SpanlensClient({
+  apiKey: process.env.SPANLENS_API_KEY!,
+  // Keep silent:true so a Spanlens outage never breaks your app,
+  // but still capture the failure for later.
+  onError: (err, context) => {
+    if (err instanceof SpanlensApiError) {
+      Sentry.captureException(err, {
+        tags: { spanlens_code: err.code, spanlens_context: context },
+        extra: { requestId: err.requestId, status: err.status },
+      })
+    } else {
+      Sentry.captureException(err, { tags: { spanlens_context: context } })
+    }
+  },
+})
+```
+
+Set `silent: false` only in test suites or CI, where you *want* a broken ingest call to fail loudly.
+
+## Sampling
+
+High-volume agents can generate a lot of trace ingest traffic. `sampleRate` lets you record a representative fraction of traces while keeping cost and volume under control.
+
+```ts
+const client = new SpanlensClient({
+  apiKey: process.env.SPANLENS_API_KEY!,
+  sampleRate: 0.1,   // ingest ~10% of traces
+})
+```
+
+- **`sampleRate`** is a number in `[0.0, 1.0]`. Default `1.0` (record everything). A malformed value (out of range, `NaN`, or a string) throws at `SpanlensClient` construction rather than silently dropping traces.
+- **Per-trace and sticky**: the keep/drop decision is made **once**, at `client.startTrace()`, and applies to every span under that trace. Sampling whole traces (never individual spans) keeps each surviving trace a fully coherent tree in the dashboard.
+- **Proxy logs are unaffected**: `sampleRate` only controls the agent-tracing layer (`/ingest/traces`, `/ingest/spans`). Your `/proxy/*` LLM request logs (cost, tokens, quota, anomalies) are **always** recorded at 100%.
+
+### Tail-based error capture
+
+Error traces are the traces you most want to keep. So even when a trace loses the sampling coin-flip, the SDK **buffers** its spans in memory instead of sending them, then:
+
+- if the trace ends with `status: 'error'`, the buffered spans are replayed to the server, so the trace is recorded in full;
+- otherwise the buffer is discarded.
+
+The result: at `sampleRate: 0.1` you still capture **100% of error traces** plus a 10% sample of successful ones. (Errors are detected either from an explicit `status: 'error'` or from passing `errorMessage` to `trace.end()`.)
+
+### Recommended: sample in prod, keep everything in staging
+
+```ts
+const client = new SpanlensClient({
+  apiKey: process.env.SPANLENS_API_KEY!,
+  sampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
+})
+```
+
+Staging traffic is low, so record everything for debugging. Production is high-volume, so sample the happy path (`0.1`) while tail-based capture guarantees every error still lands.
+
 ## Design notes
 
 - **Fire-and-forget ingest**: `startTrace()` and `trace.span()` return synchronously. Network writes run in the background so your hot path never waits on observability.
 - **Retry with back-off**: transient failures (network error, 429, 5xx) are retried up to 3 times with exponential back-off (200 ms → 400 ms → 800 ms). 4xx errors are not retried.
 - **Client-side UUIDs**: idempotent retries are safe, since the same UUID twice is a no-op on the server.
 - **No unhandled rejections**: background POST failures are silently swallowed; use the `onError` hook for visibility.
+
+## SDK versions & feature parity
+
+> **On version numbers.** The TypeScript (`@spanlens/sdk`) and Python (`spanlens`) SDKs are versioned **completely independently**. A version number in one says nothing about the other, and the gap between them is not a signal of maturity or maintenance. Both are pre-1.0 and both are actively maintained; features land in each on its own release cadence.
+
+The table below is the honest, file-level comparison of what each package ships today. Use it to check whether a capability you rely on exists in the SDK for your language before you build on it.
+
+| Capability | TypeScript (`@spanlens/sdk`) | Python (`spanlens`) |
+| --- | :---: | :---: |
+| Core tracing (client / trace / span / `observe`) | ✓ | ✓ |
+| Sampling (head-based, configurable rate) | ✓ | ✓ |
+| OpenAI auto-instrument helper | ✓ `observeOpenAI` | ✓ `observe_openai` |
+| Anthropic auto-instrument helper | ✓ `observeAnthropic` | ✓ `observe_anthropic` |
+| Gemini auto-instrument helper | ✓ `observeGemini` | ✓ `observe_gemini` |
+| Ollama auto-instrument helper (local LLMs) | ✓ `observeOllama` | ✓ `observe_ollama` |
+| Proxy client factory (OpenAI) | ✓ `createOpenAI` | ✓ `create_openai` |
+| Proxy client factory (Anthropic) | ✓ `createAnthropic` | ✓ `create_anthropic` |
+| Proxy client factory (Gemini) | ✓ `createGemini` | ✓ `create_gemini` |
+| Proxy client factory (Ollama) | ✓ `createOllama` (`@spanlens/sdk/ollama`) | ✗ (use a raw OpenAI client at `localhost:11434`) |
+| LangChain integration | ✓ | ✓ |
+| LangGraph integration | ✓ (via the LangChain handler) | ✓ (via the LangChain handler) |
+| LlamaIndex integration | ✓ | ✓ |
+| Vercel AI SDK integration | ✓ | ✗ (Vercel AI is JS-only) |
+| Evals API (script-driven prompt CI) | ✓ `EvalsApi` | ✗ (not yet) |
+| CLI (`init` wizard) | ✓ (separate [`@spanlens/cli`](https://www.npmjs.com/package/@spanlens/cli) package) | ✓ (bundled `spanlens` command) |
+
+`partial` is not used above because every current capability is either fully present or absent in a given SDK. If you need a capability marked ✗ in your language, open an issue. Parity gaps are tracked and prioritized.
 
 ## License
 


### PR DESCRIPTION
## Summary

Quick Wins 7-11 from the improvement audit: docs + copy, no runtime/logic changes.

### SDK docs (`@spanlens/sdk`, `spanlens`)
- **Error handling + Sampling** sections added to the TS SDK README, verified against `transport.ts` / `sampler.ts` / `types.ts`: `silent` / `onError` behavior, the typed `SpanlensApiError`, transport retries (3 attempts, 200/400/800ms back-off, retries network/429/5xx, not 4xx), and `sampleRate` with tail-based error capture. Includes an onError-to-Sentry example and the "0.1 in prod, 1.0 in staging" pattern.
- **Feature parity matrix + versioning note** added to both SDK READMEs so the TS `0.14` vs Python `0.7` gap does not read as abandonment. Every cell verified against the actual integration files (no fake version bump).

### Web docs & pricing
- **New `/docs/troubleshooting`** — symptom-first guide (401/403 auth + scope, the two kinds of 429, 502/503/504, "requests not appearing" with a curl check, "Spans: 0 / Tokens: 0" → upgrade SDK, truncated streams at the ~290s deadline, empty decrypt on ENCRYPTION_KEY drift). Complements the code-oriented `/docs/api/errors`.
- **New `/docs/self-host/backup`** — pg_dump + ClickHouse `BACKUP`/restore runbook, ENCRYPTION_KEY-lives-outside-the-dump warning, Docker volume snapshots, retention + restore-drill guidance, grounded in the real `docker-compose.yml` service/volume names.
- **Pricing copy** — Free plan now states the hard 429 at 50K (a cost guardrail, distinct from paid soft-limit + overage), a "Prices in USD, exclusive of applicable taxes" note, and the Enterprise CTA is now a pre-filled "Talk to sales" mailto.
- Both new pages registered in the docs sidebar.

## Test plan

- [x] `pnpm --filter web typecheck && lint && build`
- [x] In-browser (dev server): `/docs/troubleshooting` and `/docs/self-host/backup` render with full docs layout + TOC; `/pricing` shows the hard-429, tax note, and Talk to sales CTA
- [x] Fixed a duplicate-heading React key collision (two "Restore" h3s → "Restore Postgres" / "Restore ClickHouse"); TOC hrefs now unique, no console errors
- [x] No em dashes in any customer-facing text added (project style rule); repo slug corrected in the issues link

Note: SDK README changes are markdown only (no code), so no SDK republish is required; they surface on the next npm/PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
