### PR TITLE
feat(web): llms.txt pricing drift guard + citation-length compare tldrs

### DIFF
--- a/apps/web/app/compare/arize-phoenix/page.tsx
+++ b/apps/web/app/compare/arize-phoenix/page.tsx
@@ -178,7 +178,7 @@ export default function VsArizePhoenixPage() {
     <CompareTemplate
       competitor="Arize Phoenix"
       tagline="Built for the production app developer, not the ML engineer in a notebook. JS/TS gets equal billing with Python."
-      tldr="Phoenix has serious ML-observability DNA from Arize and is excellent if you're an ML engineer who lives in Python notebooks. Spanlens is built for the app developer who shipped an LLM feature last week, with proxy-first install, JS/TS equal-class with Python, statistical A/B testing, and a fully MIT-licensed codebase (Phoenix is source-available under ELv2)."
+      tldr="Phoenix has serious ML-observability DNA from Arize and is excellent if you are an ML engineer who lives in Python notebooks. Embedding drift, UMAP projections of your prompt space, and notebook-launched trace exploration are first-class, and it is the reference implementation of the OpenInference spec. The friction appears when a product team is shipping features. JS/TS support is lighter than the Python experience, instrumentation goes through OpenInference SDK wrappers that touch every call site, and the license is Elastic License 2.0, source-available rather than OSI-approved. Spanlens is built for the app developer who shipped an LLM feature last week. Install is a one-line baseURL swap, TypeScript is equal-class with Python across the SDKs so Next.js and edge runtimes are first-class targets, prompt A/B experiments report Welch t-test significance built in, and the entire codebase is MIT, so you can fork, embed, or run it as a service without a license review."
       whySpanlens={whySpanlens}
       whyCompetitor={whyCompetitor}
       groups={groups}

--- a/apps/web/app/compare/braintrust/page.tsx
+++ b/apps/web/app/compare/braintrust/page.tsx
@@ -145,7 +145,7 @@ export default function VsBraintrustPage() {
     <CompareTemplate
       competitor="Braintrust"
       tagline="A full observability platform with eval inside, not an eval product asking you to bring observability."
-      tldr="Braintrust has the most polished eval UX in the market and is the right tool if evals are your gate and you're fine with closed-source SaaS. Spanlens bundles eval into a complete observability stack with logging, tracing, anomaly detection, and cost optimization, and ships under MIT so you can self-host it."
+      tldr="Braintrust has the most polished eval UX in the market. Side-by-side output diffing, scoring rubrics, and regression detection are the product's core, and if evals are your release gate and closed-source SaaS fits your data classification, it is the specialist tool. The limits sit at the edges of that specialty. Capture runs through their SDK, so every call site gets touched, the backend is managed-only with no self-host option, and cost dashboards and security scanning are lighter surfaces. Spanlens bundles eval into a complete observability stack. A one-line baseURL swap captures every request, the same traffic feeds datasets and experiments, prompt A/B reports Welch t-test significance, judge-to-human correlation tracks when your LLM judge drifts from human raters, and anomaly detection plus the model-swap savings recommender run on the same data. The whole codebase ships under MIT, so the stack you evaluate with is also the stack you can self-host."
       whySpanlens={whySpanlens}
       whyCompetitor={whyCompetitor}
       groups={groups}

--- a/apps/web/app/compare/helicone/page.tsx
+++ b/apps/web/app/compare/helicone/page.tsx
@@ -167,7 +167,7 @@ export default function VsHeliconePage() {
     <CompareTemplate
       competitor="Helicone"
       tagline="Same proxy-first architecture, with more observability depth: Critical Path tracing, statistical A/B testing, and a fallback-replay durability layer."
-      tldr="Helicone proved the proxy-based LLM observability model and ships a polished, focused product, though it entered maintenance mode after its 2026 Mintlify acquisition. Spanlens uses the same architecture, is actively developed, and adds Critical Path tracing on agent runs, Welch t-test on A/B prompt experiments, judge to human correlation tracking, and a ClickHouse fallback-replay queue so logs are not silently dropped on infra hiccups."
+      tldr="Helicone proved the proxy-based model for LLM observability and ships a polished, focused product, but it entered maintenance mode after the 2026 Mintlify acquisition. Security patches and new-model support continue, while active feature development has ended and the founders have moved on. Choosing it today means betting on a tool that will not grow. Spanlens uses the same one-line baseURL architecture, so migrating is mostly changing an endpoint, and it is actively developed, fully MIT, and self-hostable with one Docker command. Beyond parity on request logging and cost dashboards, it adds Critical Path highlighting that shows which span actually gates an agent run's latency, Welch t-test significance on prompt A/B experiments, judge-to-human correlation for catching eval drift, and a ClickHouse fallback-replay queue that parks logs in Postgres during an analytics outage and replays them within minutes instead of dropping them silently."
       whySpanlens={whySpanlens}
       whyCompetitor={whyCompetitor}
       groups={groups}

--- a/apps/web/app/compare/langfuse/page.tsx
+++ b/apps/web/app/compare/langfuse/page.tsx
@@ -176,7 +176,7 @@ export default function VsLangfusePage() {
     <CompareTemplate
       competitor="Langfuse"
       tagline="Proxy-first instead of SDK-first. Fully MIT instead of OSS plus EE. Statistical A/B testing and savings recommendations built in."
-      tldr="Langfuse is the most mature OSS option and the safest pick if community size is the deciding factor. Spanlens wins on integration speed (1-line baseURL swap), license clarity (no EE folder), and built-in features like Prompt A/B with t-tests, judge to human correlation, and model-swap savings recommendations."
+      tldr="Langfuse is the most mature open-source option and the safest pick if community size is the deciding factor. It instruments through SDK wrappers and callback handlers, which gives deep control but means touching every chain you want traced, and while its core is MIT, an ee/ folder gates enterprise capabilities such as SCIM, audit logs, RBAC, and data masking under a commercial license. Spanlens takes the opposite approach. Integration is a one-line baseURL swap that captures every OpenAI, Anthropic, or Gemini call without per-chain changes, and the entire repository ships under MIT with no enterprise folder. Statistical rigor is built in rather than assembled. Prompt A/B experiments report Welch t-test significance on latency and cost, judge-to-human correlation warns when your LLM judge drifts from human raters, and the savings recommender turns usage data into concrete swaps like moving classifier calls to gpt-4o-mini with the monthly dollar figure attached."
       whySpanlens={whySpanlens}
       whyCompetitor={whyCompetitor}
       groups={groups}

--- a/apps/web/app/compare/langsmith/page.tsx
+++ b/apps/web/app/compare/langsmith/page.tsx
@@ -165,7 +165,7 @@ export default function VsLangSmithPage() {
     <CompareTemplate
       competitor="LangSmith"
       tagline="A 1-line proxy that works with any stack, no SDK wrapping required. MIT and self-hostable today, not a sales call away."
-      tldr="LangSmith is the right call if you're committed to LangChain or LangGraph. The integration depth is unmatched. Spanlens is the right call if you want a tool that works with anything, installs with a 1-line baseURL swap, ships fully under MIT, and bundles Prompt A/B with statistical testing."
+      tldr="LangSmith is the right call if you are committed to LangChain or LangGraph. The integration depth is unmatched there. Chains, graphs, and tools auto-instrument, and LangGraph state transitions render natively. The tradeoff is coupling. Its deepest features assume the LangChain ecosystem, so plain SDK calls or custom orchestration take extra wiring, and while enterprise self-hosting exists, it sits behind enterprise sales rather than a public download. Spanlens is the right call if you want a tool that works with anything. The proxy instruments any language or framework through a one-line baseURL swap, keeping your raw OpenAI, Anthropic, or Gemini calls exactly as they are, and OpenTelemetry ingest covers whatever cannot route through a proxy. The entire codebase ships under MIT with a docker-compose self-host, and Prompt A/B testing with Welch t-test significance on latency and cost comes built in rather than assembled from experiments."
       whySpanlens={whySpanlens}
       whyCompetitor={whyCompetitor}
       groups={groups}

--- a/apps/web/lib/llms-txt-drift.test.ts
+++ b/apps/web/lib/llms-txt-drift.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { PLANS, PLAN_REQUEST_LIMITS, PLAN_RETENTION_DAYS, PLAN_SEAT_LIMITS } from './billing-plans'
+
+/**
+ * Drift guard for public/llms.txt and public/llms-full.txt.
+ *
+ * Both files are hand-written static assets served to AI crawlers, but they
+ * restate pricing facts whose source of truth is lib/billing-plans.ts. If a
+ * plan's price, quota, retention, seats, or overage rate changes there and
+ * the llms files are not updated, AI answer engines keep citing stale prices
+ * silently (2026-07-06 GEO audit finding). This test derives the expected
+ * strings from the constants so any billing change fails CI until the llms
+ * files are re-synced.
+ *
+ * If this test fails: update the "## Plans" section (and the FAQ in
+ * llms-full.txt) to match lib/billing-plans.ts, then re-run.
+ */
+
+const PUBLIC_DIR = join(__dirname, '..', 'public')
+const LLMS_FILES = ['llms.txt', 'llms-full.txt'] as const
+
+function compactCount(n: number): string {
+  if (n >= 1_000_000) return `${n / 1_000_000}M`
+  if (n >= 1_000) return `${n / 1_000}K`
+  return String(n)
+}
+
+/** "+$8 / 100K extra requests" (billing-plans feature) → "+$8 per extra 100K" (llms.txt phrasing) */
+function overagePhrase(features: string[]): string | null {
+  for (const f of features) {
+    const m = f.match(/^\+\$(\d+) \/ 100K extra requests$/)
+    if (m) return `+$${m[1]} per extra 100K`
+  }
+  return null
+}
+
+function expectedFactsFor(planId: string): string[] {
+  const plan = PLANS.find((p) => p.id === planId)
+  if (!plan) throw new Error(`plan ${planId} missing from PLANS`)
+  const facts: string[] = []
+
+  if (plan.priceUsd !== null && plan.priceUsd > 0) facts.push(`$${plan.priceUsd}/mo`)
+
+  const requests = PLAN_REQUEST_LIMITS[planId]
+  if (requests) facts.push(`${compactCount(requests)} requests/mo`)
+
+  const retention = PLAN_RETENTION_DAYS[planId]
+  if (retention) facts.push(`${retention}-day retention`)
+
+  const seats = PLAN_SEAT_LIMITS[planId]
+  if (seats) facts.push(`${seats} seat${seats === 1 ? '' : 's'}`)
+
+  const overage = overagePhrase(plan.features)
+  if (overage) facts.push(overage)
+
+  return facts
+}
+
+describe.each(LLMS_FILES)('%s pricing facts match lib/billing-plans.ts', (file) => {
+  const content = readFileSync(join(PUBLIC_DIR, file), 'utf8')
+
+  it.each(['free', 'starter', 'team'])('plan "%s" facts are present', (planId) => {
+    for (const fact of expectedFactsFor(planId)) {
+      expect(content, `${file} is missing "${fact}" for plan "${planId}"`).toContain(fact)
+    }
+  })
+
+  it('does not state a price for Enterprise (custom pricing)', () => {
+    const enterprise = PLANS.find((p) => p.id === 'enterprise')
+    expect(enterprise?.priceUsd).toBeNull()
+    // Guard against someone hardcoding a fake Enterprise price into the file.
+    expect(content).not.toMatch(/Enterprise: \$\d/)
+  })
+})


### PR DESCRIPTION
## Summary

Final two low-priority items from the 2026-07-06 GEO audit.

### 1. llms.txt pricing drift guard
`public/llms.txt` and `llms-full.txt` are hand-written static files that restate pricing facts whose source of truth is `lib/billing-plans.ts`. A price change there would leave AI crawlers (ChatGPT, Perplexity) citing stale prices silently.

New vitest test (`lib/llms-txt-drift.test.ts`, 8 cases) derives the expected strings from the constants — price (`$29/mo`), request quota (`100K requests/mo`), retention (`90-day retention`), seats, overage rate (`+$8 per extra 100K`) — and asserts both files contain them. Any billing change now fails CI until the llms files are re-synced. Also guards against someone hardcoding a fake Enterprise price (custom pricing, `priceUsd: null`).

This is the check-based alternative to full codegen: same drift protection, no build-pipeline machinery, and the prose sections of llms.txt stay hand-curated.

### 2. Citation-length compare tldrs
The five `/compare/*` tldr blocks ran 48-60 words, short of the 134-167 word range AI answer engines prefer to cite as self-contained passages. Rewrote each to 141-151 words:
- grounded only in claims already made elsewhere on the same page (whySpanlens / whyCompetitor / feature-table rows) — no new factual claims
- quantifies tradeoffs in both directions (what the competitor is genuinely better at stays in)
- no em dashes per copy style rules

## Test plan

- [x] `pnpm --filter web typecheck` / `lint` / `test` (65 passed, 8 new) / `build`
- [x] Local render: expanded tldrs render on `/compare/langfuse` and `/compare/braintrust`, all JSON-LD blocks still parse
- [x] Drift test fails correctly when a price constant is changed without touching llms.txt (verified by construction — expected strings are derived from the constants)
