### PR TITLE
docs: update Next.js version references from 14 to 16

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,9 @@ LLM 개발자를 위한 AI 관측 플랫폼 (오픈소스 SaaS · MIT · GitHub 
 baseURL을 1줄 교체해 요청 로깅, 비용 추적, 에이전트 트레이싱 제공.
 타깃: 기존 LLM observability 도구들(인수·복잡함)의 가벼운 대안. Docker 이미지로 셀프호스팅 지원.
 라이선스 전략: 전체 레포 MIT (OSS dev-tool 표준 모델). 해자는 SaaS 운영·brand·support이며 코드 공개 자체는 신뢰 시그널. 장래 복제 위협 커지면 Sentry 방식(BSL 전환) 옵션 열려 있음.
-스택: Next.js 14 + Hono + Supabase PostgreSQL + TypeScript + pnpm monorepo
+스택: Next.js 16 + Hono + Supabase PostgreSQL + TypeScript + pnpm monorepo
 ## 구조
-apps/web/ — Next.js 14 대시보드 (App Router)
+apps/web/ — Next.js 16 대시보드 (App Router)
 apps/server/ — Hono 서버 (LLM 프록시 + REST API 통합)
 packages/sdk/ — JS/TS SDK (npm 배포용)
 supabase/ — DB 마이그레이션(migrations/) + 시드(seeds/)

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Spanlens is multi-user out of the box. Invite teammates, hand out roles, and spi
 ```
 Spanlens/
 ├── apps/
-│   ├── web/             — Next.js 14 dashboard (www.spanlens.io)
+│   ├── web/             — Next.js 16 dashboard (www.spanlens.io)
 │   └── server/          — Hono LLM proxy + REST API (server.spanlens.io)
 ├── packages/
 │   ├── sdk/             — @spanlens/sdk:  TypeScript / JavaScript SDK

--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -131,7 +131,7 @@ export default function AboutPage() {
               >
                 MIT license
               </a>
-              . The stack is Next.js 14 + Hono + Supabase Postgres + ClickHouse, with
+              . The stack is Next.js 16 + Hono + Supabase Postgres + ClickHouse, with
               TypeScript and Python SDKs. The full stack runs from one Docker compose file
               on your own infrastructure if you prefer not to use the hosted plan.
             </p>

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -4,7 +4,7 @@
 
 This is the expanded version. The short index lives at https://www.spanlens.io/llms.txt.
 
-Spanlens is positioned as a lightweight, developer-first alternative to Helicone (acquired) and Langfuse (heavy). The stack is Next.js 14 + Hono + Supabase Postgres + ClickHouse, with first-class SDKs for TypeScript and Python and OpenTelemetry (OTLP/HTTP) ingest for everything else.
+Spanlens is positioned as a lightweight, developer-first alternative to Helicone (acquired) and Langfuse (heavy). The stack is Next.js 16 + Hono + Supabase Postgres + ClickHouse, with first-class SDKs for TypeScript and Python and OpenTelemetry (OTLP/HTTP) ingest for everything else.
 
 ## What sets Spanlens apart in 2026
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -4,7 +4,7 @@
 
 > Drop-in LLM observability for OpenAI, Anthropic, and Gemini. Spanlens is an open-source (MIT) request logging, cost tracking, and agent tracing platform. Swap one line, your `baseURL` or SDK import, and get full visibility into every LLM call your app makes. Available as a hosted SaaS at https://www.spanlens.io and as a self-hostable Docker image.
 
-Spanlens is positioned as a lightweight, developer-first alternative to Helicone (acquired) and Langfuse (heavy). The stack is Next.js 14 + Hono + Supabase Postgres + ClickHouse, with first-class SDKs for TypeScript and Python and OpenTelemetry (OTLP/HTTP) ingest for everything else.
+Spanlens is positioned as a lightweight, developer-first alternative to Helicone (acquired) and Langfuse (heavy). The stack is Next.js 16 + Hono + Supabase Postgres + ClickHouse, with first-class SDKs for TypeScript and Python and OpenTelemetry (OTLP/HTTP) ingest for everything else.
 
 ## What sets Spanlens apart in 2026
 

--- a/docs/CODEMAPS/architecture.md
+++ b/docs/CODEMAPS/architecture.md
@@ -17,7 +17,7 @@ Provider (OpenAI / Anthropic / Gemini / Mistral / OpenRouter / Azure)
                                                                   ↑ fallback queue (Supabase) if CH down
                                                                     drained by /cron/replay-fallback (every 5m)
 
-apps/web (Next.js 14, App Router)
+apps/web (Next.js 16, App Router)
    │ fetch('/api/v1/*')  (Supabase JWT or sl_live_*)
    ▼
 apps/server REST API → Supabase (orgs/keys/prompts/billing) + ClickHouse (read via lib/requests-query)
@@ -27,7 +27,7 @@ apps/server REST API → Supabase (orgs/keys/prompts/billing) + ClickHouse (read
 
 | Service | Runtime | Storage | Auth |
 |---|---|---|---|
-| `apps/web` | Next.js 14 / Vercel | none (proxies to server) | Supabase JWT cookies |
+| `apps/web` | Next.js 16 / Vercel | none (proxies to server) | Supabase JWT cookies |
 | `apps/server` | Hono / Vercel Node | Supabase + ClickHouse + Upstash KV | JWT (read) / sl_live_* (write) / dual-auth (`/api/v1/*` read) |
 | `packages/sdk` | npm `@spanlens/sdk` | — | issues sl_live_* requests |
 | `packages/sdk-python` | PyPI `spanlens` | — | issues sl_live_* requests |

--- a/docs/competitive-analysis.md
+++ b/docs/competitive-analysis.md
@@ -35,7 +35,7 @@ Spanlens는 **proxy-first LLM observability 플랫폼**이다. 다른 도구들�
 
 | Layer | Technology |
 |------|-----------|
-| Web app | Next.js 14 (App Router) on Vercel |
+| Web app | Next.js 16 (App Router) on Vercel |
 | API server | Hono on Vercel (Node runtime, maxDuration 300s) |
 | Auth / OLTP | Supabase PostgreSQL (RLS-enabled) |
 | Analytics OLAP | ClickHouse Cloud Development tier |

--- a/marketing/p3-drafts/github-readme.md
+++ b/marketing/p3-drafts/github-readme.md
@@ -85,7 +85,7 @@ cp .env.example .env
 docker compose up
 ```
 
-Stack: Next.js 14 + Hono + Supabase Postgres + ClickHouse. Full guide: [/docs/self-host](https://www.spanlens.io/docs/self-host).
+Stack: Next.js 16 + Hono + Supabase Postgres + ClickHouse. Full guide: [/docs/self-host](https://www.spanlens.io/docs/self-host).
 
 ## License
 

--- a/marketing/p3-drafts/hn-show-hn.md
+++ b/marketing/p3-drafts/hn-show-hn.md
@@ -22,7 +22,7 @@ What it does:
 
 Free plan is 50K requests/mo with all features. Pro at $29/mo, Team at $149/mo. Self-hosting is free with one `docker compose up`.
 
-Stack is Next.js 14 + Hono + Supabase Postgres + ClickHouse. TypeScript and Python SDKs. OTLP/HTTP for everything else.
+Stack is Next.js 16 + Hono + Supabase Postgres + ClickHouse. TypeScript and Python SDKs. OTLP/HTTP for everything else.
 
 Limitations I want to be upfront about:
 - Younger than Langfuse — fewer pre-built evaluators in the marketplace.

--- a/marketing/p3-drafts/reddit-machinelearning.md
+++ b/marketing/p3-drafts/reddit-machinelearning.md
@@ -30,7 +30,7 @@ What we track: Pearson correlation between judge score and human annotation scor
 
 Saw this drift firsthand in a few customer instances where the judge model was unchanged but the input distribution shifted. The judge happily kept assigning high scores while human raters thought outputs got worse. Surfacing the correlation makes that visible.
 
-**Stack**: Next.js 14 + Hono + Postgres + ClickHouse. Fully MIT (no ee/ folder). Drop-in for OpenAI/Anthropic/Gemini SDKs, OTLP/HTTP for OTel, or raw proxy for any language.
+**Stack**: Next.js 16 + Hono + Postgres + ClickHouse. Fully MIT (no ee/ folder). Drop-in for OpenAI/Anthropic/Gemini SDKs, OTLP/HTTP for OTel, or raw proxy for any language.
 
 Happy to discuss the stats setup, the trace-tree data model (parent_span_id without FK because out-of-order ingestion is normal), or how we compute critical path on non-deterministic agent traces.
 


### PR DESCRIPTION
## Summary

apps/web/package.json pins next 16.2.7, but living docs still said Next.js 14. The mismatch misled the 2026-07-06 SEO audit while debugging the streaming-metadata robots bug (Next 16 behavior differs from 14).

Updated (12 references in 10 files): CLAUDE.md, README, /about page, llms.txt + llms-full.txt, docs/CODEMAPS/architecture.md, docs/competitive-analysis.md, and the three pending marketing drafts (HN / Reddit / GitHub README) so stale info doesn't get published.

Left as-is on purpose: ROADMAP.md bootstrap checklist and docs/plans/* — historical records that were accurate when written.

## Test plan
- [x] pnpm --filter web typecheck && lint (about page is the only code file touched, text-only change)