### PR TITLE
feat(sdk): FastAPI/ASGI auto-instrumentation middleware (python 0.8.0)

### DIFF
--- a/packages/sdk-python/CHANGELOG.md
+++ b/packages/sdk-python/CHANGELOG.md
@@ -10,9 +10,14 @@ FastAPI / ASGI auto-instrumentation — one line traces every HTTP request.
 - Sampling and tail-based error capture come from the underlying client, so sampled-out successful requests do zero network I/O while errors are always recorded. Health / metrics / docs routes are skipped by default (`skip_paths=` to override).
 - The middleware is pure ASGI (it does not import FastAPI), so it also works with Starlette, Litestar, Quart, and any ASGI app. New `spanlens[fastapi]` optional extra.
 
+### Security
+
+- Query strings are **not** captured into trace metadata by default (they routinely carry secrets/PII: OAuth `code`/`state`, reset tokens, signed-URL signatures). Opt in with `capture_query_string=True`.
+- The exception re-raise path uses a `_safe_str` helper so a handler exception whose `__str__` itself raises can never replace the original exception on its way back up.
+
 ### Verified
 
-- 5 new tests (success trace + `request.state` injection, default-path skipping, error capture + re-raise, build-from-`api_key`, and the missing-credentials guard). Full suite: 161 passing. `ruff` clean; `mypy --strict` clean on the new module.
+- 8 tests (success trace + `request.state` injection, default-path skipping, error capture + re-raise, build-from-`api_key`, missing-credentials guard, query-string off-by-default + opt-in, and broken-`__str__` re-raise). `ruff` clean; `mypy --strict` clean on the new module.
 
 ## 0.7.0
 

--- a/packages/sdk-python/CHANGELOG.md
+++ b/packages/sdk-python/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.8.0
+
+FastAPI / ASGI auto-instrumentation — one line traces every HTTP request.
+
+### Added
+
+- `SpanlensMiddleware` (and `install_spanlens_middleware(app, ...)`): add it with `app.add_middleware(SpanlensMiddleware, api_key=...)` (or `client=`) and every request opens a trace + a root span named `"<METHOD> <path>"`. Clean responses end `completed`; a 5xx or unhandled exception ends `error` and the exception is re-raised untouched. The trace is exposed to handlers as `request.state.spanlens` (`{trace, span, headers, trace_id, span_id}`) so nested `observe_*` LLM calls link automatically.
+- Sampling and tail-based error capture come from the underlying client, so sampled-out successful requests do zero network I/O while errors are always recorded. Health / metrics / docs routes are skipped by default (`skip_paths=` to override).
+- The middleware is pure ASGI (it does not import FastAPI), so it also works with Starlette, Litestar, Quart, and any ASGI app. New `spanlens[fastapi]` optional extra.
+
+### Verified
+
+- 5 new tests (success trace + `request.state` injection, default-path skipping, error capture + re-raise, build-from-`api_key`, and the missing-credentials guard). Full suite: 161 passing. `ruff` clean; `mypy --strict` clean on the new module.
+
 ## 0.7.0
 
 Onboarding CLI release. `pip install spanlens` now also installs a `spanlens` console command that connects a Python project to Spanlens in one step, the same wizard the Node `@spanlens/cli` ships. No extra dependency: it uses only the standard library plus `httpx` (already a runtime dependency).

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -295,6 +295,9 @@ async def chat(body: dict, request: Request):
   one connection pool across your app.
 * Health, metrics, and docs routes are skipped by default. Override with
   `skip_paths=[...]`.
+* Query strings are **not** captured into trace metadata by default, because
+  they often carry secrets or PII (OAuth `code`/`state`, reset tokens,
+  signed-URL signatures). Opt in with `capture_query_string=True`.
 * It is pure ASGI (it does not import FastAPI), so it also works with
   Starlette, Litestar, Quart, and any other ASGI app. `pip install
   spanlens[fastapi]` pulls FastAPI in if you do not already have it.

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -255,6 +255,52 @@ will bring it in.
 
 ---
 
