### PR TITLE
feat: onboarding empty states, data-silence alerts, cache savings card, quota CTA, a11y

### DIFF
--- a/.github/workflows/cron-server.yml
+++ b/.github/workflows/cron-server.yml
@@ -70,6 +70,7 @@ on:
     - cron: '0 10 * * *'       # daily 10:00 — check-past-due-downgrades
     - cron: '0 3 * * *'        # daily 03:00 — prune-judge-cache
     - cron: '0 9 * * 1'        # weekly Monday 09:00 — stale-key-reminders
+    - cron: '30 */6 * * *'     # every 6h at :30 — detect-data-silence
   workflow_dispatch:
 
 concurrency:
@@ -257,6 +258,24 @@ jobs:
           STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
             -H "Authorization: Bearer $CRON_SECRET" \
             "$BASE_URL/cron/prune-judge-cache")
+          echo "Status: $STATUS"
+          cat /tmp/body
+          if [ "$STATUS" -ge 400 ]; then exit 1; fi
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+
+  every-6h-30:
+    name: Every 6 hours at :30 (detect-data-silence)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '30 */6 * * *' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: POST /cron/detect-data-silence
+        run: |
+          BASE_URL='https://spanlens-server.vercel.app'
+          STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            "$BASE_URL/cron/detect-data-silence")
           echo "Status: $STATUS"
           cat /tmp/body
           if [ "$STATUS" -ge 400 ]; then exit 1; fi

--- a/apps/server/src/__tests__/cache-savings.test.ts
+++ b/apps/server/src/__tests__/cache-savings.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// getCacheSavings queries ClickHouse directly. Mock unscopedClickhouse() so
+// tests run without a real container; helpers below shape the response the
+// way @clickhouse/client returns it (a ResultSet whose .json() resolves to
+// an array of plain rows). Same pattern as anomaly-detect.test.ts.
+const mockChQuery = vi.hoisted(() => vi.fn())
+vi.mock('../lib/clickhouse.js', () => ({
+  unscopedClickhouse: () => ({ query: mockChQuery }),
+  toClickhouseTimestamp: (date: Date = new Date()) =>
+    date.toISOString().replace('T', ' ').replace('Z', ''),
+}))
+
+// requestsScope reads the org plan from Supabase — stub it so the test stays
+// DB-free while still asserting the WHERE scope is threaded through.
+vi.mock('../lib/requests-query.js', () => ({
+  requestsScope: vi.fn(async (orgId: string) => ({
+    whereScope:
+      'organization_id = {orgId:UUID} AND created_at >= now() - INTERVAL {retentionDays:UInt32} DAY',
+    scopeParams: { orgId, retentionDays: 14 },
+    plan: 'free',
+  })),
+}))
+
+import {
+  computeCacheSavings,
+  currentMonthStartUtc,
+  getCacheSavings,
+  type CacheSavingsRow,
+} from '../lib/cache-savings.js'
+
+function chReturn(rows: object[]) {
+  return Promise.resolve({ json: () => Promise.resolve(rows) })
+}
+
+function row(overrides: Partial<CacheSavingsRow> = {}): CacheSavingsRow {
+  return {
+    model: 'gpt-4o-mini',
+    cache_read_tokens: '0',
+    cache_hit_requests: '0',
+    ...overrides,
+  }
+}
+
+beforeEach(() => { mockChQuery.mockReset() })
+
+describe('computeCacheSavings — pricing math', () => {
+  it('prices cache reads at (input − cacheRead) per 1M tokens', () => {
+    // FALLBACK_PRICES: gpt-4o-mini → prompt 0.15, cacheRead 0.075.
+    // 1M cached tokens → saving = (0.15 − 0.075) = $0.075.
+    const totals = computeCacheSavings([
+      row({ model: 'gpt-4o-mini', cache_read_tokens: '1000000', cache_hit_requests: '10' }),
+    ])
+    expect(totals.savingsUsd).toBeCloseTo(0.075, 10)
+    expect(totals.cacheReadTokens).toBe(1_000_000)
+    expect(totals.cacheHitRequests).toBe(10)
+  })
+
+  it('sums savings across models with different discount rates', () => {
+    // claude-haiku-4.5 → prompt 1, cacheRead 0.1 → $0.90 saved per 1M cached.
+    const totals = computeCacheSavings([
+      row({ model: 'gpt-4o-mini',      cache_read_tokens: '2000000', cache_hit_requests: '20' }),
+      row({ model: 'claude-haiku-4.5', cache_read_tokens: '500000',  cache_hit_requests: '5' }),
+    ])
+    // 2 × 0.075 + 0.5 × 0.9 = 0.15 + 0.45 = 0.60
+    expect(totals.savingsUsd).toBeCloseTo(0.6, 10)
+    expect(totals.cacheReadTokens).toBe(2_500_000)
+    expect(totals.cacheHitRequests).toBe(25)
+  })
+
+  it('resolves dated model variants via the boundary-aware prefix lookup', () => {
+    // gpt-4o-mini-2024-07-18 must resolve to the gpt-4o-mini price row.
+    const totals = computeCacheSavings([
+      row({ model: 'gpt-4o-mini-2024-07-18', cache_read_tokens: '1000000', cache_hit_requests: '3' }),
+    ])
+    expect(totals.savingsUsd).toBeCloseTo(0.075, 10)
+  })
+
+  it('claims zero savings for unknown models but still counts their tokens', () => {
+    const totals = computeCacheSavings([
+      row({ model: 'future-model-9000', cache_read_tokens: '9000000', cache_hit_requests: '90' }),
+    ])
+    expect(totals.savingsUsd).toBe(0)
+    expect(totals.cacheReadTokens).toBe(9_000_000)
+    expect(totals.cacheHitRequests).toBe(90)
+  })
+
+  it('claims zero savings when a model has no discounted cacheRead price', () => {
+    // gpt-5.5-pro has no cacheRead in FALLBACK_PRICES → billed at full input
+    // rate → discount is zero.
+    const totals = computeCacheSavings([
+      row({ model: 'gpt-5.5-pro', cache_read_tokens: '1000000', cache_hit_requests: '4' }),
+    ])
+    expect(totals.savingsUsd).toBe(0)
+    expect(totals.cacheReadTokens).toBe(1_000_000)
+  })
+
+  it('ignores zero-token and malformed rows', () => {
+    const totals = computeCacheSavings([
+      row({ model: 'gpt-4o-mini', cache_read_tokens: '0',            cache_hit_requests: '2' }),
+      row({ model: 'gpt-4o-mini', cache_read_tokens: 'not-a-number', cache_hit_requests: '2' }),
+    ])
+    expect(totals).toEqual({ savingsUsd: 0, cacheReadTokens: 0, cacheHitRequests: 0 })
+  })
+
+  it('returns all-zero totals for an empty result set', () => {
+    expect(computeCacheSavings([])).toEqual({
+      savingsUsd: 0,
+      cacheReadTokens: 0,
+      cacheHitRequests: 0,
+    })
+  })
+})
+
+describe('currentMonthStartUtc', () => {
+  it('returns the UTC first-of-month boundary', () => {
+    const start = currentMonthStartUtc(new Date('2026-07-06T15:30:00Z'))
+    expect(start.toISOString()).toBe('2026-07-01T00:00:00.000Z')
+  })
+
+  it('handles the first millisecond of a month', () => {
+    const start = currentMonthStartUtc(new Date('2026-12-01T00:00:00.000Z'))
+    expect(start.toISOString()).toBe('2026-12-01T00:00:00.000Z')
+  })
+})
+
+describe('getCacheSavings — ClickHouse plumbing', () => {
+  it('aggregates rows returned by ClickHouse and reports the month start', async () => {
+    mockChQuery.mockReturnValue(chReturn([
+      row({ model: 'gpt-4o-mini', cache_read_tokens: '1000000', cache_hit_requests: '10' }),
+    ]))
+    const summary = await getCacheSavings('org-1')
+    expect(summary.savingsUsd).toBeCloseTo(0.075, 10)
+    expect(summary.cacheReadTokens).toBe(1_000_000)
+    expect(summary.cacheHitRequests).toBe(10)
+    expect(summary.monthStart).toBe(currentMonthStartUtc().toISOString())
+  })
+
+  it('threads the tenant scope + month boundary into the query', async () => {
+    mockChQuery.mockReturnValue(chReturn([]))
+    await getCacheSavings('org-9')
+    expect(mockChQuery).toHaveBeenCalledTimes(1)
+    const call = mockChQuery.mock.calls[0]![0] as {
+      query: string
+      query_params: Record<string, unknown>
+    }
+    expect(call.query).toContain('organization_id = {orgId:UUID}')
+    expect(call.query).toContain('cache_read_tokens > 0')
+    expect(call.query_params['orgId']).toBe('org-9')
+    expect(call.query_params['monthStart']).toBeDefined()
+  })
+
+  it('propagates ClickHouse failures to the caller', async () => {
+    mockChQuery.mockReturnValue(Promise.reject(new Error('connection refused')))
+    await expect(getCacheSavings('org-1')).rejects.toThrow('connection refused')
+  })
+})

