### PR TITLE
fix(server): dedup events read path + Gemini reasoning tokens

### DIFF
--- a/apps/server/src/api/requests.ts
+++ b/apps/server/src/api/requests.ts
@@ -519,7 +519,12 @@ requestsRouter.post('/:id/replay/run', requireRole('admin', 'editor'), async (c)
   } else if (provider === 'gemini') {
     const u = resBody.usageMetadata as Record<string, number> | undefined
     promptTokens    = u?.promptTokenCount     ?? 0
-    completionTokens = u?.candidatesTokenCount ?? 0
+    // Gemini 2.5+/3 thinking models report reasoning tokens in
+    // thoughtsTokenCount, which Google bills at the OUTPUT rate and which
+    // candidatesTokenCount excludes — fold them into completion tokens so cost
+    // isn't under-reported (see parsers/gemini.ts). totalTokenCount already
+    // includes thoughts, so prompt + completion stays consistent with total.
+    completionTokens = (u?.candidatesTokenCount ?? 0) + (u?.thoughtsTokenCount ?? 0)
     totalTokens     = u?.totalTokenCount      ?? promptTokens + completionTokens
   }
 

--- a/apps/server/src/lib/eval-runners/judge-calls.ts
+++ b/apps/server/src/lib/eval-runners/judge-calls.ts
@@ -188,14 +188,19 @@ async function judgeComplete(
     if (!res || !res.ok) return null
     const json = await res.json() as {
       candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
-      usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number }
+      usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number; thoughtsTokenCount?: number }
       modelVersion?: string
     }
     const text = json.candidates?.[0]?.content?.parts?.[0]?.text ?? ''
-    const tokens = (json.usageMetadata?.promptTokenCount ?? 0) + (json.usageMetadata?.candidatesTokenCount ?? 0)
+    // Fold Gemini reasoning tokens (thoughtsTokenCount) into completion tokens —
+    // Google bills them at the output rate and candidatesTokenCount excludes
+    // them (see parsers/gemini.ts).
+    const completionTokens =
+      (json.usageMetadata?.candidatesTokenCount ?? 0) + (json.usageMetadata?.thoughtsTokenCount ?? 0)
+    const tokens = (json.usageMetadata?.promptTokenCount ?? 0) + completionTokens
     const cost = calculateCost('gemini', json.modelVersion ?? model, {
       promptTokens: json.usageMetadata?.promptTokenCount ?? 0,
-      completionTokens: json.usageMetadata?.candidatesTokenCount ?? 0,
+      completionTokens,
     })?.totalCost ?? 0
     return { text, cost, tokens }
   }

--- a/apps/server/src/lib/events-query.test.ts
+++ b/apps/server/src/lib/events-query.test.ts
@@ -66,18 +66,33 @@ describe('selectGenerationsAsRequests — read-side shim for /api/v1/requests', 
     expect(call.query).toMatch(/parent_event_id\s+AS span_id/)
   })
 
