### PR TITLE
fix: pre-launch security, data-integrity, and reliability hardening

### DIFF
--- a/apps/server/api/index.ts
+++ b/apps/server/api/index.ts
@@ -82,20 +82,49 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
     // 6. Stream response body (works for both streaming SSE and plain JSON)
     if (webRes.body) {
       const reader = webRes.body.getReader()
+      // Detect client disconnect. Without this, a client that aborts mid-stream
+      // leaves res.write() returning false with no subsequent 'drain' — the loop
+      // below would await 'drain' forever, the upstream proxy pump would block on
+      // its downstream write, the 290s stream deadline (which only races
+      // reader.read(), not the write) would never fire, and the function would
+      // hang until Vercel's 300s ceiling: the row is never logged and a
+      // full-duration invocation is billed. On 'close' we stop and cancel the
+      // upstream stream so the proxy pump unblocks and logs the partial row.
+      let clientGone = false
+      const onClose = () => {
+        clientGone = true
+      }
+      res.on('close', onClose)
       try {
         for (;;) {
+          if (clientGone || res.writableEnded) break
           const { done, value } = await reader.read()
           if (done) break
           if (!res.write(value)) {
-            // Backpressure: wait for drain before writing more
-            await new Promise<void>(resolve => res.once('drain', resolve))
+            if (clientGone || res.writableEnded) break
+            // Backpressure: resume on 'drain', or bail out if the client left.
+            await new Promise<void>((resolve) => {
+              const finish = () => {
+                res.off('drain', onDrain)
+                res.off('close', onDisc)
+                resolve()
+              }
+              const onDrain = () => finish()
+              const onDisc = () => finish()
+              res.once('drain', onDrain)
+              res.once('close', onDisc)
+            })
           }
         }
       } finally {
+        res.off('close', onClose)
+        // If the client aborted, cancel the upstream/proxy stream so its pump
+        // stops waiting on our (dead) socket and runs its ClickHouse logging.
+        if (clientGone) await reader.cancel().catch(() => {})
         reader.releaseLock()
       }
     }