+## FastAPI (auto-instrumentation)
+
+One line traces every request. Each HTTP request becomes a Spanlens trace with
+a root span, and LLM calls made inside the handler link to it automatically.
+
+```python
+import os
+from fastapi import FastAPI, Request
+from spanlens import SpanlensMiddleware
+from spanlens.observe import observe_openai
+from spanlens.integrations.openai import create_async_openai
+
+app = FastAPI()
+app.add_middleware(SpanlensMiddleware, api_key=os.environ["SPANLENS_API_KEY"])
+
+
+@app.post("/chat")
+async def chat(body: dict, request: Request):
+    sl = request.state.spanlens          # {trace, span, headers, trace_id, span_id}
+    openai = create_async_openai()
+    reply = await observe_openai(
+        sl["trace"],
+        "answer",
+        lambda headers: openai.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": body["q"]}],
+            extra_headers=headers,
+        ),
+    )
+    return {"reply": reply.choices[0].message.content}
+```
+
+* On a clean response the span/trace end `completed`; a 5xx or an unhandled
+  exception ends them `error` and the exception is re-raised untouched.
+* Sampling and tail-based error capture are inherited from the client, so
+  sampled-out successful requests produce zero network overhead while errors
+  are always captured. Pass `sample_rate=0.1`, or a shared `client=` to reuse
+  one connection pool across your app.
+* Health, metrics, and docs routes are skipped by default. Override with
+  `skip_paths=[...]`.
+* It is pure ASGI (it does not import FastAPI), so it also works with
+  Starlette, Litestar, Quart, and any other ASGI app. `pip install
+  spanlens[fastapi]` pulls FastAPI in if you do not already have it.
+
+---
+
 ## Configuration reference
 
 ```python
@@ -320,6 +366,7 @@ The table below is the honest, file-level comparison of what each package ships 
 | LangChain integration | ✓ | ✓ |
 | LangGraph integration | ✓ (via the LangChain handler) | ✓ (via the LangChain handler) |
 | LlamaIndex integration | ✓ | ✓ |
+| FastAPI / ASGI middleware (per-request auto-instrument) | ✓ `SpanlensMiddleware` | ✗ (not yet) |
 | Vercel AI SDK integration | ✗ (Vercel AI is JS-only) | ✓ |
 | Evals API (script-driven prompt CI) | ✗ (not yet) | ✓ `EvalsApi` |
 | CLI (`init` wizard) | ✓ (bundled `spanlens` command) | ✓ (separate [`@spanlens/cli`](https://www.npmjs.com/package/@spanlens/cli) package) |

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "spanlens"
-version = "0.7.0"
+version = "0.8.0"
 description = "Spanlens SDK for Python. Agent tracing, LLM usage capture, and cost observability."
 readme = "README.md"
 license = { text = "MIT" }
@@ -29,6 +29,9 @@ keywords = [
     "langgraph",
     "llamaindex",
     "llama-index",
+    "fastapi",
+    "asgi",
+    "middleware",
     "ollama",
     "helicone-alternative",
     "langfuse-alternative",
@@ -62,12 +65,14 @@ anthropic = ["anthropic>=0.18.0"]
 gemini = ["google-generativeai>=0.5.0"]
 langchain = ["langchain-core>=0.1.0"]
 llama-index = ["llama-index-core>=0.10.0"]
+fastapi = ["fastapi>=0.110.0"]
 all = [
     "openai>=1.0.0",
     "anthropic>=0.18.0",
     "google-generativeai>=0.5.0",
     "langchain-core>=0.1.0",
     "llama-index-core>=0.10.0",
+    "fastapi>=0.110.0",
 ]
 dev = [
     "pytest>=7.4.0",

--- a/packages/sdk-python/spanlens/__init__.py
+++ b/packages/sdk-python/spanlens/__init__.py
@@ -26,6 +26,7 @@ For proxy-mode (zero-code) instrumentation, see
 """
 
 from .client import SpanlensClient
+from .middleware import SpanlensMiddleware, install_spanlens_middleware
 from .observe import (
     observe,
     observe_anthropic,
@@ -37,13 +38,15 @@ from .parsers import parse_anthropic_usage, parse_gemini_usage, parse_openai_usa
 from .span import SpanHandle
 from .trace import TraceHandle
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 __all__ = [
     "SpanHandle",
     "SpanlensClient",
+    "SpanlensMiddleware",
     "TraceHandle",
     "__version__",
+    "install_spanlens_middleware",
     "observe",
     "observe_anthropic",
     "observe_gemini",

--- a/packages/sdk-python/spanlens/middleware.py
+++ b/packages/sdk-python/spanlens/middleware.py
@@ -65,6 +65,16 @@ def _default_name(scope: dict[str, Any]) -> str:
     return f"{method} {path}"
 
 
+def _safe_str(exc: BaseException) -> str:
+    """str(exc) that can never raise — a broken __str__/__repr__ on a handler's
+    exception must not replace the original exception on its way back up (the
+    middleware's re-raise-untouched invariant)."""
+    try:
+        return str(exc)
+    except Exception:
+        return repr(type(exc))
+
+
 class SpanlensMiddleware:
     """ASGI middleware that records one trace + root span per HTTP request.
 
@@ -81,6 +91,11 @@ class SpanlensMiddleware:
         span_type: Span type for the root span (default ``"custom"``).
         name_factory: ``scope -> str`` to customise the trace/span name.
             Defaults to ``"<METHOD> <path>"``.
+        capture_query_string: When True, store the raw request query string in
+            the trace metadata. OFF by default because query strings routinely
+            carry secrets/PII (OAuth ``code``/``state``, password-reset or
+            magic-link ``token``, signed-URL signatures). Mirrors the
+            ``x-spanlens-log-body`` opt-out precedent for proxy bodies.
     """
 
     def __init__(
@@ -94,6 +109,7 @@ class SpanlensMiddleware:
         skip_paths: Optional[Sequence[str]] = None,
         span_type: SpanType = "custom",
         name_factory: Optional[NameFactory] = None,
+        capture_query_string: bool = False,
     ) -> None:
         self.app = app
 
@@ -114,6 +130,7 @@ class SpanlensMiddleware:
         )
         self._span_type: SpanType = span_type
         self._name_factory: NameFactory = name_factory or _default_name
+        self._capture_query: bool = capture_query_string
 
     def _should_skip(self, path: str) -> bool:
         for skip in self._skip_paths:
@@ -141,10 +158,13 @@ class SpanlensMiddleware:
             method = scope.get("method", "GET")
             path = scope.get("path", "") or "/"
             name = self._name_factory(scope)
-            query = scope.get("query_string", b"")
             metadata: dict[str, Any] = {"method": method, "path": path}
-            if query:
-                metadata["query"] = query.decode("latin-1")
+            # Query strings often carry secrets/PII, so they are NOT captured
+            # unless the caller opts in with capture_query_string=True.
+            if self._capture_query:
+                query = scope.get("query_string", b"")
+                if query:
+                    metadata["query"] = query.decode("latin-1")
 
             trace = self._client.start_trace(name, metadata=metadata)
             span = trace.span(
@@ -178,8 +198,9 @@ class SpanlensMiddleware:
             await self.app(scope, receive, send_wrapper)
         except Exception as exc:
             # Unhandled exception in the handler — record error, then re-raise
-            # so the framework's own error handling still runs.
-            self._safe_end(span, trace, status="error", error_message=str(exc))
+            # so the framework's own error handling still runs. _safe_str keeps a
+            # broken __str__ from replacing the original exception on re-raise.
+            self._safe_end(span, trace, status="error", error_message=_safe_str(exc))
             raise
 
         # A 5xx status without an exception (e.g. a returned error response) is

--- a/packages/sdk-python/spanlens/middleware.py
+++ b/packages/sdk-python/spanlens/middleware.py
@@ -1,0 +1,235 @@
+"""FastAPI / Starlette (and any ASGI) auto-instrumentation middleware.
+
+One line turns every HTTP request into a Spanlens trace with a root span::
+
+    from fastapi import FastAPI
+    from spanlens import SpanlensMiddleware
+
+    app = FastAPI()
+    app.add_middleware(SpanlensMiddleware, api_key=os.environ["SPANLENS_API_KEY"])
+
+Each request opens a trace + a root span named ``"<METHOD> <path>"``. On a
+clean response the span/trace end ``completed``; on a 5xx or an unhandled
+exception they end ``error`` (the exception is re-raised untouched). Sampling,
+tail-based error capture, and fire-and-forget transport are inherited from the
+underlying :class:`~spanlens.client.SpanlensClient`, so sampled-out successful
+requests produce zero network overhead while errors are always captured.
+
+The middleware exposes the trace to your handlers via ``request.state.spanlens``
+so nested LLM calls can be linked to this trace::
+
+    @app.post("/chat")
+    async def chat(request: Request):
+        sl = request.state.spanlens              # {trace, span, headers, ...}
+        res = await observe_openai(sl["trace"], "answer", call_openai)
+        # or pass sl["headers"] straight to the proxy client's extra_headers
+
+This is pure ASGI — it does not import FastAPI/Starlette, so importing it never
+pulls in a web framework. It works with any ASGI app (FastAPI, Starlette,
+Litestar, Quart, ...).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Optional, Sequence
+
+from .client import SpanlensClient
+from .trace import TraceHandle
+from .types import SpanType
+
+# Routes that are noise for tracing — health probes, framework docs, static
+# metadata. Matched by exact path or as a prefix (so /docs and /docs/oauth2 both
+# skip). Override with the ``skip_paths`` argument.
+_DEFAULT_SKIP_PATHS: tuple[str, ...] = (
+    "/health",
+    "/healthz",
+    "/livez",
+    "/readyz",
+    "/ping",
+    "/metrics",
+    "/favicon.ico",
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+)
+
+ASGIApp = Callable[[dict[str, Any], Callable[[], Awaitable[dict[str, Any]]], Callable[[dict[str, Any]], Awaitable[None]]], Awaitable[None]]
+
+# A callable that derives the trace/span name from the ASGI scope.
+NameFactory = Callable[[dict[str, Any]], str]
+
+
+def _default_name(scope: dict[str, Any]) -> str:
+    method = scope.get("method", "GET")
+    path = scope.get("path", "") or "/"
+    return f"{method} {path}"
+
+
+class SpanlensMiddleware:
+    """ASGI middleware that records one trace + root span per HTTP request.
+
+    Args:
+        app: The wrapped ASGI application (supplied by ``add_middleware``).
+        client: An existing :class:`SpanlensClient`. Provide this to share one
+            client (and its connection pool) across your app. If omitted, one
+            is built from ``api_key`` / ``base_url`` / ``sample_rate``.
+        api_key: Spanlens API key, used only when ``client`` is not given.
+        base_url: Override the ingest base URL (when building a client here).
+        sample_rate: Trace sample rate in ``[0, 1]`` (when building a client here).
+        skip_paths: Paths to leave un-instrumented (exact or prefix match).
+            Defaults to health/metrics/docs routes.
+        span_type: Span type for the root span (default ``"custom"``).
+        name_factory: ``scope -> str`` to customise the trace/span name.
+            Defaults to ``"<METHOD> <path>"``.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        client: Optional[SpanlensClient] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        sample_rate: Optional[float] = None,
+        skip_paths: Optional[Sequence[str]] = None,
+        span_type: SpanType = "custom",
+        name_factory: Optional[NameFactory] = None,
+    ) -> None:
+        self.app = app
+
+        if client is None:
+            if not api_key:
+                raise ValueError(
+                    "[spanlens] SpanlensMiddleware needs either client= or api_key=. "
+                    "Pass an existing SpanlensClient, or api_key=os.environ['SPANLENS_API_KEY']."
+                )
+            client = SpanlensClient(
+                api_key=api_key,
+                base_url=base_url,
+                sample_rate=sample_rate,
+            )
+        self._client = client
+        self._skip_paths: tuple[str, ...] = (
+            tuple(skip_paths) if skip_paths is not None else _DEFAULT_SKIP_PATHS
+        )
+        self._span_type: SpanType = span_type
+        self._name_factory: NameFactory = name_factory or _default_name
+
+    def _should_skip(self, path: str) -> bool:
+        for skip in self._skip_paths:
+            if path == skip or path.startswith(skip + "/"):
+                return True
+        return False
+
+    async def __call__(
+        self,
+        scope: dict[str, Any],
+        receive: Callable[[], Awaitable[dict[str, Any]]],
+        send: Callable[[dict[str, Any]], Awaitable[None]],
+    ) -> None:
+        # Only HTTP requests get traced; websockets/lifespan pass straight through.
+        if scope.get("type") != "http" or self._should_skip(scope.get("path", "")):
+            await self.app(scope, receive, send)
+            return
+
+        # Building the trace must never crash the request. If anything here
+        # throws (it shouldn't — the client is fire-and-forget), fall back to an
+        # un-instrumented passthrough.
+        trace: Optional[TraceHandle] = None
+        span = None
+        try:
+            method = scope.get("method", "GET")
+            path = scope.get("path", "") or "/"
+            name = self._name_factory(scope)
+            query = scope.get("query_string", b"")
+            metadata: dict[str, Any] = {"method": method, "path": path}
+            if query:
+                metadata["query"] = query.decode("latin-1")
+
+            trace = self._client.start_trace(name, metadata=metadata)
+            span = trace.span(
+                name,
+                span_type=self._span_type,
+                input={"method": method, "path": path},
+            )
+            # Expose to handlers: request.state.spanlens
+            state = scope.setdefault("state", {})
+            state["spanlens"] = {
+                "trace": trace,
+                "span": span,
+                "trace_id": trace.trace_id,
+                "span_id": span.span_id,
+                "headers": span.trace_headers(),
+            }
+        except Exception:
+            # Instrumentation setup failed — run the app un-traced.
+            await self.app(scope, receive, send)
+            return
+
+        status_code: Optional[int] = None
+
+        async def send_wrapper(message: dict[str, Any]) -> None:
+            nonlocal status_code
+            if message.get("type") == "http.response.start":
+                status_code = message.get("status")
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        except Exception as exc:
+            # Unhandled exception in the handler — record error, then re-raise
+            # so the framework's own error handling still runs.
+            self._safe_end(span, trace, status="error", error_message=str(exc))
+            raise
+
+        # A 5xx status without an exception (e.g. a returned error response) is
+        # still an error for tracing purposes.
+        is_error = status_code is not None and status_code >= 500
+        self._safe_end(
+            span,
+            trace,
+            status="error" if is_error else "completed",
+            output={"status_code": status_code},
+        )
+
+    @staticmethod
+    def _safe_end(
+        span: Any,
+        trace: Optional[TraceHandle],
+        *,
+        status: str,
+        output: Any = None,
+        error_message: Optional[str] = None,
+    ) -> None:
+        """End the span + trace, swallowing any error so tracing never breaks
+        the response path."""
+        try:
+            if span is not None:
+                if error_message is not None:
+                    span.end(status=status, error_message=error_message)
+                else:
+                    span.end(status=status, output=output)
+            if trace is not None:
+                if error_message is not None:
+                    trace.end(status=status, error_message=error_message)
+                else:
+                    trace.end(status=status)
+        except Exception:
+            pass
+
+
+def install_spanlens_middleware(
+    app: Any,
+    **kwargs: Any,
+) -> None:
+    """Convenience wrapper for ``app.add_middleware(SpanlensMiddleware, **kwargs)``.
+
+    Example::
+
+        from spanlens import install_spanlens_middleware
+        install_spanlens_middleware(app, api_key=os.environ["SPANLENS_API_KEY"])
+    """
+    app.add_middleware(SpanlensMiddleware, **kwargs)
+
+
+__all__ = ["SpanlensMiddleware", "install_spanlens_middleware"]

--- a/packages/sdk-python/tests/test_middleware.py
+++ b/packages/sdk-python/tests/test_middleware.py
@@ -1,0 +1,184 @@
+"""Tests for SpanlensMiddleware — the FastAPI/ASGI auto-instrumentation.
+
+The whole SDK transport is intercepted by respx, so no real network happens.
+Each test owns its own FastAPI app + client (no shared module state).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI, Request  # noqa: E402
+from httpx import ASGITransport  # noqa: E402
+
+from spanlens import SpanlensClient, SpanlensMiddleware  # noqa: E402
+
+SPANLENS_BASE = "https://test.spanlens.local"
+
+
+def _ok() -> httpx.Response:
+    return httpx.Response(200, json={"ok": True})
+
+
+def _mock_ingest() -> dict[str, respx.Route]:
+    return {
+        "trace_post": respx.post(f"{SPANLENS_BASE}/ingest/traces").mock(return_value=_ok()),
+        "span_post": respx.post(
+            re.compile(rf"{re.escape(SPANLENS_BASE)}/ingest/traces/[^/]+/spans"),
+        ).mock(return_value=_ok()),
+        "span_patch": respx.patch(
+            re.compile(rf"{re.escape(SPANLENS_BASE)}/ingest/spans/[^/]+"),
+        ).mock(return_value=_ok()),
+        "trace_patch": respx.patch(
+            re.compile(rf"{re.escape(SPANLENS_BASE)}/ingest/traces/[^/]+"),
+        ).mock(return_value=_ok()),
+    }
+
+
+def _make_client() -> SpanlensClient:
+    return SpanlensClient(api_key="sl_test_dummy", base_url=SPANLENS_BASE, silent=False)
+
+
+def _bodies(route: respx.Route) -> list[dict[str, Any]]:
+    return [json.loads(call.request.content) for call in route.calls]
+
+
+@respx.mock
+async def test_middleware_traces_successful_request() -> None:
+    routes = _mock_ingest()
+    client = _make_client()
+
+    app = FastAPI()
+    app.add_middleware(SpanlensMiddleware, client=client)
+
+    @app.get("/items/{item_id}")
+    async def read_item(item_id: str, request: Request) -> dict[str, Any]:
+        sl = request.state.spanlens
+        return {"item_id": item_id, "trace_id": sl["trace_id"], "span_id": sl["span_id"]}
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver",
+    ) as http:
+        resp = await http.get("/items/42")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    # Handler could read request.state.spanlens (proves injection worked).
+    assert body["item_id"] == "42"
+    assert isinstance(body["trace_id"], str)
+
+    client.close()
+
+    assert routes["trace_post"].call_count == 1
+    assert routes["span_post"].call_count == 1
+    assert routes["span_patch"].call_count == 1
+    assert routes["trace_patch"].call_count == 1
+
+    # Trace POST carries method + path metadata; name is "<METHOD> <path>".
+    trace_body = _bodies(routes["trace_post"])[0]
+    assert trace_body["name"] == "GET /items/42"
+    assert trace_body["metadata"]["method"] == "GET"
+    assert trace_body["metadata"]["path"] == "/items/42"
+
+    # Both end PATCHes are completed.
+    assert _bodies(routes["span_patch"])[0]["status"] == "completed"
+    assert _bodies(routes["trace_patch"])[0]["status"] == "completed"
+
+
+@respx.mock
+async def test_middleware_skips_configured_paths() -> None:
+    routes = _mock_ingest()
+    client = _make_client()
+
+    app = FastAPI()
+    app.add_middleware(SpanlensMiddleware, client=client)  # default skip list
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver",
+    ) as http:
+        resp = await http.get("/health")
+
+    assert resp.status_code == 200
+    client.close()
+
+    # No trace created for a skipped path.
+    assert routes["trace_post"].call_count == 0
+    assert routes["span_post"].call_count == 0
+
+
+@respx.mock
+async def test_middleware_records_error_and_reraises() -> None:
+    routes = _mock_ingest()
+    client = _make_client()
+
+    app = FastAPI()
+    app.add_middleware(SpanlensMiddleware, client=client)
+
+    @app.get("/boom")
+    async def boom() -> dict[str, Any]:
+        raise ValueError("kaboom")
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=True),
+        base_url="http://testserver",
+    ) as http:
+        with pytest.raises(ValueError, match="kaboom"):
+            await http.get("/boom")
+
+    client.close()
+
+    # The trace + span still opened, and both ended with error status.
+    assert routes["trace_post"].call_count == 1
+    assert routes["span_post"].call_count == 1
+    span_patch = _bodies(routes["span_patch"])[0]
+    trace_patch = _bodies(routes["trace_patch"])[0]
+    assert span_patch["status"] == "error"
+    assert span_patch["error_message"] == "kaboom"
+    assert trace_patch["status"] == "error"
+
+
+@respx.mock
+async def test_middleware_builds_client_from_api_key() -> None:
+    """When no client is passed, the middleware builds one from api_key and the
+    request still succeeds (the request path must never depend on the trace
+    flush, which is fire-and-forget on an internally-owned pool)."""
+    _mock_ingest()
+
+    app = FastAPI()
+    app.add_middleware(
+        SpanlensMiddleware,
+        api_key="sl_test_dummy",
+        base_url=SPANLENS_BASE,
+    )
+
+    @app.get("/ping-me")
+    async def ping_me() -> dict[str, str]:
+        return {"pong": "1"}
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver",
+    ) as http:
+        resp = await http.get("/ping-me")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"pong": "1"}
+
+
+def test_middleware_requires_client_or_api_key() -> None:
+    app = FastAPI()
+    with pytest.raises(ValueError, match="client= or api_key="):
+        # add_middleware defers instantiation until the app builds its stack;
+        # trigger it by constructing directly.
+        SpanlensMiddleware(app)

--- a/packages/sdk-python/tests/test_middleware.py
+++ b/packages/sdk-python/tests/test_middleware.py
@@ -176,6 +176,82 @@ async def test_middleware_builds_client_from_api_key() -> None:
     assert resp.json() == {"pong": "1"}
 
 
+@respx.mock
+async def test_middleware_does_not_capture_query_string_by_default() -> None:
+    routes = _mock_ingest()
+    client = _make_client()
+
+    app = FastAPI()
+    app.add_middleware(SpanlensMiddleware, client=client)
+
+    @app.get("/callback")
+    async def cb() -> dict[str, str]:
+        return {"ok": "1"}
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver",
+    ) as http:
+        resp = await http.get("/callback?token=supersecret&code=abc123")
+
+    assert resp.status_code == 200
+    client.close()
+
+    # Secrets in the query string must NOT be shipped by default.
+    trace_body = _bodies(routes["trace_post"])[0]
+    assert "query" not in trace_body["metadata"]
+
+
+@respx.mock
+async def test_middleware_captures_query_string_when_opted_in() -> None:
+    routes = _mock_ingest()
+    client = _make_client()
+
+    app = FastAPI()
+    app.add_middleware(SpanlensMiddleware, client=client, capture_query_string=True)
+
+    @app.get("/search")
+    async def search() -> dict[str, str]:
+        return {"ok": "1"}
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver",
+    ) as http:
+        await http.get("/search?q=ramen")
+
+    client.close()
+
+    trace_body = _bodies(routes["trace_post"])[0]
+    assert trace_body["metadata"]["query"] == "q=ramen"
+
+
+@respx.mock
+async def test_middleware_reraises_original_exception_even_with_broken_str() -> None:
+    """A handler exception whose __str__ itself raises must still propagate AS
+    ITSELF — the middleware's error-message capture must never replace it."""
+    _mock_ingest()
+    client = _make_client()
+
+    app = FastAPI()
+    app.add_middleware(SpanlensMiddleware, client=client)
+
+    class BrokenStrError(Exception):
+        def __str__(self) -> str:
+            raise RuntimeError("str is broken")
+
+    @app.get("/broken")
+    async def broken() -> dict[str, Any]:
+        raise BrokenStrError()
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=True),
+        base_url="http://testserver",
+    ) as http:
+        with pytest.raises(BrokenStrError):
+            await http.get("/broken")
+
+    client.close()
+
+
 def test_middleware_requires_client_or_api_key() -> None:
     app = FastAPI()
     with pytest.raises(ValueError, match="client= or api_key="):


### PR DESCRIPTION
## What

One-line request tracing for the **Python** SDK — closes the biggest TS↔Python gap for the FastAPI-heavy Python LLM audience.

```python
from spanlens import SpanlensMiddleware
app.add_middleware(SpanlensMiddleware, api_key=os.environ["SPANLENS_API_KEY"])
```

Each HTTP request opens a trace + a root span named `"<METHOD> <path>"`. Clean responses end `completed`; a 5xx or unhandled exception ends `error` and the exception is **re-raised untouched**. The trace is exposed to handlers as `request.state.spanlens` (`{trace, span, headers, trace_id, span_id}`) so nested `observe_*` LLM calls link to it automatically.

## Design
- **Pure ASGI** — does not import FastAPI, so it also works with Starlette, Litestar, Quart, and any ASGI app. New `spanlens[fastapi]` optional extra.
- **Sampling + tail-based error capture** inherited from the client: sampled-out successful requests do zero network I/O; errors are always captured.
- **Never breaks the request** — trace setup + `end()` calls are guarded and swallow; if setup fails the app runs un-traced.
- Health / metrics / docs paths skipped by default (`skip_paths=` to override); `name_factory=` to customise the span name.

## Test plan
- [x] `pytest` — 161 tests (5 new: success + `request.state` injection, default-path skip, error capture + re-raise, build-from-`api_key`, missing-credentials guard)
- [x] `ruff check` clean
- [x] `mypy --strict` clean on the new module (repo-wide mypy has pre-existing optional-dep stub gaps, unrelated)
- [x] README FastAPI section + parity-matrix row; CHANGELOG 0.8.0
- [ ] PyPI publish is a separate tag step (not triggered by this merge)