-  it("substitutes neutral defaults for columns that don't exist on events yet", async () => {
+  it('projects the real security / truncation columns (migration 006)', async () => {
     queryMock.mockResolvedValueOnce(jsonRes([]))
     const scope = await eventsScope('org-1')
     await selectGenerationsAsRequests({ scope })
 
     const call = queryMock.mock.calls[0]?.[0] as { query: string }
-    // flags / response_flags / has_security_flags / truncated are
-    // surfaced as empty / 0 so the dashboard's badges stay quiet.
-    expect(call.query).toMatch(/'' +AS flags/)
-    expect(call.query).toMatch(/'{}' +AS response_flags/)
-    expect(call.query).toMatch(/0 +AS has_security_flags/)
-    expect(call.query).toMatch(/0 +AS truncated/)
+    // flags / response_flags / has_security_flags / truncated are real
+    // columns since migration 006, so the dashboard's badges work under the
+    // events read path (matching the 007 events_as_requests view). The old
+    // placeholder projections must be gone.
+    expect(call.query).toMatch(/\bflags\b/)
+    expect(call.query).toMatch(/\bresponse_flags\b/)
+    expect(call.query).toMatch(/\bhas_security_flags\b/)
+    expect(call.query).toMatch(/\btruncated\b/)
+    expect(call.query).not.toMatch(/'' +AS flags/)
+    expect(call.query).not.toMatch(/0 +AS has_security_flags/)
+  })
+
+  it('dedups duplicate rows per event_id with LIMIT 1 BY id', async () => {
+    queryMock.mockResolvedValueOnce(jsonRes([]))
+    const scope = await eventsScope('org-1')
+    await selectGenerationsAsRequests({ scope, orderBy: 'created_at DESC', limit: 50 })
+
+    const call = queryMock.mock.calls[0]?.[0] as { query: string }
+    // LIMIT 1 BY id must sit AFTER ORDER BY and BEFORE the pagination LIMIT.
+    expect(call.query).toContain('LIMIT 1 BY id')
+    expect(call.query).toMatch(/ORDER BY created_at DESC\s+LIMIT 1 BY id\s+LIMIT 50/)
   })
 
   it('passes caller filters / orderBy / limit / offset through', async () => {
@@ -115,5 +130,9 @@ describe('countGenerations', () => {
     expect(total).toBe(42)
     const call = queryMock.mock.calls[0]?.[0] as { query: string }
     expect(call.query).toContain("event_type = 'generation'")
+    // Exact distinct count, not count() — duplicate event_id rows (dual-write
+    // + backfill) would otherwise double the total.
+    expect(call.query).toContain('uniqExact(event_id)')
+    expect(call.query).not.toMatch(/\bcount\(\)/)
   })
 })

--- a/apps/server/src/lib/events-query.ts
+++ b/apps/server/src/lib/events-query.ts
@@ -147,6 +147,11 @@ export async function selectGenerationsAsRequests<T>(opts: {
 
   const tail: string[] = []
   if (orderBy) tail.push(`ORDER BY ${orderBy}`)
+  // Dedup: the dual-write + the requests→events backfill can leave two
+  // identical rows per event_id (events is a plain MergeTree — no
+  // ReplacingMergeTree collapse). Keep one row per id so the list isn't
+  // doubled. LIMIT BY must precede the pagination LIMIT/OFFSET.
+  tail.push('LIMIT 1 BY id')
   if (typeof limit === 'number') tail.push(`LIMIT ${Math.max(0, Math.floor(limit))}`)
   if (typeof offset === 'number') tail.push(`OFFSET ${Math.max(0, Math.floor(offset))}`)
 
@@ -176,13 +181,14 @@ export async function selectGenerationsAsRequests<T>(opts: {
       provider_key_id,
       user_id,
       session_id,
-      -- Security flags and truncation live only in \`requests\`; surface
-      -- empty defaults so dashboard badges (no flag → no badge) stay
-      -- consistent until those columns land on \`events\`.
-      ''                                          AS flags,
-      '{}'                                        AS response_flags,
-      0                                           AS has_security_flags,
-      0                                           AS truncated,
+      -- Security flags + truncation marker: real columns since migration 006
+      -- (populated by writeRequestAsEvent). The 007 events_as_requests view
+      -- already projects these; this shim now matches so the dashboard's
+      -- security / truncated badges work under the events read path.
+      flags,
+      response_flags,
+      has_security_flags,
+      truncated,
       toString(created_at)                        AS created_at
     FROM events
     WHERE ${where}
@@ -225,7 +231,11 @@ export async function countGenerations(opts: {
   const whereParts = [scope.whereScope, "event_type = 'generation'"]
   if (filters && filters.length > 0) whereParts.push(filters)
   const where = whereParts.join(' AND ')
-  const query = `SELECT count() AS c FROM events WHERE ${where}`
+  // uniqExact(event_id) — NOT count() — because dual-write + backfill can
+  // leave duplicate rows per event_id (plain MergeTree, no collapse). count()
+  // would double the total; the exact distinct id count matches the deduped
+  // list from selectGenerationsAsRequests (LIMIT 1 BY id).
+  const query = `SELECT uniqExact(event_id) AS c FROM events WHERE ${where}`
   try {
     const res = await unscopedClickhouse().query({
       query,

--- a/apps/server/src/lib/experiment-runner.ts
+++ b/apps/server/src/lib/experiment-runner.ts
@@ -211,12 +211,16 @@ async function runPrompt(
     }
     const json = await res.json() as {
       candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
-      usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number }
+      usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number; thoughtsTokenCount?: number }
       modelVersion?: string
     }
     const output = json.candidates?.[0]?.content?.parts?.[0]?.text ?? ''
     const promptTokens = json.usageMetadata?.promptTokenCount ?? 0
-    const completionTokens = json.usageMetadata?.candidatesTokenCount ?? 0
+    // Fold Gemini reasoning tokens (thoughtsTokenCount) into completion tokens —
+    // Google bills them at the output rate and candidatesTokenCount excludes
+    // them (see parsers/gemini.ts).
+    const completionTokens =
+      (json.usageMetadata?.candidatesTokenCount ?? 0) + (json.usageMetadata?.thoughtsTokenCount ?? 0)
     const cost = calculateCost('gemini', json.modelVersion ?? model, { promptTokens, completionTokens })?.totalCost ?? 0
     return { output, cost, latencyMs, tokens: promptTokens + completionTokens }
   } catch (err) {
@@ -408,18 +412,22 @@ async function callJudge(
   if (!geminiRes.ok) return null
   const geminiJson = await geminiRes.json() as {
     candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
-    usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number }
+    usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number; thoughtsTokenCount?: number }
     modelVersion?: string
   }
   const geminiText = geminiJson.candidates?.[0]?.content?.parts?.[0]?.text ?? ''
   const geminiParsed = parseJudgeReply(geminiText, config.scale_min, config.scale_max)
   if (!geminiParsed) return null
+  // Fold Gemini reasoning tokens (thoughtsTokenCount) into completion tokens —
+  // Google bills them at the output rate and candidatesTokenCount excludes
+  // them (see parsers/gemini.ts).
+  const geminiCompletionTokens =
+    (geminiJson.usageMetadata?.candidatesTokenCount ?? 0) + (geminiJson.usageMetadata?.thoughtsTokenCount ?? 0)
   const geminiTokens =
-    (geminiJson.usageMetadata?.promptTokenCount ?? 0) +
-    (geminiJson.usageMetadata?.candidatesTokenCount ?? 0)
+    (geminiJson.usageMetadata?.promptTokenCount ?? 0) + geminiCompletionTokens
   const geminiCost = calculateCost('gemini', geminiJson.modelVersion ?? config.judge_model, {
     promptTokens: geminiJson.usageMetadata?.promptTokenCount ?? 0,
-    completionTokens: geminiJson.usageMetadata?.candidatesTokenCount ?? 0,
+    completionTokens: geminiCompletionTokens,
   })?.totalCost ?? 0
   const geminiRange = config.scale_max - config.scale_min || 1
   return {

--- a/clickhouse/migrations/009_dedup_events_as_requests_view.sql
+++ b/clickhouse/migrations/009_dedup_events_as_requests_view.sql
@@ -1,0 +1,76 @@
+-- 009_dedup_events_as_requests_view.sql
+-- Phase 5.1 — dedup the `events_as_requests` view.
+--
+-- WHY: `events` is a plain MergeTree (see 004) with no ReplacingMergeTree
+-- collapse. The live dual-write (writeRequestAsEvent: event_id = requests.id)
+-- and the requests→events backfill (mapRequestToEventRow, same id) both write a
+-- row for the same request, so any request in the dual-write/backfill overlap
+-- window exists TWICE in `events` with the SAME event_id. The stats pipeline
+-- reads this view, so sum(cost_usd) / count() were double-counting for orgs on
+-- the events read path. The requests-list path (selectGenerationsAsRequests /
+-- countGenerations) is deduped in TS; this migration is its view counterpart so
+-- both read paths agree.
+--
+-- HOW: `LIMIT 1 BY event_id` keeps one row per event_id. Duplicate rows are
+-- byte-identical, so which one survives does not matter and no ORDER BY is
+-- needed. event_id is globally unique, so dedup-then-filter and
+-- filter-then-dedup produce the same rows for any org/time predicate a caller
+-- adds on top of the view.
+--
+-- IDEMPOTENT: DROP IF EXISTS + CREATE. Metadata-only; never touches rows.
+-- ORDER: runs after 007 (lexical order), inheriting 006's columns.
+--
+-- ⚠ VERIFY BEFORE FLIPPING read_from_events: this cannot be exercised without a
+-- real ClickHouse (unit tests only assert generated SQL). Before enabling the
+-- flag for any org, smoke-test on a real cluster that (a) stats totals match
+-- the `requests` table for the same window and (b) the whole-table LIMIT BY
+-- dedup is acceptable perf. The scan-then-filter shape is a known cost; the
+-- long-term fix is a ReplacingMergeTree(event_id) or an outbox (CLAUDE.md
+-- gotcha #23), which supersedes this stopgap.
+
+DROP VIEW IF EXISTS events_as_requests;
+
+CREATE VIEW events_as_requests AS
+SELECT
+    event_id                                                       AS id,
+    organization_id,
+    project_id,
+    api_key_id,
+
+    provider,
+    model,
+
+    toUInt32OrZero(toString(usage_details['prompt_tokens']))       AS prompt_tokens,
+    toUInt32OrZero(toString(usage_details['completion_tokens']))   AS completion_tokens,
+    toUInt32OrZero(toString(usage_details['total_tokens']))        AS total_tokens,
+    toUInt32OrZero(toString(usage_details['cache_read_tokens']))   AS cache_read_tokens,
+    toUInt32OrZero(toString(usage_details['cache_write_tokens']))  AS cache_write_tokens,
+
+    total_cost_usd                                                 AS cost_usd,
+    duration_ms                                                    AS latency_ms,
+    CAST(NULL, 'Nullable(UInt32)')                                 AS proxy_overhead_ms,
+    status_code,
+
+    input                                                          AS request_body,
+    output                                                          AS response_body,
+    error_message,
+
+    trace_id,
+    parent_event_id                                                AS span_id,
+    prompt_version_id,
+    provider_key_id,
+
+    user_id,
+    session_id,
+
+    flags,
+    response_flags,
+    has_security_flags,
+    truncated,
+
+    ''                                                             AS service_tier,
+
+    created_at
+FROM events
+WHERE event_type = 'generation'
+LIMIT 1 BY event_id;


### PR DESCRIPTION
Prep for enabling `read_from_events` (recommended-order step ③). Everything here is on the off-by-default events read path except the Gemini metering, which affects live cost.

## Events read-path dedup (D-H3)
`events` is a plain MergeTree (no ReplacingMergeTree collapse). The live dual-write (`event_id = requests.id`) and the requests→events backfill both write a row for the same request, so any request in the overlap window exists twice with the same `event_id`. Reads had no dedup, so requests/tokens/cost doubled.
- `events-query.ts`: `LIMIT 1 BY id` on the list, `uniqExact(event_id)` on the count.
- `clickhouse/migrations/009`: dedup the `events_as_requests` view (stats pipeline) to match.

## Real security/truncated columns (M5)
`selectGenerationsAsRequests` hardcoded `'' AS flags` / `0 AS truncated`, hiding prompt-injection/PII/truncated badges under the events read path. Now projects the real columns (present since migration 006, already in the 007 view).

## Gemini reasoning tokens
Four internal sites extracted Gemini usage without `parseGeminiResponse` and dropped `thoughtsTokenCount` (Google bills reasoning tokens at the output rate; `candidatesTokenCount` excludes them): requests recompute, experiment-runner (x2), judge-calls. Now folded into completion tokens. This is the only live-cost fix in this PR.

## ⚠ Not flip-ready
The view dedup cannot be exercised without a real ClickHouse (unit tests assert generated SQL only). Before enabling `read_from_events` for any org, smoke-test on a real cluster: (a) stats totals match the `requests` table for the same window, (b) the whole-table `LIMIT BY` dedup perf is acceptable. Long-term fix is a `ReplacingMergeTree(event_id)` / outbox, which supersedes the view stopgap.

## Deferred
- M3: rows that fall back during a CH outage never get their `events` shadow row (parity drift, only matters under the flag during an outage).

## Verification
- server: typecheck / lint / test (1383 passing, +1 dedup test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)