--- a/apps/server/src/__tests__/data-silence.test.ts
+++ b/apps/server/src/__tests__/data-silence.test.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockFrom = vi.hoisted(() => vi.fn())
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: { from: mockFrom },
+}))
+
+const mockChQuery = vi.hoisted(() => vi.fn())
+vi.mock('../lib/clickhouse.js', () => ({
+  unscopedClickhouse: () => ({ query: mockChQuery }),
+  // Real implementation is trivial — inline it so the module under test
+  // still normalizes CH DateTime64 strings to ISO 'Z' form.
+  fromClickhouseTimestamp: (s: string | null | undefined) =>
+    s ? s.replace(' ', 'T') + 'Z' : null,
+}))
+
+const mockSendEmail = vi.hoisted(() => vi.fn())
+const mockRenderEmail = vi.hoisted(() =>
+  vi.fn(() => ({ subject: 'test subject', html: '<p>test</p>' })),
+)
+vi.mock('../lib/resend.js', () => ({
+  sendEmail: mockSendEmail,
+  renderDataSilenceEmail: mockRenderEmail,
+}))
+
+const mockGetAdminEmails = vi.hoisted(() => vi.fn())
+vi.mock('../lib/admin-emails.js', () => ({
+  getAdminEmails: mockGetAdminEmails,
+}))
+
+import {
+  planSilenceActions,
+  runDataSilenceJob,
+  DATA_SILENCE_MIN_PRIOR_REQUESTS,
+  type OrgTrafficRow,
+  type OpenEpisode,
+} from '../lib/data-silence.js'
+
+function trafficRow(overrides: Partial<OrgTrafficRow> = {}): OrgTrafficRow {
+  return {
+    organization_id: 'org-1',
+    prior_count: 120,
+    recent_count: 0,
+    last_request_at: '2026-07-05T08:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function episode(overrides: Partial<OpenEpisode> = {}): OpenEpisode {
+  return {
+    id: 'ep-1',
+    organization_id: 'org-1',
+    email_sent: true,
+    last_request_at: '2026-07-05T08:00:00.000Z',
+    prior_week_requests: 120,
+    ...overrides,
+  }
+}
+
+// ── Pure planning logic ────────────────────────────────────────────
+
+describe('planSilenceActions', () => {
+  it('opens an episode for an org with steady prior traffic and zero recent requests', () => {
+    const plan = planSilenceActions([trafficRow()], [])
+    expect(plan.toOpen).toHaveLength(1)
+    expect(plan.toOpen[0]!.organization_id).toBe('org-1')
+    expect(plan.toResolve).toEqual([])
+    expect(plan.toRetryEmail).toEqual([])
+  })
+
+  it('does NOT open for low-traffic orgs (prior below threshold)', () => {
+    const plan = planSilenceActions(
+      [trafficRow({ prior_count: DATA_SILENCE_MIN_PRIOR_REQUESTS - 1 })],
+      [],
+    )
+    expect(plan.toOpen).toEqual([])
+  })
+
+  it('opens at exactly the threshold', () => {
+    const plan = planSilenceActions(
+      [trafficRow({ prior_count: DATA_SILENCE_MIN_PRIOR_REQUESTS })],
+      [],
+    )
+    expect(plan.toOpen).toHaveLength(1)
+  })
+
+  it('does NOT open when the org still has recent traffic', () => {
+    const plan = planSilenceActions([trafficRow({ recent_count: 3 })], [])
+    expect(plan.toOpen).toEqual([])
+  })
+
+  it('does NOT open a second episode while one is already open (dedup)', () => {
+    const plan = planSilenceActions([trafficRow()], [episode()])
+    expect(plan.toOpen).toEqual([])
+  })
+
+  it('resolves an open episode when traffic resumes', () => {
+    const plan = planSilenceActions([trafficRow({ recent_count: 12 })], [episode()])
+    expect(plan.toResolve).toHaveLength(1)
+    expect(plan.toResolve[0]!.id).toBe('ep-1')
+    expect(plan.toOpen).toEqual([])
+  })
+
+  it('keeps an episode open when the org is absent from traffic (silent > lookback window)', () => {
+    const plan = planSilenceActions([], [episode()])
+    expect(plan.toResolve).toEqual([])
+  })
+
+  it('retries email for a still-silent open episode whose send failed', () => {
+    const plan = planSilenceActions([trafficRow()], [episode({ email_sent: false })])
+    expect(plan.toRetryEmail).toHaveLength(1)
+    expect(plan.toOpen).toEqual([])
+  })
+
+  it('retries email for an unsent episode whose org fell out of the lookback window', () => {
+    const plan = planSilenceActions([], [episode({ email_sent: false })])
+    expect(plan.toRetryEmail).toHaveLength(1)
+  })
+
+  it('does NOT retry email once the episode was delivered', () => {
+    const plan = planSilenceActions([trafficRow()], [episode({ email_sent: true })])
+    expect(plan.toRetryEmail).toEqual([])
+  })
+
+  it('does NOT retry email when the org has traffic again (episode resolves instead)', () => {
+    const plan = planSilenceActions(
+      [trafficRow({ recent_count: 5 })],
+      [episode({ email_sent: false })],
+    )
+    expect(plan.toRetryEmail).toEqual([])
+    expect(plan.toResolve).toHaveLength(1)
+  })
+})
+
+// ── Job integration (mocked I/O) ───────────────────────────────────
+
+interface MockState {
+  openEpisodes: OpenEpisode[]
+  insertError: null | { message: string; code?: string }
+  inserts: Record<string, unknown>[]
+  resolvedIdBatches: string[][]
+  emailSentIds: string[]
+  auditInserts: Record<string, unknown>[]
+  orgName: string
+}
+
+let state: MockState
+
+function setChTraffic(rows: Array<Record<string, unknown>>): void {
+  mockChQuery.mockResolvedValue({ json: () => Promise.resolve(rows) })
+}
+
+function setupFrom(): void {
+  mockFrom.mockImplementation((table: string) => {
+    if (table === 'data_silence_alerts') {
+      return {
+        select: () => ({
+          is: () => Promise.resolve({ data: state.openEpisodes, error: null }),
+        }),
+        update: (patch: Record<string, unknown>) => ({
+          in: (_col: string, ids: string[]) => {
+            state.resolvedIdBatches.push(ids)
+            return Promise.resolve({ error: null })
+          },
+          eq: (_col: string, id: string) => {
+            if ('email_sent' in patch) state.emailSentIds.push(id)
+            return Promise.resolve({ error: null })
+          },
+        }),
+        insert: (row: Record<string, unknown>) => {
+          state.inserts.push(row)
+          return {
+            select: () => ({
+              single: () =>
+                Promise.resolve(
+                  state.insertError
+                    ? { data: null, error: state.insertError }
+                    : { data: { id: `ep-new-${state.inserts.length}` }, error: null },
+                ),
+            }),
+          }
+        },
+      }
+    }
+    if (table === 'organizations') {
+      return {
+        select: () => ({
+          eq: () => ({
+            single: () => Promise.resolve({ data: { name: state.orgName }, error: null }),
+          }),
+        }),
+      }
+    }
+    if (table === 'audit_logs') {
+      return {
+        insert: (row: Record<string, unknown>) => {
+          state.auditInserts.push(row)
+          return Promise.resolve({ error: null })
+        },
+      }
+    }
+    throw new Error(`unexpected table ${table}`)
+  })
+}
+
+beforeEach(() => {
+  state = {
+    openEpisodes: [],
+    insertError: null,
+    inserts: [],
+    resolvedIdBatches: [],
+    emailSentIds: [],
+    auditInserts: [],
+    orgName: 'Acme Inc',
+  }
+  mockFrom.mockReset()
+  mockChQuery.mockReset()
+  mockSendEmail.mockReset()
+  mockRenderEmail.mockClear()
+  mockGetAdminEmails.mockReset()
+  setupFrom()
+  mockGetAdminEmails.mockResolvedValue(['admin@acme.test'])
+  mockSendEmail.mockResolvedValue({ sent: true })
+})
+
+describe('runDataSilenceJob — new silence episode', () => {
+  it('opens an episode, emails admins, marks email_sent, and writes an audit row', async () => {
+    // JSONEachRow returns counts as strings and DateTime64 without Z — the
+    // job must survive both (gotchas #18/#19).
+    setChTraffic([
+      {
+        organization_id: 'org-1',
+        prior_count: '120',
+        recent_count: '0',
+        last_request_at: '2026-07-05 08:00:00.000',
+      },
+    ])
+
+    const result = await runDataSilenceJob()
+
+    expect(result.episodes_opened).toBe(1)
+    expect(result.emails_sent).toBe(1)
+    expect(result.errors).toEqual([])
+
+    expect(state.inserts).toHaveLength(1)
+    expect(state.inserts[0]).toMatchObject({
+      organization_id: 'org-1',
+      prior_week_requests: 120,
+      last_request_at: '2026-07-05T08:00:00.000Z',
+    })
+    expect(state.emailSentIds).toEqual(['ep-new-1'])
+    expect(state.auditInserts).toHaveLength(1)
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'admin@acme.test' }),
+    )
+    expect(mockRenderEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgName: 'Acme Inc',
+        priorWeekRequests: 120,
+        lastRequestAt: '2026-07-05T08:00:00.000Z',
+      }),
+    )
+  })
+
+  it('skips low-traffic orgs and orgs with recent activity', async () => {
+    setChTraffic([
+      { organization_id: 'org-low', prior_count: '10', recent_count: '0', last_request_at: null },
+      { organization_id: 'org-live', prior_count: '500', recent_count: '42', last_request_at: '2026-07-06 09:00:00.000' },
+    ])
+
+    const result = await runDataSilenceJob()
+    expect(result.orgs_scanned).toBe(2)
+    expect(result.episodes_opened).toBe(0)
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('does not email again while an episode is open (one email per episode)', async () => {
+    state.openEpisodes = [episode({ email_sent: true })]
+    setChTraffic([
+      { organization_id: 'org-1', prior_count: '120', recent_count: '0', last_request_at: '2026-07-05 08:00:00.000' },
+    ])
+
+    const result = await runDataSilenceJob()
+    expect(result.episodes_opened).toBe(0)
+    expect(result.emails_sent).toBe(0)
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('treats a 23505 insert conflict as an already-open episode (no email, no error)', async () => {
+    state.insertError = { message: 'duplicate key value', code: '23505' }
+    setChTraffic([
+      { organization_id: 'org-1', prior_count: '120', recent_count: '0', last_request_at: '2026-07-05 08:00:00.000' },
+    ])
+
+    const result = await runDataSilenceJob()
+    expect(result.episodes_opened).toBe(0)
+    expect(result.errors).toEqual([])
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('records an error and leaves email_sent false when no admin recipients exist', async () => {
+    mockGetAdminEmails.mockResolvedValue([])
+    setChTraffic([
+      { organization_id: 'org-1', prior_count: '120', recent_count: '0', last_request_at: '2026-07-05 08:00:00.000' },
+    ])
+
+    const result = await runDataSilenceJob()
+    expect(result.episodes_opened).toBe(1)
+    expect(result.emails_sent).toBe(0)
+    expect(result.errors[0]).toMatch(/no admin recipients/)
+    expect(state.emailSentIds).toEqual([])
+  })
+})
+
+describe('runDataSilenceJob — resolution and retry', () => {
+  it('resolves an open episode when traffic resumes', async () => {
+    state.openEpisodes = [episode()]
+    setChTraffic([
+      { organization_id: 'org-1', prior_count: '80', recent_count: '9', last_request_at: '2026-07-06 10:00:00.000' },
+    ])
+
+    const result = await runDataSilenceJob()
+    expect(result.episodes_resolved).toBe(1)
+    expect(state.resolvedIdBatches).toEqual([['ep-1']])
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('retries a failed send on the next run without opening a new episode', async () => {
+    state.openEpisodes = [episode({ email_sent: false })]
+    // Org fell out of the lookback window entirely — still silent.
+    setChTraffic([])
+
+    const result = await runDataSilenceJob()
+    expect(result.episodes_opened).toBe(0)
+    expect(result.emails_sent).toBe(1)
+    expect(state.emailSentIds).toEqual(['ep-1'])
+    // Retry uses the stats persisted when the episode was opened.
+    expect(mockRenderEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ priorWeekRequests: 120 }),
+    )
+  })
+
+  it('counts a dev-fallback send (RESEND_API_KEY unset) as not sent so it retries later', async () => {
+    mockSendEmail.mockResolvedValue({ sent: false })
+    setChTraffic([
+      { organization_id: 'org-1', prior_count: '120', recent_count: '0', last_request_at: '2026-07-05 08:00:00.000' },
+    ])
+
+    const result = await runDataSilenceJob()
+    expect(result.episodes_opened).toBe(1)
+    expect(result.emails_sent).toBe(0)
+    expect(state.emailSentIds).toEqual([])
+  })
+})
+
+describe('runDataSilenceJob — error handling', () => {
+  it('returns an error result when ClickHouse is unreachable', async () => {
+    mockChQuery.mockRejectedValue(new Error('CH down'))
+    const result = await runDataSilenceJob()
+    expect(result.errors).toContain('CH down')
+    expect(result.episodes_opened).toBe(0)
+  })
+
+  it('continues processing other orgs when one org fails', async () => {
+    setChTraffic([
+      { organization_id: 'org-a', prior_count: '90', recent_count: '0', last_request_at: '2026-07-05 08:00:00.000' },
+      { organization_id: 'org-b', prior_count: '90', recent_count: '0', last_request_at: '2026-07-05 08:00:00.000' },
+    ])
+    mockGetAdminEmails
+      .mockRejectedValueOnce(new Error('auth API down'))
+      .mockResolvedValueOnce(['admin@acme.test'])
+
+    const result = await runDataSilenceJob()
+    expect(result.episodes_opened).toBe(2)
+    expect(result.emails_sent).toBe(1)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatch(/auth API down/)
+  })
+})

--- a/apps/server/src/__tests__/quota-warnings.test.ts
+++ b/apps/server/src/__tests__/quota-warnings.test.ts
@@ -158,4 +158,97 @@ describe('quota warning email templates', () => {
     expect(body).toContain('50,000')
     expect(body).not.toMatch(/will receive 429/i)
   })
+
+  it('100 body carries an explicit upgrade CTA with the billing URL', () => {
+    for (const overageActive of [false, true]) {
+      const body = __testing.buildQuotaBody({
+        ...baseNotification,
+        threshold: 100,
+        overageActive,
+        used: 10_042,
+      })
+      expect(body).toContain('Upgrade your plan')
+      expect(body).toContain('https://www.spanlens.io/billing')
+    }
+  })
+
+  it('100 body (overage disabled) truthfully states requests are rejected and not logged', () => {
+    const body = __testing.buildQuotaBody({
+      ...baseNotification,
+      threshold: 100,
+      overageActive: false,
+      used: 10_042,
+    })
+    expect(body.toLowerCase()).toContain('rejected with 429')
+    expect(body.toLowerCase()).toContain('not logged')
+  })
+
+  it('80 body includes the softer "raise your limit anytime" line with the billing link', () => {
+    for (const overageActive of [false, true]) {
+      const body = __testing.buildQuotaBody({
+        ...baseNotification,
+        threshold: 80,
+        overageActive,
+      })
+      expect(body).toContain('You can raise your limit anytime')
+      expect(body).toContain('https://www.spanlens.io/billing')
+    }
+  })
+
+  it('email copy contains no em dashes', () => {
+    for (const threshold of [80, 100] as const) {
+      for (const overageActive of [false, true]) {
+        const n = { ...baseNotification, threshold, overageActive }
+        expect(__testing.buildQuotaBody(n)).not.toContain('—')
+        expect(__testing.buildQuotaHtml(n)).not.toContain('—')
+      }
+    }
+  })
+})
+
+describe('quota warning HTML template', () => {
+  const baseNotification = {
+    organizationName: 'Acme <Inc>',
+    used: 10_042,
+    limit: 10_000,
+    plan: 'starter',
+    billingUrl: 'https://www.spanlens.io/billing',
+    overageActive: false,
+    hardCap: 50_000,
+  }
+
+  it('100 html renders a prominent upgrade button linking to /billing', () => {
+    const html = __testing.buildQuotaHtml({ ...baseNotification, threshold: 100 })
+    expect(html).toContain('href="https://www.spanlens.io/billing"')
+    expect(html).toContain('Upgrade your plan')
+  })
+
+  it('100 html (overage disabled) states rejection behavior', () => {
+    const html = __testing.buildQuotaHtml({ ...baseNotification, threshold: 100 })
+    expect(html).toContain('rejected with 429')
+    expect(html).toContain('not logged')
+  })
+
+  it('100 html (overage active) states overage billing and the hard cap', () => {
+    const html = __testing.buildQuotaHtml({
+      ...baseNotification,
+      threshold: 100,
+      overageActive: true,
+    })
+    expect(html.toLowerCase()).toContain('overage')
+    expect(html).toContain('50,000')
+    expect(html).toContain('href="https://www.spanlens.io/billing"')
+  })
+
+  it('80 html keeps the same billing link with softer copy', () => {
+    const html = __testing.buildQuotaHtml({ ...baseNotification, threshold: 80 })
+    expect(html).toContain('href="https://www.spanlens.io/billing"')
+    expect(html).toContain('raise your limit anytime')
+  })
+
+  it('escapes the organization name', () => {
+    const html = __testing.buildQuotaHtml({ ...baseNotification, threshold: 100 })
+    expect(html).not.toContain('Acme <Inc>')
+    expect(html).toContain('Acme &lt;Inc&gt;')
+  })
 })

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -7,6 +7,7 @@ import { computeAndReportOverages } from '../lib/paddle-usage.js'
 import { runQuotaWarningsJob } from '../lib/quota-warnings.js'
 import { snapshotAnomaliesForAllOrgs } from '../lib/anomaly-snapshot.js'
 import { runStaleKeyDigestJob } from '../lib/stale-key-digest.js'
+import { runDataSilenceJob } from '../lib/data-silence.js'
 import { runDueMigrations } from '../lib/background-migrations/runner.js'
 import { runReconciliationCron } from '../lib/events-reconciliation.js'
 import { runLeakDetectionJob } from '../lib/leak-detection.js'
@@ -168,6 +169,24 @@ cronRouter.get('/stale-key-reminders', async (c) => {
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
     logCronRun('stale-key-reminders', 'error', Date.now() - start, msg).catch(console.error)
+    throw new ApiError('INTERNAL_ERROR', msg)
+  }
+})
+
+// ── Data silence detection (every 6h) ───────────────────────────
+cronRouter.get('/detect-data-silence', async (c) => {
+  assertCronAuth(c.req.header('Authorization'))
+
+  const start = Date.now()
+  try {
+    const result = await runDataSilenceJob()
+    const status = result.errors.length > 0 ? 'error' : 'ok'
+    const errSummary = result.errors.length > 0 ? result.errors.join('; ').slice(0, 500) : undefined
+    logCronRun('detect-data-silence', status, Date.now() - start, errSummary).catch(console.error)
+    return c.json({ success: result.errors.length === 0, ...result })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'unknown'
+    logCronRun('detect-data-silence', 'error', Date.now() - start, msg).catch(console.error)
     throw new ApiError('INTERNAL_ERROR', msg)
   }
 })

--- a/apps/server/src/api/recommendations.ts
+++ b/apps/server/src/api/recommendations.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import type { JwtContext } from '../middleware/authJwt.js'
 import { authJwtOrApiKey } from '../middleware/authJwtOrApiKey.js'
 import { recommendModelSwaps } from '../lib/model-recommend.js'
+import { getCacheSavings } from '../lib/cache-savings.js'
 import { getOrgClickhouse, toClickhouseTimestamp } from '../lib/clickhouse.js'
 import { requestsScope } from '../lib/requests-query.js'
 import { parsePositiveFloat } from '../lib/params.js'
@@ -64,6 +65,26 @@ recommendationsRouter.get('/', async (c) => {
       count: recommendations.length,
     },
   })
