### PR TITLE
feat(web): add X account to Organization sameAs

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -105,6 +105,7 @@ const organizationJsonLd = {
   sameAs: [
     'https://github.com/spanlens/Spanlens',
     'https://www.npmjs.com/package/@spanlens/sdk',
+    'https://x.com/spanlens',
   ],
 }
 


### PR DESCRIPTION
x.com/spanlens is live and owned (verified 200 + owner confirmation). Adds it to the canonical Organization sameAs alongside GitHub and npm, completing the entity-linking gap from the 2026-07-06 GEO audit.

Test plan: typecheck + lint pass; JSON-LD shape unchanged (one more sameAs string).