### PR TITLE
fix(web): SEO/GEO audit fixes - robots dedup, schema entity, internal links

### DIFF
--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -31,15 +31,13 @@ const aboutJsonLd = {
   url: 'https://www.spanlens.io/about',
   name: 'About Spanlens',
   description: ABOUT_DESCRIPTION,
+  // Reference the canonical Organization node (declared once in the root
+  // layout with @id) instead of re-declaring a second Organization here —
+  // duplicate nodes with divergent sameAs/foundingDate broke entity
+  // reconciliation (2026-07-06 schema audit). foundingDate/founder/sameAs
+  // now live on the canonical node in app/layout.tsx.
   mainEntity: {
-    '@type': 'Organization',
-    name: 'Spanlens',
-    url: 'https://www.spanlens.io',
-    logo: 'https://www.spanlens.io/icon.png',
-    email: 'hi@spanlens.io',
-    foundingDate: '2026-04',
-    sameAs: ['https://github.com/spanlens/Spanlens'],
-    description: ABOUT_DESCRIPTION,
+    '@id': 'https://www.spanlens.io/#organization',
   },
 }
 
@@ -106,7 +104,7 @@ export default function AboutPage() {
             <h2 className="text-[22px] font-semibold text-text mb-3">Who is building this</h2>
             <p className="text-[15px] leading-relaxed">
               Spanlens is built by a small team led by{' '}
-              <strong className="text-text">Haeseong Kim</strong> (founder, engineering).
+              <strong className="text-text">Haeseong Jeon</strong> (founder, engineering).
               Background in production LLM application development and full-stack engineering.
               The team has shipped agent systems, RAG pipelines, and proxy infrastructure at
               scale before starting Spanlens in early 2026.

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -64,12 +64,18 @@ export const metadata: Metadata = {
     description: SITE_DESCRIPTION,
     images: ['/icon.png'],
   },
+  // NOTE: no top-level `index`/`follow` here. Explicit `index, follow` is the
+  // crawler default (zero SEO value), and on dynamic routes with an async
+  // `generateMetadata` (e.g. /share/[token]) Next.js streams the page-level
+  // metadata separately from the shell head — so the root's
+  // `<meta name="robots" content="index, follow">` and the page's `noindex`
+  // both ended up in the same document (2026-07-06 audit: duplicate robots
+  // tags on every /share URL, defeating the noindex). Omitting the directive
+  // at the root leaves page-level `robots` overrides as the only
+  // `name="robots"` tag. googleBot preview prefs carry no index directive,
+  // so they can't conflict with a page-level noindex.
   robots: {
-    index: true,
-    follow: true,
     googleBot: {
-      index: true,
-      follow: true,
       'max-image-preview': 'large',
       'max-snippet': -1,
       'max-video-preview': -1,
@@ -82,15 +88,29 @@ export const metadata: Metadata = {
   },
 }
 
+// Canonical Organization entity for the whole site. Every other JSON-LD block
+// that needs the org (e.g. /about's AboutPage.mainEntity) must reference it by
+// `@id` instead of declaring a second Organization node — two divergent nodes
+// (different sameAs / foundingDate) break entity reconciliation in Google and
+// LLM crawlers (2026-07-06 schema audit).
 const organizationJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'Organization',
+  '@id': `${SITE_URL}/#organization`,
   name: 'Spanlens',
   url: SITE_URL,
   logo: `${SITE_URL}/icon.png`,
   description: SITE_DESCRIPTION,
   email: 'hi@spanlens.io',
-  sameAs: ['https://github.com/spanlens'],
+  foundingDate: '2026-04',
+  founder: {
+    '@type': 'Person',
+    name: 'Haeseong Jeon',
+  },
+  sameAs: [
+    'https://github.com/spanlens/Spanlens',
+    'https://www.npmjs.com/package/@spanlens/sdk',
+  ],
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,5 +1,15 @@
+import type { Metadata } from 'next'
 import { Button } from '@/components/ui/button'
 import { DashboardCTALink } from '@/components/layout/dashboard-cta-link'
+
+// Without this, 404 pages inherited the homepage title and were indexable —
+// any externally-linked broken URL could enter the index as a duplicate of
+// the homepage (2026-07-06 SEO audit). `follow: true` keeps link equity
+// flowing through any links rendered on the 404 page.
+export const metadata: Metadata = {
+  title: 'Page not found · Spanlens',
+  robots: { index: false, follow: true },
+}
 
 export default function NotFound() {
   return (

--- a/apps/web/components/layout/footer.tsx
+++ b/apps/web/components/layout/footer.tsx
@@ -59,6 +59,19 @@ export function Footer() {
               <Link href="/compare/arize-phoenix" className="hover:text-text transition-colors">Arize Phoenix</Link>
             </div>
           </div>
+          {/* Guides — the keyword landing pages had zero internal inbound
+              links (sitemap-only orphans, 2026-07-06 SEO audit). Footer links
+              from every marketing/docs page restore internal link equity. */}
+          <div>
+            <div className="text-text-faint mb-2 tracking-[0.05em] uppercase text-[10px]">Guides</div>
+            <div className="flex flex-col gap-1.5">
+              <Link href="/llm-observability" className="hover:text-text transition-colors">LLM Observability</Link>
+              <Link href="/agent-tracing" className="hover:text-text transition-colors">Agent Tracing</Link>
+              <Link href="/llm-cost-tracking" className="hover:text-text transition-colors">LLM Cost Tracking</Link>
+              <Link href="/alternatives" className="hover:text-text transition-colors">Alternatives</Link>
+              <Link href="/tools/llm-cost-calculator" className="hover:text-text transition-colors">Cost Calculator</Link>
+            </div>
+          </div>
           <div>
             <div className="text-text-faint mb-2 tracking-[0.05em] uppercase text-[10px]">Open Source</div>
             <div className="flex flex-col gap-1.5">
@@ -70,6 +83,7 @@ export function Footer() {
           <div>
             <div className="text-text-faint mb-2 tracking-[0.05em] uppercase text-[10px]">Company</div>
             <div className="flex flex-col gap-1.5">
+              <Link href="/about" className="hover:text-text transition-colors">About</Link>
               <Link href="/privacy" className="hover:text-text transition-colors">Privacy</Link>
               <Link href="/terms" className="hover:text-text transition-colors">Terms</Link>
               <Link href="/dpa" className="hover:text-text transition-colors">DPA</Link>


### PR DESCRIPTION
## Summary

Five fixes from the 2026-07-06 SEO/GEO audit (Technical 84/100, GEO 88/100 — these were the Critical/High findings).

### 1. Duplicate `<meta name="robots">` tags on `/share/[token]` (High)
Live pages rendered both `noindex` (page) and `index, follow` (root layout) in the same `<head>`, defeating the noindex. Root cause: Next.js 16 streams page-level metadata separately from the shell head on dynamic routes with async `generateMetadata`, so both tags end up in the document. Fix: drop the explicit `index`/`follow` from the root layout `robots` (it is the crawler default, zero SEO value) and keep only the googleBot preview prefs, which carry no index directive and cannot conflict.

### 2. Conflicting Organization JSON-LD entities (Critical)
Root layout declared `sameAs: github.com/spanlens` while `/about` declared a second Organization with `sameAs: github.com/spanlens/Spanlens` and its own `foundingDate` — two divergent nodes break entity reconciliation in Google and LLM crawlers. Fix: one canonical node with `@id: /#organization` in the root layout (now with `foundingDate`, `founder`, and `sameAs` pointing at the GitHub repo + npm package); `/about` references it by `@id`.

### 3. Founder name inconsistency on `/about` (High, E-E-A-T)
Body said "Haeseong Kim" while the legal disclosures in the footer and privacy policy both say "Haeseong Jeon". Fixed to Jeon.

### 4. Orphaned keyword landing pages (High)
`/llm-observability`, `/agent-tracing`, `/llm-cost-tracking`, `/alternatives`, and `/about` had zero internal inbound links (sitemap-only). Added a footer "Guides" group + About under Company, so every marketing/docs page now links to them.

### 5. Indexable 404 page (High)
The global 404 inherited the homepage title and `index, follow`. Added `noindex, follow` + a unique "Page not found · Spanlens" title.

## Test plan

- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint`
- [x] `pnpm --filter web build` (151 pages)
- [x] Local render checks: no `name="robots"` tag on marketing pages (googlebot prefs only), 404 and share-404 emit noindex only, Organization `@id` reference chain resolves, all 6 new footer links render
- [ ] After deploy: `curl -s https://www.spanlens.io/share/anytoken | grep -i 'name="robots"'` shows noindex only
- [ ] After deploy: validate homepage + /about in Google Rich Results test (single Organization entity)
