### PR TITLE
feat(proxy): add Groq, DeepSeek, xAI, and Cohere providers

### DIFF
--- a/apps/server/src/__tests__/proxy-openai-compat-providers.test.ts
+++ b/apps/server/src/__tests__/proxy-openai-compat-providers.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { Context, MiddlewareHandler, Next } from 'hono'
+import { drainPendingTasks, mockUpstream, openAIChatResponse, proxyState, resetProxyMocks } from './helpers/proxy-mocks.js'
+import { installOnError } from './helpers/install-on-error.js'
+
+/**
+ * Integration tests for the four OpenAI-compatible provider proxies added
+ * together: Groq, DeepSeek, xAI, and Cohere. Each reuses the OpenAI parser +
+ * stream logger, so these tests pin the per-provider contract:
+ *   1. Upstream URL is built from the provider's base + the path with the
+ *      /proxy/<provider> prefix stripped.
+ *   2. Authorization carries the decrypted provider key, never the customer
+ *      Spanlens key.
+ *   3. The log row carries the right provider tag and cost from the seed.
+ *   4. NO_PROVIDER_KEY (400) and public-scope (403) guards behave like the
+ *      other proxies.
+ */
+
+vi.mock('../middleware/authApiKey.js', async () => {
+  const actual = await vi.importActual<typeof import('../middleware/authApiKey.js')>(
+    '../middleware/authApiKey.js',
+  )
+  return {
+    ...actual,
+    authApiKey: (async (c: Context, next: Next) => {
+      c.set('apiKeyId', proxyState.apiKeyId)
+      c.set('organizationId', proxyState.organizationId)
+      c.set('projectId', proxyState.projectId)
+      c.set('apiKeyScope', proxyState.scope)
+      await next()
+    }) as MiddlewareHandler,
+  }
+})
+
+vi.mock('../middleware/requireFullScope.js', () => ({
+  requireFullScope: (async (_c: Context, next: Next) => {
+    if (proxyState.scope === 'public') {
+      const { ApiError } = await import('../lib/errors.js')
+      throw new ApiError('PUBLIC_KEY_WRITE_FORBIDDEN', 'Public API key cannot write')
+    }
+    await next()
+  }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/rateLimit.js', () => ({
+  proxyRateLimit: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/quota.js', () => ({
+  enforceQuota: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/customerRateLimit.js', () => ({
+  customerRateLimit: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../proxy/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../proxy/utils.js')>(
+    '../proxy/utils.js',
+  )
+  return {
+    ...actual,
+    getDecryptedProviderKey: vi.fn(async () => {
+      if (proxyState.decryptedKey === '') return null
+      return {
+        plaintext: proxyState.decryptedKey,
+        id: proxyState.providerKeyId,
+        metadata: {},
+      }
+    }),
+    isBlockingEnabled: vi.fn(async () => proxyState.blockingEnabled),
+  }
+})
+
+vi.mock('../lib/logger.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/logger.js')>(
+    '../lib/logger.js',
+  )
+  return {
+    ...actual,
+    logRequestAsync: vi.fn(async (data: Record<string, unknown>) => {
+      proxyState.loggerCalls.push(data)
+    }),
+  }
+})
+
+vi.mock('../lib/resolve-prompt-version.js', () => ({
+  resolvePromptVersion: vi.fn(async () => null),
+}))
+
+vi.mock('../lib/wait-until.js', () => ({
+  fireAndForget: (_c: Context, promise: Promise<unknown>) => {
+    proxyState.pendingTasks.push(promise.catch(() => undefined))
+  },
+}))
+
+async function buildApp() {
+  const { Hono } = await import('hono')
+  const { groqProxy } = await import('../proxy/groq.js')
+  const { deepseekProxy } = await import('../proxy/deepseek.js')
+  const { xaiProxy } = await import('../proxy/xai.js')
+  const { cohereProxy } = await import('../proxy/cohere.js')
+  const app = new Hono()
+  app.route('/proxy/groq', groqProxy)
+  app.route('/proxy/deepseek', deepseekProxy)
+  app.route('/proxy/xai', xaiProxy)
+  app.route('/proxy/cohere', cohereProxy)
+  installOnError(app)
+  return app
+}
+
+interface ProviderCase {
+  slug: string
+  expectedUrl: string
+  model: string
+  // prompt 1M + completion 0.5M against the seed price → expectedCost
+  expectedCost: number
+}
+
+const CASES: ProviderCase[] = [
+  // groq llama-3.3-70b-versatile: $0.59/1M in + $0.79/1M out → 1*0.59 + 0.5*0.79
+  { slug: 'groq', expectedUrl: 'https://api.groq.com/openai/v1/chat/completions', model: 'llama-3.3-70b-versatile', expectedCost: 0.985 },
+  // deepseek-chat: $0.14/1M in + $0.28/1M out → 1*0.14 + 0.5*0.28
+  { slug: 'deepseek', expectedUrl: 'https://api.deepseek.com/v1/chat/completions', model: 'deepseek-chat', expectedCost: 0.28 },
+  // grok-4.3: $1.25/1M in + $2.50/1M out → 1*1.25 + 0.5*2.50
+  { slug: 'xai', expectedUrl: 'https://api.x.ai/v1/chat/completions', model: 'grok-4.3', expectedCost: 2.5 },
+  // command-a-03-2025: $2.50/1M in + $10.00/1M out → 1*2.50 + 0.5*10.00
+  { slug: 'cohere', expectedUrl: 'https://api.cohere.ai/compatibility/v1/chat/completions', model: 'command-a-03-2025', expectedCost: 7.5 },
+]
+
+beforeEach(() => {
+  resetProxyMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+for (const c of CASES) {
+  describe(`${c.slug} proxy`, () => {
+    test(`upstream URL strips /proxy/${c.slug} and targets the provider host`, async () => {
+      mockUpstream(openAIChatResponse({ model: c.model }))
+      const app = await buildApp()
+
+      await app.request(`/proxy/${c.slug}/v1/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: c.model, messages: [] }),
+      })
+      await drainPendingTasks()
+
+      expect(proxyState.fetchCalls[0]!.url).toBe(c.expectedUrl)
+    })
+
+    test('Authorization carries the decrypted provider key, not sl_live_*', async () => {
+      proxyState.decryptedKey = `${c.slug}-real-key-abc`
+      mockUpstream(openAIChatResponse({ model: c.model }))
+      const app = await buildApp()
+
+      await app.request(`/proxy/${c.slug}/v1/chat/completions`, {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer sl_live_customer_must_not_leak',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ model: c.model, messages: [] }),
+      })
+      await drainPendingTasks()
+
+      const sent = proxyState.fetchCalls[0]!
+      expect(sent.headers.get('authorization')).toBe(`Bearer ${c.slug}-real-key-abc`)
+      sent.headers.forEach((v) => expect(v).not.toContain('sl_live_'))
+    })
+
+    test('log row carries the provider tag + seed cost', async () => {
+      mockUpstream(openAIChatResponse({
+        model: c.model,
+        promptTokens: 1_000_000,
+        completionTokens: 500_000,
+      }))
+      const app = await buildApp()
+
+      await app.request(`/proxy/${c.slug}/v1/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: c.model, messages: [] }),
+      })
+      await drainPendingTasks()
+
+      expect(proxyState.loggerCalls).toHaveLength(1)
+      const row = proxyState.loggerCalls[0]!
+      expect(row['provider']).toBe(c.slug)
+      expect(row['model']).toBe(c.model)
+      expect(row['costUsd']).toBeCloseTo(c.expectedCost, 4)
+    })
+
+    test('NO_PROVIDER_KEY 400 with matching provider detail', async () => {
+      proxyState.decryptedKey = ''
+      const app = await buildApp()
+
+      const res = await app.request(`/proxy/${c.slug}/v1/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: c.model, messages: [] }),
+      })
+
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: { code: string; details: { provider: string } } }
+      expect(body.error.code).toBe('NO_PROVIDER_KEY')
+      expect(body.error.details.provider).toBe(c.slug)
+      expect(proxyState.fetchCalls).toHaveLength(0)
+    })
+
+    test('public-scope key returns 403 PUBLIC_KEY_WRITE_FORBIDDEN', async () => {
+      proxyState.scope = 'public'
+      const app = await buildApp()
+
+      const res = await app.request(`/proxy/${c.slug}/v1/chat/completions`, {
+        method: 'POST',
+        body: JSON.stringify({ model: c.model, messages: [] }),
+      })
+
+      expect(res.status).toBe(403)
+      expect(proxyState.fetchCalls).toHaveLength(0)
+    })
+  })
+}

--- a/apps/server/src/api/providerKeys.ts
+++ b/apps/server/src/api/providerKeys.ts
@@ -22,7 +22,10 @@ providerKeysRouter.use('*', authJwt)
 
 const requireEdit = requireRole('admin', 'editor')
 
-const VALID_PROVIDERS = new Set(['openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter'])
+const VALID_PROVIDERS = new Set([
+  'openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter',
+  'groq', 'deepseek', 'xai', 'cohere',
+])
 
 const SELECT_COLUMNS =
   'id, provider, name, is_active, api_key_id, provider_metadata, created_at, updated_at'
@@ -187,7 +190,7 @@ providerKeysRouter.post('/', requireEdit, async (c) => {
   }
 
   if (typeof body.provider !== 'string' || !VALID_PROVIDERS.has(body.provider)) {
-    throw new ApiError('VALIDATION_FAILED', 'provider must be one of: openai, anthropic, gemini, azure, mistral, openrouter')
+    throw new ApiError('VALIDATION_FAILED', 'provider must be one of: openai, anthropic, gemini, azure, mistral, openrouter, groq, deepseek, xai, cohere')
   }
   if (typeof body.key !== 'string' || body.key.trim().length === 0) {
     throw new ApiError('VALIDATION_FAILED', 'key is required')

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -13,6 +13,10 @@ import { geminiProxy }     from './proxy/gemini.js'
 import { azureProxy }      from './proxy/azure.js'
 import { mistralProxy }    from './proxy/mistral.js'
 import { openrouterProxy } from './proxy/openrouter.js'
+import { groqProxy }       from './proxy/groq.js'
+import { deepseekProxy }   from './proxy/deepseek.js'
+import { xaiProxy }        from './proxy/xai.js'
+import { cohereProxy }     from './proxy/cohere.js'
 
 import { organizationsRouter } from './api/organizations.js'
 import { projectsRouter }      from './api/projects.js'
@@ -145,6 +149,10 @@ app.route('/proxy/gemini',    geminiProxy)
 app.route('/proxy/azure',     azureProxy)
 app.route('/proxy/mistral',   mistralProxy)
 app.route('/proxy/openrouter', openrouterProxy)
+app.route('/proxy/groq',      groqProxy)
+app.route('/proxy/deepseek',  deepseekProxy)
+app.route('/proxy/xai',       xaiProxy)
+app.route('/proxy/cohere',    cohereProxy)
 
 // ── SDK ingestion routes (authApiKey middleware) ──────────────
 app.route('/ingest',          ingestRouter)

--- a/apps/server/src/lib/cost.ts
+++ b/apps/server/src/lib/cost.ts
@@ -17,7 +17,17 @@ import type { ServiceTier } from '../parsers/openai.js'
 // at OpenAI prices). The proxy in proxy/azure.ts calls calculateCost('openai', ...)
 // directly, but the type is included here so type-safe call sites that pass
 // `requests.provider` through don't have to special-case it.
-export type Provider = 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
+export type Provider =
+  | 'openai'
+  | 'anthropic'
+  | 'gemini'
+  | 'azure'
+  | 'mistral'
+  | 'openrouter'
+  | 'groq'
+  | 'deepseek'
+  | 'xai'
+  | 'cohere'
 
 export interface Usage {
   /** Total input tokens INCLUDING any cached/cache-creation portion. */

--- a/apps/server/src/lib/model-prices-cache.ts
+++ b/apps/server/src/lib/model-prices-cache.ts
@@ -144,6 +144,23 @@ export const FALLBACK_PRICES: Record<string, ModelPrice> = {
   'open-mistral-nemo':            { prompt: 0.15, completion: 0.15 },
   'mixtral-8x22b':                { prompt: 2.00, completion: 6.00 },
   'mistral-embed':                { prompt: 0.10, completion: 0 },
+  // ── Groq / DeepSeek / xAI / Cohere (OpenAI-compatible) ───────────────────
+  // Representative production models; full set lives in the seed +
+  // 20260701120100 migration. Cold-start fallback so cost lands non-NULL.
+  'llama-3.3-70b-versatile':      { prompt: 0.59,  completion: 0.79 },
+  'llama-3.1-8b-instant':         { prompt: 0.05,  completion: 0.08 },
+  'openai/gpt-oss-120b':          { prompt: 0.15,  completion: 0.60, cacheRead: 0.075 },
+  'openai/gpt-oss-20b':           { prompt: 0.075, completion: 0.30, cacheRead: 0.0375 },
+  'deepseek-chat':                { prompt: 0.14,  completion: 0.28, cacheRead: 0.0028 },
+  'deepseek-reasoner':            { prompt: 0.14,  completion: 0.28, cacheRead: 0.0028 },
+  'deepseek-v4-flash':            { prompt: 0.14,  completion: 0.28, cacheRead: 0.0028 },
+  'deepseek-v4-pro':              { prompt: 0.435, completion: 0.87, cacheRead: 0.003625 },
+  'grok-4.3':                     { prompt: 1.25,  completion: 2.50 },
+  'grok-build-0.1':               { prompt: 1.00,  completion: 2.00 },
+  'command-a-03-2025':            { prompt: 2.50,  completion: 10.00 },
+  'command-r-plus-08-2024':       { prompt: 2.50,  completion: 10.00 },
+  'command-r-08-2024':            { prompt: 0.15,  completion: 0.60 },
+  'command-r7b-12-2024':          { prompt: 0.0375, completion: 0.15 },
   // ── Anthropic: Claude 4.x (aliases + dated variants) ─────────────────────
   'claude-opus-4-7':              { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 },
   'claude-opus-4-6':              { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 }, // alias only; no dated form per docs

--- a/apps/server/src/proxy/cohere.ts
+++ b/apps/server/src/proxy/cohere.ts
@@ -1,0 +1,141 @@
+import { Hono } from 'hono'
+import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
+import { enforceQuota } from '../middleware/quota.js'
+import { proxyRateLimit } from '../middleware/rateLimit.js'
+import { customerRateLimit } from '../middleware/customerRateLimit.js'
+import { calculateCost } from '../lib/cost.js'
+import { logRequestAsync } from '../lib/logger.js'
+import { fireAndForget } from '../lib/wait-until.js'
+import { parseOpenAIResponse, type ServiceTier } from '../parsers/openai.js'
+import { buildUpstreamHeaders, buildDownstreamHeaders } from './utils.js'
+import { logOpenAIStream } from './stream-logger.js'
+import { assertProviderKey } from './shared/provider-key.js'
+import { parseProxyRequestBody, chooseFetchBody } from './shared/request-body.js'
+import { runSecurityGate } from './shared/security-gate.js'
+import { fetchUpstreamWithTimeout } from './shared/upstream-fetch.js'
+import { buildLogBase } from './shared/log-base.js'
+import { runLineBufferedStreamPump } from './shared/stream-pump.js'
+import { assertSafeProxyBase } from './shared/validate-base.js'
+
+// Cohere exposes an OpenAI-compatibility layer at `/compatibility/v1` that
+// translates to its native /v2/chat. Request shape, SSE chunk format, and the
+// `usage` object are OpenAI-compatible, so the OpenAI parser, stream logger,
+// and cost path apply unchanged. Only the upstream host + provider tag differ.
+//
+// Unlike OpenAI/Groq/DeepSeek/xAI we deliberately do NOT inject
+// `stream_options.include_usage`: Cohere's compat layer rejects/ignores a set
+// of OpenAI-only params (store, metadata, logit_bias, n, service_tier,
+// parallel_tool_calls, ...), and stream_options support on the compat surface
+// is not documented. Injecting an unrecognized param risks a 400. As a result
+// a streamed Cohere call may not carry a final usage chunk — those rows log
+// cost_usd = null (same graceful behaviour as any unknown model, gotcha #2).
+// Non-streaming Cohere calls always return usage and are costed normally. Model
+// IDs must be Cohere IDs (command-a-03-2025, command-r-08-2024, ...), not gpt-*.
+const COHERE_BASE = (
+  process.env['COHERE_API_BASE'] ?? 'https://api.cohere.ai/compatibility'
+).replace(/\/v1\/?$/, '')
+assertSafeProxyBase('COHERE_API_BASE', COHERE_BASE)
+
+export const cohereProxy = new Hono<ApiKeyContext>()
+
+cohereProxy.use('*', authApiKey)
+cohereProxy.use('*', requireFullScope)
+cohereProxy.use('*', proxyRateLimit)
+cohereProxy.use('*', enforceQuota)
+cohereProxy.use('*', customerRateLimit)
+
+cohereProxy.all('/*', async (c) => {
+  const handlerStartMs = Date.now()
+  const organizationId = c.get('organizationId')
+  const projectId = c.get('projectId') as string
+  const apiKeyId = c.get('apiKeyId')
+
+  const [providerKey, parsed] = await Promise.all([
+    assertProviderKey(apiKeyId, 'cohere'),
+    parseProxyRequestBody(c),
+  ])
+  const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
+
+  const upstreamUrl = `${COHERE_BASE}${c.req.path.replace(/^\/proxy\/cohere/, '')}`
+  const headers = buildUpstreamHeaders(c.req.raw.headers, {
+    Authorization: `Bearer ${providerKey.plaintext}`,
+    'Content-Type': 'application/json',
+  })
+
+  const { upstreamRes, latencyMs, proxyOverheadMs } = await fetchUpstreamWithTimeout({
+    url: upstreamUrl,
+    method: c.req.method,
+    headers,
+    body: chooseFetchBody(c, parsed, false),
+    provider: 'cohere',
+    handlerStartMs,
+  })
+
+  const logBase = buildLogBase({
+    c, provider: 'cohere',
+    organizationId, projectId, apiKeyId,
+    providerKey,
+    reqBodyJson: parsed.reqBodyJson,
+    requestFlags,
+    latencyMs, proxyOverheadMs,
+    statusCode: upstreamRes.status,
+  })
+
+  const model = (parsed.reqBodyJson?.['model'] as string | undefined) ?? ''
+
+  // ── Streaming path ────────────────────────────────────────────────────────
+  if (parsed.isStreaming && upstreamRes.body) {
+    return runLineBufferedStreamPump({
+      c, upstreamRes, handlerStartMs, provider: 'cohere',
+      onComplete: (lines, truncated) =>
+        logOpenAIStream(lines, { ...logBase, model }, { truncated }),
+    })
+  }
+
+  // ── Non-streaming path ────────────────────────────────────────────────────
+  const downstreamHeaders = buildDownstreamHeaders(upstreamRes.headers)
+  const resBodyText = await upstreamRes.text()
+  let resBodyJson: unknown = null
+  try { resBodyJson = JSON.parse(resBodyText) } catch { /* non-JSON response */ }
+
+  let promptTokens = 0
+  let completionTokens = 0
+  let totalTokens = 0
+  let cacheReadTokens = 0
+  let cacheWriteTokens = 0
+  let resolvedModel = model
+  let serviceTier: ServiceTier | undefined
+
+  if (upstreamRes.ok && resBodyJson) {
+    try {
+      const p = parseOpenAIResponse(resBodyJson as Record<string, unknown>)
+      if (p) {
+        resolvedModel = p.model || model
+        promptTokens = p.promptTokens
+        completionTokens = p.completionTokens
+        totalTokens = p.totalTokens
+        cacheReadTokens = p.cacheReadTokens ?? 0
+        cacheWriteTokens = p.cacheWriteTokens ?? 0
+        serviceTier = p.serviceTier
+      }
+    } catch { /* ignore */ }
+  }
+
+  const cost = calculateCost('cohere', resolvedModel, {
+    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
+  })
+
+  fireAndForget(c, logRequestAsync({
+    ...logBase,
+    model: resolvedModel,
+    promptTokens, completionTokens, totalTokens,
+    cacheReadTokens, cacheWriteTokens,
+    serviceTier: serviceTier ?? null,
+    costUsd: cost?.totalCost ?? null,
+    responseBody: resBodyJson,
+    errorMessage: upstreamRes.ok ? null : resBodyText.slice(0, 1000),
+  }))
+
+  return new Response(resBodyText, { status: upstreamRes.status, headers: downstreamHeaders })
+})

--- a/apps/server/src/proxy/deepseek.ts
+++ b/apps/server/src/proxy/deepseek.ts
@@ -1,0 +1,140 @@
+import { Hono } from 'hono'
+import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
+import { enforceQuota } from '../middleware/quota.js'
+import { proxyRateLimit } from '../middleware/rateLimit.js'
+import { customerRateLimit } from '../middleware/customerRateLimit.js'
+import { calculateCost } from '../lib/cost.js'
+import { logRequestAsync } from '../lib/logger.js'
+import { fireAndForget } from '../lib/wait-until.js'
+import { parseOpenAIResponse, type ServiceTier } from '../parsers/openai.js'
+import { buildUpstreamHeaders, buildDownstreamHeaders } from './utils.js'
+import { logOpenAIStream } from './stream-logger.js'
+import { assertProviderKey } from './shared/provider-key.js'
+import { parseProxyRequestBody, chooseFetchBody } from './shared/request-body.js'
+import { runSecurityGate } from './shared/security-gate.js'
+import { fetchUpstreamWithTimeout } from './shared/upstream-fetch.js'
+import { buildLogBase } from './shared/log-base.js'
+import { runLineBufferedStreamPump } from './shared/stream-pump.js'
+import { assertSafeProxyBase } from './shared/validate-base.js'
+
+// DeepSeek's API is OpenAI-compatible at `/v1` — request shape, SSE chunk
+// format, and `usage` field all match, so the OpenAI parser, stream logger,
+// and cost path apply unchanged. Only the upstream host + provider tag differ.
+//
+// DeepSeek honours `stream_options.include_usage`, so we inject it on
+// streaming calls to guarantee a final usage chunk (usage is null on
+// intermediate chunks without it).
+//
+// Reasoning models (deepseek-reasoner / v4 thinking mode) add a non-OpenAI
+// `reasoning_content` field to assistant messages. That's the customer's
+// concern on the request side (they must strip it from prior turns before
+// resending); the proxy passes bodies through untouched aside from the
+// stream_options injection, so no special handling is needed here.
+const DEEPSEEK_BASE = (
+  process.env['DEEPSEEK_API_BASE'] ?? 'https://api.deepseek.com'
+).replace(/\/v1\/?$/, '')
+assertSafeProxyBase('DEEPSEEK_API_BASE', DEEPSEEK_BASE)
+
+export const deepseekProxy = new Hono<ApiKeyContext>()
+
+deepseekProxy.use('*', authApiKey)
+deepseekProxy.use('*', requireFullScope)
+deepseekProxy.use('*', proxyRateLimit)
+deepseekProxy.use('*', enforceQuota)
+deepseekProxy.use('*', customerRateLimit)
+
+deepseekProxy.all('/*', async (c) => {
+  const handlerStartMs = Date.now()
+  const organizationId = c.get('organizationId')
+  const projectId = c.get('projectId') as string
+  const apiKeyId = c.get('apiKeyId')
+
+  const [providerKey, parsed] = await Promise.all([
+    assertProviderKey(apiKeyId, 'deepseek'),
+    parseProxyRequestBody(c, { injectOpenAIStreamOptions: true }),
+  ])
+  const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
+
+  const upstreamUrl = `${DEEPSEEK_BASE}${c.req.path.replace(/^\/proxy\/deepseek/, '')}`
+  const headers = buildUpstreamHeaders(c.req.raw.headers, {
+    Authorization: `Bearer ${providerKey.plaintext}`,
+    'Content-Type': 'application/json',
+  })
+
+  const { upstreamRes, latencyMs, proxyOverheadMs } = await fetchUpstreamWithTimeout({
+    url: upstreamUrl,
+    method: c.req.method,
+    headers,
+    body: chooseFetchBody(c, parsed, true),
+    provider: 'deepseek',
+    handlerStartMs,
+  })
+
+  const logBase = buildLogBase({
+    c, provider: 'deepseek',
+    organizationId, projectId, apiKeyId,
+    providerKey,
+    reqBodyJson: parsed.reqBodyJson,
+    requestFlags,
+    latencyMs, proxyOverheadMs,
+    statusCode: upstreamRes.status,
+  })
+
+  const model = (parsed.reqBodyJson?.['model'] as string | undefined) ?? ''
+
+  // ── Streaming path ────────────────────────────────────────────────────────
+  if (parsed.isStreaming && upstreamRes.body) {
+    return runLineBufferedStreamPump({
+      c, upstreamRes, handlerStartMs, provider: 'deepseek',
+      onComplete: (lines, truncated) =>
+        logOpenAIStream(lines, { ...logBase, model }, { truncated }),
+    })
+  }
+
+  // ── Non-streaming path ────────────────────────────────────────────────────
+  const downstreamHeaders = buildDownstreamHeaders(upstreamRes.headers)
+  const resBodyText = await upstreamRes.text()
+  let resBodyJson: unknown = null
+  try { resBodyJson = JSON.parse(resBodyText) } catch { /* non-JSON response */ }
+
+  let promptTokens = 0
+  let completionTokens = 0
+  let totalTokens = 0
+  let cacheReadTokens = 0
+  let cacheWriteTokens = 0
+  let resolvedModel = model
+  let serviceTier: ServiceTier | undefined
+
+  if (upstreamRes.ok && resBodyJson) {
+    try {
+      const p = parseOpenAIResponse(resBodyJson as Record<string, unknown>)
+      if (p) {
+        resolvedModel = p.model || model
+        promptTokens = p.promptTokens
+        completionTokens = p.completionTokens
+        totalTokens = p.totalTokens
+        cacheReadTokens = p.cacheReadTokens ?? 0
+        cacheWriteTokens = p.cacheWriteTokens ?? 0
+        serviceTier = p.serviceTier
+      }
+    } catch { /* ignore */ }
+  }
+
+  const cost = calculateCost('deepseek', resolvedModel, {
+    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
+  })
+
+  fireAndForget(c, logRequestAsync({
+    ...logBase,
+    model: resolvedModel,
+    promptTokens, completionTokens, totalTokens,
+    cacheReadTokens, cacheWriteTokens,
+    serviceTier: serviceTier ?? null,
+    costUsd: cost?.totalCost ?? null,
+    responseBody: resBodyJson,
+    errorMessage: upstreamRes.ok ? null : resBodyText.slice(0, 1000),
+  }))
+
+  return new Response(resBodyText, { status: upstreamRes.status, headers: downstreamHeaders })
+})

--- a/apps/server/src/proxy/groq.ts
+++ b/apps/server/src/proxy/groq.ts
@@ -1,0 +1,142 @@
+import { Hono } from 'hono'
+import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
+import { enforceQuota } from '../middleware/quota.js'
+import { proxyRateLimit } from '../middleware/rateLimit.js'
+import { customerRateLimit } from '../middleware/customerRateLimit.js'
+import { calculateCost } from '../lib/cost.js'
+import { logRequestAsync } from '../lib/logger.js'
+import { fireAndForget } from '../lib/wait-until.js'
+import { parseOpenAIResponse, type ServiceTier } from '../parsers/openai.js'
+import { buildUpstreamHeaders, buildDownstreamHeaders } from './utils.js'
+import { logOpenAIStream } from './stream-logger.js'
+import { assertProviderKey } from './shared/provider-key.js'
+import { parseProxyRequestBody, chooseFetchBody } from './shared/request-body.js'
+import { runSecurityGate } from './shared/security-gate.js'
+import { fetchUpstreamWithTimeout } from './shared/upstream-fetch.js'
+import { buildLogBase } from './shared/log-base.js'
+import { runLineBufferedStreamPump } from './shared/stream-pump.js'
+import { assertSafeProxyBase } from './shared/validate-base.js'
+
+// Groq Cloud exposes an OpenAI-compatible surface at `/openai/v1` — the
+// request shape, SSE chunk format, and `usage` field all match OpenAI, so
+// the OpenAI parser, stream logger, and cost path apply unchanged. Only the
+// upstream host + provider tag differ.
+//
+// Groq honours `stream_options.include_usage` (like OpenAI), so we inject it
+// on streaming calls to guarantee a final usage chunk — without it a streamed
+// Groq call would log 0 tokens / null cost.
+//
+// The default host bundles the `/openai` path segment so the incoming
+// `/proxy/groq/v1/chat/completions` maps to
+// `https://api.groq.com/openai/v1/chat/completions`. The trailing-/v1 strip
+// guards against an operator setting GROQ_API_BASE with a redundant /v1.
+const GROQ_BASE = (
+  process.env['GROQ_API_BASE'] ?? 'https://api.groq.com/openai'
+).replace(/\/v1\/?$/, '')
+assertSafeProxyBase('GROQ_API_BASE', GROQ_BASE)
+
+export const groqProxy = new Hono<ApiKeyContext>()
+
+groqProxy.use('*', authApiKey)
+groqProxy.use('*', requireFullScope)
+groqProxy.use('*', proxyRateLimit)
+groqProxy.use('*', enforceQuota)
+groqProxy.use('*', customerRateLimit)
+
+groqProxy.all('/*', async (c) => {
+  const handlerStartMs = Date.now()
+  const organizationId = c.get('organizationId')
+  // requireFullScope rejects 'public' keys and the DB CHECK constraint forces
+  // 'full' keys to carry a project_id, so this narrowing is safe.
+  const projectId = c.get('projectId') as string
+  const apiKeyId = c.get('apiKeyId')
+
+  const [providerKey, parsed] = await Promise.all([
+    assertProviderKey(apiKeyId, 'groq'),
+    parseProxyRequestBody(c, { injectOpenAIStreamOptions: true }),
+  ])
+  const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
+
+  const upstreamUrl = `${GROQ_BASE}${c.req.path.replace(/^\/proxy\/groq/, '')}`
+  const headers = buildUpstreamHeaders(c.req.raw.headers, {
+    Authorization: `Bearer ${providerKey.plaintext}`,
+    'Content-Type': 'application/json',
+  })
+
+  const { upstreamRes, latencyMs, proxyOverheadMs } = await fetchUpstreamWithTimeout({
+    url: upstreamUrl,
+    method: c.req.method,
+    headers,
+    body: chooseFetchBody(c, parsed, true),
+    provider: 'groq',
+    handlerStartMs,
+  })
+
+  const logBase = buildLogBase({
+    c, provider: 'groq',
+    organizationId, projectId, apiKeyId,
+    providerKey,
+    reqBodyJson: parsed.reqBodyJson,
+    requestFlags,
+    latencyMs, proxyOverheadMs,
+    statusCode: upstreamRes.status,
+  })
+
+  const model = (parsed.reqBodyJson?.['model'] as string | undefined) ?? ''
+
+  // ── Streaming path ────────────────────────────────────────────────────────
+  if (parsed.isStreaming && upstreamRes.body) {
+    return runLineBufferedStreamPump({
+      c, upstreamRes, handlerStartMs, provider: 'groq',
+      onComplete: (lines, truncated) =>
+        logOpenAIStream(lines, { ...logBase, model }, { truncated }),
+    })
+  }
+
+  // ── Non-streaming path ────────────────────────────────────────────────────
+  const downstreamHeaders = buildDownstreamHeaders(upstreamRes.headers)
+  const resBodyText = await upstreamRes.text()
+  let resBodyJson: unknown = null
+  try { resBodyJson = JSON.parse(resBodyText) } catch { /* non-JSON response */ }
+
+  let promptTokens = 0
+  let completionTokens = 0
+  let totalTokens = 0
+  let cacheReadTokens = 0
+  let cacheWriteTokens = 0
+  let resolvedModel = model
+  let serviceTier: ServiceTier | undefined
+
+  if (upstreamRes.ok && resBodyJson) {
+    try {
+      const p = parseOpenAIResponse(resBodyJson as Record<string, unknown>)
+      if (p) {
+        resolvedModel = p.model || model
+        promptTokens = p.promptTokens
+        completionTokens = p.completionTokens
+        totalTokens = p.totalTokens
+        cacheReadTokens = p.cacheReadTokens ?? 0
+        cacheWriteTokens = p.cacheWriteTokens ?? 0
+        serviceTier = p.serviceTier
+      }
+    } catch { /* ignore */ }
+  }
+
+  const cost = calculateCost('groq', resolvedModel, {
+    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
+  })
+
+  fireAndForget(c, logRequestAsync({
+    ...logBase,
+    model: resolvedModel,
+    promptTokens, completionTokens, totalTokens,
+    cacheReadTokens, cacheWriteTokens,
+    serviceTier: serviceTier ?? null,
+    costUsd: cost?.totalCost ?? null,
+    responseBody: resBodyJson,
+    errorMessage: upstreamRes.ok ? null : resBodyText.slice(0, 1000),
+  }))
+
+  return new Response(resBodyText, { status: upstreamRes.status, headers: downstreamHeaders })
+})

--- a/apps/server/src/proxy/shared/provider-key.ts
+++ b/apps/server/src/proxy/shared/provider-key.ts
@@ -16,7 +16,17 @@ import { getDecryptedProviderKey, type ResolvedProviderKey } from '../utils.js'
 
 /** Provider tag used in `NO_PROVIDER_KEY` error details and the user-visible
  * message. Matches the keys in provider_keys.provider. */
-export type ProxyProvider = 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
+export type ProxyProvider =
+  | 'openai'
+  | 'anthropic'
+  | 'gemini'
+  | 'azure'
+  | 'mistral'
+  | 'openrouter'
+  | 'groq'
+  | 'deepseek'
+  | 'xai'
+  | 'cohere'
 
 const PROVIDER_LABEL: Record<ProxyProvider, string> = {
   openai: 'OpenAI',
@@ -25,6 +35,10 @@ const PROVIDER_LABEL: Record<ProxyProvider, string> = {
   azure: 'Azure',
   mistral: 'Mistral',
   openrouter: 'OpenRouter',
+  groq: 'Groq',
+  deepseek: 'DeepSeek',
+  xai: 'xAI',
+  cohere: 'Cohere',
 }
 
 /**

--- a/apps/server/src/proxy/xai.ts
+++ b/apps/server/src/proxy/xai.ts
@@ -1,0 +1,137 @@
+import { Hono } from 'hono'
+import { authApiKey, type ApiKeyContext } from '../middleware/authApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
+import { enforceQuota } from '../middleware/quota.js'
+import { proxyRateLimit } from '../middleware/rateLimit.js'
+import { customerRateLimit } from '../middleware/customerRateLimit.js'
+import { calculateCost } from '../lib/cost.js'
+import { logRequestAsync } from '../lib/logger.js'
+import { fireAndForget } from '../lib/wait-until.js'
+import { parseOpenAIResponse, type ServiceTier } from '../parsers/openai.js'
+import { buildUpstreamHeaders, buildDownstreamHeaders } from './utils.js'
+import { logOpenAIStream } from './stream-logger.js'
+import { assertProviderKey } from './shared/provider-key.js'
+import { parseProxyRequestBody, chooseFetchBody } from './shared/request-body.js'
+import { runSecurityGate } from './shared/security-gate.js'
+import { fetchUpstreamWithTimeout } from './shared/upstream-fetch.js'
+import { buildLogBase } from './shared/log-base.js'
+import { runLineBufferedStreamPump } from './shared/stream-pump.js'
+import { assertSafeProxyBase } from './shared/validate-base.js'
+
+// xAI's Grok API is OpenAI-compatible at `/v1` — request shape, SSE chunk
+// format, and the OpenAI `usage` fields (prompt_tokens/completion_tokens) all
+// match, so the OpenAI parser, stream logger, and cost path apply unchanged.
+// Only the upstream host + provider tag differ.
+//
+// Grok honours `stream_options.include_usage` (OpenAI-compatible), so we
+// inject it on streaming calls to guarantee a final usage chunk. Grok's
+// response usage carries extra non-OpenAI fields (reasoning_tokens under
+// completion_tokens_details, num_sources_used for live search); the OpenAI
+// parser reads the standard fields and ignores the rest.
+const XAI_BASE = (
+  process.env['XAI_API_BASE'] ?? 'https://api.x.ai'
+).replace(/\/v1\/?$/, '')
+assertSafeProxyBase('XAI_API_BASE', XAI_BASE)
+
+export const xaiProxy = new Hono<ApiKeyContext>()
+
+xaiProxy.use('*', authApiKey)
+xaiProxy.use('*', requireFullScope)
+xaiProxy.use('*', proxyRateLimit)
+xaiProxy.use('*', enforceQuota)
+xaiProxy.use('*', customerRateLimit)
+
+xaiProxy.all('/*', async (c) => {
+  const handlerStartMs = Date.now()
+  const organizationId = c.get('organizationId')
+  const projectId = c.get('projectId') as string
+  const apiKeyId = c.get('apiKeyId')
+
+  const [providerKey, parsed] = await Promise.all([
+    assertProviderKey(apiKeyId, 'xai'),
+    parseProxyRequestBody(c, { injectOpenAIStreamOptions: true }),
+  ])
+  const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
+
+  const upstreamUrl = `${XAI_BASE}${c.req.path.replace(/^\/proxy\/xai/, '')}`
+  const headers = buildUpstreamHeaders(c.req.raw.headers, {
+    Authorization: `Bearer ${providerKey.plaintext}`,
+    'Content-Type': 'application/json',
+  })
+
+  const { upstreamRes, latencyMs, proxyOverheadMs } = await fetchUpstreamWithTimeout({
+    url: upstreamUrl,
+    method: c.req.method,
+    headers,
+    body: chooseFetchBody(c, parsed, true),
+    provider: 'xai',
+    handlerStartMs,
+  })
+
+  const logBase = buildLogBase({
+    c, provider: 'xai',
+    organizationId, projectId, apiKeyId,
+    providerKey,
+    reqBodyJson: parsed.reqBodyJson,
+    requestFlags,
+    latencyMs, proxyOverheadMs,
+    statusCode: upstreamRes.status,
+  })
+
+  const model = (parsed.reqBodyJson?.['model'] as string | undefined) ?? ''
+
+  // ── Streaming path ────────────────────────────────────────────────────────
+  if (parsed.isStreaming && upstreamRes.body) {
+    return runLineBufferedStreamPump({
+      c, upstreamRes, handlerStartMs, provider: 'xai',
+      onComplete: (lines, truncated) =>
+        logOpenAIStream(lines, { ...logBase, model }, { truncated }),
+    })
+  }
+
+  // ── Non-streaming path ────────────────────────────────────────────────────
+  const downstreamHeaders = buildDownstreamHeaders(upstreamRes.headers)
+  const resBodyText = await upstreamRes.text()
+  let resBodyJson: unknown = null
+  try { resBodyJson = JSON.parse(resBodyText) } catch { /* non-JSON response */ }
+
+  let promptTokens = 0
+  let completionTokens = 0
+  let totalTokens = 0
+  let cacheReadTokens = 0
+  let cacheWriteTokens = 0
+  let resolvedModel = model
+  let serviceTier: ServiceTier | undefined
+
+  if (upstreamRes.ok && resBodyJson) {
+    try {
+      const p = parseOpenAIResponse(resBodyJson as Record<string, unknown>)
+      if (p) {
+        resolvedModel = p.model || model
+        promptTokens = p.promptTokens
+        completionTokens = p.completionTokens
+        totalTokens = p.totalTokens
+        cacheReadTokens = p.cacheReadTokens ?? 0
+        cacheWriteTokens = p.cacheWriteTokens ?? 0
+        serviceTier = p.serviceTier
+      }
+    } catch { /* ignore */ }
+  }
+
+  const cost = calculateCost('xai', resolvedModel, {
+    promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
+  })
+
+  fireAndForget(c, logRequestAsync({
+    ...logBase,
+    model: resolvedModel,
+    promptTokens, completionTokens, totalTokens,
+    cacheReadTokens, cacheWriteTokens,
+    serviceTier: serviceTier ?? null,
+    costUsd: cost?.totalCost ?? null,
+    responseBody: resBodyJson,
+    errorMessage: upstreamRes.ok ? null : resBodyText.slice(0, 1000),
+  }))
+
+  return new Response(resBodyText, { status: upstreamRes.status, headers: downstreamHeaders })
+})

--- a/apps/web/app/(dashboard)/projects/projects-client.tsx
+++ b/apps/web/app/(dashboard)/projects/projects-client.tsx
@@ -76,7 +76,10 @@ function CopyIdButton({ value, label = 'Copy ID' }: { value: string; label?: str
   )
 }
 
-const PROVIDERS = ['openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter'] as const
+const PROVIDERS = [
+  'openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter',
+  'groq', 'deepseek', 'xai', 'cohere',
+] as const
 type ProviderName = typeof PROVIDERS[number]
 
 const PROVIDER_LABELS: Record<ProviderName, string> = {
@@ -86,6 +89,10 @@ const PROVIDER_LABELS: Record<ProviderName, string> = {
   azure: 'Azure OpenAI',
   mistral: 'Mistral',
   openrouter: 'OpenRouter',
+  groq: 'Groq',
+  deepseek: 'DeepSeek',
+  xai: 'xAI (Grok)',
+  cohere: 'Cohere',
 }
 
 const PROVIDER_PLACEHOLDERS: Record<ProviderName, string> = {
@@ -97,6 +104,10 @@ const PROVIDER_PLACEHOLDERS: Record<ProviderName, string> = {
   azure: '0123456789abcdef0123456789abcdef',
   mistral: 'mistral-…',
   openrouter: 'sk-or-v1-…',
+  groq: 'gsk_…',
+  deepseek: 'sk-…',
+  xai: 'xai-…',
+  cohere: 'Cohere API key',
 }
 
 /**
@@ -151,6 +162,27 @@ const openrouter = new OpenAI({
   apiKey: process.env.SPANLENS_API_KEY,
 })
 // await openrouter.chat.completions.create({ model: 'anthropic/claude-sonnet-4', messages: [...] })`,
+  groq: `import { createGroq } from '@spanlens/sdk/groq'
+
+// Groq is OpenAI-compatible — createGroq() points the OpenAI SDK at the
+// Spanlens proxy. Use any Groq model id.
+const groq = createGroq()
+// await groq.chat.completions.create({ model: 'llama-3.3-70b-versatile', messages: [...] })`,
+  deepseek: `import { createDeepSeek } from '@spanlens/sdk/deepseek'
+
+// DeepSeek is OpenAI-compatible — createDeepSeek() routes through Spanlens.
+const deepseek = createDeepSeek()
+// await deepseek.chat.completions.create({ model: 'deepseek-chat', messages: [...] })`,
+  xai: `import { createXai } from '@spanlens/sdk/xai'
+
+// xAI (Grok) is OpenAI-compatible — createXai() routes through Spanlens.
+const xai = createXai()
+// await xai.chat.completions.create({ model: 'grok-4.3', messages: [...] })`,
+  cohere: `import { createCohere } from '@spanlens/sdk/cohere'
+
+// Cohere's OpenAI-compat layer routes through Spanlens. Use Cohere model ids.
+const cohere = createCohere()
+// await cohere.chat.completions.create({ model: 'command-a-03-2025', messages: [...] })`,
 }
 
 export function ProjectsClient() {

--- a/apps/web/app/docs/proxy/page.tsx
+++ b/apps/web/app/docs/proxy/page.tsx
@@ -38,7 +38,11 @@ https://server.spanlens.io/proxy/anthropic
 https://server.spanlens.io/proxy/gemini/v1beta
 https://server.spanlens.io/proxy/azure
 https://server.spanlens.io/proxy/mistral/v1
-https://server.spanlens.io/proxy/openrouter/v1`}</CodeBlock>
+https://server.spanlens.io/proxy/openrouter/v1
+https://server.spanlens.io/proxy/groq/v1
+https://server.spanlens.io/proxy/deepseek/v1
+https://server.spanlens.io/proxy/xai/v1
+https://server.spanlens.io/proxy/cohere/v1`}</CodeBlock>
       <p>
         Send requests exactly as you would to the real provider, with two changes:
       </p>
@@ -224,6 +228,37 @@ res2 = client.chat.completions.create(
         model + no <code>usage.cost</code> → <code>cost_usd</code> lands
         NULL (visible in <a href="/requests">/requests</a> so you know to
         check OpenRouter&apos;s own dashboard for that row).
+      </p>
+
+      <h2 id="openai-compat-providers">Groq, DeepSeek, xAI, Cohere</h2>
+      <p>
+        Four more OpenAI-compatible providers route through Spanlens with the
+        same base-URL swap. Register the provider key on{' '}
+        <a href="/projects">/projects</a>, then point the OpenAI SDK (or the
+        matching <code>@spanlens/sdk</code> helper) at the proxy route:
+      </p>
+      <CodeBlock>{`import { createGroq }     from '@spanlens/sdk/groq'
+import { createDeepSeek } from '@spanlens/sdk/deepseek'
+import { createXai }      from '@spanlens/sdk/xai'
+import { createCohere }   from '@spanlens/sdk/cohere'
+
+const groq     = createGroq()      // model: 'llama-3.3-70b-versatile'
+const deepseek = createDeepSeek()  // model: 'deepseek-chat'
+const xai      = createXai()       // model: 'grok-4.3'
+const cohere   = createCohere()    // model: 'command-a-03-2025' (Cohere ids, not gpt-*)
+
+// Each behaves like a normal OpenAI client:
+// await groq.chat.completions.create({ model: 'llama-3.3-70b-versatile', messages: [...] })`}</CodeBlock>
+      <p className="text-sm text-muted-foreground">
+        All four speak the OpenAI Chat Completions protocol, so tokens, latency,
+        and cost land on every <a href="/requests">/requests</a> row. Groq,
+        DeepSeek, and xAI stream usage on the final chunk (Spanlens injects{' '}
+        <code>stream_options.include_usage</code> automatically). Cohere&apos;s
+        compatibility layer does not accept that flag, so a streamed Cohere call
+        may log <code>cost_usd</code> as null; non-streaming Cohere calls are
+        costed normally. Seeded prices cover the current production models on
+        each provider; an unpriced model logs <code>cost_usd</code> null rather
+        than a wrong number.
       </p>
 
       <h2 id="curl">curl, raw HTTP</h2>

--- a/apps/web/lib/queries/use-provider-keys.ts
+++ b/apps/web/lib/queries/use-provider-keys.ts
@@ -33,7 +33,9 @@ export function useAddProviderKey() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: async (input: {
-      provider: 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
+      provider:
+        | 'openai' | 'anthropic' | 'gemini' | 'azure' | 'mistral' | 'openrouter'
+        | 'groq' | 'deepseek' | 'xai' | 'cohere'
       key: string
       name: string
       api_key_id: string

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @spanlens/sdk changelog
 
+## 0.15.0
+
+Four more OpenAI-compatible providers: Groq, DeepSeek, xAI (Grok), and Cohere.
+
+### Added
+
+- `@spanlens/sdk/groq`, `@spanlens/sdk/deepseek`, `@spanlens/sdk/xai`, and `@spanlens/sdk/cohere` subpaths, each exporting a `createX(options?)` factory that returns an OpenAI-compatible client already pointed at the matching hosted Spanlens proxy route, plus its `observeX` tracer. `DEFAULT_SPANLENS_<PROVIDER>_PROXY` is exported for self-hosted overrides.
+- `observeGroq`, `observeDeepSeek`, `observeXai`, and `observeCohere` are also exported from the package root. All four parse the standard OpenAI `usage` shape and tag the span with the right provider.
+
+Register the provider key on your Spanlens project, set `SPANLENS_API_KEY`, and the client works like a normal OpenAI client. Streamed Groq / DeepSeek / xAI calls capture usage automatically; Cohere's compatibility layer does not accept the usage-on-stream flag, so streamed Cohere calls may log cost as null (non-streaming Cohere is costed normally).
+
 ## 0.14.0
 
 Dedicated Ollama subpath — a one-line client factory for local models.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",
@@ -26,6 +26,22 @@
     "./ollama": {
       "import": "./dist/integrations/ollama.js",
       "types": "./dist/integrations/ollama.d.ts"
+    },
+    "./groq": {
+      "import": "./dist/integrations/groq.js",
+      "types": "./dist/integrations/groq.d.ts"
+    },
+    "./deepseek": {
+      "import": "./dist/integrations/deepseek.js",
+      "types": "./dist/integrations/deepseek.d.ts"
+    },
+    "./xai": {
+      "import": "./dist/integrations/xai.js",
+      "types": "./dist/integrations/xai.d.ts"
+    },
+    "./cohere": {
+      "import": "./dist/integrations/cohere.js",
+      "types": "./dist/integrations/cohere.d.ts"
     },
     "./langchain": {
       "import": "./dist/integrations/langchain.js",
@@ -94,6 +110,11 @@
     "vercel-ai",
     "ai-sdk",
     "ollama",
+    "groq",
+    "deepseek",
+    "grok",
+    "xai",
+    "cohere",
     "next.js",
     "nextjs",
     "typescript",

--- a/packages/sdk/src/__tests__/proxy-providers.test.ts
+++ b/packages/sdk/src/__tests__/proxy-providers.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createGroq, DEFAULT_SPANLENS_GROQ_PROXY, observeGroq } from '../integrations/groq.js'
+import { createDeepSeek, DEFAULT_SPANLENS_DEEPSEEK_PROXY, observeDeepSeek } from '../integrations/deepseek.js'
+import { createXai, DEFAULT_SPANLENS_XAI_PROXY, observeXai } from '../integrations/xai.js'
+import { createCohere, DEFAULT_SPANLENS_COHERE_PROXY, observeCohere } from '../integrations/cohere.js'
+
+/**
+ * The four OpenAI-compatible provider factories all route through the hosted
+ * Spanlens proxy (unlike createOllama, which is local). They share the
+ * makeSpanlensProxyClient helper, so these tests pin the per-provider default
+ * URL, the SPANLENS_API_KEY requirement, and the observe re-export.
+ */
+
+const CASES = [
+  { name: 'Groq', create: createGroq, url: DEFAULT_SPANLENS_GROQ_PROXY, observe: observeGroq, slug: 'groq' },
+  { name: 'DeepSeek', create: createDeepSeek, url: DEFAULT_SPANLENS_DEEPSEEK_PROXY, observe: observeDeepSeek, slug: 'deepseek' },
+  { name: 'xAI', create: createXai, url: DEFAULT_SPANLENS_XAI_PROXY, observe: observeXai, slug: 'xai' },
+  { name: 'Cohere', create: createCohere, url: DEFAULT_SPANLENS_COHERE_PROXY, observe: observeCohere, slug: 'cohere' },
+] as const
+
+describe('OpenAI-compatible proxy client factories', () => {
+  let original: string | undefined
+
+  beforeEach(() => {
+    original = process.env.SPANLENS_API_KEY
+    process.env.SPANLENS_API_KEY = 'sl_live_test_key'
+  })
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.SPANLENS_API_KEY
+    else process.env.SPANLENS_API_KEY = original
+  })
+
+  for (const { name, create, url, observe, slug } of CASES) {
+    describe(name, () => {
+      it(`defaults baseURL to the Spanlens ${slug} proxy route`, () => {
+        expect(create().baseURL).toBe(url)
+        expect(url).toContain(`/proxy/${slug}/v1`)
+      })
+
+      it('picks up SPANLENS_API_KEY from the environment', () => {
+        expect(create().apiKey).toBe('sl_live_test_key')
+      })
+
+      it('throws a helpful error when SPANLENS_API_KEY is missing', () => {
+        delete process.env.SPANLENS_API_KEY
+        expect(() => create()).toThrow(/SPANLENS_API_KEY/)
+      })
+
+      it('accepts explicit apiKey + baseURL overrides', () => {
+        const client = create({ apiKey: 'override', baseURL: 'https://self-hosted.example/proxy' })
+        expect(client.apiKey).toBe('override')
+        expect(client.baseURL).toBe('https://self-hosted.example/proxy')
+      })
+
+      it('re-exports its observe helper for single-import ergonomics', () => {
+        expect(typeof observe).toBe('function')
+      })
+    })
+  }
+})

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,7 +1,17 @@
 export { SpanlensClient } from './client.js'
 export { TraceHandle } from './trace.js'
 export { SpanHandle } from './span.js'
-export { observe, observeOpenAI, observeAnthropic, observeGemini, observeOllama } from './observe.js'
+export {
+  observe,
+  observeOpenAI,
+  observeAnthropic,
+  observeGemini,
+  observeOllama,
+  observeGroq,
+  observeDeepSeek,
+  observeXai,
+  observeCohere,
+} from './observe.js'
 export { parseOpenAIUsage, parseAnthropicUsage, parseGeminiUsage } from './parsers.js'
 // Sprint 7 R-15 + R-20: typed exception thrown on Spanlens server errors
 // that follow the standard envelope. See transport.ts for the shape.

--- a/packages/sdk/src/integrations/_proxy-client.ts
+++ b/packages/sdk/src/integrations/_proxy-client.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared factory for OpenAI-compatible providers routed through the Spanlens
+ * proxy (Groq, DeepSeek, xAI, Cohere, ...).
+ *
+ * These providers all speak the OpenAI Chat Completions wire protocol, so the
+ * client is just `new OpenAI(...)` with `baseURL` pointed at the matching
+ * Spanlens proxy route (which records the call in /requests, enforces quota,
+ * and forwards to the real provider using the encrypted provider key stored
+ * server-side). `apiKey` is your **Spanlens** key (SPANLENS_API_KEY), not the
+ * upstream provider key — the provider key never leaves the server.
+ *
+ * `openai` is a peer dependency — install it alongside this SDK.
+ */
+
+import OpenAI from 'openai'
+import type { ClientOptions } from 'openai'
+
+function readEnv(name: string): string | undefined {
+  // Node + Vercel Edge both expose process.env; guard for browser bundles.
+  if (typeof process !== 'undefined' && process.env) {
+    return process.env[name]
+  }
+  return undefined
+}
+
+/**
+ * Build an OpenAI-SDK client whose requests flow through a Spanlens proxy
+ * route for an OpenAI-compatible provider.
+ *
+ * @param providerLabel Capitalized helper name used in the missing-key error
+ *   (e.g. `'Groq'` → "...pass { apiKey } to createGroq()").
+ * @param defaultProxyUrl Default `baseURL` (the hosted Spanlens proxy route).
+ * @param options Forwards to `new OpenAI(options)`. `apiKey` defaults to
+ *   `SPANLENS_API_KEY`; override `baseURL` for self-hosted deployments.
+ *
+ * @throws Error if `apiKey` is missing (env + explicit both unset).
+ */
+export function makeSpanlensProxyClient(
+  providerLabel: string,
+  defaultProxyUrl: string,
+  options: ClientOptions = {},
+): OpenAI {
+  const apiKey = options.apiKey ?? readEnv('SPANLENS_API_KEY')
+
+  if (!apiKey) {
+    throw new Error(
+      `[spanlens] SPANLENS_API_KEY is not set. Pass { apiKey } to create${providerLabel}() ` +
+        'or add SPANLENS_API_KEY to your environment (e.g. .env.local, Vercel env).',
+    )
+  }
+
+  return new OpenAI({
+    ...options,
+    apiKey,
+    baseURL: options.baseURL ?? defaultProxyUrl,
+  })
+}

--- a/packages/sdk/src/integrations/cohere.ts
+++ b/packages/sdk/src/integrations/cohere.ts
@@ -1,0 +1,45 @@
+/**
+ * Cohere client helper — pre-configured for the Spanlens proxy.
+ *
+ * Cohere exposes an OpenAI-compatibility layer, so the OpenAI SDK works with
+ * `baseURL` pointed at the Spanlens Cohere proxy route. Requests are recorded
+ * in /requests (tokens, latency, cost) and forwarded to Cohere using the
+ * Cohere key you registered in Spanlens. Use Cohere model ids
+ * (`command-a-03-2025`, `command-r-08-2024`, ...), not `gpt-*` names.
+ *
+ *   import { createCohere, observeCohere } from '@spanlens/sdk/cohere'
+ *   const cohere = createCohere()
+ *
+ * `openai` is a peer dependency — install it alongside this SDK.
+ *
+ * @example
+ *   import { SpanlensClient } from '@spanlens/sdk'
+ *   import { createCohere, observeCohere } from '@spanlens/sdk/cohere'
+ *
+ *   const spanlens = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+ *   const cohere = createCohere()
+ *
+ *   const trace = spanlens.startTrace({ name: 'chat' })
+ *   const res = await observeCohere(trace, 'chat', (headers) =>
+ *     cohere.chat.completions.create(
+ *       { model: 'command-a-03-2025', messages: [{ role: 'user', content: 'Hi' }] },
+ *       { headers },
+ *     ),
+ *   )
+ *   await trace.end({ status: 'completed' })
+ */
+
+import type OpenAI from 'openai'
+import type { ClientOptions } from 'openai'
+import { makeSpanlensProxyClient } from './_proxy-client.js'
+
+/** Default Spanlens Cohere proxy URL. Override for self-hosted deployments. */
+export const DEFAULT_SPANLENS_COHERE_PROXY =
+  'https://spanlens-server.vercel.app/proxy/cohere/v1'
+
+/** Build an OpenAI-compatible client whose requests flow through the Spanlens Cohere proxy. */
+export function createCohere(options: ClientOptions = {}): OpenAI {
+  return makeSpanlensProxyClient('Cohere', DEFAULT_SPANLENS_COHERE_PROXY, options)
+}
+
+export { observeCohere } from '../observe.js'

--- a/packages/sdk/src/integrations/deepseek.ts
+++ b/packages/sdk/src/integrations/deepseek.ts
@@ -1,0 +1,44 @@
+/**
+ * DeepSeek client helper — pre-configured for the Spanlens proxy.
+ *
+ * DeepSeek exposes an OpenAI-compatible API, so the OpenAI SDK works unchanged
+ * with `baseURL` pointed at the Spanlens DeepSeek proxy route. Requests are
+ * recorded in /requests (tokens, latency, cost) and forwarded to DeepSeek
+ * using the DeepSeek key you registered in Spanlens.
+ *
+ *   import { createDeepSeek, observeDeepSeek } from '@spanlens/sdk/deepseek'
+ *   const deepseek = createDeepSeek()
+ *
+ * `openai` is a peer dependency — install it alongside this SDK.
+ *
+ * @example
+ *   import { SpanlensClient } from '@spanlens/sdk'
+ *   import { createDeepSeek, observeDeepSeek } from '@spanlens/sdk/deepseek'
+ *
+ *   const spanlens = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+ *   const deepseek = createDeepSeek()
+ *
+ *   const trace = spanlens.startTrace({ name: 'chat' })
+ *   const res = await observeDeepSeek(trace, 'chat', (headers) =>
+ *     deepseek.chat.completions.create(
+ *       { model: 'deepseek-chat', messages: [{ role: 'user', content: 'Hi' }] },
+ *       { headers },
+ *     ),
+ *   )
+ *   await trace.end({ status: 'completed' })
+ */
+
+import type OpenAI from 'openai'
+import type { ClientOptions } from 'openai'
+import { makeSpanlensProxyClient } from './_proxy-client.js'
+
+/** Default Spanlens DeepSeek proxy URL. Override for self-hosted deployments. */
+export const DEFAULT_SPANLENS_DEEPSEEK_PROXY =
+  'https://spanlens-server.vercel.app/proxy/deepseek/v1'
+
+/** Build an OpenAI-compatible client whose requests flow through the Spanlens DeepSeek proxy. */
+export function createDeepSeek(options: ClientOptions = {}): OpenAI {
+  return makeSpanlensProxyClient('DeepSeek', DEFAULT_SPANLENS_DEEPSEEK_PROXY, options)
+}
+
+export { observeDeepSeek } from '../observe.js'

--- a/packages/sdk/src/integrations/groq.ts
+++ b/packages/sdk/src/integrations/groq.ts
@@ -1,0 +1,46 @@
+/**
+ * Groq client helper — pre-configured for the Spanlens proxy.
+ *
+ * Groq exposes an OpenAI-compatible API, so the OpenAI SDK works unchanged
+ * with `baseURL` pointed at the Spanlens Groq proxy route. Your requests are
+ * recorded in /requests (tokens, latency, cost) and forwarded to Groq using
+ * the Groq key you registered in Spanlens.
+ *
+ *   import { createGroq, observeGroq } from '@spanlens/sdk/groq'
+ *   const groq = createGroq()
+ *
+ * `openai` is a peer dependency — install it alongside this SDK.
+ *
+ * @example  Full traced call.
+ *   import { SpanlensClient } from '@spanlens/sdk'
+ *   import { createGroq, observeGroq } from '@spanlens/sdk/groq'
+ *
+ *   const spanlens = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+ *   const groq = createGroq()
+ *
+ *   const trace = spanlens.startTrace({ name: 'chat' })
+ *   const res = await observeGroq(trace, 'chat', (headers) =>
+ *     groq.chat.completions.create(
+ *       { model: 'llama-3.3-70b-versatile', messages: [{ role: 'user', content: 'Hi' }] },
+ *       { headers },
+ *     ),
+ *   )
+ *   await trace.end({ status: 'completed' })
+ */
+
+import type OpenAI from 'openai'
+import type { ClientOptions } from 'openai'
+import { makeSpanlensProxyClient } from './_proxy-client.js'
+
+/** Default Spanlens Groq proxy URL. Override for self-hosted deployments. */
+export const DEFAULT_SPANLENS_GROQ_PROXY =
+  'https://spanlens-server.vercel.app/proxy/groq/v1'
+
+/** Build an OpenAI-compatible client whose requests flow through the Spanlens Groq proxy. */
+export function createGroq(options: ClientOptions = {}): OpenAI {
+  return makeSpanlensProxyClient('Groq', DEFAULT_SPANLENS_GROQ_PROXY, options)
+}
+
+// Re-export the tracer so a single `@spanlens/sdk/groq` import gives both the
+// client factory and the matching `observe` helper.
+export { observeGroq } from '../observe.js'

--- a/packages/sdk/src/integrations/xai.ts
+++ b/packages/sdk/src/integrations/xai.ts
@@ -1,0 +1,44 @@
+/**
+ * xAI (Grok) client helper — pre-configured for the Spanlens proxy.
+ *
+ * xAI's API is OpenAI-compatible, so the OpenAI SDK works unchanged with
+ * `baseURL` pointed at the Spanlens xAI proxy route. Requests are recorded in
+ * /requests (tokens, latency, cost) and forwarded to xAI using the xAI key
+ * you registered in Spanlens.
+ *
+ *   import { createXai, observeXai } from '@spanlens/sdk/xai'
+ *   const xai = createXai()
+ *
+ * `openai` is a peer dependency — install it alongside this SDK.
+ *
+ * @example
+ *   import { SpanlensClient } from '@spanlens/sdk'
+ *   import { createXai, observeXai } from '@spanlens/sdk/xai'
+ *
+ *   const spanlens = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+ *   const xai = createXai()
+ *
+ *   const trace = spanlens.startTrace({ name: 'chat' })
+ *   const res = await observeXai(trace, 'chat', (headers) =>
+ *     xai.chat.completions.create(
+ *       { model: 'grok-4.3', messages: [{ role: 'user', content: 'Hi' }] },
+ *       { headers },
+ *     ),
+ *   )
+ *   await trace.end({ status: 'completed' })
+ */
+
+import type OpenAI from 'openai'
+import type { ClientOptions } from 'openai'
+import { makeSpanlensProxyClient } from './_proxy-client.js'
+
+/** Default Spanlens xAI proxy URL. Override for self-hosted deployments. */
+export const DEFAULT_SPANLENS_XAI_PROXY =
+  'https://spanlens-server.vercel.app/proxy/xai/v1'
+
+/** Build an OpenAI-compatible client whose requests flow through the Spanlens xAI proxy. */
+export function createXai(options: ClientOptions = {}): OpenAI {
+  return makeSpanlensProxyClient('Xai', DEFAULT_SPANLENS_XAI_PROXY, options)
+}
+
+export { observeXai } from '../observe.js'

--- a/packages/sdk/src/observe.ts
+++ b/packages/sdk/src/observe.ts
@@ -58,7 +58,21 @@ export async function observe<T>(
 //     openai.chat.completions.create({ ... }, { headers })
 //   )
 
-type Usage = 'openai' | 'anthropic' | 'gemini' | 'ollama'
+type Usage =
+  | 'openai'
+  | 'anthropic'
+  | 'gemini'
+  | 'ollama'
+  | 'groq'
+  | 'deepseek'
+  | 'xai'
+  | 'cohere'
+
+// OpenAI-compatible providers whose responses carry the standard OpenAI
+// `usage` shape (prompt_tokens / completion_tokens) — parsed by parseOpenAIUsage.
+const OPENAI_SHAPED = new Set<Usage>([
+  'openai', 'ollama', 'groq', 'deepseek', 'xai', 'cohere',
+])
 
 const PROMPT_VERSION_HEADER = 'x-spanlens-prompt-version'
 const LOG_BODY_HEADER = 'x-spanlens-log-body'
@@ -131,10 +145,11 @@ async function observeProvider<T>(
     const result = await fn(headers)
 
     // Auto-parse usage from the provider response shape.
-    // Ollama uses OpenAI's response schema (it exposes an /v1 OpenAI-compat
-    // surface) so the OpenAI parser works as-is — only the provider tag differs.
+    // OpenAI-compatible providers (Ollama, Groq, DeepSeek, xAI, Cohere) expose
+    // an OpenAI-shaped `usage` field, so the OpenAI parser works as-is — only
+    // the provider tag differs.
     const parsed =
-      provider === 'openai' || provider === 'ollama'
+      OPENAI_SHAPED.has(provider)
         ? parseOpenAIUsage(result)
         : provider === 'anthropic'
           ? parseAnthropicUsage(result)
@@ -236,4 +251,44 @@ export function observeOllama<T>(
   fn: (headers: Record<string, string>) => Promise<T>,
 ): Promise<T> {
   return observeProvider('ollama', parent, nameOrOptions, fn)
+}
+
+/**
+ * Groq variant — Groq's API is OpenAI-compatible, so `usage` is parsed with
+ * the OpenAI parser and the span is tagged `provider: 'groq'`. Prefer the
+ * dedicated `createGroq()` client from `@spanlens/sdk/groq`.
+ */
+export function observeGroq<T>(
+  parent: TraceHandle | SpanHandle,
+  nameOrOptions: string | ProviderObserveOptions,
+  fn: (headers: Record<string, string>) => Promise<T>,
+): Promise<T> {
+  return observeProvider('groq', parent, nameOrOptions, fn)
+}
+
+/** DeepSeek variant — OpenAI-compatible `usage`, span tagged `provider: 'deepseek'`. */
+export function observeDeepSeek<T>(
+  parent: TraceHandle | SpanHandle,
+  nameOrOptions: string | ProviderObserveOptions,
+  fn: (headers: Record<string, string>) => Promise<T>,
+): Promise<T> {
+  return observeProvider('deepseek', parent, nameOrOptions, fn)
+}
+
+/** xAI (Grok) variant — OpenAI-compatible `usage`, span tagged `provider: 'xai'`. */
+export function observeXai<T>(
+  parent: TraceHandle | SpanHandle,
+  nameOrOptions: string | ProviderObserveOptions,
+  fn: (headers: Record<string, string>) => Promise<T>,
+): Promise<T> {
+  return observeProvider('xai', parent, nameOrOptions, fn)
+}
+
+/** Cohere variant — OpenAI-compatible `usage`, span tagged `provider: 'cohere'`. */
+export function observeCohere<T>(
+  parent: TraceHandle | SpanHandle,
+  nameOrOptions: string | ProviderObserveOptions,
+  fn: (headers: Record<string, string>) => Promise<T>,
+): Promise<T> {
+  return observeProvider('cohere', parent, nameOrOptions, fn)
 }

--- a/supabase/migrations/20260701120000_provider_keys_add_groq_deepseek_xai_cohere.sql
+++ b/supabase/migrations/20260701120000_provider_keys_add_groq_deepseek_xai_cohere.sql
@@ -1,0 +1,24 @@
+-- Migration: provider_keys — extend provider CHECK to allow the four new
+-- OpenAI-compatible providers 'groq', 'deepseek', 'xai', and 'cohere'.
+--
+-- The proxy routes (apps/server/src/proxy/{groq,deepseek,xai,cohere}.ts) and
+-- the app-layer validator in apps/server/src/api/providerKeys.ts now accept
+-- all four, but the DB CHECK constraint (last set in
+-- 20260613030000_provider_keys_mistral_openrouter.sql) still rejects rows with
+-- provider outside openai/anthropic/gemini/azure/mistral/openrouter. Without
+-- this, any UI attempt to register a Groq / DeepSeek / xAI / Cohere key 500s
+-- on check_violation.
+--
+-- Same swap-with-IF-EXISTS pattern the mistral/openrouter + azure migrations
+-- used. The constraint name (provider_keys_provider_check) is the PG-default
+-- for the inline CHECK in the initial schema.
+
+ALTER TABLE provider_keys
+  DROP CONSTRAINT IF EXISTS provider_keys_provider_check;
+
+ALTER TABLE provider_keys
+  ADD CONSTRAINT provider_keys_provider_check
+  CHECK (provider IN (
+    'openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter',
+    'groq', 'deepseek', 'xai', 'cohere'
+  ));

--- a/supabase/migrations/20260701120100_seed_groq_deepseek_xai_cohere_prices.sql
+++ b/supabase/migrations/20260701120100_seed_groq_deepseek_xai_cohere_prices.sql
@@ -1,0 +1,50 @@
+-- Seed pricing rows for the four new OpenAI-compatible providers:
+-- Groq, DeepSeek, xAI (Grok), and Cohere.
+--
+-- All four expose an OpenAI-compatible chat surface (same request shape, SSE
+-- chunk format, and `usage` field), so the proxy reuses the OpenAI parser,
+-- stream logger, and cost path. The only provider-specific data is pricing.
+-- Provider tag flows into requests.provider so the dashboard groups by it.
+--
+-- Prices are standard on-demand USD per 1M tokens, verified against the
+-- providers' official pricing + model docs (2026-07). Notes:
+--   • Groq: prompt caching / Batch API cut rates ~50% (not modelled here —
+--     cache_read seeded where a published cached-input rate exists).
+--   • DeepSeek: cache_read is the published cache-HIT input rate; deepseek-chat
+--     and deepseek-reasoner are compatibility aliases scheduled to fold into
+--     deepseek-v4-flash — all three seeded so cost matches either id.
+--   • xAI: no cached-input rate published for these model ids → cache NULL.
+--   • Cohere: only the dated Command ids have public per-token prices; the
+--     command-a-plus / specialized command-a-* models are sales-quoted and are
+--     intentionally NOT seeded (those rows log cost_usd = NULL, gotcha #2).
+
+INSERT INTO model_prices (
+  provider, model,
+  prompt_price_per_1m, completion_price_per_1m,
+  cache_read_price_per_1m, cache_write_price_per_1m
+) VALUES
+  -- ── Groq (GroqCloud, api.groq.com/openai/v1) ─────────────────────────────
+  ('groq', 'llama-3.3-70b-versatile',                    0.59,  0.79,    NULL,     NULL),
+  ('groq', 'llama-3.1-8b-instant',                       0.05,  0.08,    NULL,     NULL),
+  ('groq', 'openai/gpt-oss-120b',                        0.15,  0.60,    0.075,    NULL),
+  ('groq', 'openai/gpt-oss-20b',                         0.075, 0.30,    0.0375,   NULL),
+  ('groq', 'meta-llama/llama-4-scout-17b-16e-instruct',  0.11,  0.34,    NULL,     NULL),
+  ('groq', 'qwen/qwen3-32b',                             0.29,  0.59,    NULL,     NULL),
+  ('groq', 'moonshotai/kimi-k2-instruct-0905',           1.00,  3.00,    0.50,     NULL),
+  -- ── DeepSeek (api.deepseek.com/v1) ───────────────────────────────────────
+  ('deepseek', 'deepseek-chat',                          0.14,  0.28,    0.0028,   NULL),
+  ('deepseek', 'deepseek-reasoner',                      0.14,  0.28,    0.0028,   NULL),
+  ('deepseek', 'deepseek-v4-flash',                      0.14,  0.28,    0.0028,   NULL),
+  ('deepseek', 'deepseek-v4-pro',                        0.435, 0.87,    0.003625, NULL),
+  -- ── xAI / Grok (api.x.ai/v1) ─────────────────────────────────────────────
+  ('xai', 'grok-4.3',                                    1.25,  2.50,    NULL,     NULL),
+  ('xai', 'grok-4.20-0309-reasoning',                    1.25,  2.50,    NULL,     NULL),
+  ('xai', 'grok-4.20-0309-non-reasoning',                1.25,  2.50,    NULL,     NULL),
+  ('xai', 'grok-4.20-multi-agent-0309',                  1.25,  2.50,    NULL,     NULL),
+  ('xai', 'grok-build-0.1',                              1.00,  2.00,    NULL,     NULL),
+  -- ── Cohere (api.cohere.ai/compatibility/v1) ──────────────────────────────
+  ('cohere', 'command-a-03-2025',                        2.50,  10.00,   NULL,     NULL),
+  ('cohere', 'command-r-plus-08-2024',                   2.50,  10.00,   NULL,     NULL),
+  ('cohere', 'command-r-08-2024',                        0.15,  0.60,    NULL,     NULL),
+  ('cohere', 'command-r7b-12-2024',                      0.0375, 0.15,   NULL,     NULL)
+ON CONFLICT (provider, model) DO NOTHING;

--- a/supabase/seeds/model_prices.sql
+++ b/supabase/seeds/model_prices.sql
@@ -81,6 +81,30 @@ INSERT INTO model_prices (
   ('mistral', 'open-mistral-nemo',               0.15,   0.15,   NULL,   NULL),
   ('mistral', 'mixtral-8x22b',                   2.00,   6.00,   NULL,   NULL),
   ('mistral', 'mistral-embed',                   0.10,   0.000,  NULL,   NULL),
+  -- ── Groq (OpenAI-compatible, api.groq.com/openai/v1) ─────────────────────
+  ('groq', 'llama-3.3-70b-versatile',                    0.59,  0.79,    NULL,     NULL),
+  ('groq', 'llama-3.1-8b-instant',                       0.05,  0.08,    NULL,     NULL),
+  ('groq', 'openai/gpt-oss-120b',                        0.15,  0.60,    0.075,    NULL),
+  ('groq', 'openai/gpt-oss-20b',                         0.075, 0.30,    0.0375,   NULL),
+  ('groq', 'meta-llama/llama-4-scout-17b-16e-instruct',  0.11,  0.34,    NULL,     NULL),
+  ('groq', 'qwen/qwen3-32b',                             0.29,  0.59,    NULL,     NULL),
+  ('groq', 'moonshotai/kimi-k2-instruct-0905',           1.00,  3.00,    0.50,     NULL),
+  -- ── DeepSeek (OpenAI-compatible, api.deepseek.com/v1) ────────────────────
+  ('deepseek', 'deepseek-chat',                          0.14,  0.28,    0.0028,   NULL),
+  ('deepseek', 'deepseek-reasoner',                      0.14,  0.28,    0.0028,   NULL),
+  ('deepseek', 'deepseek-v4-flash',                      0.14,  0.28,    0.0028,   NULL),
+  ('deepseek', 'deepseek-v4-pro',                        0.435, 0.87,    0.003625, NULL),
+  -- ── xAI / Grok (OpenAI-compatible, api.x.ai/v1) ──────────────────────────
+  ('xai', 'grok-4.3',                                    1.25,  2.50,    NULL,     NULL),
+  ('xai', 'grok-4.20-0309-reasoning',                    1.25,  2.50,    NULL,     NULL),
+  ('xai', 'grok-4.20-0309-non-reasoning',                1.25,  2.50,    NULL,     NULL),
+  ('xai', 'grok-4.20-multi-agent-0309',                  1.25,  2.50,    NULL,     NULL),
+  ('xai', 'grok-build-0.1',                              1.00,  2.00,    NULL,     NULL),
+  -- ── Cohere (OpenAI-compatible, api.cohere.ai/compatibility/v1) ───────────
+  ('cohere', 'command-a-03-2025',                        2.50,  10.00,   NULL,     NULL),
+  ('cohere', 'command-r-plus-08-2024',                   2.50,  10.00,   NULL,     NULL),
+  ('cohere', 'command-r-08-2024',                        0.15,  0.60,    NULL,     NULL),
+  ('cohere', 'command-r7b-12-2024',                      0.0375, 0.15,   NULL,     NULL),
   -- ── Anthropic: Claude 4.x (aliases + dated variants) ────────────────────
   ('anthropic', 'claude-opus-4-7',               5.00,  25.00,   0.50,   6.25),
   ('anthropic', 'claude-opus-4-6',               5.00,  25.00,   0.50,   6.25), -- alias only; no dated form per docs


### PR DESCRIPTION
## What

Adds four more OpenAI-compatible LLM providers to the proxy, SDK, and dashboard, following the existing Mistral/OpenRouter precedent (PR #327/#328).

| Provider | Base URL | Streaming usage |
|---|---|---|
| Groq | `api.groq.com/openai/v1` | injected `stream_options.include_usage` |
| DeepSeek | `api.deepseek.com/v1` | injected `stream_options.include_usage` |
| xAI (Grok) | `api.x.ai/v1` | injected `stream_options.include_usage` |
| Cohere | `api.cohere.ai/compatibility/v1` | **not** injected (compat layer rejects it) → streamed calls may log null cost |

Base URLs, models, and per-1M pricing were researched + adversarially verified against each provider's official docs (2026-07).

## Server
- `proxy/{groq,deepseek,xai,cohere}.ts` — each reuses the OpenAI parser, stream logger, and cost path; only the upstream host + provider tag differ.
- Extend `ProxyProvider` + `PROVIDER_LABEL`, `cost.ts` `Provider`, `providerKeys` `VALID_PROVIDERS`; mount the four routes in `app.ts`.
- Migration `20260701120000` extends the `provider_keys.provider` CHECK; `20260701120100` seeds prices (idempotent `ON CONFLICT DO NOTHING`). Same rows mirrored into `seeds/model_prices.sql` + `FALLBACK_PRICES` for cold-start.

## SDK — `@spanlens/sdk` 0.15.0
- New subpaths `./groq ./deepseek ./xai ./cohere`, each a `createX()` factory over a shared `makeSpanlensProxyClient` helper, re-exporting its `observeX` tracer. `observeGroq/DeepSeek/Xai/Cohere` also exported from the root.

## Web
- Four providers added to the `/projects` provider dropdown (label, placeholder, copy-paste snippet using the new SDK factories) and documented on `/docs/proxy`.

## Test plan
- [x] `pnpm typecheck` (all packages)
- [x] `pnpm lint`
- [x] server suite — 1369 tests (incl. new parametrized proxy test: URL / auth-key-forwarding / provider-tag+cost / NO_PROVIDER_KEY / public-scope guards)
- [x] sdk suite — 157 tests (incl. new factory test) + `sdk build`
- [x] `/docs/proxy` renders in preview, no console errors
- [ ] Migrations validated by CI on throwaway DB
- [ ] Per-customer: each provider needs a real upstream key registered via `/projects`