+})
+
+/**
+ * GET /api/v1/recommendations/cache-savings
+ *
+ * Month-to-date USD saved by prompt caching (cached input tokens billed at
+ * the provider's discounted cache-read rate instead of the full input rate).
+ * Powers the "Prompt caching saved you $X this month" card on /savings.
+ */
+recommendationsRouter.get('/cache-savings', async (c) => {
+  const orgId = c.get('orgId')
+  if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
+
+  try {
+    const summary = await getCacheSavings(orgId)
+    return c.json({ success: true, data: summary })
+  } catch (err) {
+    console.error('cache-savings failed', err)
+    throw new ApiError('INTERNAL_ERROR', 'Failed to compute cache savings')
+  }
 })
 
 recommendationsRouter.get('/percentiles', async (c) => {

--- a/apps/server/src/lib/admin-emails.ts
+++ b/apps/server/src/lib/admin-emails.ts
@@ -10,6 +10,12 @@ import { supabaseAdmin } from './db.js'
  * `security_alert_emails` preference (default true; only users who
  * explicitly turned it off are excluded). Quota-warning emails use a
  * separate owner-only lookup in logger.ts.
+ *
+ * NOTE: data-silence.ts (integration-broken retention alert) also reuses
+ * this lookup, so opting out of security alerts currently opts admins out
+ * of data-silence alerts too. Deliberate for now (one admin-alert switch,
+ * no extra pref migration); if alert volume grows, split into a distinct
+ * preference column instead of forking this helper.
  */
 export async function getAdminEmails(orgId: string): Promise<string[]> {
   const { data: members } = await supabaseAdmin

--- a/apps/server/src/lib/cache-savings.ts
+++ b/apps/server/src/lib/cache-savings.ts
@@ -1,0 +1,118 @@
+import { unscopedClickhouse, toClickhouseTimestamp } from './clickhouse.js'
+import { requestsScope } from './requests-query.js'
+import { lookupPrice } from './cost.js'
+
+/**
+ * Prompt-cache savings estimator.
+ *
+ * Providers bill cached input tokens (`cache_read_tokens`) at a discounted
+ * rate compared to the regular input price. This module aggregates the
+ * calendar-month cache-read volume per model from ClickHouse and converts it
+ * into an estimated USD amount the org did NOT pay thanks to prompt caching:
+ *
+ *   savings = Σ_model  cache_read_tokens × (input_price − cache_read_price) / 1M
+ *
+ * Prices come from the same synchronous cache `calculateCost()` uses
+ * (lib/model-prices-cache.ts via `lookupPrice`) — exact match + boundary-aware
+ * longest-prefix fallback, so dated variants like `gpt-4o-mini-2024-07-18`
+ * resolve correctly. Models with no price row (or no discounted cache rate)
+ * contribute zero savings but still count toward token/request totals.
+ *
+ * Retention note: the query goes through `requestsScope` WITHOUT
+ * `ignoreRetention`, so the number is computed only over data the org's plan
+ * can actually see. A Free org late in the month sees a partial-month
+ * estimate rather than numbers derived from rows it has no access to.
+ */
+
+/** Shape returned by the ClickHouse aggregate (JSONEachRow → numerics as strings). */
+export interface CacheSavingsRow {
+  model: string
+  cache_read_tokens: string
+  cache_hit_requests: string
+}
+
+export interface CacheSavingsTotals {
+  /** Estimated USD not paid this month thanks to discounted cache reads. */
+  savingsUsd: number
+  /** Total cached input tokens this month (all models, priced or not). */
+  cacheReadTokens: number
+  /** Requests this month that had at least one cache hit. */
+  cacheHitRequests: number
+}
+
+export interface CacheSavingsSummary extends CacheSavingsTotals {
+  /** ISO timestamp of the UTC month boundary the window starts at. */
+  monthStart: string
+}
+
+/** UTC calendar-month boundary — injectable `now` keeps the math testable. */
+export function currentMonthStartUtc(now: Date = new Date()): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+}
+
+/**
+ * Pure computation over aggregate rows. Separated from the ClickHouse query
+ * so unit tests can exercise the pricing math without a database.
+ */
+export function computeCacheSavings(rows: CacheSavingsRow[]): CacheSavingsTotals {
+  let savingsUsd = 0
+  let cacheReadTokens = 0
+  let cacheHitRequests = 0
+
+  for (const row of rows) {
+    // JSONEachRow returns UInt64/sum columns as strings — coerce defensively.
+    const tokens = Number(row.cache_read_tokens ?? 0)
+    const hits = Number(row.cache_hit_requests ?? 0)
+    if (!Number.isFinite(tokens) || tokens <= 0) continue
+
+    cacheReadTokens += tokens
+    cacheHitRequests += Number.isFinite(hits) ? hits : 0
+
+    const price = lookupPrice(row.model)
+    if (!price) continue // unknown model — no price data, no savings claim
+
+    // No explicit cacheRead price means the provider bills cache reads at the
+    // full input rate — the discount (and therefore the saving) is zero.
+    const cacheReadPrice = price.cacheRead ?? price.prompt
+    const discountPer1m = Math.max(0, price.prompt - cacheReadPrice)
+    savingsUsd += (tokens / 1_000_000) * discountPer1m
+  }
+
+  return { savingsUsd, cacheReadTokens, cacheHitRequests }
+}
+
+/**
+ * Month-to-date cache savings for one org. Tenant isolation + plan retention
+ * enforced via `requestsScope`. Throws on ClickHouse failure — callers decide
+ * how to surface it (the API route maps it to INTERNAL_ERROR).
+ */
+export async function getCacheSavings(organizationId: string): Promise<CacheSavingsSummary> {
+  const monthStartDate = currentMonthStartUtc()
+  const scope = await requestsScope(organizationId)
+
+  const res = await unscopedClickhouse().query({
+    query: `
+      SELECT
+        model,
+        sum(cache_read_tokens) AS cache_read_tokens,
+        count()                AS cache_hit_requests
+      FROM requests
+      WHERE ${scope.whereScope}
+        AND created_at >= parseDateTime64BestEffort({monthStart:String})
+        AND status_code IN (200, 201, 202, 204)
+        AND cache_read_tokens > 0
+      GROUP BY model
+    `,
+    query_params: {
+      ...scope.scopeParams,
+      monthStart: toClickhouseTimestamp(monthStartDate),
+    },
+    format: 'JSONEachRow',
+  })
+  const rows = await res.json<CacheSavingsRow>()
+
+  return {
+    ...computeCacheSavings(rows),
+    monthStart: monthStartDate.toISOString(),
+  }
+}

--- a/apps/server/src/lib/cost.ts
+++ b/apps/server/src/lib/cost.ts
@@ -92,8 +92,11 @@ export interface CostResult {
  * OpenAI는 종종 dated suffix를 포함해 모델명을 반환합니다 (예: gpt-4o-mini-2024-07-18).
  * 정확 매칭이 실패하면 등록된 키들 중 가장 긴 prefix를 찾아 fallback 매칭합니다.
  * (boundary-aware: 다음 글자가 단어 경계가 되도록 — 'gpt-4'가 'gpt-4o' prefix로 잘못 잡히는 일 방지)
+ *
+ * Exported so other cost math (e.g. lib/cache-savings.ts) reuses this exact
+ * matching algorithm instead of re-implementing it. Do NOT copy this logic.
  */
-function lookupPrice(model: string): ModelPrice | null {
+export function lookupPrice(model: string): ModelPrice | null {
   const prices = getCachedPrices()
   const exact = prices[model]
   if (exact) return exact

--- a/apps/server/src/lib/data-silence.ts
+++ b/apps/server/src/lib/data-silence.ts
@@ -1,0 +1,309 @@
+/**
+ * "Data went silent" retention alert.
+ *
+ * An org that previously had steady traffic (>= DATA_SILENCE_MIN_PRIOR_REQUESTS
+ * requests in the 7 days ending 24h ago) but sent ZERO requests in the last
+ * 24h gets one email per silence episode telling admins their integration
+ * probably broke. Runs every 6 hours via /cron/detect-data-silence.
+ *
+ * Dedup: one open episode per org, persisted in `data_silence_alerts`
+ * (partial unique index on organization_id WHERE resolved_at IS NULL).
+ * When traffic resumes the episode is resolved, so a future silence can
+ * alert again. If email delivery failed on the run that opened the
+ * episode (`email_sent = false`), the next run retries delivery without
+ * opening a second episode.
+ *
+ * Structure mirrors stale-key-digest.ts: global ClickHouse aggregation is
+ * allowed here (lib file) because organization_id is part of the GROUP BY
+ * and every downstream write/emails are keyed per org.
+ */
+
+import { supabaseAdmin } from './db.js'
+import { unscopedClickhouse, fromClickhouseTimestamp } from './clickhouse.js'
+import { sendEmail, renderDataSilenceEmail } from './resend.js'
+import { getAdminEmails } from './admin-emails.js'
+
+/** Minimum prior-week volume before silence is considered meaningful. */
+export const DATA_SILENCE_MIN_PRIOR_REQUESTS = 50
+/** Silence window: zero requests in the last N hours triggers the alert. */
+export const DATA_SILENCE_WINDOW_HOURS = 24
+/** Baseline window: the 7 days ENDING at the start of the silence window. */
+export const DATA_SILENCE_PRIOR_WINDOW_DAYS = 7
+
+export interface OrgTrafficRow {
+  organization_id: string
+  /** Requests in the 7-day baseline window ending 24h ago. */
+  prior_count: number
+  /** Requests in the last 24h. */
+  recent_count: number
+  /** ISO-8601 UTC ('...Z') timestamp of the org's most recent request, or null. */
+  last_request_at: string | null
+}
+
+export interface OpenEpisode {
+  id: string
+  organization_id: string
+  email_sent: boolean
+  last_request_at: string | null
+  prior_week_requests: number
+}
+
+export interface SilencePlan {
+  /** Orgs entering a new silence episode this run. */
+  toOpen: OrgTrafficRow[]
+  /** Open episodes whose org has traffic again. */
+  toResolve: OpenEpisode[]
+  /** Open episodes still silent whose alert email never went out. */
+  toRetryEmail: OpenEpisode[]
+}
+
+/**
+ * Pure decision logic — no I/O. Given per-org traffic counts and the set of
+ * currently-open episodes, decide which episodes to open, resolve, and
+ * which failed sends to retry.
+ *
+ * An org absent from `rows` had zero requests in the whole lookback window
+ * (8 days), so it is still silent: its open episode stays open but it can
+ * never OPEN a new episode (prior_count would be 0 < threshold).
+ */
+export function planSilenceActions(
+  rows: OrgTrafficRow[],
+  openEpisodes: OpenEpisode[],
+): SilencePlan {
+  const openByOrg = new Map(openEpisodes.map((e) => [e.organization_id, e]))
+  const rowByOrg = new Map(rows.map((r) => [r.organization_id, r]))
+
+  const toOpen = rows.filter(
+    (r) =>
+      r.recent_count === 0 &&
+      r.prior_count >= DATA_SILENCE_MIN_PRIOR_REQUESTS &&
+      !openByOrg.has(r.organization_id),
+  )
+
+  const toResolve = openEpisodes.filter((e) => {
+    const row = rowByOrg.get(e.organization_id)
+    return row !== undefined && row.recent_count > 0
+  })
+
+  const toRetryEmail = openEpisodes.filter((e) => {
+    if (e.email_sent) return false
+    const row = rowByOrg.get(e.organization_id)
+    // Absent from rows = zero traffic for 8 days = still silent.
+    return row === undefined || row.recent_count === 0
+  })
+
+  return { toOpen, toResolve, toRetryEmail }
+}
+
+/**
+ * One global ClickHouse round-trip: per-org counts for the baseline window
+ * and the silence window, plus the most recent request timestamp.
+ * organization_id is in the GROUP BY so every row is org-scoped.
+ */
+async function fetchOrgTraffic(): Promise<OrgTrafficRow[]> {
+  const totalDays = DATA_SILENCE_PRIOR_WINDOW_DAYS + 1 // baseline + silence window
+  const result = await unscopedClickhouse().query({
+    query:
+      'SELECT organization_id, ' +
+      `  countIf(created_at < now() - INTERVAL {windowHours:UInt32} HOUR) AS prior_count, ` +
+      `  countIf(created_at >= now() - INTERVAL {windowHours:UInt32} HOUR) AS recent_count, ` +
+      '  max(created_at) AS last_request_at ' +
+      'FROM requests ' +
+      `WHERE created_at >= now() - INTERVAL {totalDays:UInt32} DAY ` +
+      'GROUP BY organization_id',
+    query_params: {
+      windowHours: DATA_SILENCE_WINDOW_HOURS,
+      totalDays,
+    },
+    format: 'JSONEachRow',
+  })
+
+  // JSONEachRow returns UInt64 counts as strings and DateTime64 without the
+  // trailing 'Z' — normalize both at the boundary (gotchas #18/#19).
+  const raw = (await result.json()) as Array<{
+    organization_id: string
+    prior_count: string | number
+    recent_count: string | number
+    last_request_at: string | null
+  }>
+
+  return raw.map((r) => ({
+    organization_id: r.organization_id,
+    prior_count: Number(r.prior_count ?? 0),
+    recent_count: Number(r.recent_count ?? 0),
+    last_request_at: fromClickhouseTimestamp(r.last_request_at),
+  }))
+}
+
+async function fetchOpenEpisodes(): Promise<OpenEpisode[]> {
+  const { data, error } = await supabaseAdmin
+    .from('data_silence_alerts')
+    .select('id, organization_id, email_sent, last_request_at, prior_week_requests')
+    .is('resolved_at', null)
+
+  if (error) throw new Error(`failed to list open episodes: ${error.message}`)
+  return (data ?? []) as OpenEpisode[]
+}
+
+export interface DataSilenceRunResult {
+  orgs_scanned: number
+  episodes_opened: number
+  episodes_resolved: number
+  /** Orgs where Resend accepted at least one recipient. Stays 0 without RESEND_API_KEY. */
+  emails_sent: number
+  errors: string[]
+}
+
+/**
+ * Send the silence alert for one episode and flip email_sent on success.
+ * Returns true if at least one recipient accepted delivery.
+ */
+async function deliverSilenceAlert(
+  episodeId: string,
+  orgId: string,
+  lastRequestAt: string | null,
+  priorWeekRequests: number,
+  dashboardBase: string,
+  errors: string[],
+): Promise<boolean> {
+  const { data: org } = await supabaseAdmin
+    .from('organizations')
+    .select('name')
+    .eq('id', orgId)
+    .single()
+  const orgName = (org?.name as string | undefined) ?? 'your workspace'
+
+  const recipients = await getAdminEmails(orgId)
+  if (recipients.length === 0) {
+    errors.push(`no admin recipients for org ${orgId}`)
+    return false
+  }
+
+  const { subject, html } = renderDataSilenceEmail({
+    orgName,
+    lastRequestAt,
+    priorWeekRequests,
+    silenceWindowHours: DATA_SILENCE_WINDOW_HOURS,
+    dashboardUrl: `${dashboardBase}/requests`,
+    quickStartUrl: `${dashboardBase}/docs/quick-start`,
+  })
+
+  let sentToAtLeastOne = false
+  for (const to of recipients) {
+    const r = await sendEmail({ to, subject, html })
+    if (r.sent) sentToAtLeastOne = true
+  }
+
+  if (sentToAtLeastOne) {
+    await supabaseAdmin
+      .from('data_silence_alerts')
+      .update({ email_sent: true })
+      .eq('id', episodeId)
+
+    await supabaseAdmin.from('audit_logs').insert({
+      organization_id: orgId,
+      action: 'retention.data_silence_alert_sent',
+      resource_type: 'organization',
+      resource_id: orgId,
+      metadata: { prior_week_requests: priorWeekRequests, recipients: recipients.length },
+    })
+  }
+
+  return sentToAtLeastOne
+}
+
+export async function runDataSilenceJob(): Promise<DataSilenceRunResult> {
+  const result: DataSilenceRunResult = {
+    orgs_scanned: 0,
+    episodes_opened: 0,
+    episodes_resolved: 0,
+    emails_sent: 0,
+    errors: [],
+  }
+
+  let rows: OrgTrafficRow[]
+  let openEpisodes: OpenEpisode[]
+  try {
+    ;[rows, openEpisodes] = await Promise.all([fetchOrgTraffic(), fetchOpenEpisodes()])
+  } catch (err) {
+    result.errors.push(err instanceof Error ? err.message : 'unknown')
+    return result
+  }
+
+  result.orgs_scanned = rows.length
+  const plan = planSilenceActions(rows, openEpisodes)
+  const dashboardBase = process.env['WEB_URL'] ?? 'https://www.spanlens.io'
+
+  // 1. Resolve episodes whose org has data again.
+  if (plan.toResolve.length > 0) {
+    const { error } = await supabaseAdmin
+      .from('data_silence_alerts')
+      .update({ resolved_at: new Date().toISOString() })
+      .in('id', plan.toResolve.map((e) => e.id))
+    if (error) {
+      result.errors.push(`failed to resolve episodes: ${error.message}`)
+    } else {
+      result.episodes_resolved = plan.toResolve.length
+    }
+  }
+
+  // 2. Open new episodes and send the alert email.
+  for (const row of plan.toOpen) {
+    try {
+      const { data: inserted, error: insertErr } = await supabaseAdmin
+        .from('data_silence_alerts')
+        .insert({
+          organization_id: row.organization_id,
+          last_request_at: row.last_request_at,
+          prior_week_requests: row.prior_count,
+        })
+        .select('id')
+        .single()
+
+      if (insertErr) {
+        // 23505 = the partial unique index caught a concurrent run that
+        // already opened this episode. Skip quietly — the other run emails.
+        if (insertErr.code === '23505') continue
+        result.errors.push(`org ${row.organization_id}: insert failed: ${insertErr.message}`)
+        continue
+      }
+
+      result.episodes_opened++
+
+      const sent = await deliverSilenceAlert(
+        (inserted as { id: string }).id,
+        row.organization_id,
+        row.last_request_at,
+        row.prior_count,
+        dashboardBase,
+        result.errors,
+      )
+      if (sent) result.emails_sent++
+    } catch (err) {
+      result.errors.push(
+        `org ${row.organization_id}: ${err instanceof Error ? err.message : 'unknown'}`,
+      )
+    }
+  }
+
+  // 3. Retry delivery for still-silent episodes whose email never went out.
+  for (const episode of plan.toRetryEmail) {
+    try {
+      const sent = await deliverSilenceAlert(
+        episode.id,
+        episode.organization_id,
+        episode.last_request_at,
+        episode.prior_week_requests,
+        dashboardBase,
+        result.errors,
+      )
+      if (sent) result.emails_sent++
+    } catch (err) {
+      result.errors.push(
+        `org ${episode.organization_id}: retry failed: ${err instanceof Error ? err.message : 'unknown'}`,
+      )
+    }
+  }
+
+  return result
+}

--- a/apps/server/src/lib/notifiers.ts
+++ b/apps/server/src/lib/notifiers.ts
@@ -5,6 +5,8 @@
  * result into `alert_deliveries`.
  */
 
+import { escapeHtml } from './resend.js'
+
 interface DeliveryResult {
   ok: boolean
   error?: string
@@ -62,7 +64,7 @@ function buildPlainBody(n: AlertNotification): string {
     .join('\n')
 }
 
-// ── Email via Resend ───────────────────────────────────────────
+// ── Email via Resend ───────────────────────────────────
 
 export async function sendEmailAlert(
   toAddress: string,
@@ -197,8 +199,8 @@ export interface QuotaWarningNotification {
   billingUrl: string
   /**
    * Pattern C: at 100%, is overage billing authorized on this org?
-   * - true  → requests keep flowing, they'll be billed for overage
-   * - false → requests are being rejected with 429 (free or user-disabled)
+   * - true  — requests keep flowing, they'll be billed for overage
+   * - false — requests are being rejected with 429 (free or user-disabled)
    */
   overageActive: boolean
   /** Hard cap = limit × overage_cap_multiplier. */
@@ -220,34 +222,39 @@ function buildQuotaBody(n: QuotaWarningNotification): string {
   if (n.threshold === 100) {
     if (n.overageActive) {
       return [
-        `${n.organizationName} has passed its monthly request quota — overage billing is now active.`,
+        `${n.organizationName} has passed its monthly request quota and overage billing is now active.`,
         ``,
         `Usage:     ${n.used.toLocaleString()} / ${n.limit.toLocaleString()} requests (${pct}%)`,
         `Plan:      ${n.plan}`,
         `Hard cap:  ${n.hardCap.toLocaleString()} requests (requests above this return 429)`,
         ``,
-        `Additional requests beyond your included quota will be billed on your next invoice`,
-        `at the overage rate for your plan. You can disable overage or adjust the cap in`,
-        `${n.billingUrl}.`,
+        `What happens now: your requests keep flowing. Additional requests beyond your`,
+        `included quota will be billed on your next invoice at the overage rate for your`,
+        `plan. Once usage reaches the hard cap, further requests are rejected with 429.`,
+        ``,
+        `Upgrade your plan to raise your included quota, or adjust overage settings:`,
+        `${n.billingUrl}`,
       ].join('\n')
     }
     return [
-      `Heads up — ${n.organizationName} has hit its monthly request quota.`,
+      `${n.organizationName} has reached its monthly request quota.`,
       ``,
       `Usage:  ${n.used.toLocaleString()} / ${n.limit.toLocaleString()} requests (${pct}%)`,
       `Plan:   ${n.plan}`,
       ``,
-      `Additional requests through the Spanlens proxy will receive 429 (Too Many Requests)`,
-      `until your billing period renews, or until you upgrade / enable overage billing.`,
+      `What happens now: new requests through the Spanlens proxy are rejected with 429`,
+      `(Too Many Requests) before they reach your provider, and they are not logged.`,
+      `This continues until your quota resets next month, or until you upgrade your`,
+      `plan or enable overage billing.`,
       ``,
-      `Settings: ${n.billingUrl}`,
+      `Upgrade your plan: ${n.billingUrl}`,
     ].join('\n')
   }
 
   // 80% — include a note about whether overage will kick in at 100
   const tail = n.overageActive
-    ? `Overage billing is enabled — once you hit 100%, extra requests will be billed on\nyour next invoice instead of being rejected. You can adjust this in ${n.billingUrl}.`
-    : `Overage billing is disabled — requests past 100% will be rejected with 429.\nUpgrade or enable overage: ${n.billingUrl}`
+    ? `Overage billing is enabled, so once you hit 100% extra requests will be billed on\nyour next invoice instead of being rejected. You can adjust this in ${n.billingUrl}.`
+    : `Overage billing is disabled, so requests past 100% will be rejected with 429.`
 
   return [
     `${n.organizationName} has used 80% of this month's request quota.`,
@@ -256,7 +263,88 @@ function buildQuotaBody(n: QuotaWarningNotification): string {
     `Plan:   ${n.plan}`,
     ``,
     tail,
+    ``,
+    `You can raise your limit anytime: ${n.billingUrl}`,
   ].join('\n')
+}
+
+/**
+ * HTML version of the quota warning, styled like the other resend.ts emails.
+ * The 100% email carries a prominent "Upgrade your plan" button pointing at
+ * the billing page; the 80% email uses the same link with softer copy.
+ */
+function buildQuotaHtml(n: QuotaWarningNotification): string {
+  const pct = Math.floor((n.used / n.limit) * 100)
+  const orgName = escapeHtml(n.organizationName)
+  const usage = `${n.used.toLocaleString()} / ${n.limit.toLocaleString()} requests (${pct}%)`
+
+  let headerBg: string
+  let headerBorder: string
+  let headerColor: string
+  let headerTitle: string
+  let body: string
+  let ctaLabel: string
+
+  if (n.threshold === 100) {
+    headerBg = '#fef2f2'
+    headerBorder = '#fecaca'
+    headerColor = '#991b1b'
+    if (n.overageActive) {
+      headerTitle = 'Overage billing is now active'
+      body = `
+        <strong>${orgName}</strong> has passed its monthly request quota.
+        Your requests keep flowing, and usage beyond the included quota will be billed
+        on your next invoice at the overage rate for your plan. Once usage reaches the
+        hard cap of ${n.hardCap.toLocaleString()} requests, further requests are rejected with 429.
+      `
+      ctaLabel = 'Upgrade your plan'
+    } else {
+      headerTitle = 'Monthly request quota reached'
+      body = `
+        <strong>${orgName}</strong> has reached its monthly request quota.
+        New requests through the Spanlens proxy are rejected with 429 before they reach
+        your provider, and they are not logged. This continues until your quota resets
+        next month, or until you upgrade your plan or enable overage billing.
+      `
+      ctaLabel = 'Upgrade your plan'
+    }
+  } else {
+    headerBg = '#fff7ed'
+    headerBorder = '#fed7aa'
+    headerColor = '#9a3412'
+    headerTitle = "80% of this month's quota used"
+    body = n.overageActive
+      ? `
+        <strong>${orgName}</strong> has used 80% of this month's request quota.
+        Overage billing is enabled, so once you hit 100% extra requests will be billed
+        on your next invoice instead of being rejected. You can raise your limit anytime.
+      `
+      : `
+        <strong>${orgName}</strong> has used 80% of this month's request quota.
+        Overage billing is disabled, so requests past 100% will be rejected with 429.
+        You can raise your limit anytime.
+      `
+    ctaLabel = 'Review plans and usage'
+  }
+
+  return `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 580px; margin: 0 auto; padding: 24px; color: #111;">
+      <div style="background: ${headerBg}; border: 1px solid ${headerBorder}; border-radius: 8px; padding: 14px 16px; margin-bottom: 18px;">
+        <div style="font-weight: 600; font-size: 14px; color: ${headerColor};">${headerTitle}</div>
+      </div>
+      <p style="margin: 0 0 14px; color: #333; font-size: 13.5px; line-height: 1.55;">${body.trim()}</p>
+      <table style="width: 100%; font-size: 13px; margin-bottom: 16px;">
+        <tr><td style="padding: 4px 0; color: #888; width: 90px;">Usage</td><td style="font-family: ui-monospace, monospace;">${escapeHtml(usage)}</td></tr>
+        <tr><td style="padding: 4px 0; color: #888;">Plan</td><td style="font-family: ui-monospace, monospace;">${escapeHtml(n.plan)}</td></tr>
+      </table>
+      <p style="margin: 22px 0;">
+        <a href="${n.billingUrl}" style="display: inline-block; padding: 11px 20px; background: #111; color: #fff; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 13px;">${ctaLabel}</a>
+      </p>
+      <p style="margin: 18px 0 0; color: #aaa; font-size: 11.5px;">
+        Questions about quotas or billing? Reply to this email and it goes straight to the team.
+      </p>
+    </div>
+  `.trim()
 }
 
 export async function sendQuotaWarningEmail(
@@ -280,6 +368,7 @@ export async function sendQuotaWarningEmail(
         to: [toAddress],
         subject: buildQuotaSubject(notification),
         text: buildQuotaBody(notification),
+        html: buildQuotaHtml(notification),
       }),
       signal: AbortSignal.timeout(5000),
     })
@@ -294,7 +383,7 @@ export async function sendQuotaWarningEmail(
 }
 
 // Exported for testing (no network side effects)
-export const __testing = { buildQuotaSubject, buildQuotaBody }
+export const __testing = { buildQuotaSubject, buildQuotaBody, buildQuotaHtml }
 
 export async function deliverToChannel(
   kind: 'email' | 'slack' | 'discord',

--- a/apps/server/src/lib/quota-warnings.ts
+++ b/apps/server/src/lib/quota-warnings.ts
@@ -71,6 +71,10 @@ export async function runQuotaWarningsJob(): Promise<QuotaWarningRunResult> {
 
   const result: QuotaWarningRunResult = { checked: 0, sent80: 0, sent100: 0, errors: 0 }
 
+  // Same env-driven base the other lifecycle emails use (stale-key-digest,
+  // data-silence) so the upgrade CTA lands on the right host in every env.
+  const billingUrl = `${process.env['WEB_URL'] ?? 'https://www.spanlens.io'}/billing`
+
   for (const org of orgs) {
     result.checked++
     const limit = MONTHLY_REQUEST_LIMITS[org.plan]
@@ -125,7 +129,7 @@ export async function runQuotaWarningsJob(): Promise<QuotaWarningRunResult> {
       used,
       limit,
       plan: org.plan,
-      billingUrl: 'https://www.spanlens.io/billing',
+      billingUrl,
       overageActive,
       hardCap: limit * org.overage_cap_multiplier,
     })

--- a/apps/server/src/lib/resend.ts
+++ b/apps/server/src/lib/resend.ts
@@ -136,7 +136,7 @@ export function renderWaitlistConfirmationEmail(): { subject: string; html: stri
   return { subject, html }
 }
 
-function escapeHtml(s: string): string {
+export function escapeHtml(s: string): string {
   return s
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -193,6 +193,63 @@ export function renderStaleKeyDigestEmail(params: {
       <p style="margin: 18px 0 0; color: #aaa; font-size: 11.5px;">
         Notification-only — Spanlens never auto-revokes keys.
         To stop these reminders: Settings → Provider keys → Stale key reminders.
+      </p>
+    </div>
+  `.trim()
+
+  return { subject, html }
+}
+
+/**
+ * "Data went silent" retention alert. Sent once per silence episode by
+ * lib/data-silence.ts when an org with steady prior traffic stops sending
+ * requests entirely. Copy is intentionally diagnostic: the most common
+ * cause is a broken integration the customer has not noticed yet.
+ */
+export function renderDataSilenceEmail(params: {
+  orgName: string
+  /** ISO-8601 UTC timestamp of the last request we received, or null. */
+  lastRequestAt: string | null
+  priorWeekRequests: number
+  silenceWindowHours: number
+  dashboardUrl: string
+  quickStartUrl: string
+}): { subject: string; html: string } {
+  const { orgName, lastRequestAt, priorWeekRequests, silenceWindowHours, dashboardUrl, quickStartUrl } = params
+  const subject = `Spanlens has not received data from ${orgName} in ${silenceWindowHours} hours`
+
+  const lastSeenLabel = lastRequestAt
+    ? new Date(lastRequestAt).toLocaleString('en-US', {
+        year: 'numeric', month: 'short', day: 'numeric',
+        hour: '2-digit', minute: '2-digit', timeZone: 'UTC', timeZoneName: 'short',
+      })
+    : 'unknown'
+
+  const html = `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 580px; margin: 0 auto; padding: 24px; color: #111;">
+      <div style="background: #fff7ed; border: 1px solid #fed7aa; border-radius: 8px; padding: 14px 16px; margin-bottom: 18px;">
+        <div style="font-weight: 600; font-size: 14px; color: #9a3412; margin-bottom: 4px;">No data received in the last ${silenceWindowHours} hours</div>
+        <div style="font-size: 13px; color: #7c2d12;">Spanlens stopped receiving requests from <strong>${escapeHtml(orgName)}</strong>.</div>
+      </div>
+      <p style="margin: 0 0 14px; color: #333; font-size: 13.5px; line-height: 1.55;">
+        Your workspace logged <strong>${priorWeekRequests.toLocaleString('en-US')} requests</strong> over the previous 7 days,
+        but nothing has arrived in the last ${silenceWindowHours} hours.
+        The last request we received was at <strong>${escapeHtml(lastSeenLabel)}</strong>.
+      </p>
+      <p style="margin: 0 0 8px; color: #333; font-size: 13.5px;">If this drop is unexpected, the usual causes are:</p>
+      <ul style="margin: 0 0 16px; padding-left: 20px; color: #444; font-size: 13.5px; line-height: 1.7;">
+        <li>Your Spanlens API key was rotated or removed, so requests are being rejected.</li>
+        <li>A recent deploy dropped the baseURL override or the environment variable that points traffic at Spanlens.</li>
+        <li>Your provider key (OpenAI, Anthropic, or Gemini) was revoked, so calls fail before they reach us.</li>
+      </ul>
+      <p style="margin: 22px 0;">
+        <a href="${dashboardUrl}" style="display: inline-block; padding: 10px 18px; background: #111; color: #fff; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 13px;">Open the requests dashboard</a>
+      </p>
+      <p style="margin: 0 0 14px; color: #555; font-size: 13px;">
+        Need to re-check your setup? The <a href="${quickStartUrl}" style="color: #111;">quick-start guide</a> walks through the baseURL change and key configuration in a couple of minutes.
+      </p>
+      <p style="margin: 18px 0 0; color: #aaa; font-size: 11.5px;">
+        You will not receive another email for this incident. If traffic resumes and stops again later, we will let you know.
       </p>
     </div>
   `.trim()

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -25,6 +25,7 @@
     { "path": "/cron/self-monitor",               "schedule": "31 * * * *" },
     { "path": "/cron/detect-orphan-spans",        "schedule": "17 * * * *" },
     { "path": "/cron/keep-warm",                  "schedule": "*/5 * * * *" },
-    { "path": "/cron/prune-judge-cache",          "schedule": "0 3 * * *" }
+    { "path": "/cron/prune-judge-cache",          "schedule": "0 3 * * *" },
+    { "path": "/cron/detect-data-silence",        "schedule": "30 */6 * * *" }
   ]
 }

--- a/apps/web/app/(dashboard)/anomalies/anomalies-client.tsx
+++ b/apps/web/app/(dashboard)/anomalies/anomalies-client.tsx
@@ -16,6 +16,11 @@ import {
 import { Topbar, LiveDot } from '@/components/layout/topbar'
 import { PermissionGate } from '@/components/permission-gate'
 import { ExportDropdown } from '@/components/ui/export-dropdown'
+import {
+  buildInvestigateHref,
+  investigateRangeForObservationHours,
+  type InvestigateRange,
+} from '@/lib/anomaly-investigate'
 import { cn } from '@/lib/utils'
 
 type KindFilter = 'all' | AnomalyKind
@@ -159,7 +164,7 @@ interface AnomRowProps {
   ackPending: boolean
   dimmed?: boolean
   /** Investigate link maps the observation window to /requests `timeRange`. */
-  investigateRange: 'today' | '7d' | '30d'
+  investigateRange: InvestigateRange
 }
 
 function AnomRow({ a, last, onAck, onUnack, ackPending, dimmed, investigateRange }: AnomRowProps) {
@@ -169,8 +174,7 @@ function AnomRow({ a, last, onAck, onUnack, ackPending, dimmed, investigateRange
   const dotBg = isHigh ? 'bg-bad' : 'bg-accent'
   const anomId = anomDisplayId(a.provider, a.model, a.kind)
 
-  const investigateHref =
-    `/requests?provider=${encodeURIComponent(a.provider)}&model=${encodeURIComponent(a.model)}&timeRange=${investigateRange}`
+  const investigateHref = buildInvestigateHref(a.provider, a.model, investigateRange)
 
   return (
     <div
@@ -337,12 +341,6 @@ function confidenceRank(c: AnomalyConfidence | undefined | null): number {
   return 0
 }
 
-function investigateRangeForWindow(w: WindowPreset): 'today' | '7d' | '30d' {
-  // 1h / 24h obs both fit inside `today` (24h). 7d obs maps to 7d range.
-  if (w === '7d-30d') return '7d'
-  return 'today'
-}
-
 export function AnomaliesClient() {
   const router = useRouter()
   const sp = useSearchParams()
@@ -368,7 +366,8 @@ export function AnomaliesClient() {
   }
 
   const win = WINDOW_PRESETS[windowPreset]
-  const investigateRange = investigateRangeForWindow(windowPreset)
+  // 1h / 24h obs both fit inside `today` (24h). 7d obs maps to 7d range.
+  const investigateRange = investigateRangeForObservationHours(win.obs)
 
   const {
     data: anomalyResult,

--- a/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
@@ -15,6 +15,7 @@ import { useAuditLogs } from '@/lib/queries/use-audit-logs'
 import { usePrompts } from '@/lib/queries/use-prompts'
 import { useSecuritySummary } from '@/lib/queries/use-security'
 import { useDismissals, useDismissCard } from '@/lib/queries/use-dismissals'
+import { buildInvestigateHref, investigateRangeForObservationHours } from '@/lib/anomaly-investigate'
 import { cn, formatTime } from '@/lib/utils'
 import { linkPrefetchFor } from '@/lib/heavy-pages'
 import dynamic from 'next/dynamic'
@@ -506,7 +507,14 @@ export function DashboardClient() {
         meta: `${topAnomaly.deviations.toFixed(1)}σ · ${topAnomaly.provider}`,
         hint: `Current ${topAnomaly.currentValue.toFixed(0)} vs baseline ${topAnomaly.baselineMean.toFixed(0)}`,
         cta: 'Investigate requests →',
-        href: `/requests?${qs}`,
+        // Same prefilled /requests filters as the "Investigate" link on
+        // /anomalies — the dashboard anomalies query observes `hours`, so
+        // the drill-down time range is derived from the same window.
+        href: buildInvestigateHref(
+          topAnomaly.provider,
+          topAnomaly.model,
+          investigateRangeForObservationHours(hours),
+        ),
         secondary: { label: 'View anomaly →', href: `/anomalies?${qs}` },
       })
     }
@@ -570,7 +578,7 @@ export function DashboardClient() {
     }
 
     return cards
-  }, [anomalies.data, firingAlerts, recommendations.data, securitySummary.data, staleKeys.revoke, staleKeys.sampleName, timeRange, customRange, mountNow])
+  }, [anomalies.data, firingAlerts, recommendations.data, securitySummary.data, staleKeys.revoke, staleKeys.sampleName, timeRange, customRange, mountNow, hours])
 
   // Border classes for KPI cells — responsive 2-col (mobile) / 4-col (lg)
   const kpiCellClasses: [string, string, string, string] = [

--- a/apps/web/app/(dashboard)/requests/requests-client.tsx
+++ b/apps/web/app/(dashboard)/requests/requests-client.tsx
@@ -100,6 +100,15 @@ function statusPillClass(code: number): string {
   return 'border-border bg-bg text-text-muted'
 }
 
+// Accessible label for the status pill — screen readers get the error class
+// spelled out instead of relying on the pill hue.
+function statusPillAria(code: number): string {
+  if (code >= 500) return `HTTP ${code} server error`
+  if (code >= 400) return `HTTP ${code} client error`
+  if (code >= 200 && code < 300) return `HTTP ${code} success`
+  return `HTTP ${code}`
+}
+
 // Maps the URL `timeRange` enum to a human label used in stat-strip and
 // any "Last X" copy that the page renders.
 function timeRangeLabel(r: 'all' | 'today' | '7d' | '30d'): string {
@@ -1254,10 +1263,16 @@ function RequestsTable({
                   <span>
                     <span
                       className={cn(
-                        'inline-flex items-center justify-center font-mono text-[10.5px] px-1.5 py-px rounded-[3px] border tabular-nums',
+                        'inline-flex items-center justify-center gap-0.5 font-mono text-[10.5px] px-1.5 py-px rounded-[3px] border tabular-nums',
                         statusPillClass(req.status_code),
                       )}
+                      aria-label={statusPillAria(req.status_code)}
                     >
+                      {/* 5xx gets a small glyph so severity is not carried by
+                          color alone (WCAG 1.4.1 use of color). */}
+                      {req.status_code >= 500 && (
+                        <span aria-hidden="true" className="text-[8px] leading-none">▲</span>
+                      )}
                       {req.status_code}
                     </span>
                   </span>

--- a/apps/web/app/(dashboard)/savings/savings-client.tsx
+++ b/apps/web/app/(dashboard)/savings/savings-client.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useMemo, useRef, useSyncExternalStore } from 'reac
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useRecommendations, type ModelRecommendation } from '@/lib/queries/use-recommendations'
+import { useCacheSavings } from '@/lib/queries/use-cache-savings'
 import { usePercentiles } from '@/lib/queries/use-recommendation-percentiles'
 import { usePrompts, usePlaygroundRun, type PlaygroundResult } from '@/lib/queries/use-prompts'
 import { useProviderKeys } from '@/lib/queries/use-provider-keys'
@@ -63,6 +64,53 @@ function ConfidenceBar({ level }: { level: 'high' | 'medium' | 'low' }) {
       <span className={cn('font-mono text-[11px] capitalize', level === 'high' ? 'text-good' : level === 'medium' ? 'text-text' : 'text-text-faint')}>
         {level}
       </span>
+    </div>
+  )
+}
+
+// ── Prompt caching savings card ───────────────────────────────────────────────
+
+function fmtTokenCount(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return n.toLocaleString()
+}
+
+function CacheSavingsCard() {
+  const { data, isLoading, error } = useCacheSavings()
+
+  // Supplementary card: stay quiet while loading or on failure. The
+  // recommendations list below has its own loading and error surfaces, and a
+  // second error banner for the same backend would double up on this page.
+  if (isLoading || error || !data) return null
+
+  if (data.cacheHitRequests === 0) {
+    return (
+      <div className="border-b border-border px-[22px] py-[12px]">
+        <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint mb-1">
+          Prompt caching
+        </div>
+        <p className="text-[12.5px] text-text-muted">
+          No cache hits yet this month. Prompt caching savings will show up here automatically.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="border-b border-border bg-good/5 px-[22px] py-[12px]">
+      <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-good mb-1">
+        Prompt caching
+      </div>
+      <p className="text-[14px] font-medium text-text">
+        Prompt caching saved you <span className="text-good">{fmtUsd(data.savingsUsd)}</span> this month
+      </p>
+      <p className="text-[12px] text-text-faint mt-1 leading-relaxed">
+        Estimated from {fmtTokenCount(data.cacheReadTokens)} cached input tokens across{' '}
+        {data.cacheHitRequests.toLocaleString()} requests. Cached tokens are billed at a
+        discounted rate instead of the full input price.
+      </p>
     </div>
   )
 }
@@ -993,6 +1041,10 @@ export function SavingsClient() {
         />
         <h1 className="sr-only">Savings</h1>
       </div>
+
+      {/* Prompt caching savings — passive savings already earned this month,
+          shown above the actionable model-swap recommendations. */}
+      <CacheSavingsCard />
 
       {/* Hero strip — Open / Achieved cards are buttons that scroll to the
           matching section when populated. Same pattern as anomalies / security. */}

--- a/apps/web/app/(dashboard)/traces/empty-traces-hint.tsx
+++ b/apps/web/app/(dashboard)/traces/empty-traces-hint.tsx
@@ -5,23 +5,28 @@ import Link from 'next/link'
 import { Copy, Check, Terminal } from 'lucide-react'
 
 /**
- * First-run hint shown in the requests table when the account has no logged
- * requests yet (and no filters are hiding them). Gives a copy-paste test
- * call so a new user can confirm the proxy works without wiring code first;
- * the request list polls on its own, so the row appears here automatically
- * once the call lands.
+ * First-run hint shown in the traces table when the account has no traces
+ * yet (and no filters are hiding them). Unlike requests, traces don't come
+ * for free from the proxy — they need SDK instrumentation — so this gives
+ * the minimal startTrace / observe snippet; the trace list polls on its
+ * own, so the row appears here automatically once the first trace lands.
  */
-const TEST_CURL = `curl https://server.spanlens.io/proxy/openai/v1/chat/completions \\
-  -H "Authorization: Bearer $SPANLENS_API_KEY" \\
-  -H "Content-Type: application/json" \\
-  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hello from Spanlens"}]}'`
+const TRACE_SNIPPET = `import { SpanlensClient, observe } from '@spanlens/sdk'
 
-export function EmptyRequestsHint() {
+const client = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+
+const trace = client.startTrace({ name: 'my_workflow' })
+await observe(trace, { name: 'llm_step', spanType: 'llm' }, async (span) => {
+  // your LLM call here
+})
+await trace.end({ status: 'completed' })`
+
+export function EmptyTracesHint() {
   const [copied, setCopied] = useState(false)
 
   async function copy() {
     try {
-      await navigator.clipboard.writeText(TEST_CURL)
+      await navigator.clipboard.writeText(TRACE_SNIPPET)
       setCopied(true)
       setTimeout(() => setCopied(false), 1500)
     } catch {
@@ -32,13 +37,14 @@ export function EmptyRequestsHint() {
   return (
     <div className="flex flex-col items-center gap-3 max-w-xl w-full">
       <span className="text-[13px] text-text-muted">
-        No requests yet. Make your first API call through the proxy, or fire a quick test:
+        No traces yet. Traces group multiple LLM calls into one workflow, so an agent run reads
+        as a single timeline instead of scattered requests:
       </span>
 
       <div className="w-full rounded-md border border-border bg-[#1a1816] px-3 py-2.5 text-left">
         <div className="flex items-center justify-between mb-1.5">
           <span className="font-mono text-[10px] uppercase tracking-[0.05em] text-[#7c7770] flex items-center gap-1.5">
-            <Terminal className="w-3 h-3" /> Test call · curl
+            <Terminal className="w-3 h-3" /> Instrument · @spanlens/sdk
           </span>
           <button
             type="button"
@@ -57,34 +63,25 @@ export function EmptyRequestsHint() {
           </button>
         </div>
         <pre className="font-mono text-[11px] text-good leading-relaxed whitespace-pre-wrap break-words">
-          {TEST_CURL}
+          {TRACE_SNIPPET}
         </pre>
       </div>
 
       <span className="font-mono text-[10.5px] text-text-faint">
-        Set <code className="text-text-muted">SPANLENS_API_KEY</code> first. Requests usually appear
-        here within a few seconds of the call completing, and the list refreshes on its own.
-      </span>
-
-      <span className="font-mono text-[10.5px] text-text-faint">
-        Nothing showing up? Check that the key env var is set (and restart your dev server after
-        adding it), that a provider key exists, and that your baseURL points at the Spanlens
-        proxy. The{' '}
-        <Link href="/docs/quick-start" className="text-text-muted hover:text-text transition-colors">
-          quick start
-        </Link>{' '}
-        walks through each step.
+        Wrap your workflow with <code className="text-text-muted">startTrace</code> and{' '}
+        <code className="text-text-muted">observe</code> from the SDK. New traces appear here
+        automatically.
       </span>
 
       <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1">
         <Link
-          href="/projects"
+          href="/docs/features/traces"
           className="font-mono text-[11.5px] text-accent hover:opacity-80 transition-opacity"
         >
-          Add provider key →
+          Tracing docs →
         </Link>
         <Link
-          href="/docs/quick-start"
+          href="/docs/quick-start#tracing"
           className="font-mono text-[11.5px] text-text-muted hover:text-text transition-colors"
         >
           Quick start →

--- a/apps/web/app/(dashboard)/traces/traces-client.tsx
+++ b/apps/web/app/(dashboard)/traces/traces-client.tsx
@@ -1,12 +1,12 @@
 'use client'
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
-import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useTraces } from '@/lib/queries/use-traces'
 import { LIVE_REFETCH_MS_SECONDARY } from '@/lib/queries/live-polling'
 import type { TraceRow, TraceStatus } from '@/lib/queries/types'
 import { Topbar } from '@/components/layout/topbar'
 import { ExportDropdown } from '@/components/ui/export-dropdown'
+import { EmptyTracesHint } from './empty-traces-hint'
 import { cn, formatDateTime } from '@/lib/utils'
 
 // Hydration-safe "is this the client?" gate — same pattern as the dashboard
@@ -464,23 +464,7 @@ export function TracesClient() {
                 </button>
               </>
             ) : (
-              <>
-                <p className="text-[13px] text-text-muted">No traces yet — wire up agent tracing to start collecting them.</p>
-                <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1">
-                  <Link
-                    href="/projects"
-                    className="font-mono text-[11.5px] text-accent hover:opacity-80 transition-opacity"
-                  >
-                    Add provider key →
-                  </Link>
-                  <Link
-                    href="/docs/quick-start#tracing"
-                    className="font-mono text-[11.5px] text-text-muted hover:text-text transition-colors"
-                  >
-                    Tracing quick start →
-                  </Link>
-                </div>
-              </>
+              <EmptyTracesHint />
             )}
           </div>
         ) : (

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -11,7 +11,9 @@
     --border-strong: #d4d1ca;
     --text: #18181b;
     --text-muted: #5c5b57;
-    --text-faint: #94928c;
+    /* WCAG AA: previous #94928c was 2.98:1 on --bg. #706e68 is 4.88:1 on
+       --bg, 5.10:1 on --bg-elev, 4.59:1 on --bg-muted (same warm hue). */
+    --text-faint: #706e68;
     --accent: #b45309;
     --accent-bg: #fdf1df;
     --accent-border: #eccc99;
@@ -52,7 +54,9 @@
     --border-strong: #3a3a3f;
     --text: #fafaf9;
     --text-muted: #a1a1aa;
-    --text-faint: #61615f;
+    /* WCAG AA: previous #61615f was 3.15:1 on --bg. #8a8a86 is 5.64:1 on
+       --bg, 5.31:1 on --bg-elev, 5.11:1 on --bg-muted (same warm hue). */
+    --text-faint: #8a8a86;
     --accent: #f2a855;
     --accent-bg: #2a1c0a;
     --accent-border: #4a3010;

--- a/apps/web/components/dashboard/welcome-banner.tsx
+++ b/apps/web/components/dashboard/welcome-banner.tsx
@@ -299,7 +299,11 @@ function WelcomeBannerInner({ apiKey, onDismiss }: { apiKey: string; onDismiss: 
                   {buildTestCurl(apiKey)}
                 </pre>
               </div>
-              <div className="flex items-center gap-2 mt-2">
+              <p className="text-[11px] text-text-faint mt-2 leading-relaxed">
+                Requests usually show up within a few seconds of the call completing, and this
+                dashboard refreshes on its own.
+              </p>
+              <div className="flex items-center gap-2 mt-1.5">
                 <span className="inline-flex items-center gap-1.5 font-mono text-[11px] text-text-faint">
                   <Loader2 className="w-3.5 h-3.5 animate-spin" />
                   Waiting for your first request…

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { useTheme } from '@/components/providers/theme-provider'
-import { Sun, Moon, Monitor, X, MessageSquarePlus, PanelLeftClose } from 'lucide-react'
+import { Sun, Moon, Monitor, X, MessageSquarePlus, PanelLeftClose, TriangleAlert } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { createClient } from '@/lib/supabase/client'
 import { clearQueryClient } from '@/lib/query-client'
@@ -350,17 +350,37 @@ export function Sidebar() {
   ).length
   const savingsTotal = (recommendations.data ?? []).reduce((s, r) => s + r.estimatedMonthlySavingsUsd, 0)
 
-  const BADGES: Record<string, { label?: string; warn?: boolean }> = {
-    '/requests':   reqCount != null ? { label: reqCount > 999 ? (reqCount / 1000).toFixed(0) + 'k' : String(reqCount) } : {},
-    '/anomalies':  anomalyCount > 0 ? { label: String(anomalyCount), warn: true } : {},
+  // `aria` spells out what the badge means so screen-reader users are not
+  // left decoding a bare number whose severity is otherwise carried by hue.
+  const BADGES: Record<string, { label?: string; warn?: boolean; aria?: string }> = {
+    '/requests':   reqCount != null ? {
+      label: reqCount > 999 ? (reqCount / 1000).toFixed(0) + 'k' : String(reqCount),
+      aria: `${reqCount} requests in the last 24 hours`,
+    } : {},
+    '/anomalies':  anomalyCount > 0 ? {
+      label: String(anomalyCount),
+      warn: true,
+      aria: `${anomalyCount} active ${anomalyCount === 1 ? 'anomaly' : 'anomalies'}`,
+    } : {},
     '/security':   {},
-    '/savings': savingsTotal > 0 ? { label: '$' + (savingsTotal >= 1000 ? (savingsTotal / 1000).toFixed(0) + 'k' : savingsTotal.toFixed(0)) } : {},
-    '/alerts':     firingCount > 0 ? { label: String(firingCount), warn: true } : {},
+    '/savings': savingsTotal > 0 ? {
+      label: '$' + (savingsTotal >= 1000 ? (savingsTotal / 1000).toFixed(0) + 'k' : savingsTotal.toFixed(0)),
+      aria: `estimated savings of $${savingsTotal.toFixed(0)} per month available`,
+    } : {},
+    '/alerts':     firingCount > 0 ? {
+      label: String(firingCount),
+      warn: true,
+      aria: `${firingCount} firing ${firingCount === 1 ? 'alert' : 'alerts'}`,
+    } : {},
     // Sum stale + revoke so the badge surfaces both tiers in one glance.
     // We don't separate them here — the dashboard "Needs Attention" card
     // and the in-row badges on /projects already split them.
     '/projects':   staleKeys.revoke + staleKeys.stale > 0
-      ? { label: String(staleKeys.revoke + staleKeys.stale), warn: staleKeys.revoke > 0 }
+      ? {
+          label: String(staleKeys.revoke + staleKeys.stale),
+          warn: staleKeys.revoke > 0,
+          aria: `${staleKeys.revoke + staleKeys.stale} API ${staleKeys.revoke + staleKeys.stale === 1 ? 'key needs' : 'keys need'} attention`,
+        }
       : {},
   }
 
@@ -489,12 +509,20 @@ export function Sidebar() {
                 >
                   <span>{label}</span>
                   {badge?.label && (
-                    <span className={cn(
-                      'font-mono text-[10px] px-[6px] py-[1px] rounded-[3px] border',
-                      badge.warn
-                        ? 'bg-accent-bg text-accent border-accent-border'
-                        : 'bg-bg text-text-faint border-border',
-                    )}>
+                    <span
+                      className={cn(
+                        'inline-flex items-center gap-[3px] font-mono text-[10px] px-[6px] py-[1px] rounded-[3px] border',
+                        badge.warn
+                          ? 'bg-accent-bg text-accent border-accent-border'
+                          : 'bg-bg text-text-faint border-border',
+                      )}
+                      aria-label={badge.aria ?? badge.label}
+                    >
+                      {/* Warn badges carry a small icon so severity is not
+                          conveyed by color alone (WCAG 1.4.1). */}
+                      {badge.warn && (
+                        <TriangleAlert aria-hidden="true" className="h-[9px] w-[9px] shrink-0" />
+                      )}
                       {badge.label}
                     </span>
                   )}

--- a/apps/web/lib/anomaly-investigate.ts
+++ b/apps/web/lib/anomaly-investigate.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared URL-building logic for anomaly "Investigate" links. Used by the
+ * anomaly rows on /anomalies and the anomaly attention card on /dashboard
+ * so both drill into /requests with identical prefilled filters
+ * (provider + model + timeRange).
+ */
+
+export type InvestigateRange = 'today' | '7d' | '30d'
+
+/**
+ * Map an anomaly observation window (in hours) to the /requests `timeRange`
+ * param. 1h / 24h observations both fit inside `today` (24h); up to 7d maps
+ * to the 7d range; anything longer falls back to 30d.
+ */
+export function investigateRangeForObservationHours(obsHours: number): InvestigateRange {
+  if (obsHours <= 24) return 'today'
+  if (obsHours <= 24 * 7) return '7d'
+  return '30d'
+}
+
+/** Build the /requests href with provider / model / timeRange prefilled. */
+export function buildInvestigateHref(
+  provider: string,
+  model: string,
+  range: InvestigateRange,
+): string {
+  return `/requests?provider=${encodeURIComponent(provider)}&model=${encodeURIComponent(model)}&timeRange=${range}`
+}

--- a/apps/web/lib/queries/use-cache-savings.ts
+++ b/apps/web/lib/queries/use-cache-savings.ts
@@ -1,0 +1,30 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { apiGet } from '@/lib/api'
+import type { ApiEnvelope } from './types'
+
+/** Mirrors CacheSavingsSummary in apps/server/src/lib/cache-savings.ts. */
+export interface CacheSavingsSummary {
+  /** Estimated USD not paid this month thanks to discounted cache reads. */
+  savingsUsd: number
+  /** Total cached input tokens this month. */
+  cacheReadTokens: number
+  /** Requests this month that had at least one cache hit. */
+  cacheHitRequests: number
+  /** ISO timestamp of the UTC month boundary the window starts at. */
+  monthStart: string
+}
+
+export function useCacheSavings() {
+  return useQuery({
+    queryKey: ['cache-savings'] as const,
+    queryFn: async () => {
+      const res = await apiGet<ApiEnvelope<CacheSavingsSummary>>(
+        '/api/v1/recommendations/cache-savings',
+      )
+      return res.data ?? null
+    },
+    staleTime: 10 * 60_000,
+  })
+}

--- a/supabase/migrations/20260706130000_data_silence_alerts.sql
+++ b/supabase/migrations/20260706130000_data_silence_alerts.sql
@@ -1,0 +1,36 @@
+-- Data silence alert episodes (retention improvement, 2026-07-06).
+--
+-- Tracks "org went quiet" episodes: an org that had steady traffic
+-- (>= 50 requests in the 7 days ending 24h ago) but zero requests in the
+-- last 24h gets one email per episode. When data resumes the episode is
+-- resolved so a future silence can alert again.
+--
+-- Server-only table: written and read exclusively via supabaseAdmin from
+-- the /cron/detect-data-silence job. RLS enabled with no policies so the
+-- anon/authenticated roles cannot touch it.
+
+CREATE TABLE IF NOT EXISTS data_silence_alerts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  detected_at timestamptz NOT NULL DEFAULT now(),
+  resolved_at timestamptz,
+  -- Last request we saw before the silence started (null if unknown).
+  last_request_at timestamptz,
+  -- Volume in the 7-day window ending 24h before detection. Kept for the
+  -- email body and for later tuning of the threshold.
+  prior_week_requests integer NOT NULL DEFAULT 0,
+  -- True once at least one admin recipient accepted the email. Lets the
+  -- cron retry delivery on the next run without opening a new episode.
+  email_sent boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- One OPEN episode per org — DB-level dedup even if the cron double-fires.
+CREATE UNIQUE INDEX IF NOT EXISTS data_silence_alerts_one_open_per_org
+  ON data_silence_alerts (organization_id)
+  WHERE resolved_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS data_silence_alerts_org_idx
+  ON data_silence_alerts (organization_id, detected_at DESC);
+
+ALTER TABLE data_silence_alerts ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary

First batch from the product review: six improvements targeting onboarding first impressions, daily-use friction, silent churn, and accessibility.

### 1. Empty-state package (onboarding)
- Requests empty state now says results appear within a few seconds and lists the three common setup causes (env var not loaded, provider key missing, wrong baseURL) with a quick-start link.
- New `EmptyTracesHint` on /traces explains that traces require SDK instrumentation with `observe()` and links the tracing docs. Shown only when the list is empty with no active filters.
- Welcome banner step 4 notes that the dashboard refreshes automatically.

### 2. Anomaly drill-down
- The dashboard "Needs attention" Investigate link now carries the matching time range, so landing on /requests shows the right window. URL building is shared with the anomalies page via `apps/web/lib/anomaly-investigate.ts` (no behavior change there).

### 3. Data-silence alert (retention)
- New 6-hour cron `detect-data-silence`: orgs with 50+ requests in the prior 7 days and zero in the last 24 hours get an admin email with last request time, prior volume, three likely causes, and links to /requests and the quick-start docs.
- One open episode per org (partial unique index), auto-resolves when data resumes so future silences re-alert. Unsent emails retry on the next run.
- New `data_silence_alerts` table (RLS enabled, server-only access).

### 4. Quota upgrade CTA
- The 100% quota email now has an "Upgrade your plan" button linking to /billing, an HTML variant, and truthful enforcement copy per the org's overage setting (429 before upstream when overage is off; overage billing to the hard cap when on). The 80% email gains a softer raise-your-limit line.

### 5. Prompt cache savings card
- /savings now shows "Prompt caching saved you $X this month", computed from the `cache_read_tokens` we already store: sum of cached tokens times (input price minus cache-read price), month-to-date, tenant-scoped via `requestsScope`.
- New `GET /api/v1/recommendations/cache-savings` on the existing dual-auth router. `lookupPrice` exported from `lib/cost.ts` rather than duplicated.

### 6. Badge legibility and contrast
- Status pills: aria-labels plus a non-color cue on 5xx.
- Sidebar alert/anomaly badges: aria-labels plus a warning icon.
- `--text-faint` raised to WCAG AA: dark 3.15:1 to 5.64:1, light 2.98:1 to 4.88:1.

## Test plan
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` (1428 tests), `pnpm build` all pass locally
- [x] New tests: data-silence (21), cache-savings (12), quota-warnings (+12 assertions)
- [x] Code review pass: 0 critical/high; both medium findings fixed in this branch (generic error message on the new endpoint, documented alert-email opt-out coupling)
- [ ] After deploy: run `supabase gen types --lang typescript --local > supabase/types.ts` and commit the regenerated types
- [ ] After deploy: verify `cron_job_runs` shows `detect-data-silence` firing (gotcha 32); add a Better Stack monitor if it under-fires
- [ ] Manual smoke: /traces empty state for a fresh org, /savings card with and without cache hits, quota email rendering
