### PR TITLE
feat(server): webhook dead-letter queue + disaster-recovery runbook

### DIFF
--- a/apps/server/src/__tests__/health.test.ts
+++ b/apps/server/src/__tests__/health.test.ts
@@ -132,7 +132,12 @@ function pgDeepCronChainError() {
   }
 }
 
-function pgDeepWebhookChain(backlog: number) {
+// /health/deep queries webhook_deliveries TWICE:
+//   backlog: .select().eq().not().lt()   (deliveries past their retry window)
+//   dlq:     .select().not()             (permanently dead-lettered)
+// The single mock object must satisfy both — .select() exposes `eq` (backlog)
+// and `not` (dlq).
+function pgDeepWebhookChain(backlog: number, dlq = 0) {
   return {
     select: () => ({
       eq: () => ({
@@ -140,6 +145,7 @@ function pgDeepWebhookChain(backlog: number) {
           lt: () => Promise.resolve({ count: backlog, error: null }),
         }),
       }),
+      not: () => Promise.resolve({ count: dlq, error: null }),
     }),
   }
 }
@@ -152,6 +158,22 @@ function pgDeepWebhookChainError() {
           lt: () => Promise.reject(new Error('webhook query failed')),
         }),
       }),
+      not: () => Promise.reject(new Error('webhook dlq query failed')),
+    }),
+  }
+}
+
+// Backlog resolves, but the dlq count query itself fails → dlq_count must be
+// null (not a fake 0), same null-vs-0 convention as the other deep metrics.
+function pgDeepWebhookChainDlqError(backlog: number) {
+  return {
+    select: () => ({
+      eq: () => ({
+        not: () => ({
+          lt: () => Promise.resolve({ count: backlog, error: null }),
+        }),
+      }),
+      not: () => Promise.reject(new Error('webhook dlq query failed')),
     }),
   }
 }
