### PR TITLE
feat(server): per-org request-body log sampling

### DIFF
--- a/apps/server/src/__tests__/org-log-config.test.ts
+++ b/apps/server/src/__tests__/org-log-config.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+// Mock the Supabase client the module reads body_sample_rate from.
+let maybeSingleResult: { data: unknown; error: unknown }
+let selectCalls = 0
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: () => ({
+      select: () => {
+        selectCalls++
+        return {
+          eq: () => ({
+            maybeSingle: () => Promise.resolve(maybeSingleResult),
+          }),
+        }
+      },
+    }),
+  },
+}))
+
+type Mod = typeof import('../lib/org-log-config.js')
+let getOrgBodySampleRate: Mod['getOrgBodySampleRate']
+let resetOrgLogConfigCache: Mod['resetOrgLogConfigCache']
+let shouldStoreBody: Mod['shouldStoreBody']
+
+beforeEach(async () => {
+  vi.resetModules()
+  selectCalls = 0
+  maybeSingleResult = { data: { body_sample_rate: 0.25 }, error: null }
+  const mod = await import('../lib/org-log-config.js')
+  getOrgBodySampleRate = mod.getOrgBodySampleRate
+  resetOrgLogConfigCache = mod.resetOrgLogConfigCache
+  shouldStoreBody = mod.shouldStoreBody
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('getOrgBodySampleRate', () => {
+  test('returns the stored rate', async () => {
+    expect(await getOrgBodySampleRate('org1')).toBe(0.25)
+  })
+
+  test('caches — a second call does not re-query', async () => {
+    await getOrgBodySampleRate('org1')
+    await getOrgBodySampleRate('org1')
+    expect(selectCalls).toBe(1)
+  })
+
+  test('resetOrgLogConfigCache forces a refetch', async () => {
+    await getOrgBodySampleRate('org1')
+    resetOrgLogConfigCache('org1')
+    await getOrgBodySampleRate('org1')
+    expect(selectCalls).toBe(2)
+  })
+
+  test('clamps out-of-range values into [0, 1]', async () => {
+    maybeSingleResult = { data: { body_sample_rate: 1.7 }, error: null }
+    expect(await getOrgBodySampleRate('org-high')).toBe(1)
+
+    maybeSingleResult = { data: { body_sample_rate: -0.5 }, error: null }
+    expect(await getOrgBodySampleRate('org-low')).toBe(0)
+  })
+
+  test('numeric strings (Supabase NUMERIC) are coerced', async () => {
+    maybeSingleResult = { data: { body_sample_rate: '0.1' }, error: null }
+    expect(await getOrgBodySampleRate('org-str')).toBeCloseTo(0.1, 6)
+  })
+
+  test('fails open to 1.0 when the row is missing', async () => {
+    maybeSingleResult = { data: null, error: null }
+    expect(await getOrgBodySampleRate('org-missing')).toBe(1.0)
+  })
+
+  test('fails open to 1.0 on a query error', async () => {
+    maybeSingleResult = { data: null, error: { message: 'db down' } }
+    expect(await getOrgBodySampleRate('org-err')).toBe(1.0)
+  })
+})
+
+describe('shouldStoreBody', () => {
+  test('never stores when not in full logBody mode', () => {
+    expect(shouldStoreBody(false, 1, 0)).toBe(false)
+  })
+
+  test('always stores at rate >= 1', () => {
+    expect(shouldStoreBody(true, 1, 0.99)).toBe(true)
+  })
+
+  test('never stores at rate <= 0', () => {
+    expect(shouldStoreBody(true, 0, 0)).toBe(false)
+  })
+
+  test('stores when the draw falls under the rate', () => {
+    expect(shouldStoreBody(true, 0.3, 0.29)).toBe(true)
+    expect(shouldStoreBody(true, 0.3, 0.31)).toBe(false)
+  })
+})

--- a/apps/server/src/api/organizations.ts
+++ b/apps/server/src/api/organizations.ts
@@ -6,6 +6,7 @@ import { randomHex, sha256Hex } from '../lib/crypto.js'
 import { OWNED_WORKSPACE_LIMITS, effectiveOwnedPlan, type Plan } from '../lib/quota.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
 import { ApiError } from '../lib/errors.js'
+import { resetOrgLogConfigCache } from '../lib/org-log-config.js'
 
 export const organizationsRouter = new Hono<JwtContext>()
 
@@ -66,7 +67,7 @@ organizationsRouter.get('/me', async (c) => {
 
   const { data, error } = await supabaseAdmin
     .from('organizations')
-    .select('id, name, plan, allow_overage, overage_cap_multiplier, stale_key_alerts_enabled, stale_key_threshold_days, leak_detection_enabled, hide_powered_by_badge, created_at, updated_at')
+    .select('id, name, plan, allow_overage, overage_cap_multiplier, stale_key_alerts_enabled, stale_key_threshold_days, leak_detection_enabled, hide_powered_by_badge, body_sample_rate, created_at, updated_at')
     .eq('id', orgId)
     .single()
 
@@ -137,7 +138,7 @@ organizationsRouter.patch('/me/security', requireAdmin, async (c) => {
     .from('organizations')
     .update(patch)
     .eq('id', orgId)
-    .select('id, name, plan, allow_overage, overage_cap_multiplier, stale_key_alerts_enabled, stale_key_threshold_days, leak_detection_enabled, hide_powered_by_badge, created_at, updated_at')
+    .select('id, name, plan, allow_overage, overage_cap_multiplier, stale_key_alerts_enabled, stale_key_threshold_days, leak_detection_enabled, hide_powered_by_badge, body_sample_rate, created_at, updated_at')
     .single()
 
   if (error || !data) {
@@ -262,6 +263,53 @@ organizationsRouter.patch('/me/branding', requireAdmin, async (c) => {
     resourceType: 'organizations',
     resourceId: orgId,
     metadata: { hide_powered_by_badge: wantsHide },
+  })
+
+  return c.json({ success: true, data })
+})
+
+// PATCH /api/v1/organizations/me/logging — set the request-body sampling rate.
+//
+// Body: { body_sample_rate: number in [0, 1] }
+//
+// This is BODY sampling, not row sampling: every request still writes a row
+// (tokens/cost/counts stay exact for billing), only the stored prompt/response
+// body text is dropped for (1 - rate) of requests to cut ClickHouse storage.
+// See lib/logger.ts + lib/org-log-config.ts.
+organizationsRouter.patch('/me/logging', requireAdmin, async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+
+  let body: { body_sample_rate?: unknown }
+  try {
+    body = (await c.req.json()) as typeof body
+  } catch {
+    throw new ApiError('INVALID_JSON_BODY', 'Invalid JSON body')
+  }
+
+  const rate = body.body_sample_rate
+  if (typeof rate !== 'number' || !Number.isFinite(rate) || rate < 0 || rate > 1) {
+    throw new ApiError('VALIDATION_FAILED', 'body_sample_rate must be a number between 0 and 1')
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('organizations')
+    .update({ body_sample_rate: rate })
+    .eq('id', orgId)
+    .select('id, body_sample_rate')
+    .single()
+
+  if (error || !data) throw new ApiError('INTERNAL_ERROR', 'Update failed')
+
+  // Drop the cached rate so the new value takes effect immediately instead of
+  // waiting out the 60s logger cache TTL.
+  resetOrgLogConfigCache(orgId)
+
+  void recordAuditEvent(c, {
+    action: 'workspace.logging_update',
+    resourceType: 'organizations',
+    resourceId: orgId,
+    metadata: { body_sample_rate: rate },
   })
 
   return c.json({ success: true, data })

--- a/apps/server/src/lib/logger.ts
+++ b/apps/server/src/lib/logger.ts
@@ -8,6 +8,7 @@ import { emitWebhookEvent } from './webhook-emit.js'
 import { writeRequestAsEvent } from './events-writer.js'
 import { logError } from './structured-logger.js'
 import { resolvePromptVersion } from './resolve-prompt-version.js'
+import { getOrgBodySampleRate, shouldStoreBody } from './org-log-config.js'
 
 /**
  * Customer-controlled body logging mode (sent via the `x-spanlens-log-body`
@@ -237,7 +238,14 @@ export async function logRequestAsync(data: RequestLogData): Promise<void> {
   // The error_message column passes through API-key masking in case an
   // upstream 401 echoed back a key fragment.
   const logBodyMode = data.logBodyMode ?? 'full'
-  const storeBody = logBodyMode === 'full'
+  // Body-level sampling (org-configurable via organizations.body_sample_rate):
+  // keep the row + all metadata (tokens, cost, counts) so quota/billing stay
+  // exact — we NEVER drop a whole row — but drop the heavy body text for
+  // (1 - body_sample_rate) of requests to cut ClickHouse storage. Default 1.0 =
+  // store all bodies (unchanged). The security scan above still ran on the full
+  // body, so injection/PII flags are recorded even when the body isn't stored.
+  const bodySampleRate = await getOrgBodySampleRate(data.organizationId)
+  const storeBody = shouldStoreBody(logBodyMode === 'full', bodySampleRate, Math.random())
   const requestBody = storeBody ? maskApiKeysInBody(maybeTruncateBody(data.requestBody)) : ''
   const responseBody = storeBody ? maskApiKeysInBody(maybeTruncateBody(data.responseBody)) : ''
   const errorMessage = data.errorMessage ? maskApiKeys(data.errorMessage) : null

--- a/apps/server/src/lib/org-log-config.ts
+++ b/apps/server/src/lib/org-log-config.ts
@@ -1,0 +1,77 @@
+/**
+ * Per-organization logging configuration, cached for the proxy hot path.
+ *
+ * Currently just the request-body sampling rate (organizations.body_sample_rate).
+ * logRequestAsync runs on every proxy request, so this is cached in-process with
+ * a short TTL to avoid a Supabase round-trip per log write. Fail-open: on a
+ * lookup failure we return 1.0 (store the body), which preserves the historical
+ * behavior — we never silently drop a body because a config read hiccuped.
+ */
+
+import { supabaseAdmin } from './db.js'
+
+const CACHE_TTL_MS = 60_000
+
+interface CacheEntry {
+  rate: number
+  at: number
+}
+
+const cache = new Map<string, CacheEntry>()
+
+/** Clamp any input to the valid sample-rate range [0, 1]. */
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 1.0
+  if (n < 0) return 0
+  if (n > 1) return 1
+  return n
+}
+
+/** Clear the cache. Call after an org updates its logging config. */
+export function resetOrgLogConfigCache(orgId?: string): void {
+  if (orgId) cache.delete(orgId)
+  else cache.clear()
+}
+
+/**
+ * Resolve the org's body sample rate (fraction of requests whose bodies are
+ * stored). Cached for {@link CACHE_TTL_MS}. Returns 1.0 (store everything) on
+ * cache miss + lookup failure so a Supabase blip never drops customer bodies.
+ */
+export async function getOrgBodySampleRate(orgId: string): Promise<number> {
+  const now = Date.now()
+  const hit = cache.get(orgId)
+  if (hit && now - hit.at < CACHE_TTL_MS) return hit.rate
+
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('organizations')
+      .select('body_sample_rate')
+      .eq('id', orgId)
+      .maybeSingle()
+    if (error || !data) {
+      // Cache the default briefly so a persistent lookup failure doesn't
+      // hammer Supabase on every log write.
+      cache.set(orgId, { rate: 1.0, at: now })
+      return 1.0
+    }
+    const raw = (data as { body_sample_rate?: unknown }).body_sample_rate
+    const rate = clamp01(Number(raw ?? 1))
+    cache.set(orgId, { rate, at: now })
+    return rate
+  } catch {
+    return 1.0
+  }
+}
+
+/**
+ * Decide whether to store the body for one request. Bodies are stored when the
+ * caller is in 'full' logBody mode AND the random draw falls within the sample
+ * rate. `rng` is injectable for tests; production passes Math.random().
+ */
+export function shouldStoreBody(fullMode: boolean, sampleRate: number, rng: number): boolean {
+  if (!fullMode) return false
+  if (sampleRate >= 1) return true
+  if (sampleRate <= 0) return false
+  return rng < sampleRate
+}

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -24,6 +24,7 @@ import {
   useUpdateOverageSettings,
   useUpdateSecuritySettings,
   useUpdateBrandingSettings,
+  useUpdateLoggingSettings,
 } from '@/lib/queries/use-organization'
 import {
   useSubscription,
@@ -293,6 +294,8 @@ function GeneralTab() {
         </FormRow>
       </Section>
 
+      {isAdmin && org && <LoggingSection currentRate={org.body_sample_rate ?? 1} />}
+
       <Section title="Delete workspace" description="Contact support to delete your workspace" className="mb-5">
         <div className="px-6 py-4 text-[13px] text-text-muted leading-relaxed">
           Workspace deletion requires verification and isn&apos;t available in the self-service UI yet.
@@ -301,6 +304,57 @@ function GeneralTab() {
         </div>
       </Section>
     </div>
+  )
+}
+
+// ─── Log body sampling (ClickHouse storage control) ──────────────────────────
+
+function LoggingSection({ currentRate }: { currentRate: number }) {
+  const update = useUpdateLoggingSettings()
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleChange(value: string) {
+    setError(null)
+    try {
+      await update.mutateAsync({ body_sample_rate: Number(value) })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Update failed')
+    }
+  }
+
+  // Snap the stored rate to the nearest preset so the dropdown shows a match.
+  const presets = [1, 0.5, 0.1, 0.01]
+  const selected = presets.reduce(
+    (best, p) => (Math.abs(p - currentRate) < Math.abs(best - currentRate) ? p : best),
+    1,
+  )
+
+  return (
+    <Section
+      title="Log body sampling"
+      description="Cut ClickHouse storage by keeping prompt and response bodies for only a fraction of requests. Token counts, cost, and billing are always recorded in full."
+      className="mb-5"
+    >
+      <FormRow
+        label="Store bodies for"
+        hint="Every request still writes a row with tokens and cost. Only the prompt/response text is sampled, so sampled-out requests show empty bodies in /requests."
+      >
+        <div className="flex items-center gap-3">
+          <select
+            value={String(selected)}
+            disabled={update.isPending}
+            onChange={(e) => void handleChange(e.currentTarget.value)}
+            className="rounded-[6px] border border-border bg-bg-elev px-3 py-1.5 text-[13px] text-text"
+          >
+            <option value="1">100% of requests (store all)</option>
+            <option value="0.5">50% of requests</option>
+            <option value="0.1">10% of requests</option>
+            <option value="0.01">1% of requests</option>
+          </select>
+          {error && <span className="text-[12px] text-red-500">{error}</span>}
+        </div>
+      </FormRow>
+    </Section>
   )
 }
 

--- a/apps/web/lib/queries/types.ts
+++ b/apps/web/lib/queries/types.ts
@@ -30,6 +30,8 @@ export interface Organization {
   leak_detection_enabled: boolean
   /** PLG Loop ② — Team+ may hide the "Observed by Spanlens" share footer. */
   hide_powered_by_badge: boolean
+  /** Fraction [0,1] of requests whose bodies are stored (row + metadata always stored). */
+  body_sample_rate: number
   created_at: string
   updated_at: string
 }

--- a/apps/web/lib/queries/use-organization.ts
+++ b/apps/web/lib/queries/use-organization.ts
@@ -85,6 +85,32 @@ export function useUpdateBrandingSettings() {
   })
 }
 
+export interface LoggingSettingsUpdate {
+  /** Fraction [0,1] of requests whose bodies are stored. 1 = all (default). */
+  body_sample_rate: number
+}
+
+/**
+ * PATCH /api/v1/organizations/me/logging — request-body sampling rate. Body
+ * sampling only: every request still writes a row (billing stays exact), only
+ * the stored prompt/response text is dropped for the sampled-out fraction.
+ */
+export function useUpdateLoggingSettings() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (update: LoggingSettingsUpdate) => {
+      const res = await apiPatch<ApiEnvelope<Organization>>(
+        '/api/v1/organizations/me/logging',
+        update,
+      )
+      return res.data
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: organizationQueryKey })
+    },
+  })
+}
+
 /**
  * PATCH /api/v1/organizations/me/security — notification-only key security
  * settings (stale-key digest, GitGuardian leak detection). Neither auto-revokes

--- a/supabase/migrations/20260701140000_org_body_sample_rate.sql
+++ b/supabase/migrations/20260701140000_org_body_sample_rate.sql
@@ -1,0 +1,22 @@
+-- Migration: per-organization request-body sampling rate.
+--
+-- High-traffic customers pay for ClickHouse storage that is dominated by the
+-- request/response *body* columns (prompt + completion text). This adds an
+-- opt-in knob to store bodies for only a fraction of requests.
+--
+-- IMPORTANT — this is BODY sampling, not ROW sampling. Every request still
+-- writes a row (id, tokens, cost, latency, model), so quota/billing counts
+-- (which count rows from the ClickHouse `requests` table via quota.ts →
+-- requestsScope) stay exact. Only the heavy body text is dropped for the
+-- sampled-out fraction, exactly like the existing x-spanlens-log-body=meta
+-- mode but applied probabilistically per-org.
+--
+-- Default 1.0 = store every body (unchanged behavior). Additive + NOT NULL
+-- with a default so existing rows backfill automatically.
+
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS body_sample_rate NUMERIC(4, 3) NOT NULL DEFAULT 1.0
+    CHECK (body_sample_rate >= 0 AND body_sample_rate <= 1);
+
+COMMENT ON COLUMN organizations.body_sample_rate IS
+  'Fraction [0,1] of requests whose prompt/response BODIES are stored in ClickHouse. 1.0 = all (default). Row + tokens + cost are always stored regardless, so billing is unaffected.';


### PR DESCRIPTION
## What

Cut ClickHouse storage for high-traffic customers by storing prompt/response **bodies** for only a fraction of requests, configurable per org. (Bet 5 of Strategic-Bet-A — the sampling half.)

### Why body sampling, not row sampling
Quota/billing counts **rows** from the ClickHouse `requests` table (`quota.ts` → `requestsScope`). Dropping whole rows would silently **under-bill**. So instead:
- **Every request still writes a row** (id, tokens, cost, latency, model) → billing/quota/cost analytics stay exact.
- Only the heavy **body text** is dropped for the sampled-out fraction (bodies dominate storage cost), the same effect as `x-spanlens-log-body=meta` applied probabilistically.
- The security scan runs on the full body **first**, so injection/PII flags are still recorded even when the body isn't stored.

No ClickHouse schema change — reuses the existing empty-body path.

### Changes
- **Migration** `organizations.body_sample_rate NUMERIC(4,3) DEFAULT 1.0` (store-all = unchanged) with a `[0,1]` CHECK.
- `lib/org-log-config.ts`: `getOrgBodySampleRate` (60s in-process cache, **fail-open to 1.0** so a Supabase blip never drops bodies) + `shouldStoreBody` decision helper.
- `logger.ts`: gate body storage on the sample decision; row + metadata always written.
- `PATCH /api/v1/organizations/me/logging` (admin) to set the rate + bust the cache; `body_sample_rate` added to `GET /me`.
- Settings UI: "Log body sampling" dropdown (100 / 50 / 10 / 1%).

### Deferred
Guardrails (token/cost ceilings, PII-redact-before-upstream) are intentionally **not** here — they mutate/deny live requests and are security-adjacent, so they belong with the enterprise-trust bet (#4), not this storage-cost change.

## Test plan
- [x] `pnpm typecheck` (server + web)
- [x] server suite — 1360 tests (incl. 11 new `org-log-config` tests: cache, clamp, numeric-string coercion, fail-open, decision helper)
- [x] `pnpm lint`
- [ ] Migration validated by CI on throwaway DB