-    res.end()
+    if (!res.writableEnded) res.end()
   } catch (err) {
     console.error('[handler] unhandled error:', err)
     captureError(err, { url: req.url, method: req.method })

--- a/apps/server/src/__tests__/proxy-openai.test.ts
+++ b/apps/server/src/__tests__/proxy-openai.test.ts
@@ -301,12 +301,16 @@ describe('openai proxy — logging + cost calculation', () => {
     mockUpstream(openAIChatResponse())
     const app = await buildApp()
 
+    // The SDK generates trace/span ids with crypto.randomUUID(); requests.trace_id
+    // and span_id are ClickHouse Nullable(UUID), so valid UUIDs flow through.
+    const traceId = '11111111-1111-4111-8111-111111111111'
+    const spanId = '22222222-2222-4222-8222-222222222222'
     await app.request('/proxy/openai/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-trace-id': 'trace_test_123',
-        'x-span-id': 'span_test_456',
+        'x-trace-id': traceId,
+        'x-span-id': spanId,
         'x-spanlens-user': 'usr_end_customer',
         'x-spanlens-session': 'sess_abc',
       },
@@ -315,10 +319,35 @@ describe('openai proxy — logging + cost calculation', () => {
     await drainPendingTasks()
 
     const row = proxyState.loggerCalls[0]!
-    expect(row['traceId']).toBe('trace_test_123')
-    expect(row['spanId']).toBe('span_test_456')
+    expect(row['traceId']).toBe(traceId)
+    expect(row['spanId']).toBe(spanId)
     expect(row['userId']).toBe('usr_end_customer')
     expect(row['sessionId']).toBe('sess_abc')
+  })
+
+  test('non-UUID trace/span ids are nulled so the Nullable(UUID) insert never drops the row', async () => {
+    mockUpstream(openAIChatResponse())
+    const app = await buildApp()
+
+    await app.request('/proxy/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-trace-id': 'trace_test_123',
+        'x-span-id': 'span_test_456',
+        'x-spanlens-user': 'usr_end_customer',
+      },
+      body: JSON.stringify({ model: 'gpt-4o-mini', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    const row = proxyState.loggerCalls[0]!
+    // Invalid UUIDs must coerce to null — otherwise they poison the ClickHouse
+    // Nullable(UUID) column and the whole row is silently dropped at flush time.
+    expect(row['traceId']).toBeNull()
+    expect(row['spanId']).toBeNull()
+    // Customer identifiers are Strings, so non-UUID values still flow.
+    expect(row['userId']).toBe('usr_end_customer')
   })
 })
 

--- a/apps/server/src/api/apiKeys.ts
+++ b/apps/server/src/api/apiKeys.ts
@@ -243,11 +243,29 @@ apiKeysRouter.patch('/:id', requireEdit, async (c) => {
   if (!ownership) throw new ApiError('NOT_FOUND', 'API key not found')
   if (ownership.orgId !== orgId) throw new ApiError('FORBIDDEN', 'Access denied')
 
+  // When disabling a key we need its key_hash to evict the auth cache below.
+  // Load it before the update so the row is guaranteed to still exist.
+  let keyHash: string | null = null
+  if (body.is_active === false) {
+    const { data: keyRow } = await supabaseAdmin
+      .from('api_keys')
+      .select('key_hash')
+      .eq('id', keyId)
+      .maybeSingle()
+    keyHash = (keyRow as { key_hash?: string } | null)?.key_hash ?? null
+  }
+
   const { error } = await supabaseAdmin
     .from('api_keys')
     .update({ is_active: body.is_active })
     .eq('id', keyId)
   if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to update API key')
+
+  // R-4/R-5: mirror the DELETE handler — drop the cached auth entry the instant
+  // a key is disabled. Without this, the 30-60s cache TTL would keep a disabled
+  // sl_live_* key authenticating proxy/ingest traffic. Only evict on disable so
+  // an unrelated PATCH (e.g. a future rename) doesn't over-invalidate.
+  if (body.is_active === false && keyHash) invalidateApiKeyCache(keyHash)
 
   void recordAuditEvent(c, {
     action: body.is_active ? 'api_key.enable' : 'api_key.disable',

--- a/apps/server/src/api/billing.ts
+++ b/apps/server/src/api/billing.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { requireRole } from '../middleware/requireRole.js'
 import { supabaseAdmin } from '../lib/db.js'
 import {
   createPaddleCustomer,
@@ -57,10 +58,28 @@ billingRouter.get('/quota', async (c) => {
 // ── POST /api/v1/billing/checkout ───────────────────────────────
 // Body: { plan: 'starter' | 'team' | 'enterprise', successUrl?: string }
 // Returns: { url: 'https://...' } — browser redirects to Paddle-hosted checkout
-billingRouter.post('/checkout', async (c) => {
+billingRouter.post('/checkout', requireRole('admin'), async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+
+  // Guard against double-billing. The Paddle webhook upserts subscriptions by
+  // paddle_subscription_id, so a second checkout completed against a live
+  // subscription persists a SECOND row and Paddle bills both. Reject up front
+  // and steer the caller to the plan-change flow instead.
+  const { data: existingSub } = await supabaseAdmin
+    .from('subscriptions')
+    .select('id')
+    .eq('organization_id', orgId)
+    .in('status', ['active', 'trialing', 'past_due', 'paused'])
+    .limit(1)
+    .maybeSingle()
+  if (existingSub) {
+    throw new ApiError(
+      'CONFLICT',
+      'This workspace already has an active subscription; use plan change instead',
+    )
+  }
 
   let body: { plan?: unknown }
   try {
@@ -143,7 +162,7 @@ billingRouter.post('/checkout', async (c) => {
 // ── POST /api/v1/billing/cancel ─────────────────────────────────
 // Cancels the active subscription at period end so the customer keeps access
 // through the current billing period (matches Terms section 5).
-billingRouter.post('/cancel', async (c) => {
+billingRouter.post('/cancel', requireRole('admin'), async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 

--- a/apps/server/src/api/datasets.ts
+++ b/apps/server/src/api/datasets.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { requireRole } from '../middleware/requireRole.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { requestsScope, selectRequests } from '../lib/requests-query.js'
 import { ApiError } from '../lib/errors.js'
@@ -8,10 +9,12 @@ export const datasetsRouter = new Hono<JwtContext>()
 
 datasetsRouter.use('*', authJwt)
 
+const requireEdit = requireRole('admin', 'editor')
+
 // ── Datasets ────────────────────────────────────────────────────────────────
 
 // POST /api/v1/datasets — create
-datasetsRouter.post('/', async (c) => {
+datasetsRouter.post('/', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
@@ -114,7 +117,7 @@ datasetsRouter.get('/:id', async (c) => {
 })
 
 // DELETE /api/v1/datasets/:id — soft delete (archive)
-datasetsRouter.delete('/:id', async (c) => {
+datasetsRouter.delete('/:id', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
@@ -132,7 +135,7 @@ datasetsRouter.delete('/:id', async (c) => {
 // ── Dataset items ──────────────────────────────────────────────────────────
 
 // POST /api/v1/datasets/:id/items — add a single item
-datasetsRouter.post('/:id/items', async (c) => {
+datasetsRouter.post('/:id/items', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
@@ -189,7 +192,7 @@ datasetsRouter.post('/:id/items', async (c) => {
 // from a client-side parsed file (JSON / CSV). Treats each row as an
 // independent item; partial-failure surfaced with per-row status so the UI
 // can show "8/10 inserted, 2 skipped (missing input)".
-datasetsRouter.post('/:id/items/bulk', async (c) => {
+datasetsRouter.post('/:id/items/bulk', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
@@ -275,7 +278,7 @@ datasetsRouter.post('/:id/items/bulk', async (c) => {
 })
 
 // POST /api/v1/datasets/:id/items/import-requests — bulk import from production
-datasetsRouter.post('/:id/items/import-requests', async (c) => {
+datasetsRouter.post('/:id/items/import-requests', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
@@ -383,7 +386,7 @@ datasetsRouter.post('/:id/items/import-requests', async (c) => {
 })
 
 // DELETE /api/v1/datasets/:id/items/:itemId
-datasetsRouter.delete('/:id/items/:itemId', async (c) => {
+datasetsRouter.delete('/:id/items/:itemId', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 

--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import { createMiddleware } from 'hono/factory'
 import { authJwtOrApiKey, type DualAuthContext } from '../middleware/authJwtOrApiKey.js'
 import { requireFullScope } from '../middleware/requireFullScope.js'
 import { supabaseAdmin } from '../lib/db.js'
@@ -18,10 +19,26 @@ export const evalsRouter = new Hono<DualAuthContext>()
 
 evalsRouter.use('*', authJwtOrApiKey)
 
+// Dual-auth write gate for evaluator CRUD + eval-run triggers.
+//   - API-key path: `role` is null and requireFullScope has already narrowed the
+//     caller to a FULL sl_live_* key. That is the intended "prompt CI with an
+//     sl_live_* key" flow (see header comment), so allow it through.
+//   - JWT (dashboard) path: require admin/editor so a viewer-role member can't
+//     create evaluators or trigger billable eval runs.
+// Plain requireRole('admin','editor') would reject the null-role API-key path
+// and break CI, so this variant only enforces the role check when a role is set.
+const requireEdit = createMiddleware<DualAuthContext>(async (c, next) => {
+  const role = c.get('role')
+  if (role != null && role !== 'admin' && role !== 'editor') {
+    throw ApiError.from('FORBIDDEN', { required: ['admin', 'editor'], actual: role })
+  }
+  return next()
+})
+
 // ── Evaluators (定義) ────────────────────────────────────────────────────────
 
 // POST /api/v1/evaluators — create a reusable evaluator
-evalsRouter.post('/evaluators', requireFullScope, async (c) => {
+evalsRouter.post('/evaluators', requireFullScope, requireEdit, async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
@@ -387,7 +404,7 @@ evalsRouter.delete('/evaluators/:id', requireFullScope, async (c) => {
 // ── Eval runs (실행) ─────────────────────────────────────────────────────────
 
 // POST /api/v1/eval-runs — kick off a run (returns immediately, run executes in background)
-evalsRouter.post('/eval-runs', requireFullScope, async (c) => {
+evalsRouter.post('/eval-runs', requireFullScope, requireEdit, async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')

--- a/apps/server/src/api/experiments.ts
+++ b/apps/server/src/api/experiments.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { requireRole } from '../middleware/requireRole.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { runExperiment } from '../lib/experiment-runner.js'
 import { fireAndForget } from '../lib/wait-until.js'
@@ -9,8 +10,10 @@ export const experimentsRouter = new Hono<JwtContext>()
 
 experimentsRouter.use('*', authJwt)
 
+const requireEdit = requireRole('admin', 'editor')
+
 // POST /api/v1/experiments — create + kick off
-experimentsRouter.post('/', async (c) => {
+experimentsRouter.post('/', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')

--- a/apps/server/src/api/exports.ts
+++ b/apps/server/src/api/exports.ts
@@ -44,6 +44,27 @@ const EXPORT_COLUMNS = [
 type ExportColumn = (typeof EXPORT_COLUMNS)[number]
 type ExportRow = Record<ExportColumn, unknown>
 
+/**
+ * Numeric ClickHouse columns come back over JSONEachRow as strings (Decimal /
+ * UInt → string, gotcha #19). Coerce them to real numbers at the export
+ * boundary so downstream tooling (pandas, BigQuery) receives numbers, not
+ * strings like "0.00012345". `null` is preserved (cost can be unknown). CSV is
+ * unaffected — String(number) and String(numeric-string) render identically.
+ */
+const NUMERIC_EXPORT_COLUMNS: readonly ExportColumn[] = [
+  'prompt_tokens', 'completion_tokens', 'total_tokens',
+  'cost_usd', 'latency_ms', 'status_code',
+]
+
+function coerceNumericColumns<Row extends Record<string, unknown>>(row: Row): Row {
+  const out: Record<string, unknown> = { ...row }
+  for (const col of NUMERIC_EXPORT_COLUMNS) {
+    const v = out[col]
+    if (v !== null && v !== undefined && v !== '') out[col] = Number(v)
+  }
+  return out as Row
+}
+
 function escapeCsv(val: unknown): string {
   if (val === null || val === undefined) return ''
   const s = String(val)
@@ -79,11 +100,15 @@ export async function* withIsoCreatedAt<Row extends Record<string, unknown>>(
   rows: AsyncIterable<Row>,
 ): AsyncGenerator<Row, void, undefined> {
   for await (const row of rows) {
-    const raw = row['created_at']
+    // Coerce ClickHouse string-encoded numerics (cost_usd, tokens, etc.) to
+    // numbers so JSONL consumers get numbers, not strings (gotcha #19). CSV is
+    // unaffected. Then normalise created_at to ISO UTC.
+    const coerced = coerceNumericColumns(row)
+    const raw = coerced['created_at']
     if (typeof raw === 'string') {
-      yield { ...row, created_at: fromClickhouseTimestamp(raw) ?? raw }
+      yield { ...coerced, created_at: fromClickhouseTimestamp(raw) ?? raw }
     } else {
-      yield row
+      yield coerced
     }
   }
 }
@@ -205,12 +230,15 @@ exportsRouter.get('/requests', async (c) => {
       console.error('[exports:requests] ClickHouse query failed:', err instanceof Error ? err.message : err)
       throw new ApiError('INTERNAL_ERROR', 'Failed to export requests')
     }
-    // ClickHouse DateTime64 → ISO UTC (gotcha #18). Streaming CSV/JSONL paths
-    // below still emit raw format; they should be wrapped too in a follow-up.
-    const normalised = rows.map((r) => ({
-      ...r,
-      created_at: fromClickhouseTimestamp(typeof r.created_at === 'string' ? r.created_at : null) ?? r.created_at,
-    }))
+    // ClickHouse DateTime64 → ISO UTC (gotcha #18) + string-encoded numerics
+    // → numbers (gotcha #19) so pandas/BigQuery receive numbers, not strings.
+    const normalised = rows.map((r) => {
+      const coerced = coerceNumericColumns(r)
+      return {
+        ...coerced,
+        created_at: fromClickhouseTimestamp(typeof coerced.created_at === 'string' ? coerced.created_at : null) ?? coerced.created_at,
+      }
+    })
     const body = JSON.stringify(
       { exported_at: new Date().toISOString(), count: normalised.length, data: normalised },
       null,

--- a/apps/server/src/api/human-evals.ts
+++ b/apps/server/src/api/human-evals.ts
@@ -376,7 +376,18 @@ humanEvalsRouter.get('/human-evals/correlation', async (c) => {
   // Resolve scope to prompt_version_ids
   let versionIds: string[] = []
   if (promptVersionId) {
-    versionIds = [promptVersionId]
+    // IDOR guard: a raw prompt_version_id from the query string MUST be verified
+    // to belong to the caller's org before it scopes any downstream query.
+    // Without this, org A could pass org B's version id and read B's paired
+    // judge/human scores (the human_evals / eval_results reads below filter
+    // only by prompt_version_id / request_id, so ownership must be pinned here).
+    const { data: ownedVersion } = await supabaseAdmin
+      .from('prompt_versions')
+      .select('id')
+      .eq('id', promptVersionId)
+      .eq('organization_id', orgId)
+      .maybeSingle()
+    versionIds = ownedVersion ? [ownedVersion.id] : []
   } else if (promptName) {
     const { data: versions } = await supabaseAdmin
       .from('prompt_versions')

--- a/apps/server/src/api/invitations.ts
+++ b/apps/server/src/api/invitations.ts
@@ -92,16 +92,24 @@ orgInvitationsRouter.post('/', requireRole('admin'), async (c) => {
     }
   }
 
-  // Reject duplicate pending invite for the same email/org pair.
-  const { data: pending } = await supabaseAdmin
+  // Reject duplicate pending invite for the same email/org pair. Use limit(1)
+  // rather than maybeSingle(): there is no unique constraint on
+  // (organization_id, email, pending), so a double-click race can leave 2+
+  // pending rows. maybeSingle() returns { data: null, error } on a multi-row
+  // match, so the guard would fall through and EVERY later invite to that
+  // email would pass (duplicate emails sent). limit(1) treats "≥1 pending
+  // row exists" as the dedup hit. Same maybeSingle blind spot as the
+  // organizations.ts bootstrap membership check.
+  const { data: pendingRows, error: pendingErr } = await supabaseAdmin
     .from('org_invitations')
     .select('id')
     .eq('organization_id', orgId)
     .eq('email', email)
     .is('accepted_at', null)
     .gt('expires_at', new Date().toISOString())
-    .maybeSingle()
-  if (pending) {
+    .limit(1)
+  if (pendingErr) throw new ApiError('INTERNAL_ERROR', 'Failed to check pending invitations')
+  if (pendingRows && pendingRows.length > 0) {
     throw new ApiError('CONFLICT', 'A pending invitation for this email already exists')
   }
 

--- a/apps/server/src/api/invitations.ts
+++ b/apps/server/src/api/invitations.ts
@@ -10,6 +10,7 @@ import {
   recordAuditLog,
 } from '../lib/audit-log.js'
 import { ApiError } from '../lib/errors.js'
+import { isUuid } from '../lib/params.js'
 
 /**
  * Invitations — email-based org member onboarding.
@@ -339,6 +340,9 @@ invitationsRouter.delete('/:id', authJwt, requireRole('admin'), async (c) => {
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const id = c.req.param('id')
+  // Malformed id would hit Postgres as an invalid-uuid error → raw 500.
+  // Treat it like a nonexistent id (same 404 the count===0 path returns).
+  if (!isUuid(id)) throw new ApiError('NOT_FOUND', 'Invitation not found')
 
   // Scope the delete to the user's org so admins can't cancel invitations
   // belonging to other orgs.
@@ -486,10 +490,15 @@ meInvitationsRouter.delete('/:id', async (c) => {
   const email = c.get('email')
   if (!email) throw new ApiError('BAD_REQUEST', 'User has no email')
 
+  const id = c.req.param('id')
+  // Malformed id would hit Postgres as an invalid-uuid error → raw 500.
+  // Treat it like a nonexistent id (same 404 the count===0 path returns).
+  if (!isUuid(id)) throw new ApiError('NOT_FOUND', 'Invitation not found')
+
   const { error, count } = await supabaseAdmin
     .from('org_invitations')
     .delete({ count: 'exact' })
-    .eq('id', c.req.param('id'))
+    .eq('id', id)
     .ilike('email', email)
     .is('accepted_at', null)
 

--- a/apps/server/src/api/organizations.ts
+++ b/apps/server/src/api/organizations.ts
@@ -333,14 +333,39 @@ organizationsRouter.patch('/me/logging', requireAdmin, async (c) => {
 organizationsRouter.post('/bootstrap', async (c) => {
   const userId = c.get('userId')
 
-  // Reject if already onboarded.
-  const { data: existingMember } = await supabaseAdmin
+  // Reject if already onboarded. Use limit(1) rather than maybeSingle(): a
+  // user who belongs to 2+ orgs (their own + an accepted invite) makes
+  // maybeSingle() return { data: null } on the multi-row match, so the guard
+  // would fall through and re-bootstrap a whole new workspace on every call —
+  // bypassing the Free=1 owned-workspace limit. limit(1) returns the first
+  // membership and treats "has any membership" as already onboarded.
+  const { data: existingMembers, error: memberCheckErr } = await supabaseAdmin
     .from('org_members')
     .select('organization_id')
     .eq('user_id', userId)
-    .maybeSingle()
-  if (existingMember) {
-    throw new ApiError('CONFLICT', 'Already onboarded', { organizationId: existingMember.organization_id })
+    .limit(1)
+  if (memberCheckErr) throw new ApiError('INTERNAL_ERROR', 'Failed to check membership')
+  if (existingMembers && existingMembers.length > 0) {
+    throw new ApiError('CONFLICT', 'Already onboarded', { organizationId: existingMembers[0]!.organization_id })
+  }
+
+  // Owned-workspace cap — mirror the check POST /organizations enforces so
+  // bootstrap can't create a workspace beyond the plan limit. Free=1 / Pro=2 /
+  // Team=5 / Enterprise=unlimited, gated on the highest tier the user owns.
+  const { data: ownedRows, error: ownedErr } = await supabaseAdmin
+    .from('organizations')
+    .select('plan')
+    .eq('owner_id', userId)
+  if (ownedErr) throw new ApiError('INTERNAL_ERROR', 'Failed to check workspace count')
+  const ownedPlans = (ownedRows ?? []).map((r) => r.plan as Plan)
+  const effective = effectiveOwnedPlan(ownedPlans)
+  const cap = OWNED_WORKSPACE_LIMITS[effective]
+  if (cap !== null && ownedPlans.length >= cap) {
+    throw new ApiError(
+      'PAYMENT_REQUIRED',
+      `You already own ${ownedPlans.length} workspace${ownedPlans.length === 1 ? '' : 's'} on the ${effective === 'starter' ? 'Pro' : effective[0]!.toUpperCase() + effective.slice(1)} plan (limit ${cap}). Upgrade an existing workspace to create more.`,
+      { reason: 'workspace_limit_reached', owned: ownedPlans.length, limit: cap, effectivePlan: effective },
+    )
   }
 
   // Body parse — body is OPTIONAL on this endpoint (legacy clients send

--- a/apps/server/src/api/paddleWebhook.ts
+++ b/apps/server/src/api/paddleWebhook.ts
@@ -113,14 +113,36 @@ async function upsertSubscription(
   //                            its own 7-day window from scratch.
   //   3. Any other status:     leave untouched (carry through canceled
   //                            for analytics).
+  // ── out-of-order guard ─────────────────────────────────────────────────
+  // Paddle does not guarantee delivery order: a delayed subscription.updated
+  // arriving AFTER a subscription.canceled would otherwise flip status/plan
+  // back to active. We stamp each applied event's occurred_at into
+  // metadata.occurred_at, and skip the write ONLY when we can positively
+  // determine the incoming event is strictly OLDER than the last applied one.
+  // If the comparison is ambiguous (no stored timestamp, missing/invalid
+  // occurred_at) we apply as before — never drop a valid update.
+  const { data: existingRow } = await supabaseAdmin
+    .from('subscriptions')
+    .select('past_due_since, metadata')
+    .eq('paddle_subscription_id', sub.id)
+    .maybeSingle()
+
+  const lastOccurredAtRaw = (existingRow as { metadata?: { occurred_at?: string } | null } | null)
+    ?.metadata?.occurred_at
+  const incomingTs = Date.parse(event.occurred_at)
+  const lastTs = lastOccurredAtRaw ? Date.parse(lastOccurredAtRaw) : NaN
+  if (!Number.isNaN(incomingTs) && !Number.isNaN(lastTs) && incomingTs < lastTs) {
+    console.warn(
+      '[paddle-webhook] skipping out-of-order event',
+      event.event_id, event.event_type,
+      'occurred_at', event.occurred_at, '<', lastOccurredAtRaw,
+    )
+    return
+  }
+
   let pastDueSinceUpdate: { past_due_since: string | null } | Record<string, never> = {}
   if (sub.status === 'past_due') {
-    const { data: existing } = await supabaseAdmin
-      .from('subscriptions')
-      .select('past_due_since')
-      .eq('paddle_subscription_id', sub.id)
-      .maybeSingle()
-    if (!(existing as { past_due_since?: string | null } | null)?.past_due_since) {
+    if (!(existingRow as { past_due_since?: string | null } | null)?.past_due_since) {
       pastDueSinceUpdate = { past_due_since: new Date().toISOString() }
     }
   } else if (sub.status === 'active' || sub.status === 'trialing') {

--- a/apps/server/src/api/projects.ts
+++ b/apps/server/src/api/projects.ts
@@ -5,6 +5,7 @@ import { supabaseAdmin } from '../lib/db.js'
 import { checkProjectQuota } from '../lib/quota.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
 import { ApiError } from '../lib/errors.js'
+import { isUuid } from '../lib/params.js'
 
 export const projectsRouter = new Hono<JwtContext>()
 
@@ -147,6 +148,9 @@ projectsRouter.delete('/:id', requireAdmin, async (c) => {
   const projectId = c.req.param('id')
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+  // Malformed id would hit Postgres as an invalid-uuid error → raw 500.
+  // Treat it like a well-formed-but-nonexistent id (same 404 as GET/PATCH).
+  if (!isUuid(projectId)) throw new ApiError('NOT_FOUND', 'Project not found')
 
   const { error } = await supabaseAdmin
     .from('projects')

--- a/apps/server/src/api/prompts-playground.ts
+++ b/apps/server/src/api/prompts-playground.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { requireRole } from '../middleware/requireRole.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { aes256Decrypt } from '../lib/crypto.js'
 import { calculateCost } from '../lib/cost.js'
@@ -10,6 +11,12 @@ import { ApiError } from '../lib/errors.js'
 export const promptsPlaygroundRouter = new Hono<JwtContext>()
 
 promptsPlaygroundRouter.use('*', authJwt)
+
+// /run decrypts a provider key and makes a real billable upstream LLM call, so
+// it must not be reachable by a viewer-role member (per-user in-memory rate
+// limiting alone doesn't gate role). authJwt is JWT-only, so a plain requireRole
+// gate is correct here.
+const requireEdit = requireRole('admin', 'editor')
 
 // Simple in-memory rate limit: 20 req per user per 60s
 const rateLimitMap = new Map<string, { count: number; resetAt: number }>()
@@ -28,7 +35,7 @@ function checkRateLimit(userId: string): boolean {
   return true
 }
 
-promptsPlaygroundRouter.post('/run', async (c) => {
+promptsPlaygroundRouter.post('/run', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')

--- a/apps/server/src/api/prompts.ts
+++ b/apps/server/src/api/prompts.ts
@@ -277,6 +277,18 @@ promptsRouter.post('/', requireEdit, async (c) => {
     typeof body.metadata === 'object' && body.metadata !== null ? body.metadata : {}
   const projectId = typeof body.projectId === 'string' ? body.projectId : null
 
+  // Verify the project belongs to this org so a caller can't attach a prompt
+  // to another org's project UUID (cross-project filter pollution).
+  if (projectId) {
+    const { data: proj } = await supabaseAdmin
+      .from('projects')
+      .select('id')
+      .eq('id', projectId)
+      .eq('organization_id', orgId)
+      .maybeSingle()
+    if (!proj) throw new ApiError('NOT_FOUND', 'Project not found')
+  }
+
   // Find the latest version for this name and increment
   const { data: latest } = await supabaseAdmin
     .from('prompt_versions')

--- a/apps/server/src/api/prompts.ts
+++ b/apps/server/src/api/prompts.ts
@@ -304,7 +304,15 @@ promptsRouter.post('/', requireEdit, async (c) => {
     .select('id, name, version, content, variables, metadata, project_id, created_at, created_by')
     .single()
 
-  if (error || !data) throw new ApiError('INTERNAL_ERROR', 'Failed to create version')
+  if (error || !data) {
+    // UNIQUE(organization_id, name, version) — a concurrent save that computed
+    // the same nextVersion loses the insert race. Surface a clean 409 (the
+    // caller can retry and get the next number) instead of a raw 500.
+    if (error?.code === '23505') {
+      throw new ApiError('CONFLICT', 'This prompt version already exists. Retry to create the next version.')
+    }
+    throw new ApiError('INTERNAL_ERROR', 'Failed to create version')
+  }
   // Invalidate resolve-prompt-version cache for this prompt name so the new
   // latest version is served immediately on the next proxy call.
   await invalidatePromptName(orgId, name)
@@ -405,7 +413,14 @@ promptsRouter.post('/:name/:version/rollback', requireEdit, async (c) => {
     .select('id, name, version, content, variables, metadata, project_id, created_at, created_by')
     .single()
 
-  if (error || !data) throw new ApiError('INTERNAL_ERROR', 'Failed to create rollback version')
+  if (error || !data) {
+    // Same UNIQUE(organization_id, name, version) race as POST / — a
+    // concurrent rollback/save that grabbed the same nextVersion loses.
+    if (error?.code === '23505') {
+      throw new ApiError('CONFLICT', 'This prompt version already exists. Retry to create the next version.')
+    }
+    throw new ApiError('INTERNAL_ERROR', 'Failed to create rollback version')
+  }
   await invalidatePromptName(orgId, name)
 
   void recordAuditEvent(c, {

--- a/apps/server/src/api/providerKeys.ts
+++ b/apps/server/src/api/providerKeys.ts
@@ -7,6 +7,7 @@ import { aes256Encrypt } from '../lib/crypto.js'
 import { enqueueDeletion } from '../lib/pending-deletions.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
 import { resetProviderKeyNamesCache } from '../lib/requests-query.js'
+import { validateOptionalUuid } from '../lib/params.js'
 import { ApiError } from '../lib/errors.js'
 
 /**
@@ -92,7 +93,10 @@ providerKeysRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
-  const apiKeyIdFilter = c.req.query('apiKeyId')
+  // apiKeyId is bound into a Postgres UUID column filter — a malformed value
+  // (e.g. ?apiKeyId=abc) fails UUID parsing and throws a raw 500. Validate so
+  // this dual-auth read surface (MCP/BI tools) gets a clean 400 instead.
+  const apiKeyIdFilter = validateOptionalUuid(c.req.query('apiKeyId'), 'apiKeyId')
 
   let query = supabaseAdmin
     .from('provider_keys')

--- a/apps/server/src/api/publicShare.ts
+++ b/apps/server/src/api/publicShare.ts
@@ -10,6 +10,7 @@ import {
 } from '../lib/requests-query.js'
 import { fromClickhouseTimestamp } from '../lib/clickhouse.js'
 import { checkRateLimit } from '../lib/rate-limit.js'
+import { fireAndForget } from '../lib/wait-until.js'
 import { ApiError } from '../lib/errors.js'
 
 /**
@@ -111,14 +112,23 @@ publicShareRouter.get('/:token', async (c) => {
   const hidePoweredBy = await shouldHidePoweredBy(share.organization_id)
 
   // Bump view_count. Fire-and-forget — a viewer should never see a 500 because
-  // the counter update failed. The next page load will sync.
-  supabaseAdmin
-    .from('shared_links')
-    .update({ view_count: share.view_count + 1 })
-    .eq('token', token)
-    .then(({ error }) => {
-      if (error) console.error('[share:get] view_count bump failed:', error.message)
-    })
+  // the counter update failed. Wrapped in fireAndForget so the pending promise
+  // survives on Vercel (a bare .then() is dropped on Edge/serverless — gotcha
+  // #8). Atomic increment via RPC avoids the read-modify-write lost-update race
+  // under concurrent viewers (supabase-js .update() cannot express
+  // `view_count = view_count + 1`).
+  fireAndForget(
+    c,
+    // Promise.resolve() because supabase-js returns a thenable PostgrestBuilder
+    // (PromiseLike), not a real Promise, and fireAndForget expects a Promise.
+    Promise.resolve(
+      supabaseAdmin
+        .rpc('increment_share_view_count', { p_token: token })
+        .then(({ error }) => {
+          if (error) console.error('[share:get] view_count bump failed:', error.message)
+        }),
+    ),
+  )
 
   return c.json({
     success: true,

--- a/apps/server/src/api/requests.ts
+++ b/apps/server/src/api/requests.ts
@@ -6,7 +6,7 @@ import { getDecryptedProviderKeyById, getDecryptedProviderKey } from '../proxy/u
 import { calculateCost } from '../lib/cost.js'
 import { logRequestAsync } from '../lib/logger.js'
 import { fireAndForget } from '../lib/wait-until.js'
-import { parsePageLimit, validateOptionalUuid, validateOptionalDate } from '../lib/params.js'
+import { parsePageLimit, validateOptionalUuid, validateOptionalDate, isUuid } from '../lib/params.js'
 import {
   requestsScope,
   selectRequests,
@@ -306,6 +306,9 @@ requestsRouter.post('/:id/replay', requireRole('admin', 'editor'), async (c) => 
   const requestId = c.req.param('id')
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+  // Malformed id would fail the ClickHouse {requestId:UUID} binding → raw 500.
+  // Treat it like a nonexistent id (same 404 as GET /:id).
+  if (!isUuid(requestId)) throw new ApiError('NOT_FOUND', 'Request not found')
 
   let body: { model?: unknown } = {}
   try {
@@ -386,6 +389,9 @@ requestsRouter.post('/:id/replay/run', requireRole('admin', 'editor'), async (c)
   const requestId = c.req.param('id')
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+  // Malformed id would fail the ClickHouse {requestId:UUID} binding → raw 500.
+  // Treat it like a nonexistent id (same 404 as GET /:id).
+  if (!isUuid(requestId)) throw new ApiError('NOT_FOUND', 'Request not found')
 
   let body: { model?: unknown } = {}
   try { body = (await c.req.json()) as { model?: unknown } } catch { body = {} }

--- a/apps/server/src/api/requests.ts
+++ b/apps/server/src/api/requests.ts
@@ -6,7 +6,7 @@ import { getDecryptedProviderKeyById, getDecryptedProviderKey } from '../proxy/u
 import { calculateCost } from '../lib/cost.js'
 import { logRequestAsync } from '../lib/logger.js'
 import { fireAndForget } from '../lib/wait-until.js'
-import { parsePageLimit } from '../lib/params.js'
+import { parsePageLimit, validateOptionalUuid, validateOptionalDate } from '../lib/params.js'
 import {
   requestsScope,
   selectRequests,
@@ -64,13 +64,17 @@ requestsRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
-  const projectId       = c.req.query('projectId')
+  // UUID + date params are bound into ClickHouse {x:UUID} / parseDateTime64
+  // placeholders. A malformed value (e.g. ?projectId=abc, ?from=garbage) fails
+  // the binding and throws a raw 500 — validate up front so these documented
+  // external surfaces (MCP/BI tools pass arbitrary filter args) get a clean 400.
+  const projectId       = validateOptionalUuid(c.req.query('projectId'), 'projectId')
   const provider        = c.req.query('provider')
   const model           = c.req.query('model')
-  const from            = c.req.query('from')
-  const to              = c.req.query('to')
-  const providerKeyId   = c.req.query('providerKeyId')
-  const promptVersionId = c.req.query('promptVersionId')
+  const from            = validateOptionalDate(c.req.query('from'), 'from')
+  const to              = validateOptionalDate(c.req.query('to'), 'to')
+  const providerKeyId   = validateOptionalUuid(c.req.query('providerKeyId'), 'providerKeyId')
+  const promptVersionId = validateOptionalUuid(c.req.query('promptVersionId'), 'promptVersionId')
   const userIdFilter    = c.req.query('userId')
   const sessionIdFilter = c.req.query('sessionId')
   const status          = c.req.query('status')

--- a/apps/server/src/api/scoreConfigs.ts
+++ b/apps/server/src/api/scoreConfigs.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { requireRole } from '../middleware/requireRole.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
 import {
@@ -28,6 +29,8 @@ import { ApiError } from '../lib/errors.js'
 export const scoreConfigsRouter = new Hono<JwtContext>()
 
 scoreConfigsRouter.use('*', authJwt)
+
+const requireEdit = requireRole('admin', 'editor')
 
 interface ScoreConfigBody {
   name?: unknown
@@ -82,7 +85,7 @@ scoreConfigsRouter.get('/:id', async (c) => {
 })
 
 // POST /api/v1/score-configs — create a new config
-scoreConfigsRouter.post('/', async (c) => {
+scoreConfigsRouter.post('/', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
@@ -185,7 +188,7 @@ scoreConfigsRouter.post('/', async (c) => {
 })
 
 // PATCH /api/v1/score-configs/:id — update mutable fields
-scoreConfigsRouter.patch('/:id', async (c) => {
+scoreConfigsRouter.patch('/:id', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
   const id = c.req.param('id')
@@ -318,7 +321,7 @@ scoreConfigsRouter.patch('/:id', async (c) => {
 // reference this config and a hard delete would silently break the
 // dashboard charts that group by score_config_id. The unused-config
 // cleanup is a separate concern handled by a future cron.
-scoreConfigsRouter.delete('/:id', async (c) => {
+scoreConfigsRouter.delete('/:id', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
   const id = c.req.param('id')

--- a/apps/server/src/api/security.ts
+++ b/apps/server/src/api/security.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { authJwt, type JwtContext } from '../middleware/authJwt.js'
+import { requireRole } from '../middleware/requireRole.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { requestsScope, selectRequests, countRequests } from '../lib/requests-query.js'
 import { fromClickhouseTimestamp } from '../lib/clickhouse.js'
@@ -20,6 +21,10 @@ import { ApiError } from '../lib/errors.js'
 export const securityRouter = new Hono<JwtContext>()
 
 securityRouter.use('*', authJwt)
+
+// Org-wide security toggles are admin-only (matches organizations.ts
+// branding/security PATCH gating). Reads stay open to viewers.
+const requireAdmin = requireRole('admin')
 
 // GET /api/v1/security/flagged?limit=50&offset=0
 securityRouter.get('/flagged', async (c) => {
@@ -140,7 +145,7 @@ securityRouter.get('/settings', async (c) => {
 
 // PATCH /api/v1/security/alert
 // Body: { enabled: boolean }
-securityRouter.patch('/alert', async (c) => {
+securityRouter.patch('/alert', requireAdmin, async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
@@ -167,7 +172,7 @@ securityRouter.patch('/alert', async (c) => {
 
 // PATCH /api/v1/security/projects/:projectId/block
 // Body: { enabled: boolean }
-securityRouter.patch('/projects/:projectId/block', async (c) => {
+securityRouter.patch('/projects/:projectId/block', requireAdmin, async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 

--- a/apps/server/src/api/stats.ts
+++ b/apps/server/src/api/stats.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import type { JwtContext } from '../middleware/authJwt.js'
 import { authJwtOrApiKey } from '../middleware/authJwtOrApiKey.js'
-import { parseClampedFloat } from '../lib/params.js'
+import { parseClampedFloat, validateOptionalDate } from '../lib/params.js'
 import {
   getStatsOverview,
   getStatsModels,
@@ -60,8 +60,11 @@ statsRouter.get('/overview', async (c) => {
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const projectId = c.req.query('projectId')
-  const from = c.req.query('from')
-  const to = c.req.query('to')
+  // Garbage dates (?to=garbage) otherwise reach `new Date(x).toISOString()` in
+  // the compare branch and throw a RangeError → raw 500. Validate up front so
+  // this documented external surface (MCP/BI tools) gets a clean 400 instead.
+  const from = validateOptionalDate(c.req.query('from'), 'from')
+  const to = validateOptionalDate(c.req.query('to'), 'to')
   const compare = c.req.query('compare') === 'true'
 
   try {

--- a/apps/server/src/api/traces.ts
+++ b/apps/server/src/api/traces.ts
@@ -3,7 +3,7 @@ import type { JwtContext } from '../middleware/authJwt.js'
 import { authJwtOrApiKey } from '../middleware/authJwtOrApiKey.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { computeCriticalPath } from '../lib/critical-path.js'
-import { parsePageLimit } from '../lib/params.js'
+import { parsePageLimit, validateOptionalUuid, validateOptionalDate } from '../lib/params.js'
 import { useEventsForTraces } from '../lib/events-read-flag.js'
 import {
   listTracesFromEvents,
@@ -23,10 +23,14 @@ tracesRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
-  const projectId = c.req.query('projectId')
+  // projectId reaches a ClickHouse UUID binding (events path) / Postgres eq;
+  // from/to feed date comparisons on both paths. Validate up front so a
+  // malformed value (e.g. ?projectId=abc, ?from=garbage) returns a clean 400
+  // instead of a raw 500 — these are documented external (MCP/BI) surfaces.
+  const projectId = validateOptionalUuid(c.req.query('projectId'), 'projectId')
   const status = c.req.query('status')
-  const from = c.req.query('from')
-  const to = c.req.query('to')
+  const from = validateOptionalDate(c.req.query('from'), 'from')
+  const to = validateOptionalDate(c.req.query('to'), 'to')
   // `q` does a case-insensitive substring search over both `name` and `id`.
   // Without this the /traces page filtered client-side over the current 50-row
   // page only, which silently dropped matches living on other pages.

--- a/apps/server/src/api/users.ts
+++ b/apps/server/src/api/users.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import type { JwtContext } from '../middleware/authJwt.js'
 import { authJwtOrApiKey } from '../middleware/authJwtOrApiKey.js'
-import { parsePageLimit } from '../lib/params.js'
+import { parsePageLimit, validateOptionalUuid, validateOptionalDate } from '../lib/params.js'
 import { getUserAnalytics, type UserAnalyticsRow } from '../lib/stats-queries.js'
 import { requestsScope, selectRequests } from '../lib/requests-query.js'
 import { ApiError } from '../lib/errors.js'
@@ -29,10 +29,12 @@ usersRouter.get('/', async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
-  const projectId = c.req.query('projectId') ?? null
+  // projectId is bound as a ClickHouse UUID and from/to feed date parsing
+  // downstream; validate up front so a malformed value returns 400 not 500.
+  const projectId = validateOptionalUuid(c.req.query('projectId'), 'projectId') ?? null
   const search    = c.req.query('search') ?? null
-  const from      = c.req.query('from') ?? null
-  const to        = c.req.query('to') ?? null
+  const from      = validateOptionalDate(c.req.query('from'), 'from') ?? null
+  const to        = validateOptionalDate(c.req.query('to'), 'to') ?? null
   const sortByRaw = c.req.query('sortBy') ?? 'cost'
   const sortDirRaw = c.req.query('sortDir') ?? 'desc'
   const sortBy: 'cost' | 'requests' | 'tokens' | 'last_seen' | 'latency' =
@@ -72,9 +74,12 @@ usersRouter.get('/:userId', async (c) => {
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
   const userId = c.req.param('userId')
 
-  const projectId = c.req.query('projectId') ?? null
-  const from      = c.req.query('from') ?? null
-  const to        = c.req.query('to') ?? null
+  // userId is a customer-supplied string identifier (x-spanlens-user), not a
+  // UUID — do not UUID-validate it. projectId is a ClickHouse UUID and from/to
+  // feed date parsing, so validate those to return 400 rather than a raw 500.
+  const projectId = validateOptionalUuid(c.req.query('projectId'), 'projectId') ?? null
+  const from      = validateOptionalDate(c.req.query('from'), 'from') ?? null
+  const to        = validateOptionalDate(c.req.query('to'), 'to') ?? null
 
   // Aggregate query reuses the same helper with a pre-narrowed search.
   let aggRows: UserAnalyticsRow[]

--- a/apps/server/src/api/waitlist.ts
+++ b/apps/server/src/api/waitlist.ts
@@ -1,7 +1,9 @@
 import { Hono } from 'hono'
+import { createMiddleware } from 'hono/factory'
 import { supabaseAdmin } from '../lib/db.js'
 import { sendEmail, renderWaitlistConfirmationEmail } from '../lib/resend.js'
 import { fireAndForget } from '../lib/wait-until.js'
+import { checkRateLimit } from '../lib/rate-limit.js'
 import { ApiError } from '../lib/errors.js'
 
 /**
@@ -16,7 +18,26 @@ import { ApiError } from '../lib/errors.js'
 
 export const waitlistRouter = new Hono()
 
-waitlistRouter.post('/', async (c) => {
+// Per-IP cap on this unauthenticated endpoint. Without it the POST has no rate
+// limiting at all (it is mounted before the global apiRateLimit, which also
+// fails open for tokenless requests) and could be abused to amplify
+// confirmation emails / flood the waitlist table.
+const WAITLIST_RATE_LIMIT = 10 // per IP per minute
+
+const waitlistRateLimit = createMiddleware(async (c, next) => {
+  const ip =
+    c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+    c.req.header('x-real-ip') ||
+    'unknown'
+  const allowed = await checkRateLimit(`waitlist:${ip}`, WAITLIST_RATE_LIMIT)
+  if (!allowed) {
+    c.header('Retry-After', '60')
+    return c.text('Too many requests', 429)
+  }
+  return next()
+})
+
+waitlistRouter.post('/', waitlistRateLimit, async (c) => {
   let body: Record<string, unknown>
   try {
     body = await c.req.json() as Record<string, unknown>

--- a/apps/server/src/api/webhooks.ts
+++ b/apps/server/src/api/webhooks.ts
@@ -8,6 +8,7 @@ import { invalidateWebhookCache } from '../lib/webhook-emit.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
 import { ApiError } from '../lib/errors.js'
 import { validateOutboundUrl } from '../lib/safe-url.js'
+import { isUuid } from '../lib/params.js'
 
 export const webhooksRouter = new Hono<JwtContext>()
 webhooksRouter.use('*', authJwt)
@@ -176,6 +177,9 @@ webhooksRouter.delete('/:id', requireEdit, async (c) => {
   const orgId = c.get('orgId')
   const id = c.req.param('id')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+  // Malformed id would hit Postgres as an invalid-uuid error → raw 500.
+  // Treat it like a nonexistent id (same 404 as GET/PATCH siblings).
+  if (!isUuid(id)) throw new ApiError('NOT_FOUND', 'Webhook not found')
 
   const { error } = await supabaseAdmin
     .from('webhooks')

--- a/apps/server/src/lib/cost.ts
+++ b/apps/server/src/lib/cost.ts
@@ -100,7 +100,11 @@ function lookupPrice(model: string): ModelPrice | null {
 
   let bestKey = ''
   for (const key of Object.keys(prices)) {
-    if (!model.startsWith(key)) continue
+    // Boundary-aware: only accept a prefix match when the next char after the
+    // key is a version boundary ('-'), so a shorter key (e.g. 'gpt-4') can't
+    // bleed across into a longer variant (e.g. 'gpt-4.5-preview'). Dated
+    // variants like 'gpt-4o-mini-2024-07-18' still match 'gpt-4o-mini'.
+    if (!(model === key || model.startsWith(key + '-'))) continue
     // longest prefix wins
     if (key.length > bestKey.length) bestKey = key
   }

--- a/apps/server/src/lib/events-writer.ts
+++ b/apps/server/src/lib/events-writer.ts
@@ -130,6 +130,16 @@ export async function writeRequestAsEvent(
   const hasSecurityFlagsValue = requestRow.has_security_flags ?? false
   const truncatedValue = requestRow.truncated ?? (data.truncated ? 1 : 0)
 
+  // Honor the customer's x-spanlens-log-body opt-out for end-user identifiers,
+  // mirroring logger.ts's `dropIdentifiers` logic on the requests row. Under
+  // mode 'none' we must NOT persist user_id / session_id in events either —
+  // otherwise the strictest minimization tier leaks identifiers on every call.
+  // (Bodies are already scrubbed upstream via requestRow, so we only touch
+  // identifiers here.)
+  const dropIdentifiers = (data.logBodyMode ?? 'full') === 'none'
+  const userIdValue = dropIdentifiers ? null : (data.userId ?? null)
+  const sessionIdValue = dropIdentifiers ? null : (data.sessionId ?? null)
+
   const eventRow = {
     event_id: requestRow.id,
     // For an LLM call without an explicit trace we generate a
@@ -158,8 +168,8 @@ export async function writeRequestAsEvent(
     status_code: data.statusCode,
     error_message: requestRow.error_message,
     metadata,
-    user_id: data.userId ?? null,
-    session_id: data.sessionId ?? null,
+    user_id: userIdValue,
+    session_id: sessionIdValue,
     prompt_version_id: requestRow.prompt_version_id ?? data.promptVersionId ?? null,
     provider_key_id: data.providerKeyId ?? null,
     flags: flagsValue,

--- a/apps/server/src/lib/paddle-usage.ts
+++ b/apps/server/src/lib/paddle-usage.ts
@@ -16,9 +16,10 @@
  *      because the pending row blocks future re-runs (safe fail direction:
  *      we under-bill rather than double-bill).
  *   5. Charge via POST /subscriptions/{id}/charge with
- *      effective_from: next_billing_period. This bundles the overage into
- *      the NEXT invoice (no separate charge to the customer, one invoice
- *      per month with a visible overage line item).
+ *      effective_from: immediately. The charge settles in real time during the
+ *      48-hour charging window, before the user can cancel and escape the
+ *      overage revenue (see the note at the charge call site for why we do not
+ *      use next_billing_period here).
  *
  * Prerequisites (Paddle dashboard):
  *   - Create non-recurring prices for Starter and Team overage units.

--- a/apps/server/src/lib/params.ts
+++ b/apps/server/src/lib/params.ts
@@ -11,6 +11,17 @@ import { ApiError } from './errors.js'
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 /**
+ * Predicate for a well-formed UUID. Use for REQUIRED path params (`:id`) where
+ * a malformed value should behave like a well-formed-but-nonexistent id — i.e.
+ * the handler throws its own not-found `ApiError` (404) rather than letting the
+ * malformed value reach the DB and surface as a raw 500. Keeps the 404 behavior
+ * consistent with the file's GET/PATCH siblings.
+ */
+export function isUuid(raw: string | undefined | null): boolean {
+  return typeof raw === 'string' && UUID_RE.test(raw)
+}
+
+/**
  * Validate an optional UUID-typed query param before it reaches a bound
  * ClickHouse `{x:UUID}` placeholder. A malformed value (e.g. `?projectId=abc`)
  * otherwise fails inside ClickHouse and surfaces as a raw 500. These read APIs

--- a/apps/server/src/lib/params.ts
+++ b/apps/server/src/lib/params.ts
@@ -5,6 +5,54 @@
  * default rather than throwing.
  */
 
+import { ApiError } from './errors.js'
+
+/** Canonical 8-4-4-4-12 UUID (any version). */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * Validate an optional UUID-typed query param before it reaches a bound
+ * ClickHouse `{x:UUID}` placeholder. A malformed value (e.g. `?projectId=abc`)
+ * otherwise fails inside ClickHouse and surfaces as a raw 500. These read APIs
+ * are documented external surfaces (the MCP server passes arbitrary filter
+ * args), so a malformed value should be a clean 400 instead.
+ *
+ * Returns the value unchanged when present + valid, `undefined` when absent.
+ * Throws `ApiError('VALIDATION_FAILED')` (→ 400) when present + malformed.
+ * There is no injection risk here (the value is always bound, never
+ * interpolated) — this is purely to convert a 500 into a 400.
+ */
+export function validateOptionalUuid(
+  raw: string | undefined | null,
+  field: string,
+): string | undefined {
+  if (raw === undefined || raw === null || raw === '') return undefined
+  if (!UUID_RE.test(raw)) {
+    throw new ApiError('VALIDATION_FAILED', `${field} must be a valid UUID`)
+  }
+  return raw
+}
+
+/**
+ * Validate an optional ISO date query param before it reaches a Postgres date
+ * comparison or a ClickHouse `parseDateTime64BestEffort` binding. A garbage
+ * value (e.g. `?from=garbage`) otherwise throws deep in the query layer as a
+ * raw 500; convert it to a clean 400.
+ *
+ * Returns the value unchanged when present + parseable, `undefined` when absent.
+ * Throws `ApiError('VALIDATION_FAILED')` (→ 400) when present + unparseable.
+ */
+export function validateOptionalDate(
+  raw: string | undefined | null,
+  field: string,
+): string | undefined {
+  if (raw === undefined || raw === null || raw === '') return undefined
+  if (Number.isNaN(Date.parse(raw))) {
+    throw new ApiError('VALIDATION_FAILED', `${field} must be a valid ISO date`)
+  }
+  return raw
+}
+
 /** Parse a positive float; returns fallback if missing, non-finite, or ≤ 0. */
 export function parsePositiveFloat(raw: string | undefined, fallback: number): number {
   if (!raw) return fallback

--- a/apps/server/src/lib/quota.ts
+++ b/apps/server/src/lib/quota.ts
@@ -317,7 +317,27 @@ export async function checkMonthlyQuota(
 
   // Billing accuracy: count the full UTC month, bypassing plan retention.
   // Free's 14-day window would otherwise undercount usage past day 14.
-  const used = await getCachedMonthlyCount(organizationId, monthStart)
+  let used: number
+  try {
+    used = await getCachedMonthlyCount(organizationId, monthStart)
+  } catch (err) {
+    // ClickHouse unreachable — FAIL OPEN. This runs on every /proxy/* request;
+    // if the count lookup throws, letting it propagate would 500 the whole
+    // proxy on a CH outage (the exact scenario the requests_fallback queue,
+    // gotcha #23, was built to survive). The quota band is a soft monetization
+    // gate, not a security boundary, and BYOK means traffic past the limit
+    // costs us nothing — so allowing the request through is the safe direction.
+    console.error('[quota] monthly count lookup failed, failing open:', err)
+    return {
+      allowed: true,
+      usedThisMonth: 0,
+      limit,
+      plan,
+      overageActive: false,
+      allowOverage,
+      capMultiplier,
+    }
+  }
 
   // Apply Pattern C policy
   const decision = evaluateQuotaPolicy({

--- a/apps/server/src/lib/stats-queries.ts
+++ b/apps/server/src/lib/stats-queries.ts
@@ -642,8 +642,11 @@ export async function getSecuritySummary(
   organizationId: string,
   hours: number,
 ): Promise<SecuritySummaryRow[]> {
+  // User-facing security dashboard read: respect plan retention like other
+  // dashboard reads. Do NOT bypass retention here — a Free org (14d) must not
+  // aggregate flags up to the 720h (30d) query window.
   const [scope, source] = await Promise.all([
-    requestsScope(organizationId, { ignoreRetention: true }),
+    requestsScope(organizationId),
     statsSource(organizationId),
   ])
   const sql = `

--- a/apps/server/src/parsers/gemini.ts
+++ b/apps/server/src/parsers/gemini.ts
@@ -22,9 +22,16 @@ function coerceGeminiTier(value: unknown): ServiceTier | undefined {
 export function parseGeminiResponse(body: Record<string, unknown>): ParsedUsage | null {
   const meta = body.usageMetadata as Record<string, unknown> | undefined
   if (!meta) return null
+  const candidatesTokens = (meta.candidatesTokenCount as number) ?? 0
+  // Gemini 2.5+/3 models (thinking on by default) report reasoning tokens in
+  // `thoughtsTokenCount`. Google bills these at the OUTPUT token rate and
+  // `candidatesTokenCount` EXCLUDES them, so fold them into completion tokens —
+  // otherwise cost is systematically under-reported. `totalTokenCount` already
+  // includes thoughts, so prompt + completion stays consistent with total.
+  const thoughtsTokens = (meta.thoughtsTokenCount as number) ?? 0
   return {
     promptTokens: (meta.promptTokenCount as number) ?? 0,
-    completionTokens: (meta.candidatesTokenCount as number) ?? 0,
+    completionTokens: candidatesTokens + thoughtsTokens,
     totalTokens: (meta.totalTokenCount as number) ?? 0,
     model: (body.modelVersion as string) ?? '',
     serviceTier: coerceGeminiTier(meta.serviceTier),

--- a/apps/server/src/proxy/gemini.ts
+++ b/apps/server/src/proxy/gemini.ts
@@ -94,26 +94,50 @@ geminiProxy.all('/*', async (c) => {
       onComplete: async (buffer, truncated) => {
         const text = extractGeminiStreamText(buffer.split('\n'))
 
-        // Best-effort: recover usage + model from the last full JSON object
-        // in the array. usage may be missing on aborted streams — acceptable.
+        // Best-effort: recover usage + model from the LAST chunk that carries
+        // usageMetadata (Gemini emits it on the final chunk). The @google/
+        // generative-ai SDK requests `?alt=sse`, so the buffer is normally SSE
+        // `data: {...}` lines — walk those first, then fall back to the legacy
+        // JSON-array framing for non-SSE callers. usage may be missing on
+        // aborted streams — acceptable.
         let model = modelMatch?.[1] ?? ''
         let promptTokens = 0
         let completionTokens = 0
         let totalTokens = 0
         let serviceTier: ServiceTier | undefined
+        const applyUsage = (obj: Record<string, unknown>): void => {
+          if (!obj.usageMetadata) return
+          const p = parseGeminiResponse(obj)
+          if (!p) return
+          model = p.model || model
+          promptTokens = p.promptTokens
+          completionTokens = p.completionTokens
+          totalTokens = p.totalTokens
+          serviceTier = p.serviceTier
+        }
         try {
-          const lastChunkText = buffer.trim().replace(/^\[/, '').replace(/\]$/, '')
-          const candidates = lastChunkText.split(/(?<=})\s*,\s*(?=\{)/g)
-          const last = candidates[candidates.length - 1]
-          if (last) {
-            const p = parseGeminiResponse(JSON.parse(last) as Record<string, unknown>)
-            if (p) {
-              model = p.model || model
-              promptTokens = p.promptTokens
-              completionTokens = p.completionTokens
-              totalTokens = p.totalTokens
-              serviceTier = p.serviceTier
+          const lines = buffer.split('\n')
+          const sseChunks: Record<string, unknown>[] = []
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue
+            const data = line.slice(6).trim()
+            if (!data || data === '[DONE]') continue
+            try {
+              sseChunks.push(JSON.parse(data) as Record<string, unknown>)
+            } catch { /* partial/non-JSON chunk — skip */ }
+          }
+          if (sseChunks.length > 0) {
+            // Take usageMetadata from the last SSE chunk that carries it.
+            for (let i = sseChunks.length - 1; i >= 0; i--) {
+              const chunk = sseChunks[i]
+              if (chunk?.usageMetadata) { applyUsage(chunk); break }
             }
+          } else {
+            // Legacy JSON-array framing: recover the last full JSON object.
+            const lastChunkText = buffer.trim().replace(/^\[/, '').replace(/\]$/, '')
+            const candidates = lastChunkText.split(/(?<=})\s*,\s*(?=\{)/g)
+            const last = candidates[candidates.length - 1]
+            if (last) applyUsage(JSON.parse(last) as Record<string, unknown>)
           }
         } catch { /* parser drift on aborted streams — acceptable */ }
 
@@ -124,7 +148,13 @@ geminiProxy.all('/*', async (c) => {
           logWarn('UNCATEGORIZED', { provider: 'gemini', kind: 'capture_empty', bytes: buffer.length })
         }
 
-        const cost = calculateCost('gemini', model, { promptTokens, completionTokens, serviceTier })
+        // No usage captured (truncated/aborted stream before the final chunk)
+        // → record null cost, not a misleading $0. Mirrors the OpenAI/Anthropic
+        // stream loggers (proxy/stream-logger.ts `hasUsage` guard).
+        const hasUsage = promptTokens > 0 || completionTokens > 0
+        const cost = hasUsage
+          ? calculateCost('gemini', model, { promptTokens, completionTokens, serviceTier })
+          : null
         const responseBody = text ? {
           candidates: [{ content: { parts: [{ text }] } }],
           modelVersion: model,

--- a/apps/server/src/proxy/shared/log-base.ts
+++ b/apps/server/src/proxy/shared/log-base.ts
@@ -56,8 +56,22 @@ export interface BuildLogBaseInput {
   statusCode: number
 }
 
+// requests.trace_id / span_id are ClickHouse Nullable(UUID). A non-UUID header
+// value fails JSONEachRow parsing at async flush time (after insert() already
+// ACKed), losing the whole row with NO requests_fallback entry. Validate and
+// coerce invalid values to null so the row still logs (minus trace grouping).
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function isUuid(value: string): boolean {
+  return UUID_RE.test(value)
+}
+
+function uuidHeaderOrNull(value: string | undefined): string | null {
+  return value && isUuid(value) ? value : null
+}
+
 export function buildLogBase(input: BuildLogBaseInput): ProxyLogBase {
-  const traceId = input.c.req.header('x-trace-id') ?? null
+  const traceId = uuidHeaderOrNull(input.c.req.header('x-trace-id'))
   return {
     organizationId: input.organizationId,
     projectId: input.projectId,
@@ -70,7 +84,7 @@ export function buildLogBase(input: BuildLogBaseInput): ProxyLogBase {
     responseBody: null,
     errorMessage: null,
     traceId,
-    spanId: input.c.req.header('x-span-id') ?? null,
+    spanId: uuidHeaderOrNull(input.c.req.header('x-span-id')),
     promptVersionId: null,
     promptVersionHeader: input.c.req.header('x-spanlens-prompt-version') ?? null,
     providerKeyId: input.providerKey.id,

--- a/apps/server/src/proxy/shared/stream-pump.ts
+++ b/apps/server/src/proxy/shared/stream-pump.ts
@@ -71,7 +71,17 @@ export function runLineBufferedStreamPump(input: StreamPumpInput): Response {
           logError('UPSTREAM_FETCH_FAILED', { provider: input.provider, phase: 'stream' }, outcome.error)
           break pump
         case 'chunk': {
-          await honoStream.write(outcome.value)
+          try {
+            await honoStream.write(outcome.value)
+          } catch {
+            // Client disconnected — the downstream response stream was canceled
+            // (api/index.ts cancels it when the Node socket closes). Stop pumping
+            // and fall through to onComplete so the partial row is still logged
+            // (truncated) instead of the write hanging or the log being skipped.
+            truncated = true
+            await cancelReaderSilently(reader)
+            break pump
+          }
           buffer += decoder.decode(outcome.value, { stream: true })
           const parts = buffer.split('\n')
           buffer = parts.pop() ?? ''
@@ -134,7 +144,14 @@ export function runChunkAccumulatedStreamPump(input: ChunkAccumulatedStreamPumpI
           logError('UPSTREAM_FETCH_FAILED', { provider: input.provider, phase: 'stream' }, outcome.error)
           break pump
         case 'chunk':
-          await honoStream.write(outcome.value)
+          try {
+            await honoStream.write(outcome.value)
+          } catch {
+            // Client disconnected — see runLineBufferedStreamPump for rationale.
+            truncated = true
+            await cancelReaderSilently(reader)
+            break pump
+          }
           chunks.push(decoder.decode(outcome.value, { stream: true }))
           break
       }

--- a/apps/server/src/proxy/stream-logger.ts
+++ b/apps/server/src/proxy/stream-logger.ts
@@ -286,7 +286,11 @@ export async function logAnthropicStream(
       continue
     }
     const delta = parseAnthropicStreamChunk(line)
-    if (delta?.completionTokens) completionTokens += delta.completionTokens
+    // Anthropic's message_delta.usage.output_tokens is CUMULATIVE (the running
+    // total so far), not a per-delta increment. Assign the latest value rather
+    // than summing — today exactly one message_delta arrives, but a future
+    // multi-delta stream would double-count with `+=`.
+    if (delta?.completionTokens) completionTokens = delta.completionTokens
   }
 
   const totalTokens = promptTokens + completionTokens

--- a/apps/server/src/proxy/utils.ts
+++ b/apps/server/src/proxy/utils.ts
@@ -93,8 +93,17 @@ export async function isBlockingEnabled(projectId: string): Promise<boolean> {
 // (e.g. inject stream_options) so the original length is wrong.
 // Node.js undici (unlike Cloudflare Workers fetch) throws on mismatch.
 // Let fetch recalculate content-length from the actual body.
+//
+// authorization / x-api-key / x-goog-api-key are ALL Spanlens key transports
+// accepted by authApiKey (Bearer, OpenAI-style, Gemini-style). They carry the
+// caller's sl_live_* key and must never reach the upstream provider — each
+// proxy re-adds the real provider credential via `overrides`, which is applied
+// after this strip. Missing x-api-key/x-goog-api-key here leaks the Spanlens
+// key to OpenAI/Google on every request that authenticates via those headers.
 const STRIP_HEADERS = new Set([
   'authorization',
+  'x-api-key',
+  'x-goog-api-key',
   'host',
   'connection',
   'keep-alive',
@@ -127,12 +136,19 @@ export function buildUpstreamHeaders(
   return out
 }
 
-// Strip hop-by-hop headers from the upstream response before sending to client
+// Strip hop-by-hop headers from the upstream response before sending to client.
+// content-length is stripped alongside content-encoding: undici transparently
+// decompresses gzip/br responses but leaves the ORIGINAL (compressed)
+// content-length on the headers. Forwarding that stale length makes Node
+// truncate the (larger) decoded body to the compressed byte count, so the
+// client receives a cut-off JSON payload. Let the runtime recompute the length
+// from the actual body we send.
 const STRIP_RESPONSE_HEADERS = new Set([
   'connection',
   'keep-alive',
   'transfer-encoding',
   'content-encoding', // body already decoded by fetch
+  'content-length', // stale (compressed) length after fetch decodes the body
   'te',
 ])
 

--- a/apps/web/app/(dashboard)/billing/billing-client.tsx
+++ b/apps/web/app/(dashboard)/billing/billing-client.tsx
@@ -25,7 +25,7 @@ export function BillingClient() {
   // card is highlighted when the user lands here from the nudge.
   const highlightPlan = params.get('plan')
 
-  const { data: subscription, isLoading } = useSubscription()
+  const { data: subscription, isLoading, isError: subscriptionError } = useSubscription()
   const createCheckout = useCreateCheckout()
   const cancelSubscription = useCancelSubscription()
   const refreshSubscription = useRefreshSubscription()
@@ -34,7 +34,18 @@ export function BillingClient() {
   // effect needed for that branch.
   const [runtimeError, setRuntimeError] = useState<string | null>(null)
   const [paddle, setPaddle] = useState<Paddle | null>(null)
+  // initializePaddle can reject (ad-block, network) with no way to recover in
+  // this session. Without tracking that, `paddle` stays null forever and the
+  // Upgrade button is stuck on "Loading…" with no explanation. This flag flips
+  // the error banner to an actionable message instead.
+  const [paddleLoadFailed, setPaddleLoadFailed] = useState(false)
   const [checkoutCompleted, setCheckoutCompleted] = useState(false)
+  // Sticky "an upgrade is being processed in this session" lock. currentPlan
+  // stays 'free' until the webhook upserts the subscription, so without this
+  // flag the Upgrade button re-enables the moment the overlay closes and the
+  // user can start a SECOND checkout → double billing. Set when a checkout is
+  // initiated or completed; only cleared by a real subscription refresh.
+  const [upgradeInProgress, setUpgradeInProgress] = useState(false)
   const [showCancelConfirm, setShowCancelConfirm] = useState(false)
   const [cancelDone, setCancelDone] = useState(false)
 
@@ -45,7 +56,9 @@ export function BillingClient() {
 
   const errorMessage = runtimeError
     ?? (clientToken
-      ? null
+      ? paddleLoadFailed
+        ? 'Payment system failed to load. Please disable ad-blockers and retry.'
+        : null
       : 'Paddle client token not configured. Set NEXT_PUBLIC_PADDLE_CLIENT_TOKEN.')
 
   useEffect(() => {
@@ -58,12 +71,17 @@ export function BillingClient() {
       eventCallback: (event) => {
         if (event.name === 'checkout.completed') {
           setCheckoutCompleted(true)
+          setUpgradeInProgress(true)
           setTimeout(() => refreshSubscription(), 1500)
         }
       },
-    }).then((instance) => {
-      if (!cancelled && instance) setPaddle(instance)
     })
+      .then((instance) => {
+        if (!cancelled && instance) setPaddle(instance)
+      })
+      .catch(() => {
+        if (!cancelled) setPaddleLoadFailed(true)
+      })
 
     return () => {
       cancelled = true
@@ -91,6 +109,11 @@ export function BillingClient() {
       try {
         const res = await createCheckout.mutateAsync({ plan })
         paddle.Checkout.open({ transactionId: res.transactionId })
+        // Lock the upgrade action for the rest of this session. The overlay is
+        // now open; even after the user closes it the plan won't flip to paid
+        // until the webhook lands, so re-enabling the button here would let a
+        // second checkout start against the same upgrade.
+        setUpgradeInProgress(true)
       } catch (err) {
         setRuntimeError(
           err instanceof Error ? err.message : 'Failed to start checkout',
@@ -113,6 +136,12 @@ export function BillingClient() {
   }, [cancelSubscription])
 
   const currentPlan: BillingPlan = subscription?.plan ?? 'free'
+
+  // Sticky upgrade lock releases automatically once a real (paid) subscription
+  // lands — `subscription` is only truthy after the webhook upserts it. Derived
+  // instead of cleared in an effect (React 19 forbids setState-in-effect, and
+  // `subscription.plan` is never 'free', so an equality check wouldn't type).
+  const upgradeLocked = upgradeInProgress && !subscription
 
   return (
     <div className="-mx-4 -my-4 md:-mx-8 md:-my-7 flex flex-col h-screen overflow-hidden">
@@ -211,6 +240,28 @@ export function BillingClient() {
                     </button>
                   )}
                 </div>
+              </div>
+            ) : subscriptionError ? (
+              // Don't fall through to the "Free plan" default on error — a paid
+              // user hitting a transient failure would otherwise see a Free card
+              // plus an Upgrade button and could be pushed into a duplicate
+              // checkout. Show the load failure and let them retry instead.
+              <div className="flex items-start justify-between gap-3 flex-wrap">
+                <div>
+                  <h2 className="text-[15px] font-semibold text-text mb-1">
+                    Couldn&apos;t load your subscription
+                  </h2>
+                  <p className="text-[13px] text-text-muted">
+                    We couldn&apos;t reach billing just now. Your current plan is unchanged.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => refreshSubscription()}
+                  className="font-mono text-[12px] text-accent hover:opacity-80 transition-opacity shrink-0"
+                >
+                  Retry
+                </button>
               </div>
             ) : (
               <div className="flex items-start justify-between gap-3 flex-wrap">
@@ -319,17 +370,24 @@ export function BillingClient() {
                     ) : (
                       <button
                         type="button"
-                        disabled={isCurrent || createCheckout.isPending || !paddle}
+                        disabled={
+                          isCurrent ||
+                          createCheckout.isPending ||
+                          !paddle ||
+                          upgradeLocked
+                        }
                         onClick={() => void handleUpgrade(plan.id as 'starter' | 'team')}
                         className="w-full h-8 rounded-[6px] bg-text text-bg text-[12.5px] font-medium hover:opacity-90 transition-opacity disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
                       >
                         {isCurrent
                           ? 'Current plan'
-                          : isUpgradeInFlight
-                            ? 'Opening checkout…'
-                            : !paddle
-                              ? 'Loading…'
-                              : `Upgrade to ${plan.name}`}
+                          : upgradeLocked
+                            ? 'Plan updating…'
+                            : isUpgradeInFlight
+                              ? 'Opening checkout…'
+                              : !paddle
+                                ? 'Loading…'
+                                : `Upgrade to ${plan.name}`}
                       </button>
                     )}
                   </div>

--- a/apps/web/app/(dashboard)/projects/projects-client.tsx
+++ b/apps/web/app/(dashboard)/projects/projects-client.tsx
@@ -245,6 +245,11 @@ export function ProjectsClient() {
   // Delete confirms
   const [deleteApiKeyId, setDeleteApiKeyId] = useState<string | null>(null)
   const [deleteProvKeyId, setDeleteProvKeyId] = useState<string | null>(null)
+  // Public-key revoke confirm — mirrors the Spanlens-key delete flow so a
+  // single misclick can't revoke a workspace credential. Separate state from
+  // deleteApiKeyId because the two dialogs describe different consequences.
+  const [revokePublicKeyId, setRevokePublicKeyId] = useState<string | null>(null)
+  const [revokePublicError, setRevokePublicError] = useState<string | null>(null)
   // Project delete requires typing the project name as confirmation —
   // deleting a project cascades through every Spanlens key, provider key,
   // and (in ClickHouse) every request row's project_id reference.
@@ -382,6 +387,17 @@ export function ProjectsClient() {
     if (!deleteApiKeyId) return
     await deleteApiKey.mutateAsync(deleteApiKeyId)
     setDeleteApiKeyId(null)
+  }
+
+  async function handleRevokePublicKey() {
+    if (!revokePublicKeyId) return
+    setRevokePublicError(null)
+    try {
+      await deleteApiKey.mutateAsync(revokePublicKeyId)
+      setRevokePublicKeyId(null)
+    } catch (err) {
+      setRevokePublicError(err instanceof Error ? err.message : 'Failed to revoke key')
+    }
   }
 
   async function handleDeleteProviderKey() {
@@ -742,7 +758,7 @@ export function ProjectsClient() {
                     <PermissionGate need="edit">
                       <button
                         type="button"
-                        onClick={() => deleteApiKey.mutate(key.id)}
+                        onClick={() => { setRevokePublicError(null); setRevokePublicKeyId(key.id) }}
                         className="text-text-faint hover:text-bad transition-colors p-1"
                         title="Revoke"
                         aria-label="Revoke public key"
@@ -1444,6 +1460,43 @@ export function ProjectsClient() {
                 className="flex-1 h-9 rounded-[6px] bg-bad text-white font-medium text-[13px] hover:opacity-90 transition-opacity disabled:opacity-40"
               >
                 {deleteApiKey.isPending ? 'Deleting…' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Revoke public key confirm */}
+      <Dialog
+        open={revokePublicKeyId !== null}
+        onOpenChange={(open) => { if (!open) { setRevokePublicKeyId(null); setRevokePublicError(null) } }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Revoke public key</DialogTitle>
+          </DialogHeader>
+          <DialogDescription className="text-[12.5px] text-text-muted mt-1">
+            This permanently revokes the public key. Any MCP server, BI tool, or
+            embed using it will stop reading your workspace data immediately.
+          </DialogDescription>
+
+          <div className="space-y-4 mt-2">
+            {revokePublicError && (
+              <div className="rounded-md border border-bad/30 bg-bad/10 px-3 py-2 text-[12px] text-bad">
+                {revokePublicError}
+              </div>
+            )}
+            <div className="flex gap-3">
+              <GhostBtn className="flex-1" onClick={() => { setRevokePublicKeyId(null); setRevokePublicError(null) }}>
+                Cancel
+              </GhostBtn>
+              <button
+                type="button"
+                onClick={() => void handleRevokePublicKey()}
+                disabled={deleteApiKey.isPending}
+                className="flex-1 h-9 rounded-[6px] bg-bad text-white font-medium text-[13px] hover:opacity-90 transition-opacity disabled:opacity-40"
+              >
+                {deleteApiKey.isPending ? 'Revoking…' : 'Revoke'}
               </button>
             </div>
           </div>

--- a/apps/web/app/(dashboard)/projects/projects-client.tsx
+++ b/apps/web/app/(dashboard)/projects/projects-client.tsx
@@ -209,6 +209,7 @@ export function ProjectsClient() {
   // Create project dialog
   const [projDialogOpen, setProjDialogOpen] = useState(false)
   const [projName, setProjName] = useState('')
+  const [projError, setProjError] = useState<string | null>(null)
 
   // Add provider key dialog (now scoped to a Spanlens key)
   const [addProvDialogOpen, setAddProvDialogOpen] = useState(false)
@@ -268,9 +269,14 @@ export function ProjectsClient() {
   }
 
   async function handleCreateProject() {
-    await createProject.mutateAsync({ name: projName })
-    setProjName('')
-    setProjDialogOpen(false)
+    setProjError(null)
+    try {
+      await createProject.mutateAsync({ name: projName.trim() })
+      setProjName('')
+      setProjDialogOpen(false)
+    } catch (err) {
+      setProjError(err instanceof Error ? err.message : 'Failed to create project')
+    }
   }
 
   function openAddProvDialog(apiKeyId: string) {
@@ -428,6 +434,13 @@ export function ProjectsClient() {
     projectsQuery.isFetching ||
     apiKeysQuery.isFetching ||
     providerKeysQuery.isFetching
+  // List-load failure (distinct from the create-dialog's projError). Without
+  // this, a 500 falls through to the "No projects yet" onboarding CTA even for
+  // a workspace that has projects. Show an error + retry instead.
+  const listError =
+    projectsQuery.isError ||
+    apiKeysQuery.isError ||
+    providerKeysQuery.isError
   const allProjects = useMemo(() => projectsQuery.data ?? [], [projectsQuery.data])
   const allApiKeys = useMemo(() => apiKeysQuery.data ?? [], [apiKeysQuery.data])
   const allProviderKeys = useMemo(() => providerKeysQuery.data ?? [], [providerKeysQuery.data])
@@ -782,6 +795,24 @@ export function ProjectsClient() {
                 </div>
               ))}
             </div>
+          ) : listError ? (
+            <div className="rounded-xl border border-dashed border-border p-10 text-center">
+              <h2 className="text-[14px] font-semibold text-text mb-1.5">Couldn&apos;t load projects</h2>
+              <p className="text-[12.5px] text-text-muted max-w-md mx-auto mb-4">
+                We couldn&apos;t reach the server just now. Your projects and keys are safe.
+              </p>
+              <button
+                type="button"
+                onClick={() => {
+                  void projectsQuery.refetch()
+                  void apiKeysQuery.refetch()
+                  void providerKeysQuery.refetch()
+                }}
+                className="font-mono text-[11.5px] px-2.5 py-1 rounded border border-border text-text-muted hover:text-text hover:border-border-strong transition-colors inline-block"
+              >
+                Retry
+              </button>
+            </div>
           ) : allProjects.length === 0 ? (
             <div className="rounded-xl border border-dashed border-border p-10 text-center">
               <h2 className="text-[14px] font-semibold text-text mb-1.5">No projects yet</h2>
@@ -1037,7 +1068,13 @@ export function ProjectsClient() {
       </div>
 
       {/* Create project dialog */}
-      <Dialog open={projDialogOpen} onOpenChange={setProjDialogOpen}>
+      <Dialog
+        open={projDialogOpen}
+        onOpenChange={(open) => {
+          setProjDialogOpen(open)
+          if (!open) setProjError(null)
+        }}
+      >
         <DialogContent aria-describedby={undefined}>
           <DialogHeader>
             <DialogTitle>Create project</DialogTitle>
@@ -1048,11 +1085,16 @@ export function ProjectsClient() {
               <input
                 value={projName}
                 onChange={(e) => setProjName(e.target.value)}
-                onKeyDown={(e) => { if (e.key === 'Enter' && projName.trim()) void handleCreateProject() }}
+                onKeyDown={(e) => { if (e.key === 'Enter' && projName.trim() && !createProject.isPending) void handleCreateProject() }}
                 placeholder="e.g. Production"
                 className="w-full h-9 px-3 rounded-[6px] border border-border bg-bg text-[13px] text-text placeholder:text-text-faint focus:outline-none focus:border-border-strong transition-colors"
               />
             </div>
+            {projError && (
+              <div className="rounded-md border border-bad/30 bg-bad/10 px-3 py-2 text-[12px] text-bad">
+                {projError}
+              </div>
+            )}
             <PrimaryBtn
               onClick={() => void handleCreateProject()}
               disabled={!projName.trim() || createProject.isPending}

--- a/apps/web/app/(dashboard)/requests/requests-client.tsx
+++ b/apps/web/app/(dashboard)/requests/requests-client.tsx
@@ -1087,6 +1087,8 @@ function SortBtn({ field, label, sortField, sortDir, onSort }: {
 function RequestsTable({
   rows,
   isLoading,
+  isError,
+  onRetry,
   selectedId,
   onSelect,
   drawerOpen,
@@ -1097,6 +1099,8 @@ function RequestsTable({
 }: {
   rows: RequestRow[]
   isLoading: boolean
+  isError: boolean
+  onRetry: () => void
   selectedId: string | null
   onSelect: (id: string) => void
   drawerOpen: boolean
@@ -1173,6 +1177,22 @@ function RequestsTable({
               <Skeleton className="h-4 w-8 ml-auto" />
             </div>
           ))
+        : isError
+          ? (
+            // Don't render the "add a provider key" onboarding hint on a load
+            // failure — a customer with millions of rows would see a new-user
+            // empty state. Show the error + a retry instead.
+            <div className="py-12 font-mono text-[12.5px] text-text-faint flex flex-col items-center gap-3 text-center px-4">
+              <span className="text-accent">Couldn&apos;t load requests.</span>
+              <button
+                type="button"
+                onClick={onRetry}
+                className="px-2.5 py-1 border border-border rounded text-text-muted hover:text-text hover:border-border-strong transition-colors"
+              >
+                Retry
+              </button>
+            </div>
+          )
         : rows.length === 0
           ? (
             <div className="py-12 font-mono text-[12.5px] text-text-faint flex flex-col items-center gap-3 text-center px-4">
@@ -1359,7 +1379,7 @@ export function RequestsClient() {
     [page, filters.provider, filters.model, filters.providerKeyId, filters.status, fromIso, sortField, sortDir, promptVersionId, userIdFilter, sessionIdFilter],
   )
 
-  const { data, isLoading, isFetching, refetch } = useRequests(serverFilters)
+  const { data, isLoading, isError, isFetching, refetch } = useRequests(serverFilters)
   const providerKeysQuery = useProviderKeys()
 
   // Filter dropdown: lets the user narrow requests to a specific provider key.
@@ -1636,6 +1656,8 @@ export function RequestsClient() {
             <RequestsTable
               rows={requests}
               isLoading={isLoading}
+              isError={isError}
+              onRetry={() => void refetch()}
               selectedId={selectedId}
               onSelect={handleSelect}
               drawerOpen={drawerOpen}

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -571,6 +571,19 @@ function MembersTab() {
             client renders the loaded list, triggering React #418. */}
         {!mounted || members.isLoading ? (
           <div className="px-6 py-4 text-[12.5px] text-text-faint">Loading…</div>
+        ) : members.isError ? (
+          // Don't fall through to "No members yet" on a load failure — a
+          // populated workspace would look empty. Show the error + a retry.
+          <div className="px-6 py-4 flex items-center justify-between gap-3 flex-wrap">
+            <span className="text-[12.5px] text-bad">Couldn&apos;t load members.</span>
+            <button
+              type="button"
+              onClick={() => void members.refetch()}
+              className="font-mono text-[11.5px] px-2.5 py-1 border border-border rounded text-text-muted hover:text-text hover:border-border-strong transition-colors"
+            >
+              Retry
+            </button>
+          </div>
         ) : (members.data ?? []).length === 0 ? (
           <div className="px-6 py-4 text-[12.5px] text-text-faint">No members yet.</div>
         ) : (
@@ -1000,7 +1013,7 @@ function SystemTab() {
 // ─── BILLING tab ──────────────────────────────────────────────────────────────
 
 function BillingTab() {
-  const { data: subscription, isLoading } = useSubscription()
+  const { data: subscription, isLoading, isError, refetch } = useSubscription()
   const { data: quota } = useQuota()
 
   const planName = subscription?.plan ?? 'free'
@@ -1022,6 +1035,23 @@ function BillingTab() {
           <div className="font-mono text-[10px] text-text-faint uppercase tracking-[0.05em] mb-3">Current plan</div>
           {isLoading ? (
             <div className="h-8 w-32 bg-bg-muted rounded animate-pulse mb-4" />
+          ) : isError ? (
+            // Don't render the Free-plan default on error — a paying user
+            // hitting a transient failure would otherwise see "Free", which is
+            // wrong and alarming. Show the load failure and a retry instead.
+            <div className="mb-4">
+              <div className="text-[15px] font-medium text-text mb-1">Couldn&apos;t load your plan</div>
+              <p className="text-[12.5px] text-text-muted mb-2">
+                We couldn&apos;t reach billing just now. Your current plan is unchanged.
+              </p>
+              <button
+                type="button"
+                onClick={() => refetch()}
+                className="font-mono text-[12px] text-accent hover:opacity-80 transition-opacity"
+              >
+                Retry
+              </button>
+            </div>
           ) : (
             <>
               <div className="flex items-center gap-3 mb-1">
@@ -1110,7 +1140,7 @@ function BillingTab() {
 
 function PlanLimitsTab() {
   const { data: org } = useOrganization()
-  const { data: subscription, isLoading: subLoading } = useSubscription()
+  const { data: subscription, isLoading: subLoading, isError: subError } = useSubscription()
   const { data: quota } = useQuota()
   const createCheckout = useCreateCheckout()
   const refreshSubscription = useRefreshSubscription()
@@ -1120,6 +1150,10 @@ function PlanLimitsTab() {
   const [multiplierDraft, setMultiplierDraft] = useState(String(org?.overage_cap_multiplier ?? 2))
   const [paddle, setPaddle] = useState<Paddle | null>(null)
   const [checkoutError, setCheckoutError] = useState<string | null>(null)
+  // initializePaddle can reject (ad-block, network). Without catching it,
+  // `paddle` stays null forever and every Upgrade button is stuck on
+  // "Loading…" with no explanation. Surface an actionable error instead.
+  const [paddleLoadFailed, setPaddleLoadFailed] = useState(false)
 
   const clientToken = process.env['NEXT_PUBLIC_PADDLE_CLIENT_TOKEN']
   const paddleEnv = (process.env['NEXT_PUBLIC_PADDLE_ENVIRONMENT'] ?? 'sandbox') as 'sandbox' | 'production'
@@ -1135,9 +1169,13 @@ function PlanLimitsTab() {
           setTimeout(() => refreshSubscription(), 1500)
         }
       },
-    }).then((instance) => {
-      if (!cancelled && instance) setPaddle(instance)
     })
+      .then((instance) => {
+        if (!cancelled && instance) setPaddle(instance)
+      })
+      .catch(() => {
+        if (!cancelled) setPaddleLoadFailed(true)
+      })
     return () => { cancelled = true }
   }, [clientToken, paddleEnv, refreshSubscription])
 
@@ -1176,12 +1214,37 @@ function PlanLimitsTab() {
     <div className="max-w-[1040px]">
       <TabHeader title="Plan & limits" description="Compare plans. Hard limits apply per-workspace; can be lifted on Enterprise." />
 
-      {checkoutError && (
+      {(checkoutError || paddleLoadFailed) && (
         <div className="rounded-lg border border-accent-border bg-accent-bg px-4 py-3 mb-5 text-[13px] text-accent">
-          {checkoutError}
+          {checkoutError
+            ?? 'Payment system failed to load. Please disable ad-blockers and retry.'}
         </div>
       )}
 
+      {/* Subscription load failure — don't fall through to the Free-plan
+          default below. A paying user hitting a transient 500 would otherwise
+          see Free + Upgrade buttons and could start a duplicate checkout.
+          Show the failure and a retry instead. */}
+      {subError ? (
+        <div className="rounded-lg border border-border bg-bg-elev px-4 py-3 mb-6 flex items-center justify-between gap-3 flex-wrap">
+          <div>
+            <div className="text-[13px] font-medium text-text mb-0.5">
+              Couldn&apos;t load your plan
+            </div>
+            <p className="text-[12.5px] text-text-muted">
+              We couldn&apos;t reach billing just now. Your current plan is unchanged.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => refreshSubscription()}
+            className="font-mono text-[12px] text-accent hover:opacity-80 transition-opacity shrink-0"
+          >
+            Retry
+          </button>
+        </div>
+      ) : (
+      <>
       {/* Plan cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3 mb-6">
         {PLANS.map((plan) => {
@@ -1360,6 +1423,8 @@ function PlanLimitsTab() {
             </>
           )}
         </Section>
+      )}
+      </>
       )}
     </div>
   )

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -227,8 +227,19 @@ function GeneralTab() {
   const { data: org } = useOrganization()
   const updateOrg = useUpdateOrganization()
   const [name, setName] = useState(org?.name ?? '')
+  const [nameError, setNameError] = useState<string | null>(null)
   const currentMember = useCurrentMember()
   const isAdmin = currentMember?.role === 'admin'
+
+  async function handleSaveName() {
+    if (!org) return
+    setNameError(null)
+    try {
+      await updateOrg.mutateAsync({ id: org.id, name })
+    } catch (err) {
+      setNameError(err instanceof Error ? err.message : 'Update failed')
+    }
+  }
   // useSyncExternalStore returns false on the server and true on the client
   // without needing useEffect + setState (avoids react-hooks/set-state-in-effect).
   const mounted = useSyncExternalStore(
@@ -253,20 +264,25 @@ function GeneralTab() {
 
       <Section title="Identity" description="Visible within your workspace" className="mb-5">
         <FormRow label="Workspace name" hint="Shown in the app header and on shared traces.">
-          <div className="flex items-center gap-3 w-full max-w-[460px]">
-            <NativeInput
-              value={name || (org?.name ?? '')}
-              onChange={(e) => setName(e.target.value)}
-              className="flex-1 font-mono text-[12.5px]"
-              disabled={!isAdmin}
-            />
-            {isAdmin && (
-              <GhostBtn
-                disabled={updateOrg.isPending || !name.trim() || name === org?.name}
-                onClick={() => org && void updateOrg.mutateAsync({ id: org.id, name })}
-              >
-                {updateOrg.isPending ? 'Saving…' : 'Save'}
-              </GhostBtn>
+          <div className="flex flex-col gap-2 w-full max-w-[460px]">
+            <div className="flex items-center gap-3">
+              <NativeInput
+                value={name || (org?.name ?? '')}
+                onChange={(e) => setName(e.target.value)}
+                className="flex-1 font-mono text-[12.5px]"
+                disabled={!isAdmin}
+              />
+              {isAdmin && (
+                <GhostBtn
+                  disabled={updateOrg.isPending || !name.trim() || name === org?.name}
+                  onClick={() => void handleSaveName()}
+                >
+                  {updateOrg.isPending ? 'Saving…' : 'Save'}
+                </GhostBtn>
+              )}
+            </div>
+            {nameError && (
+              <span className="font-mono text-[11.5px] text-status-error">{nameError}</span>
             )}
           </div>
         </FormRow>
@@ -751,17 +767,41 @@ function SecurityTabInner() {
   const [thresholdDays, setThresholdDays] = useState<string>(
     org ? String(org.stale_key_threshold_days) : '90',
   )
+  const [error, setError] = useState<string | null>(null)
   const staleAlertsEnabled = org?.stale_key_alerts_enabled ?? true
   const leakDetectionEnabled = org?.leak_detection_enabled ?? false
 
-  function commitThreshold() {
+  async function commitThreshold() {
     const n = Number(thresholdDays)
     if (!Number.isInteger(n) || n < 30 || n > 365) {
       if (org) setThresholdDays(String(org.stale_key_threshold_days))
       return
     }
     if (org && n === org.stale_key_threshold_days) return
-    void updateSecurity.mutateAsync({ stale_key_threshold_days: n })
+    setError(null)
+    try {
+      await updateSecurity.mutateAsync({ stale_key_threshold_days: n })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Update failed')
+    }
+  }
+
+  async function toggleStaleAlerts() {
+    setError(null)
+    try {
+      await updateSecurity.mutateAsync({ stale_key_alerts_enabled: !staleAlertsEnabled })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Update failed')
+    }
+  }
+
+  async function toggleLeakDetection() {
+    setError(null)
+    try {
+      await updateSecurity.mutateAsync({ leak_detection_enabled: !leakDetectionEnabled })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Update failed')
+    }
   }
 
   return (
@@ -779,7 +819,7 @@ function SecurityTabInner() {
               max={365}
               value={thresholdDays}
               onChange={(e) => setThresholdDays(e.target.value)}
-              onBlur={commitThreshold}
+              onBlur={() => void commitThreshold()}
               disabled={!staleAlertsEnabled || updateSecurity.isPending}
               className="w-20 font-mono text-[12.5px]"
             />
@@ -787,7 +827,7 @@ function SecurityTabInner() {
             <Toggle
               on={staleAlertsEnabled}
               disabled={updateSecurity.isPending}
-              onToggle={() => void updateSecurity.mutateAsync({ stale_key_alerts_enabled: !staleAlertsEnabled })}
+              onToggle={() => void toggleStaleAlerts()}
             />
           </div>
         </FormRow>
@@ -795,9 +835,14 @@ function SecurityTabInner() {
           <Toggle
             on={leakDetectionEnabled}
             disabled={updateSecurity.isPending}
-            onToggle={() => void updateSecurity.mutateAsync({ leak_detection_enabled: !leakDetectionEnabled })}
+            onToggle={() => void toggleLeakDetection()}
           />
         </FormRow>
+        {error && (
+          <div className="px-6 pb-4 -mt-2 font-mono text-[11.5px] text-status-error">
+            {error}
+          </div>
+        )}
       </Section>
     </div>
   )
@@ -1148,6 +1193,7 @@ function PlanLimitsTab() {
   const currentMember = useCurrentMember()
   const isAdmin = currentMember?.role === 'admin'
   const [multiplierDraft, setMultiplierDraft] = useState(String(org?.overage_cap_multiplier ?? 2))
+  const [overageError, setOverageError] = useState<string | null>(null)
   const [paddle, setPaddle] = useState<Paddle | null>(null)
   const [checkoutError, setCheckoutError] = useState<string | null>(null)
   // initializePaddle can reject (ad-block, network). Without catching it,
@@ -1192,6 +1238,24 @@ function PlanLimitsTab() {
       setCheckoutError(err instanceof Error ? err.message : 'Failed to start checkout')
     }
   }, [paddle, createCheckout])
+
+  async function toggleOverage() {
+    setOverageError(null)
+    try {
+      await update.mutateAsync({ allow_overage: !(org?.allow_overage ?? false) })
+    } catch (err) {
+      setOverageError(err instanceof Error ? err.message : 'Update failed')
+    }
+  }
+
+  async function saveMultiplier() {
+    setOverageError(null)
+    try {
+      await update.mutateAsync({ overage_cap_multiplier: Number(multiplierDraft) })
+    } catch (err) {
+      setOverageError(err instanceof Error ? err.message : 'Update failed')
+    }
+  }
 
   const currentPlan: BillingPlan = subscription?.plan ?? 'free'
   const isFree = currentPlan === 'free'
@@ -1385,7 +1449,7 @@ function PlanLimitsTab() {
                 <Toggle
                   on={org?.allow_overage ?? false}
                   disabled={update.isPending || !isAdmin}
-                  onToggle={() => void update.mutateAsync({ allow_overage: !(org?.allow_overage ?? false) })}
+                  onToggle={() => void toggleOverage()}
                 />
               </FormRow>
               <FormRow label="Max overage multiplier" hint="Hard cap = monthly limit × this value. Requests past the cap return 429.">
@@ -1410,13 +1474,18 @@ function PlanLimitsTab() {
                         Number(multiplierDraft) < 1 ||
                         Number(multiplierDraft) > 100
                       }
-                      onClick={() => void update.mutateAsync({ overage_cap_multiplier: Number(multiplierDraft) })}
+                      onClick={() => void saveMultiplier()}
                     >
                       {update.isPending ? 'Saving…' : 'Save'}
                     </GhostBtn>
                   )}
                 </div>
               </FormRow>
+              {overageError && (
+                <div className="px-6 pb-4 -mt-2 font-mono text-[11.5px] text-status-error">
+                  {overageError}
+                </div>
+              )}
               {!isAdmin && (
                 <div className="px-6 pb-4 text-[11.5px] text-text-faint">Only admins can change overage settings.</div>
               )}
@@ -1717,6 +1786,16 @@ const NOTIFICATION_PREFS: NotificationPrefDef[] = [
 function NotificationsTab() {
   const { data: prefs, isLoading } = useNotificationPrefs()
   const update = useUpdateNotificationPrefs()
+  const [error, setError] = useState<string | null>(null)
+
+  async function togglePref(key: NotificationPrefDef['key']) {
+    setError(null)
+    try {
+      await update.mutateAsync({ [key]: !(prefs?.[key] ?? true) })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Update failed')
+    }
+  }
 
   return (
     <div className="max-w-[980px]">
@@ -1731,12 +1810,15 @@ function NotificationsTab() {
             <Toggle
               on={prefs?.[pref.key] ?? true}
               disabled={isLoading || update.isPending}
-              onToggle={() =>
-                void update.mutateAsync({ [pref.key]: !(prefs?.[pref.key] ?? true) })
-              }
+              onToggle={() => void togglePref(pref.key)}
             />
           </FormRow>
         ))}
+        {error && (
+          <div className="px-6 pb-4 -mt-2 font-mono text-[11.5px] text-status-error">
+            {error}
+          </div>
+        )}
       </Section>
 
       <Section title="Alert routing" className="mb-5">
@@ -1907,9 +1989,19 @@ function WebhooksTab() {
 
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [testResult, setTestResult] = useState<Record<string, string>>({})
+  const [toggleError, setToggleError] = useState<string | null>(null)
 
   const currentMember = useCurrentMember()
   const canEdit = currentMember?.role === 'admin' || currentMember?.role === 'editor'
+
+  async function handleToggleActive(webhook: WebhookRow) {
+    setToggleError(null)
+    try {
+      await updateWebhook.mutateAsync({ id: webhook.id, is_active: !webhook.is_active })
+    } catch (err) {
+      setToggleError(err instanceof Error ? err.message : 'Failed to update webhook')
+    }
+  }
 
   function toggleEvent(ev: WebhookEvent) {
     setNewEvents((prev) =>
@@ -1971,6 +2063,11 @@ function WebhooksTab() {
       />
 
       <Section title="Webhook endpoints" className="mb-5">
+        {toggleError && (
+          <div className="px-6 pt-4 font-mono text-[11.5px] text-status-error">
+            {toggleError}
+          </div>
+        )}
         {isLoading ? (
           <div className="px-6 py-8 text-center font-mono text-[12.5px] text-text-faint">Loading…</div>
         ) : (webhooks ?? []).length === 0 ? (
@@ -2004,7 +2101,7 @@ function WebhooksTab() {
                   <Toggle
                     on={wh.is_active}
                     disabled={!canEdit || updateWebhook.isPending}
-                    onToggle={() => void updateWebhook.mutateAsync({ id: wh.id, is_active: !wh.is_active })}
+                    onToggle={() => void handleToggleActive(wh)}
                   />
                   <MonoPill variant={wh.is_active ? 'good' : 'faint'} dot>
                     {wh.is_active ? 'active' : 'off'}

--- a/apps/web/app/(dashboard)/traces/traces-client.tsx
+++ b/apps/web/app/(dashboard)/traces/traces-client.tsx
@@ -191,7 +191,7 @@ export function TracesClient() {
     }
   }, [debouncedSearch])
 
-  const { data, isLoading, isFetching, refetch } = useTraces(
+  const { data, isLoading, isError, isFetching, refetch } = useTraces(
     {
       page,
       limit: 50,
@@ -435,6 +435,20 @@ export function TracesClient() {
             {[1, 2, 3, 4, 5].map((i) => (
               <div key={i} className="h-10 bg-bg-elev rounded animate-pulse" />
             ))}
+          </div>
+        ) : isError ? (
+          // Don't fall through to the "wire up agent tracing" onboarding hint
+          // on a load failure — a workspace with existing traces would look
+          // brand-new. Show the error + a retry instead.
+          <div className="flex flex-col items-center gap-3 text-text-muted py-20 px-6 text-center">
+            <p className="text-[13px] text-accent">Couldn&apos;t load traces.</p>
+            <button
+              type="button"
+              onClick={() => void refetch()}
+              className="font-mono text-[11.5px] px-2.5 py-1 border border-border rounded text-text-muted hover:text-text hover:border-border-strong transition-colors"
+            >
+              Retry
+            </button>
           </div>
         ) : traces.length === 0 ? (
           <div className="flex flex-col items-center gap-3 text-text-muted py-20 px-6 text-center">

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -25,6 +25,22 @@ import { recordOAuthConsentIfMissing } from '@/lib/oauth-consent'
  * server round-trip. Helper is idempotent so re-logins do nothing.
  */
 const OAUTH_RETURN_COOKIE = 'sl_oauth_return'
+const DEFAULT_NEXT = '/dashboard'
+
+/**
+ * Accept a post-callback destination only when it's a same-origin relative
+ * path. `next` is attacker-controllable (query param or cookie), and it gets
+ * concatenated as `${redirectBase}${next}`. A value like `//evil.com` or
+ * `@evil.com` would redirect off-origin — a phishing vector on a trusted
+ * domain. Require a single leading slash (relative path) and reject
+ * protocol-relative (`//`) URLs; everything else falls back to /dashboard.
+ */
+function sanitizeNext(candidate: string | null | undefined): string {
+  if (!candidate || !candidate.startsWith('/') || candidate.startsWith('//')) {
+    return DEFAULT_NEXT
+  }
+  return candidate
+}
 
 export async function GET(request: Request): Promise<NextResponse> {
   const { searchParams, origin } = new URL(request.url)
@@ -43,10 +59,15 @@ export async function GET(request: Request): Promise<NextResponse> {
   // so a stale value never persists into the next sign-in.
   const cookieStore = await cookies()
   const returnCookie = cookieStore.get(OAUTH_RETURN_COOKIE)?.value
-  const next =
+  // Both sources are attacker-controllable. Resolve the raw candidate with the
+  // existing precedence (query param, then cookie), then sanitize the result so
+  // an unsafe value from either source falls back to /dashboard rather than
+  // redirecting off-origin. `??` means the cookie is only read when the query
+  // param is absent, matching the original precedence.
+  const rawNext =
     searchParams.get('next') ??
-    (returnCookie ? decodeURIComponent(returnCookie) : null) ??
-    '/dashboard'
+    (returnCookie ? decodeURIComponent(returnCookie) : null)
+  const next = sanitizeNext(rawNext)
 
   if (!code) {
     const r = NextResponse.redirect(`${redirectBase}${next}`)

--- a/apps/web/app/invite/page.tsx
+++ b/apps/web/app/invite/page.tsx
@@ -69,30 +69,39 @@ function InvitePageInner() {
         return
       }
 
-      // Resolve invite meta from the server (public endpoint).
-      const res = await fetch(`/api/v1/invitations/accept?token=${encodeURIComponent(token)}`)
-      if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string }
-        setStatus({ kind: 'invalid', message: body.error ?? 'Invalid invitation.' })
-        return
-      }
-      const body = (await res.json()) as { data: InviteMeta }
-      const meta = body.data
+      try {
+        // Resolve invite meta from the server (public endpoint).
+        const res = await fetch(`/api/v1/invitations/accept?token=${encodeURIComponent(token)}`)
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as { error?: string }
+          setStatus({ kind: 'invalid', message: body.error ?? 'Invalid invitation.' })
+          return
+        }
+        const body = (await res.json()) as { data: InviteMeta }
+        const meta = body.data
 
-      // Check current auth session.
-      const supabase = createClient()
-      const { data: { session } } = await supabase.auth.getSession()
+        // Check current auth session.
+        const supabase = createClient()
+        const { data: { session } } = await supabase.auth.getSession()
 
-      if (!session) {
-        setStatus({ kind: 'needs_auth', meta })
-        return
-      }
+        if (!session) {
+          setStatus({ kind: 'needs_auth', meta })
+          return
+        }
 
-      const currentEmail = session.user.email?.toLowerCase() ?? ''
-      if (currentEmail === meta.email.toLowerCase()) {
-        setStatus({ kind: 'email_match', meta })
-      } else {
-        setStatus({ kind: 'email_mismatch', meta, currentEmail })
+        const currentEmail = session.user.email?.toLowerCase() ?? ''
+        if (currentEmail === meta.email.toLowerCase()) {
+          setStatus({ kind: 'email_match', meta })
+        } else {
+          setStatus({ kind: 'email_mismatch', meta, currentEmail })
+        }
+      } catch {
+        // Network failure while verifying — show a recoverable invalid state
+        // with a hint to retry rather than leaving the page stuck on "loading".
+        setStatus({
+          kind: 'invalid',
+          message: 'Could not reach the server. Check your connection and try again.',
+        })
       }
     })()
   }, [token])
@@ -111,31 +120,39 @@ function InvitePageInner() {
       return
     }
 
-    const res = await fetch('/api/v1/invitations/accept', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
-      body: JSON.stringify({ token }),
-    })
-    if (!res.ok) {
-      const body = (await res.json().catch(() => ({}))) as { error?: string }
-      setAcceptError(body.error ?? 'Failed to accept invitation.')
-      setStatus({ kind: 'email_match', meta: status.meta })
-      return
-    }
+    const prevMeta = status.meta
+    try {
+      const res = await fetch('/api/v1/invitations/accept', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+        body: JSON.stringify({ token }),
+      })
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string }
+        setAcceptError(body.error ?? 'Failed to accept invitation.')
+        setStatus({ kind: 'email_match', meta: prevMeta })
+        return
+      }
 
-    // Switch the active workspace to the joined one so the dashboard
-    // opens straight into it. The accept endpoint returns
-    // `data.organizationId` exactly so the client can do this.
-    const body = (await res.json().catch(() => ({}))) as {
-      data?: { organizationId?: string }
-    }
-    if (body.data?.organizationId) writeWorkspaceCookie(body.data.organizationId)
+      // Switch the active workspace to the joined one so the dashboard
+      // opens straight into it. The accept endpoint returns
+      // `data.organizationId` exactly so the client can do this.
+      const body = (await res.json().catch(() => ({}))) as {
+        data?: { organizationId?: string }
+      }
+      if (body.data?.organizationId) writeWorkspaceCookie(body.data.organizationId)
 
-    setStatus({ kind: 'done' })
-    // Hard navigation — middleware needs to re-resolve sb-ws + onboarded
-    // headers, otherwise the dashboard layout might bounce based on the
-    // pre-accept request's cached state.
-    setTimeout(() => { window.location.href = '/dashboard' }, 800)
+      setStatus({ kind: 'done' })
+      // Hard navigation — middleware needs to re-resolve sb-ws + onboarded
+      // headers, otherwise the dashboard layout might bounce based on the
+      // pre-accept request's cached state.
+      setTimeout(() => { window.location.href = '/dashboard' }, 800)
+    } catch {
+      // Network failure — restore the interactive state so both buttons
+      // re-enable and the invitee can retry. First-touch flow must recover.
+      setAcceptError('Could not reach the server. Please try again.')
+      setStatus({ kind: 'email_match', meta: prevMeta })
+    }
   }
 
   async function handleDecline() {
@@ -152,22 +169,32 @@ function InvitePageInner() {
       return
     }
 
-    const res = await fetch('/api/v1/invitations/decline', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
-      body: JSON.stringify({ token }),
-    })
-    if (!res.ok) {
-      const body = (await res.json().catch(() => ({}))) as { error?: string }
-      setAcceptError(body.error ?? 'Failed to decline invitation.')
-      setStatus({ kind: 'email_match', meta: status.meta })
-      return
-    }
+    const prevMeta = status.meta
+    try {
+      const res = await fetch('/api/v1/invitations/decline', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+        body: JSON.stringify({ token }),
+      })
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string }
+        setAcceptError(body.error ?? 'Failed to decline invitation.')
+        setStatus({ kind: 'email_match', meta: prevMeta })
+        return
+      }
 
-    // Decline lands the user back in their own dashboard (they may not
-    // have one yet — if they don't, the dashboard layout's onboarding
-    // gate will sweep them to /onboarding which is the right outcome).
-    router.push('/dashboard')
+      // Decline lands the user back in their own dashboard (they may not
+      // have one yet — if they don't, the dashboard layout's onboarding
+      // gate will sweep them to /onboarding which is the right outcome).
+      // Hard navigation so middleware re-resolves sb-ws + onboarded headers
+      // (mirrors the accept path). See CLAUDE.md gotcha #15.
+      window.location.href = '/dashboard'
+    } catch {
+      // Network failure — restore the interactive state so both buttons
+      // re-enable and the invitee can retry.
+      setAcceptError('Could not reach the server. Please try again.')
+      setStatus({ kind: 'email_match', meta: prevMeta })
+    }
   }
 
   async function handleSignOut() {

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -2,7 +2,6 @@
 import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
 import { GithubIcon, GoogleIcon } from '@/components/ui/provider-icons'
 
@@ -44,7 +43,6 @@ function ProofRow({ k, v }: { k: string; v: string }) {
 }
 
 export default function LoginPage() {
-  const router = useRouter()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
@@ -82,8 +80,11 @@ export default function LoginPage() {
       setLoading(false)
       return
     }
-    router.push('/dashboard')
-    router.refresh()
+    // Hard nav (not router.push) so the dashboard boots in a fresh JS context
+    // with a re-evaluated middleware pass and an empty TanStack cache. This
+    // guarantees the incoming account never renders against a previous
+    // account's cached queries. See CLAUDE.md gotcha #15.
+    window.location.href = '/dashboard'
   }
 
   async function handleOAuth(provider: 'google' | 'github') {

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -7,6 +7,7 @@ import { useTheme } from '@/components/providers/theme-provider'
 import { Sun, Moon, Monitor, X, MessageSquarePlus, PanelLeftClose } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { createClient } from '@/lib/supabase/client'
+import { clearQueryClient } from '@/lib/query-client'
 import { useStatsOverview } from '@/lib/queries/use-stats'
 import { useQuota } from '@/lib/queries/use-billing'
 import { formatPlanLabel } from '@/lib/billing-plans'
@@ -372,8 +373,14 @@ export function Sidebar() {
     clearWelcomeStash()
     const supabase = createClient()
     await supabase.auth.signOut()
-    router.push('/login')
-    router.refresh()
+    // Drop the previous account's TanStack cache. The browser QueryClient is a
+    // singleton that survives navigation and query keys don't include orgId, so
+    // without this the next account to sign in on this tab would render account
+    // A's cached stats / quota / org name until staleTime elapses.
+    clearQueryClient()
+    // Hard nav (not router.push) so the next session boots in a fresh JS
+    // context with fully re-evaluated middleware. See CLAUDE.md gotcha #15.
+    window.location.href = '/login'
   }
 
   return (

--- a/apps/web/lib/query-client.ts
+++ b/apps/web/lib/query-client.ts
@@ -1,4 +1,29 @@
-import { QueryClient } from '@tanstack/react-query'
+import { QueryClient, QueryCache, MutationCache } from '@tanstack/react-query'
+import { ApiError } from './api'
+
+/**
+ * Global 401 handler.
+ *
+ * When any query or mutation fails with a 401 (expired / blank session), the
+ * cached data on screen is stale and every poll silently errors. Redirect the
+ * user to /login via a HARD navigation (`window.location.href`) — a soft
+ * `router.push` would keep the RSC tree + middleware state (see CLAUDE.md
+ * gotcha #15), so the fresh middleware pass that clears the session never runs.
+ *
+ * Guarded so it fires only in the browser, only once (a module-level flag), and
+ * never while already on /login — otherwise a 401 from a login-page query would
+ * loop the redirect.
+ */
+let redirectingToLogin = false
+
+function handleGlobalError(error: unknown): void {
+  if (typeof window === 'undefined') return
+  if (!(error instanceof ApiError) || error.status !== 401) return
+  if (redirectingToLogin) return
+  if (window.location.pathname === '/login') return
+  redirectingToLogin = true
+  window.location.href = '/login'
+}
 
 /**
  * Create a fresh QueryClient for every React tree.
@@ -32,6 +57,10 @@ import { QueryClient } from '@tanstack/react-query'
  */
 export function makeQueryClient(): QueryClient {
   return new QueryClient({
+    // A single onError on both caches catches every query AND mutation failure,
+    // so the 401 redirect is wired in exactly one place.
+    queryCache: new QueryCache({ onError: handleGlobalError }),
+    mutationCache: new MutationCache({ onError: handleGlobalError }),
     defaultOptions: {
       queries: {
         // staleTime: how long a query is considered fresh. Within this window,
@@ -60,4 +89,17 @@ export function getQueryClient(): QueryClient {
   // Client: reuse the same instance across HMR reloads.
   if (!browserQueryClient) browserQueryClient = makeQueryClient()
   return browserQueryClient
+}
+
+/**
+ * Wipe every cached query on the browser client.
+ *
+ * Call this on sign-out: the `browserQueryClient` singleton persists across a
+ * soft navigation, and query keys don't include the orgId, so without an
+ * explicit clear the next account that signs in on the same tab would mount
+ * against the previous account's cached stats / quota / org name until
+ * staleTime elapses. Pair with a hard nav for a fully fresh context.
+ */
+export function clearQueryClient(): void {
+  browserQueryClient?.clear()
 }

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -12,7 +12,7 @@ import { NextResponse, type NextRequest } from 'next/server'
  * instead of two.
  */
 
-const PUBLIC_PATHS = ['/', '/pricing', '/login', '/signup', '/auth/', '/terms', '/privacy', '/invite', '/demo', '/forgot-password', '/reset-password']
+const PUBLIC_PATHS = ['/', '/pricing', '/login', '/signup', '/auth/', '/terms', '/privacy', '/invite', '/demo', '/forgot-password', '/reset-password', '/verify-email']
 
 export async function middleware(request: NextRequest) {
   // Skip auth middleware when Supabase env vars are absent (local preview without .env.local)
@@ -51,7 +51,18 @@ export async function middleware(request: NextRequest) {
   } = await supabase.auth.getUser()
 
   const path = request.nextUrl.pathname
-  const isPublic = PUBLIC_PATHS.some((p) => path === p || path.startsWith(p))
+  // Root ('/') must match EXACTLY — `path.startsWith('/')` is true for every
+  // URL, so treating it as a prefix would make isPublic always true and defeat
+  // the auth guard below. Every other entry matches as a true path-segment
+  // prefix (boundary-aware): `/pricing` covers `/pricing/x` but `/privacy`
+  // never accidentally matches an unrelated path that merely shares the string.
+  // Trailing slashes on entries (e.g. `/auth/`) are normalized first so the
+  // boundary check stays correct.
+  const isPublic = PUBLIC_PATHS.some((p) => {
+    if (p === '/') return path === '/'
+    const base = p.endsWith('/') ? p.slice(0, -1) : p
+    return path === base || path.startsWith(base + '/')
+  })
 
   if (!user && !isPublic) {
     const url = request.nextUrl.clone()
@@ -144,11 +155,26 @@ export async function middleware(request: NextRequest) {
     if (orgId) requestHeaders.set('x-spanlens-org-id', orgId)
     if (onboarded) requestHeaders.set('x-spanlens-onboarded', '1')
 
+    // getUser() may have rotated the Supabase session; setAll() wrote the fresh
+    // cookies onto request.cookies (for THIS request's SSR) and onto the old
+    // supabaseResponse (for the browser). Sync the rotated cookies into the
+    // downstream request header so RSC forwards the fresh token to the API.
+    requestHeaders.set('cookie', request.cookies.toString())
+
     // Re-materialize the response with the updated headers so downstream RSC
     // (notably (dashboard)/layout.tsx) sees them via next/headers.
-    supabaseResponse = NextResponse.next({
+    const finalResponse = NextResponse.next({
       request: { headers: requestHeaders },
     })
+    // CRITICAL: carry over any auth cookies the Supabase client rotated during
+    // getUser(). Creating a fresh NextResponse here would otherwise DROP the
+    // refreshed session cookies set on supabaseResponse — the browser would
+    // then keep replaying the old refresh token, tripping Supabase reuse
+    // detection and randomly logging the user out.
+    for (const cookie of supabaseResponse.cookies.getAll()) {
+      finalResponse.cookies.set(cookie)
+    }
+    supabaseResponse = finalResponse
   }
 
   return supabaseResponse

--- a/packages/sdk/src/integrations/llamaindex.ts
+++ b/packages/sdk/src/integrations/llamaindex.ts
@@ -137,12 +137,41 @@ export function registerSpanlensCallbacks(
     }
   }
 
+  // Error path: LlamaIndex emits an error event when an LLM call throws. Without
+  // handling it the span never ends (stays 'running' in the dashboard forever)
+  // and its `runs` Map entry leaks. End the span/trace with error status and
+  // delete the entry, mirroring onEnd's cleanup.
+  function onError(event: unknown): void {
+    const detail = (event as { detail?: { id?: string; error?: unknown } }).detail
+    const id = detail?.id
+    if (!id) return
+    const run = runs.get(id)
+    if (!run) return
+    runs.delete(id)
+
+    const rawError = detail?.error
+    const errorMessage =
+      rawError instanceof Error ? rawError.message : rawError != null ? String(rawError) : 'LLM error'
+
+    run.span.end({ status: 'error', errorMessage }).catch(() => undefined)
+
+    if (run.isLocalTrace) {
+      run.trace.end({ status: 'error' }).catch(() => undefined)
+    }
+  }
+
   settings.callbackManager.on('llm-start', onStart)
   settings.callbackManager.on('llm-end', onEnd)
+  // Event name varies by LlamaIndex version; register the known variants so the
+  // error path is covered regardless. Unused registrations are harmless.
+  settings.callbackManager.on('llm-error', onError)
+  settings.callbackManager.on('llm-stream-error', onError)
 
   return function unregister(): void {
     settings.callbackManager.off('llm-start', onStart)
     settings.callbackManager.off('llm-end', onEnd)
+    settings.callbackManager.off('llm-error', onError)
+    settings.callbackManager.off('llm-stream-error', onError)
     runs.clear()
   }
 }

--- a/packages/sdk/src/integrations/vercel-ai.ts
+++ b/packages/sdk/src/integrations/vercel-ai.ts
@@ -17,6 +17,7 @@
  *     messages: [...],
  *     onStepFinish: tracker.onStepFinish,
  *     onFinish: tracker.onFinish,
+ *     onError: tracker.onError, // ends the span on failure (streamText/streamObject)
  *   })
  *
  * @example Attach to an existing trace
@@ -92,6 +93,12 @@ export interface SpanlensVercelAITracker {
   onStepFinish: (event: VercelAIStepFinishEvent) => Promise<void>
   /** Pass to `onFinish` — closes the span with final total usage. */
   onFinish: (event: VercelAIFinishEvent) => Promise<void>
+  /**
+   * Pass to `onError` (streamText/streamObject) — closes the span/trace with
+   * `status: 'error'` when the underlying call fails. Without this the span
+   * stays 'running' forever in the dashboard because `onFinish` never fires.
+   */
+  onError: (event: { error?: unknown } | unknown) => Promise<void>
 }
 
 /**
@@ -114,6 +121,7 @@ export function createSpanlensTracker(
   })
 
   let stepCount = 0
+  let settled = false
 
   return {
     async onStepFinish(_event: VercelAIStepFinishEvent): Promise<void> {
@@ -124,6 +132,8 @@ export function createSpanlensTracker(
     },
 
     async onFinish(event: VercelAIFinishEvent): Promise<void> {
+      if (settled) return
+      settled = true
       const { usage, finishReason, text, response } = event
       const resolvedModel =
         response?.modelId ?? response?.model ?? modelName ?? 'unknown'
@@ -147,6 +157,29 @@ export function createSpanlensTracker(
 
       if (isLocalTrace) {
         await trace.end({ status: isError ? 'error' : 'completed' })
+      }
+    },
+
+    async onError(event: { error?: unknown } | unknown): Promise<void> {
+      // The underlying call errored — end the span/trace so it does not stay
+      // 'running' forever. Guarded by `settled` so a later onFinish (or vice
+      // versa) does not double-end.
+      if (settled) return
+      settled = true
+      const raw =
+        event != null && typeof event === 'object' && 'error' in event
+          ? (event as { error?: unknown }).error
+          : event
+      const errorMessage = raw instanceof Error ? raw.message : String(raw)
+
+      await span.end({
+        status: 'error',
+        errorMessage,
+        metadata: { model: modelName ?? 'unknown' },
+      })
+
+      if (isLocalTrace) {
+        await trace.end({ status: 'error' })
       }
     },
   }

--- a/packages/sdk/src/observe.ts
+++ b/packages/sdk/src/observe.ts
@@ -32,20 +32,40 @@ export async function observe<T>(
 
   try {
     const result = await fn(span)
-    // Auto-capture return value as output unless it's a stream (not serialisable).
-    // If the user already called span.end() manually inside fn (e.g. streaming),
-    // SpanHandle.end() will send a supplementary output-only PATCH.
-    const isStream =
-      result != null &&
-      typeof result === 'object' &&
-      (Symbol.asyncIterator in (result as object) || Symbol.iterator in (result as object))
+    // Auto-capture return value as output unless it's a genuine stream (not
+    // serialisable). If the user already called span.end() manually inside fn
+    // (e.g. streaming), SpanHandle.end() will send a supplementary output-only PATCH.
+    const isStream = isStreamLike(result)
     await span.end({ status: 'completed', output: isStream ? undefined : result })
     return result
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err)
-    await span.end({ status: 'error', errorMessage })
+    // Do not let a failing span.end() mask the user's original error — swallow
+    // the end() rejection so `throw err` always runs and propagates unchanged.
+    await span.end({ status: 'error', errorMessage }).catch(() => {})
     throw err
   }
+}
+
+/**
+ * True only for genuine streams whose contents are NOT safely serialisable as
+ * span output: async iterables (async generators) and ReadableStream-likes.
+ *
+ * Plain sync-iterable containers (arrays, Map, Set, etc.) are explicitly
+ * EXCLUDED — they are serialisable return values (e.g. a retrieval result
+ * array) and must be captured as output, not silently dropped as "a stream".
+ */
+function isStreamLike(result: unknown): boolean {
+  if (result == null || typeof result !== 'object') return false
+  // Arrays and other plain sync-iterable containers are serialisable output.
+  if (Array.isArray(result)) return false
+  const obj = result as Record<PropertyKey, unknown>
+  // Async iterables (async generators) are real streams.
+  if (Symbol.asyncIterator in obj) return true
+  // ReadableStream (Web Streams) — direct instance or duck-typed.
+  if (typeof ReadableStream !== 'undefined' && result instanceof ReadableStream) return true
+  if (typeof obj['getReader'] === 'function' || typeof obj['tee'] === 'function') return true
+  return false
 }
 
 // ── Provider-specific auto-instrumentation helpers ─────────────
@@ -165,17 +185,16 @@ async function observeProvider<T>(
     }
     const enriched = { ...parsed, metadata: metadataWithProvider }
 
-    // Capture the full response as output unless it's a stream (not serializable)
-    const isStream = result != null &&
-      typeof result === 'object' &&
-      (Symbol.asyncIterator in (result as object) || Symbol.iterator in (result as object))
-    const output = isStream ? undefined : result
+    // Capture the full response as output unless it's a genuine stream (not serializable)
+    const output = isStreamLike(result) ? undefined : result
 
     await span.end({ status: 'completed', output, ...enriched })
     return result
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err)
-    await span.end({ status: 'error', errorMessage })
+    // Do not let a failing span.end() mask the user's original error — swallow
+    // the end() rejection so `throw err` always runs and propagates unchanged.
+    await span.end({ status: 'error', errorMessage }).catch(() => {})
     throw err
   }
 }

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -103,6 +103,26 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+/**
+ * Invoke the user-supplied onError callback without ever letting it throw.
+ * These transport calls run fire-and-forget from span.end(); if a user's
+ * callback threw here the promise would reject even under `silent: true`,
+ * surfacing as an unhandled rejection that can crash the host process. The
+ * SDK's "never crash user code" guarantee means a user callback must never
+ * escape.
+ */
+function safeOnError(
+  cb: SpanlensConfig['onError'],
+  err: unknown,
+  meta: string,
+): void {
+  try {
+    cb?.(err, meta)
+  } catch {
+    /* user callback must never crash the SDK */
+  }
+}
+
 export function createTransport(config: SpanlensConfig): Transport {
   const baseUrl = (config.baseUrl ?? 'https://spanlens-server.vercel.app').replace(/\/$/, '')
   const timeoutMs = config.timeoutMs ?? 3000
@@ -133,11 +153,17 @@ export function createTransport(config: SpanlensConfig): Transport {
           body: JSON.stringify(body),
           signal: controller.signal,
         })
-        clearTimeout(timer)
+        // NOTE: the abort timer stays armed through the body read below. A
+        // server that returns headers then stalls the body would otherwise
+        // hang flush()/beforeExit forever. controller.abort() rejects the
+        // pending res.text() so the deadline covers the whole request. The
+        // timer is cleared only after the body is fully consumed (on every
+        // return path) or in the catch block.
 
         // 4xx = client error, don't retry
         if (res.status >= 400 && res.status < 500) {
           const text = await res.text().catch(() => '')
+          clearTimeout(timer)
           // If the server speaks the standard error envelope (post Sprint 7
           // R-15), give callers the typed exception so they can branch on
           // error.code without string-comparing the message.
@@ -145,24 +171,28 @@ export function createTransport(config: SpanlensConfig): Transport {
           const err = apiError
             ? apiError
             : new Error(`[spanlens] ${method} ${path} -> ${res.status} ${text.slice(0, 200)}`)
-          onError?.(err, `${method} ${path}`)
+          safeOnError(onError, err, `${method} ${path}`)
           if (!silent) throw err
           return null
         }
 
         // 5xx / 429 — retryable
         if (!res.ok) {
+          clearTimeout(timer)
           lastErr = new Error(`[spanlens] ${method} ${path} → ${res.status}`)
           if (attempt < MAX_RETRIES) {
             await sleep(retryDelayMs(attempt))
             continue
           }
-          onError?.(lastErr, `${method} ${path}`)
+          safeOnError(onError, lastErr, `${method} ${path}`)
           if (!silent) throw lastErr
           return null
         }
 
+        // Body read is still covered by the abort timer (armed above); it is
+        // cleared only once the full body has been consumed.
         const text = await res.text()
+        clearTimeout(timer)
         if (!text) return null
         try { return JSON.parse(text) } catch { return null }
       } catch (err) {
@@ -190,7 +220,7 @@ export function createTransport(config: SpanlensConfig): Transport {
         // Call onError on every occurrence so callers receive the notification
         // promptly rather than only after all retries are exhausted.
         lastErr = err
-        onError?.(err, `${method} ${path}`)
+        safeOnError(onError, err, `${method} ${path}`)
         if (attempt < MAX_RETRIES) {
           await sleep(retryDelayMs(attempt))
           continue

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -139,6 +139,25 @@ export function createTransport(config: SpanlensConfig): Transport {
   ): Promise<unknown> {
     let lastErr: unknown
 
+    // Serialize once, before the retry loop. A circular reference (or any
+    // non-serializable value) in user-supplied metadata makes JSON.stringify
+    // throw a TypeError. That failure is deterministic — the payload can never
+    // serialize — so retrying it is pointless: it would burn all MAX_RETRIES
+    // attempts and then silently drop the event. Classify it as non-retryable
+    // and fail fast with a clear onError, mirroring the 4xx no-retry path.
+    let serializedBody: string
+    try {
+      serializedBody = JSON.stringify(body)
+    } catch (err) {
+      safeOnError(
+        onError,
+        err,
+        `${method} ${path}: failed to serialize payload (circular reference in metadata?)`,
+      )
+      if (!silent) throw err
+      return null
+    }
+
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
       const controller = new AbortController()
       const timer = setTimeout(() => controller.abort(), timeoutMs)
@@ -150,7 +169,7 @@ export function createTransport(config: SpanlensConfig): Transport {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${config.apiKey}`,
           },
-          body: JSON.stringify(body),
+          body: serializedBody,
           signal: controller.signal,
         })
         // NOTE: the abort timer stays armed through the body read below. A

--- a/supabase/migrations/20260706120000_rls_hardening_advisory_lock_and_price_history.sql
+++ b/supabase/migrations/20260706120000_rls_hardening_advisory_lock_and_price_history.sql
@@ -1,0 +1,42 @@
+-- Post-launch RLS hardening (2026-07-06).
+-- Two gaps surfaced by the pre-launch security review, both introduced AFTER
+-- the 2026-05-21 revoke-rpc-public sweep (20260521000600) and therefore missed
+-- by it. Both fixes are idempotent.
+
+-- ── 1. Advisory-lock RPCs left EXECUTE-able by PUBLIC (unauthenticated DoS) ───
+-- 20260608030000_background_migrations.sql created
+-- try_advisory_lock_for_migration / release_advisory_lock_for_migration as
+-- SECURITY DEFINER and GRANTed EXECUTE to service_role, but never revoked the
+-- default PUBLIC EXECUTE that Postgres grants on every new function. Any anon /
+-- authenticated caller can therefore hit them via PostgREST
+-- (POST /rest/v1/rpc/try_advisory_lock_for_migration) and squat the
+-- background-migration advisory lock (789456123, hashtext(name)), stalling the
+-- /cron/run-background-migrations runner indefinitely. This is the exact gap the
+-- 20260521000600 sweep closed for the older RPCs.
+REVOKE EXECUTE ON FUNCTION public.try_advisory_lock_for_migration(text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.release_advisory_lock_for_migration(text)
+  FROM PUBLIC, anon, authenticated;
+
+-- Pin search_path for consistency with the other SECURITY DEFINER helpers
+-- (20260521000200). The bodies only call pg_catalog builtins, so this is
+-- belt-and-suspenders, not a live injection fix.
+ALTER FUNCTION public.try_advisory_lock_for_migration(text)
+  SET search_path = pg_catalog, public;
+ALTER FUNCTION public.release_advisory_lock_for_migration(text)
+  SET search_path = pg_catalog, public;
+
+-- ── 2. model_price_history admin SELECT policy effectively public ─────────────
+-- 20260519000000 (re-affirmed verbatim in 20260521000400) created
+-- "model_price_history_admin_select" with a subquery that checks whether the
+-- caller is an admin of ANY org — no organization constraint. Since every
+-- self-service signup becomes admin of their own workspace, the policy resolves
+-- to "any authenticated user", exposing the global price-change audit trail
+-- (including changed_by, which holds internal Spanlens operator auth.users
+-- UUIDs). model_price_history is a platform-global table with no org scope and
+-- is only ever read server-side via supabaseAdmin (the /admin/model-prices UI
+-- goes through the server). Drop the policy and rely on service_role: RLS-on +
+-- zero policies = deny-all for anon/authenticated, matching the
+-- background_migrations / internal_alerts pattern. supabaseAdmin (service_role)
+-- bypasses RLS, so server reads are unaffected.
+DROP POLICY IF EXISTS "model_price_history_admin_select" ON model_price_history;

--- a/supabase/migrations/20260706120100_share_view_count_rpc.sql
+++ b/supabase/migrations/20260706120100_share_view_count_rpc.sql
@@ -1,0 +1,21 @@
+-- Atomic view-count increment for public shares (2026-07-06).
+-- Backs apps/server/src/api/publicShare.ts, which switched from a
+-- read-modify-write `.update({ view_count: share.view_count + 1 })` (a
+-- lost-update race under concurrent viewers) to this atomic RPC. supabase-js
+-- `.update()` cannot express `view_count = view_count + 1`, so the increment
+-- must live in SQL. Called only via supabaseAdmin (service_role), fire-and-forget.
+CREATE OR REPLACE FUNCTION public.increment_share_view_count(p_token text)
+RETURNS void
+LANGUAGE sql
+SET search_path = pg_catalog, public
+AS $$
+  UPDATE public.shared_links SET view_count = view_count + 1 WHERE token = p_token;
+$$;
+
+-- Lock the RPC down to the server. shared_links is deny-by-default RLS; this
+-- function is only ever invoked by supabaseAdmin (service_role, which bypasses
+-- RLS). Revoke the default PUBLIC EXECUTE so an anon/authenticated caller can't
+-- inflate view counts through PostgREST (the RLS-M1 lesson from the same review).
+REVOKE EXECUTE ON FUNCTION public.increment_share_view_count(text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.increment_share_view_count(text) TO service_role;


### PR DESCRIPTION
Pre-launch review across four lenses (security, data integrity, edge cases, auth/state flow), consolidated and deduped. Two commits: Critical/High/Medium, then Low.

## Critical
- **proxy gzip truncation** — `STRIP_RESPONSE_HEADERS` drops stale `content-length`; gzip responses were cut to the compressed byte count (broken JSON for every customer).
- **`sl_live_*` key leak** — `STRIP_HEADERS` drops `x-api-key`/`x-goog-api-key`; the Spanlens key was forwarded to OpenAI/Google on those transports.
- **cross-tenant IDOR** — `/human-evals/correlation` verifies `prompt_version` org ownership before scoping.
- **ClickHouse outage → total proxy outage** — quota count lookup fails open instead of 500ing every `/proxy/*`.
- **random logouts** — web middleware preserves rotated Supabase session cookies.

## High
- Gemini streaming metering (SSE-aware usage + `thoughtsTokenCount`; was 0 tokens/$0).
- Client disconnect mid-stream cancels upstream so the row still logs (was hanging to the 300s ceiling).
- Billing `requireRole` + active-subscription guard (viewer cancel; double-checkout).
- Robust bootstrap membership check (workspace-limit bypass).
- `log-body=none` drops user/session ids in the events table too.
- Web: 401→login handling, cache clear on auth change, public-route guard fix, invite-page failure recovery, project-create duplicate guard.
- SDK: user `onError` callback can no longer crash the host process.

## Medium
- authz: `requireRole` on scoreConfigs/experiments/datasets/security writes; dual-auth-aware gate on evals (keeps `sl_live_*` CI working); apiKeys disable invalidates the auth cache.
- robustness: `23505`→409 on prompt versions, invite dedup, UUID/date param validation → 400.
- data: boundary-aware price prefix, UUID-validate trace/span headers, Paddle out-of-order guard, atomic `share.view_count`.
- web: Paddle-init failure UI, subscription-error branch, list-page error states.
- SDK: array/Map/Set stream misdetection, catch-path `end()` masking, body-read timeout, integration trace leaks on error.

## Low
- exports numeric-string coercion; Anthropic cumulative output_tokens; security-summary retention; 404/400 on malformed `:id`/date params; prompts projectId org check; waitlist rate limit; playground `requireRole`; public-key revoke confirm+error; settings-toggle error UI; SDK non-retryable serialization failure.

## Migrations — apply BEFORE code deploy (gotcha #25)
- `20260706120000` — revoke PUBLIC execute on advisory-lock RPCs; drop over-broad `model_price_history` admin SELECT policy.
- `20260706120100` — add atomic `increment_share_view_count` RPC.

Run `supabase gen types` after applying.

## Verification
- server: typecheck / lint / test (1382 passing)
- web: typecheck / lint / build
- sdk: build / typecheck

## Deferred (not in this PR)
- Events double-count under `read_from_events` (flag off at launch; fix before enabling).
- Three internal Gemini `thoughtsTokenCount` sites (recompute/experiment/judge) — refactor to reuse `parseGeminiResponse`.
- RLS restrictive-`FOR ALL` dead SELECT policies (fail-closed, cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)