@@ -259,7 +281,7 @@ describe('GET /health/deep', () => {
 
   test('200 with new R-11 metrics surfaced', async () => {
     pingClickhouseMock.mockResolvedValue(true)
-    wireDeepFroms(pgDeepCronChain(1234), pgDeepWebhookChain(5))
+    wireDeepFroms(pgDeepCronChain(1234), pgDeepWebhookChain(5, 3))
 
     const res = await healthRouter.request('/health/deep')
     expect(res.status).toBe(200)
@@ -267,7 +289,7 @@ describe('GET /health/deep', () => {
       status: string
       version: string | null
       crons: { max_runtime_ms: number | null }
-      webhooks: { backlog_count: number | null }
+      webhooks: { backlog_count: number | null; dlq_count: number | null }
       clickhouse: { ok: boolean; latencyMs: number }
       fallback: { queue: number | null; eventsQueue: number | null }
     }
@@ -275,8 +297,22 @@ describe('GET /health/deep', () => {
     expect(body.version).toBeNull()
     expect(body.crons.max_runtime_ms).toBe(1234)
     expect(body.webhooks.backlog_count).toBe(5)
+    expect(body.webhooks.dlq_count).toBe(3)
     expect(body.clickhouse.ok).toBe(true)
     expect(body.fallback.queue).toBe(0)
+  })
+
+  test('webhooks.dlq_count = null when the dlq count query fails', async () => {
+    pingClickhouseMock.mockResolvedValue(true)
+    wireDeepFroms(pgDeepCronChain(500), pgDeepWebhookChainDlqError(2))
+
+    const res = await healthRouter.request('/health/deep')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      webhooks: { backlog_count: number | null; dlq_count: number | null }
+    }
+    expect(body.webhooks.backlog_count).toBe(2)
+    expect(body.webhooks.dlq_count).toBeNull()
   })
 
   test('crons.max_runtime_ms = null when cron query fails (degrades, does not 503)', async () => {

--- a/apps/server/src/api/health.ts
+++ b/apps/server/src/api/health.ts
@@ -131,7 +131,7 @@ healthRouter.get('/health/deep', async (c) => {
   // R-22 added two new aggregate queries here. Run them inside the same
   // Promise.all the ping/queue lookups already use — p95 stays bounded by
   // the slowest dependency, not the sum.
-  const [chOk, fallbackQueue, eventsFallback, cronMaxRuntime, webhookBacklog] =
+  const [chOk, fallbackQueue, eventsFallback, cronMaxRuntime, webhookBacklog, webhookDlq] =
     await Promise.all([
       pingClickhouse().catch(() => false),
       fallbackQueueSize().catch(() => null),
@@ -163,6 +163,18 @@ healthRouter.get('/health/deep', async (c) => {
           (res) => (res.error ? null : res.count ?? 0),
           () => null,
         ),
+      // webhooks.dlq_count: deliveries permanently dead-lettered (gave up after
+      // MAX_ATTEMPTS, or the webhook was deleted). Covered by the dlq partial
+      // index from migration 20260701130000. A rising dlq_count = an endpoint
+      // down long enough to burn through every retry — page on it.
+      supabaseAdmin
+        .from('webhook_deliveries')
+        .select('id', { count: 'exact', head: true })
+        .not('dlq_at', 'is', null)
+        .then(
+          (res) => (res.error ? null : res.count ?? 0),
+          () => null,
+        ),
     ])
   const chLatency = Date.now() - start
 
@@ -188,7 +200,7 @@ healthRouter.get('/health/deep', async (c) => {
       // `crons.max_runtime_ms` null = either no cron ran in 24h (cold env)
       // OR the Supabase query failed — both are actionable.
       crons: { max_runtime_ms: cronMaxRuntime },
-      webhooks: { backlog_count: webhookBacklog },
+      webhooks: { backlog_count: webhookBacklog, dlq_count: webhookDlq },
     },
     overallOk ? 200 : 503,
   )

--- a/apps/server/src/lib/structured-logger.ts
+++ b/apps/server/src/lib/structured-logger.ts
@@ -36,6 +36,7 @@ export type LogCode =
   // webhook delivery
   | 'WEBHOOK_DISPATCH_FAILED'
   | 'WEBHOOK_FETCH_FAILED'
+  | 'WEBHOOK_DLQ_ALERT_FAILED'
   // proxy upstream
   | 'UPSTREAM_FETCH_FAILED'
   // rate limiting backend (Redis/Upstash) unavailable — fail-open is in effect

--- a/apps/server/src/lib/webhook-dispatch.ts
+++ b/apps/server/src/lib/webhook-dispatch.ts
@@ -199,10 +199,16 @@ export async function retryFailedWebhooks(): Promise<{
   }>) {
     const webhook = delivery.webhooks
     if (!webhook?.is_active || !delivery.payload) {
-      // Mark exhausted if webhook was deleted/disabled or payload missing
+      // Dead-letter: the webhook was deleted/disabled or the payload row is
+      // gone, so no retry can ever succeed. Mark it terminally.
       await supabaseAdmin
         .from('webhook_deliveries')
-        .update({ next_retry_at: null, attempt_count: MAX_ATTEMPTS })
+        .update({
+          next_retry_at: null,
+          attempt_count: MAX_ATTEMPTS,
+          dlq_at: new Date().toISOString(),
+          dlq_reason: !delivery.payload ? 'payload_missing' : 'webhook_deleted',
+        })
         .eq('id', delivery.id)
       continue
     }
@@ -228,7 +234,11 @@ export async function retryFailedWebhooks(): Promise<{
         .eq('id', delivery.id)
       succeeded++
     } else {
-      const nextRetryAt = attempt >= MAX_ATTEMPTS
+      // When this attempt was the last one, dead-letter it: stop retrying and
+      // stamp dlq_at so it's counted + surfaced instead of silently rotting in
+      // the failed pile.
+      const exhaustedNow = attempt >= MAX_ATTEMPTS
+      const nextRetryAt = exhaustedNow
         ? null
         : new Date(Date.now() + nextRetryDelayMs(attempt)).toISOString()
 
@@ -240,15 +250,84 @@ export async function retryFailedWebhooks(): Promise<{
           duration_ms: durationMs,
           attempt_count: attempt,
           next_retry_at: nextRetryAt,
+          ...(exhaustedNow
+            ? { dlq_at: new Date().toISOString(), dlq_reason: 'exhausted' }
+            : {}),
         })
         .eq('id', delivery.id)
       failed++
     }
   }
 
+  // Page operators if too many deliveries have permanently dead-lettered (an
+  // endpoint down long enough to burn through all retries). Best-effort — a
+  // failure here must never break the retry cron.
+  await alertOnWebhookDlq().catch(() => undefined)
+
   const exhausted = pending.filter(
     (d) => (d as { attempt_count: number }).attempt_count + 1 >= MAX_ATTEMPTS && failed > 0
   ).length
 
   return { retried: pending.length, succeeded, failed, exhausted }
+}
+
+/**
+ * Count of dead-lettered webhook deliveries (permanently given up on). Returns
+ * `null` when the count query itself fails, so callers can distinguish "zero
+ * dead" from "couldn't check" (same convention as /health/deep metrics).
+ */
+export async function webhookDlqSize(): Promise<number | null> {
+  const { count, error } = await supabaseAdmin
+    .from('webhook_deliveries')
+    .select('id', { count: 'exact', head: true })
+    .not('dlq_at', 'is', null)
+  if (error) return null
+  return count ?? 0
+}
+
+/** Dead-letter queue size above which an operator alert is raised. */
+export const WEBHOOK_DLQ_ALERT_THRESHOLD = 100
+
+/**
+ * Raise an `internal_alerts` row (kind `webhook_backlog`, already declared in
+ * 20260609110000_internal_alerts.sql) when the dead-letter queue exceeds
+ * `threshold`. Surfaced to operators at /admin/alerts.
+ *
+ * Deduplicated: if an unresolved `webhook_backlog` alert is already open, this
+ * is a no-op — a persistently-down endpoint pages once, not every cron tick.
+ * Mirrors `alertOnFallbackBacklog` in lib/fallback-replay.ts.
+ */
+export async function alertOnWebhookDlq(
+  threshold: number = WEBHOOK_DLQ_ALERT_THRESHOLD,
+): Promise<{ dlqSize: number | null; alerted: boolean }> {
+  const dlqSize = await webhookDlqSize()
+  if (dlqSize === null || dlqSize <= threshold) return { dlqSize, alerted: false }
+
+  try {
+    const { data: existing } = await supabaseAdmin
+      .from('internal_alerts')
+      .select('id')
+      .eq('kind', 'webhook_backlog')
+      .is('resolved_at', null)
+      .limit(1)
+      .maybeSingle()
+    if (existing) return { dlqSize, alerted: false }
+
+    await supabaseAdmin.from('internal_alerts').insert({
+      kind: 'webhook_backlog',
+      severity: 'error',
+      message:
+        `Webhook dead-letter queue over ${threshold} ` +
+        `(${dlqSize} deliveries permanently failed). An endpoint is likely down or misconfigured.`,
+      details: { dlq_size: dlqSize, threshold },
+    })
+    return { dlqSize, alerted: true }
+  } catch (err) {
+    logError(
+      'WEBHOOK_DLQ_ALERT_FAILED',
+      { kind: 'webhook_dlq_alert' },
+      err instanceof Error ? err.message : 'unknown',
+    )
+    return { dlqSize, alerted: false }
+  }
 }

--- a/apps/web/app/docs/_components/sidebar.tsx
+++ b/apps/web/app/docs/_components/sidebar.tsx
@@ -119,6 +119,7 @@ const NAV: NavGroup[] = [
     title: 'Production',
     items: [
       { title: 'Reliability', href: '/docs/production/reliability' },
+      { title: 'Disaster recovery', href: '/docs/production/disaster-recovery' },
       { title: 'Scaling', href: '/docs/production/scaling' },
     ],
   },

--- a/apps/web/app/docs/production/disaster-recovery/page.tsx
+++ b/apps/web/app/docs/production/disaster-recovery/page.tsx
@@ -1,0 +1,254 @@
+import { CodeBlock } from '../../_components/code-block'
+
+export const metadata = {
+  title: 'Disaster recovery · Spanlens Docs',
+  description:
+    'Operator runbook for Spanlens outages: what data is at risk in each failure mode, how the fallback queues protect it, and the exact recovery steps for ClickHouse, Supabase, cron, and webhook incidents.',
+  alternates: { canonical: '/docs/production/disaster-recovery' },
+}
+
+export default function DisasterRecoveryDocs() {
+  return (
+    <div>
+      <h1>Disaster recovery</h1>
+      <p className="lead">
+        A runbook for the person on call. Each failure mode below lists what data is at
+        risk, what protects it automatically, and the steps to recover. Pair this with{' '}
+        <a href="/docs/production/reliability">Reliability</a> (how the system degrades) and{' '}
+        <a href="/docs/self-host/backup">Backup and restore</a> (the restore commands).
+      </p>
+
+      <h2 id="objectives">Recovery objectives</h2>
+      <p>
+        Spanlens is designed so a dependency outage never fails your end users&apos; LLM
+        calls: the proxy returns the provider response before any logging happens. The
+        risk in an outage is <strong>observability data</strong> (request logs, traces,
+        usage), not your application traffic. The targets below are what the queues and
+        backups are sized for.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Data</th>
+            <th>Store</th>
+            <th>Protection</th>
+            <th>Recovery point</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Request logs</td>
+            <td>ClickHouse</td>
+            <td><code>requests_fallback</code> queue in Supabase (7 day TTL)</td>
+            <td>0 while the queue holds</td>
+          </tr>
+          <tr>
+            <td>Trace events</td>
+            <td>ClickHouse</td>
+            <td><code>events_fallback</code> queue in Supabase (7 day TTL)</td>
+            <td>0 while the queue holds</td>
+          </tr>
+          <tr>
+            <td>Accounts, keys, billing</td>
+            <td>Supabase Postgres</td>
+            <td>Managed daily backups + PITR</td>
+            <td>Provider backup cadence</td>
+          </tr>
+          <tr>
+            <td>Outbound webhooks</td>
+            <td>Supabase Postgres</td>
+            <td>5 retries with backoff, then dead-lettered</td>
+            <td>At-least-once while the endpoint is up</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 id="clickhouse-down">ClickHouse is down or paused</h2>
+      <p>
+        This is the most common incident on the ClickHouse Cloud Development tier, which
+        auto-pauses when idle. The proxy keeps serving traffic. Log inserts that fail are
+        written to the <code>requests_fallback</code> / <code>events_fallback</code> tables
+        in Supabase instead of being lost.
+      </p>
+      <p>
+        <strong>Automatic recovery:</strong> the <code>/cron/replay-fallback</code> job
+        drains those queues back into ClickHouse every 5 minutes, in batches, skipping any
+        row already present (idempotent). Once ClickHouse is reachable the backlog clears
+        on its own.
+      </p>
+      <p><strong>Manual steps if the backlog is not draining:</strong></p>
+      <ol>
+        <li>
+          Confirm ClickHouse is reachable and un-paused (ClickHouse Cloud console, or{' '}
+          <code>GET /health/ready</code> which pings it).
+        </li>
+        <li>
+          Check the queue depth in <code>GET /health/deep</code> under{' '}
+          <code>fallback.queue</code> and <code>fallback.eventsQueue</code>. A rising number
+          means the replay cron is not firing (see{' '}
+          <a href="#cron-dropout">cron dropout</a> below).
+        </li>
+        <li>
+          Trigger a drain by hand:
+          <CodeBlock language="bash">{`curl -X GET https://server.spanlens.io/cron/replay-fallback \\
+  -H "Authorization: Bearer $CRON_SECRET"`}</CodeBlock>
+        </li>
+        <li>
+          If the outage exceeds the <strong>7 day</strong> queue TTL, rows past the TTL are
+          expired to bound Supabase storage. That is the only window in which request-log
+          data is permanently lost. Upgrade the ClickHouse tier off Development so it does
+          not auto-pause, which removes this class of incident entirely.
+        </li>
+      </ol>
+      <p>
+        When the queue exceeds 1000 rows an <code>internal_alerts</code> row (kind{' '}
+        <code>fallback_queue_high</code>) is raised and shown at <code>/admin/alerts</code>.
+      </p>
+
+      <h2 id="supabase-down">Supabase is down</h2>
+      <p>
+        Supabase holds accounts, API keys, provider keys, billing, and the fallback queues
+        themselves. While it is down:
+      </p>
+      <ul>
+        <li>
+          The dashboard and REST API are unavailable. Proxy auth uses a short in-memory
+          cache, so in-flight keys keep working briefly, but new key lookups fail closed.
+        </li>
+        <li>
+          The fallback queues cannot absorb ClickHouse failures, because they live in
+          Supabase. A <em>simultaneous</em> ClickHouse + Supabase outage is the one case
+          where new request logs can be lost (see below).
+        </li>
+      </ul>
+      <p><strong>Recovery:</strong></p>
+      <ol>
+        <li>Restore Supabase from the managed backup or point-in-time recovery. See{' '}
+          <a href="/docs/self-host/backup#restore-postgres">Restore Postgres</a>.</li>
+        <li>
+          Because migrations are additive and the deploy pipeline runs{' '}
+          <code>migrate</code> before <code>deploy</code>, the server code tolerates a
+          schema that is briefly behind. Verify the schema version after restore and
+          re-run <code>supabase db push --linked</code> if needed.
+        </li>
+        <li>
+          After restore, watch <code>/health/deep</code> for the fallback queues to begin
+          draining again.
+        </li>
+      </ol>
+
+      <h2 id="both-down">ClickHouse and Supabase both down</h2>
+      <p>
+        This is the only total-loss window for new request logs: there is nowhere to queue
+        a failed insert. Your application traffic is unaffected because the proxy still
+        returns provider responses. The mitigation is to keep the two on independent
+        providers (they already are) so a correlated outage is unlikely, and to run
+        managed backups on both. There is no in-app queue that survives losing both stores
+        at once; do not design new write paths that assume one is always available.
+      </p>
+
+      <h2 id="cron-dropout">Scheduled jobs stop firing</h2>
+      <p>
+        Vercel&apos;s cron scheduler is known to silently drop short-interval jobs (as low
+        as a few percent fire rate for <code>*/5</code> schedules). If the replay,
+        self-monitor, or pending-deletion crons stop, backlogs build up with no error.
+      </p>
+      <p><strong>Detection:</strong> query how often each job actually ran in the last day.</p>
+      <CodeBlock language="sql">{`SELECT job_name, count(*) AS runs, max(ran_at) AS last_run
+FROM cron_job_runs
+WHERE ran_at > now() - interval '24 hours'
+GROUP BY job_name
+ORDER BY runs;`}</CodeBlock>
+      <p>
+        Compare the run counts to the schedule in <code>apps/server/vercel.json</code>. A
+        job that is defined but missing from this list, or running far below its schedule,
+        is being dropped.
+      </p>
+      <p><strong>Mitigation (defense in depth):</strong></p>
+      <ul>
+        <li>
+          <strong>GitHub Actions</strong> re-fires the critical routes on a schedule
+          (<code>.github/workflows/cron-server.yml</code>). GitHub also throttles short
+          intervals, so this is a partial backstop, not a full replacement.
+        </li>
+        <li>
+          <strong>External heartbeat monitor</strong> is the reliable fix. Register a
+          monitor (for example Better Stack) that calls the critical endpoints on a fixed
+          interval with the <code>Authorization: Bearer $CRON_SECRET</code> header. Because
+          it runs outside Vercel and GitHub, it is unaffected by their scheduler gaps and
+          fires at close to 100%. Cover at least{' '}
+          <code>/cron/replay-fallback</code> (3 min) and <code>/cron/self-monitor</code> (30
+          min).
+        </li>
+      </ul>
+      <p>
+        Keep <code>CRON_SECRET</code> synchronized across the three schedulers (Vercel env,
+        GitHub Actions secret, and the external monitor header) whenever it is rotated.
+      </p>
+
+      <h2 id="migration-stalled">A background migration is stuck</h2>
+      <p>
+        Large backfills run as chunked background migrations with a Postgres advisory lock
+        and a heartbeat, driven by <code>/cron/run-background-migrations</code>. If that
+        cron stops firing (see above) the queue stalls with no error.
+      </p>
+      <ol>
+        <li>
+          Check the queue:
+          <CodeBlock language="sql">{`SELECT name, status, progress_current, progress_total, last_heartbeat_at
+FROM background_migrations
+WHERE status IN ('pending', 'running')
+ORDER BY created_at;`}</CodeBlock>
+        </li>
+        <li>
+          A row stuck in <code>running</code> with a stale <code>last_heartbeat_at</code>{' '}
+          (older than a few minutes) means the worker died mid-chunk. The next cron tick
+          reclaims the lock and resumes from where it left off, so the usual fix is simply
+          to make the cron fire again.
+        </li>
+        <li>Trigger one run by hand to resume:
+          <CodeBlock language="bash">{`curl -X GET https://server.spanlens.io/cron/run-background-migrations \\
+  -H "Authorization: Bearer $CRON_SECRET"`}</CodeBlock>
+        </li>
+      </ol>
+
+      <h2 id="webhook-dlq">Webhook deliveries are dead-lettering</h2>
+      <p>
+        Outbound webhooks retry 5 times with exponential backoff. A delivery that exhausts
+        its retries, or whose endpoint was deleted, is <strong>dead-lettered</strong>:
+        marked with <code>dlq_at</code> and a <code>dlq_reason</code> instead of retrying
+        forever. A dead-letter count that climbs means a customer endpoint has been down
+        long enough to burn through every retry.
+      </p>
+      <ol>
+        <li>
+          Watch <code>webhooks.dlq_count</code> in <code>GET /health/deep</code>. When it
+          crosses the threshold an <code>internal_alerts</code> row (kind{' '}
+          <code>webhook_backlog</code>) is raised at <code>/admin/alerts</code>.
+        </li>
+        <li>
+          Inspect what is dead-lettered and why:
+          <CodeBlock language="sql">{`SELECT webhook_id, dlq_reason, count(*)
+FROM webhook_deliveries
+WHERE dlq_at IS NOT NULL
+GROUP BY webhook_id, dlq_reason
+ORDER BY count DESC;`}</CodeBlock>
+        </li>
+        <li>
+          <code>exhausted</code> means the endpoint returned errors or timed out for the
+          full retry window (contact the customer). <code>webhook_deleted</code> and{' '}
+          <code>payload_missing</code> are terminal and need no action.
+        </li>
+      </ol>
+
+      <h2 id="drills">Restore drills</h2>
+      <p>
+        Backups are only real if a restore has been tested. On a schedule (quarterly is a
+        reasonable default), restore the latest Supabase backup and a ClickHouse backup
+        into a throwaway environment and confirm the dashboard renders, using the exact
+        commands in <a href="/docs/self-host/backup">Backup and restore</a>. Record how
+        long the restore took; that is your real recovery time, not an estimate.
+      </p>
+    </div>
+  )
+}

--- a/supabase/migrations/20260701130000_webhook_deliveries_dlq.sql
+++ b/supabase/migrations/20260701130000_webhook_deliveries_dlq.sql
@@ -1,0 +1,31 @@
+-- Migration: webhook_deliveries dead-letter marking.
+--
+-- Before this, a delivery that exhausted its 5 retry attempts (or whose
+-- webhook was deleted/disabled, or whose payload row was lost) stayed in
+-- webhook_deliveries with status='failed' + next_retry_at=NULL, indistinguishable
+-- from a delivery that is merely between retries. There was no way to count
+-- permanently-dead deliveries, page on them, or inspect them after the fact —
+-- a webhook endpoint down for >~1h would silently drop every event.
+--
+-- This adds an explicit dead-letter marker (additive, nullable — existing rows
+-- stay NULL = not dead-lettered). retryFailedWebhooks() stamps dlq_at + a
+-- reason when it gives up, and a cheap partial index makes "how many are dead"
+-- a covered count for /health/deep and the operator alert.
+
+ALTER TABLE webhook_deliveries
+  ADD COLUMN IF NOT EXISTS dlq_at TIMESTAMPTZ;
+
+ALTER TABLE webhook_deliveries
+  ADD COLUMN IF NOT EXISTS dlq_reason TEXT
+    CHECK (dlq_reason IN ('exhausted', 'webhook_deleted', 'payload_missing'));
+
+-- "How many dead-lettered deliveries" — exact shape of the health metric +
+-- alert query. Shrinks to the dead set only (live deliveries are excluded).
+CREATE INDEX IF NOT EXISTS webhook_deliveries_dlq_idx
+  ON webhook_deliveries (dlq_at)
+  WHERE dlq_at IS NOT NULL;
+
+COMMENT ON COLUMN webhook_deliveries.dlq_at IS
+  'When the delivery was permanently given up on (dead-lettered). NULL = still live (delivered or retryable).';
+COMMENT ON COLUMN webhook_deliveries.dlq_reason IS
+  'Why it was dead-lettered: exhausted (hit MAX_ATTEMPTS), webhook_deleted (endpoint removed/disabled), or payload_missing.';

--- a/supabase/migrations/20260701130100_backfill_webhook_dlq.sql
+++ b/supabase/migrations/20260701130100_backfill_webhook_dlq.sql
@@ -1,0 +1,20 @@
+-- One-time backfill: mark webhook_deliveries that already exhausted their
+-- retries BEFORE 20260701130000_webhook_deliveries_dlq.sql shipped.
+--
+-- Those rows reached attempt_count = MAX_ATTEMPTS (5) with next_retry_at = NULL
+-- under the old exhaustion path, and retryFailedWebhooks() only ever re-fetches
+-- rows with attempt_count < MAX_ATTEMPTS. So they can never reach the new code
+-- that stamps dlq_at/dlq_reason. Without this backfill, /health/deep dlq_count,
+-- alertOnWebhookDlq, and the DR runbook's `WHERE dlq_at IS NOT NULL` query would
+-- permanently under-count the historical dead-letter set.
+--
+-- Idempotent: only touches rows not already marked (dlq_at IS NULL). MAX_ATTEMPTS
+-- (5) is hardcoded to match the constant in apps/server/src/lib/webhook-dispatch.ts.
+
+UPDATE webhook_deliveries
+SET dlq_at = now(),
+    dlq_reason = 'exhausted'
+WHERE dlq_at IS NULL
+  AND status = 'failed'
+  AND next_retry_at IS NULL
+  AND attempt_count >= 5;


### PR DESCRIPTION
## What

Reliability hardening — closes the silent webhook-loss gap and gives the on-call operator a runbook. (Bet 3 of the Strategic-Bet-A series.)

### Webhook dead-letter queue
Before: a delivery that exhausted its 5 retries (or whose endpoint was deleted) stayed in `webhook_deliveries` as `status=failed, next_retry_at=NULL`, indistinguishable from a delivery merely between retries. No way to count, page on, or inspect permanently-dead deliveries.

- **Migration** adds `dlq_at` + `dlq_reason` (additive, nullable) + a partial index for cheap counting.
- `retryFailedWebhooks()` stamps `dlq_at` + reason (`exhausted` / `webhook_deleted` / `payload_missing`) when it permanently gives up.
- `webhookDlqSize()` + `alertOnWebhookDlq()` raise an `internal_alerts` row (reusing the already-declared `webhook_backlog` kind, deduped) when the dead-letter count crosses 100 → surfaced at `/admin/alerts`.
- `/health/deep` exposes `webhooks.dlq_count` so an external monitor can page on it.

### Disaster-recovery runbook
New `/docs/production/disaster-recovery` page: per-failure-mode recovery steps (ClickHouse down / Supabase down / both / Vercel cron dropout / stalled background migration / webhook DLQ) with the exact SQL + curl to run, an RPO/RTO table, and the external-heartbeat-monitor mitigation for Vercel's cron drops. Registered in the docs sidebar.

## Test plan
- [x] `pnpm typecheck` (server + web)
- [x] server suite — 1350 tests, incl. updated `/health/deep` coverage (`dlq_count` value + null-on-query-failure)
- [x] `pnpm lint`
- [x] DR doc renders in preview (8 unique-id sections, no console errors)
- [ ] Migration validated by CI on throwaway DB
- [ ] External Better Stack monitors are an ops setup step (documented, not code)