### PR TITLE
feat: weekly digest, proxy response caching, CLI-first onboarding, SDK error ergonomics

### DIFF
--- a/.github/workflows/cron-server.yml
+++ b/.github/workflows/cron-server.yml
@@ -69,7 +69,7 @@ on:
     - cron: '0 9 * * *'        # daily 09:00 — recommend-savings-alerts
     - cron: '0 10 * * *'       # daily 10:00 — check-past-due-downgrades
     - cron: '0 3 * * *'        # daily 03:00 — prune-judge-cache
-    - cron: '0 9 * * 1'        # weekly Monday 09:00 — stale-key-reminders
+    - cron: '0 9 * * 1'        # weekly Monday 09:00 — stale-key-reminders + weekly-digest
     - cron: '30 */6 * * *'     # every 6h at :30 — detect-data-silence
   workflow_dispatch:
 
@@ -283,7 +283,7 @@ jobs:
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
 
   weekly-mon-09:
-    name: Weekly Monday 09:00 UTC (stale-key-reminders)
+    name: Weekly Monday 09:00 UTC (stale-key-reminders + weekly-digest)
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '0 9 * * 1' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -294,6 +294,21 @@ jobs:
           STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
             -H "Authorization: Bearer $CRON_SECRET" \
             "$BASE_URL/cron/stale-key-reminders")
+          echo "Status: $STATUS"
+          cat /tmp/body
+          if [ "$STATUS" -ge 400 ]; then exit 1; fi
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+
+      # Weekly usage digest. Safe to double-fire alongside the Vercel cron:
+      # the handler checks cron_job_runs for a successful run in the same
+      # ISO week and no-ops when one exists.
+      - name: POST /cron/weekly-digest
+        run: |
+          BASE_URL='https://spanlens-server.vercel.app'
+          STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            "$BASE_URL/cron/weekly-digest")
           echo "Status: $STATUS"
           cat /tmp/body
           if [ "$STATUS" -ge 400 ]; then exit 1; fi

--- a/apps/server/src/__tests__/proxy-cache-integration.test.ts
+++ b/apps/server/src/__tests__/proxy-cache-integration.test.ts
@@ -1,0 +1,344 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { Context, MiddlewareHandler, Next } from 'hono'
+import { drainPendingTasks, mockUpstream, openAIChatResponse, proxyState, resetProxyMocks } from './helpers/proxy-mocks.js'
+import { installOnError } from './helpers/install-on-error.js'
+
+/**
+ * Integration tests for the opt-in response cache (x-spanlens-cache header)
+ * wired through the OpenAI proxy handler. Follows the proxy-openai.test.ts
+ * harness: middleware no-op'd, upstream fetch spied, fireAndForget queued into
+ * proxyState.pendingTasks, and — new here — supabaseAdmin replaced with an
+ * in-memory Map backing the `proxy_response_cache` table so the real
+ * lib/proxy-cache.ts read/write paths execute end to end.
+ *
+ * Contract pinned:
+ *   1. MISS: upstream called, `x-spanlens-cache: miss` on the response, row
+ *      stored with expires_at.
+ *   2. HIT: identical request served WITHOUT calling upstream, byte-identical
+ *      body, `x-spanlens-cache: hit`, logged with cacheHit=true + costUsd=0
+ *      and the ORIGINAL token counts.
+ *   3. No header → no caching, no cache response header.
+ *   4. stream:true + header → `x-spanlens-cache: bypass`, nothing stored.
+ *   5. Different Spanlens key → the cached entry is NOT shared (security).
+ */
+
+// === In-memory proxy_response_cache store ==================================
+
+const cacheStore = new Map<string, Record<string, unknown>>()
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: (table: string) => {
+      if (table !== 'proxy_response_cache') {
+        throw new Error(`unexpected table in proxy-cache integration test: ${table}`)
+      }
+      return {
+        select: () => ({
+          eq: (_col: string, keyHash: string) => ({
+            maybeSingle: async () => ({ data: cacheStore.get(keyHash) ?? null, error: null }),
+          }),
+        }),
+        upsert: async (row: Record<string, unknown>) => {
+          cacheStore.set(row['key_hash'] as string, row)
+          return { error: null }
+        },
+        delete: () => ({
+          eq: (_col: string, keyHash: string) => ({
+            lt: async () => {
+              cacheStore.delete(keyHash)
+              return { error: null }
+            },
+          }),
+        }),
+      }
+    },
+  },
+  supabaseClient: {},
+}))
+
+// === Standard proxy harness mocks (same shape as proxy-openai.test.ts) =====
+
+vi.mock('../middleware/authApiKey.js', async () => {
+  const actual = await vi.importActual<typeof import('../middleware/authApiKey.js')>(
+    '../middleware/authApiKey.js',
+  )
+  return {
+    ...actual,
+    authApiKey: (async (c: Context, next: Next) => {
+      c.set('apiKeyId', proxyState.apiKeyId)
+      c.set('organizationId', proxyState.organizationId)
+      c.set('projectId', proxyState.projectId)
+      c.set('apiKeyScope', proxyState.scope)
+      await next()
+    }) as MiddlewareHandler,
+  }
+})
+
+vi.mock('../middleware/requireFullScope.js', () => ({
+  requireFullScope: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/rateLimit.js', () => ({
+  proxyRateLimit: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/quota.js', () => ({
+  enforceQuota: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../middleware/customerRateLimit.js', () => ({
+  customerRateLimit: (async (_c: Context, next: Next) => { await next() }) as MiddlewareHandler,
+}))
+
+vi.mock('../proxy/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../proxy/utils.js')>(
+    '../proxy/utils.js',
+  )
+  return {
+    ...actual,
+    getDecryptedProviderKey: vi.fn(async () => ({
+      plaintext: proxyState.decryptedKey,
+      id: proxyState.providerKeyId,
+      metadata: {},
+    })),
+    isBlockingEnabled: vi.fn(async () => proxyState.blockingEnabled),
+  }
+})
+
+vi.mock('../lib/logger.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/logger.js')>(
+    '../lib/logger.js',
+  )
+  return {
+    ...actual,
+    logRequestAsync: vi.fn(async (data: Record<string, unknown>) => {
+      proxyState.loggerCalls.push(data)
+    }),
+  }
+})
+
+vi.mock('../lib/resolve-prompt-version.js', () => ({
+  resolvePromptVersion: vi.fn(async () => null),
+}))
+
+vi.mock('../lib/wait-until.js', () => ({
+  fireAndForget: (_c: Context, promise: Promise<unknown>) => {
+    proxyState.pendingTasks.push(promise.catch(() => undefined))
+  },
+}))
+
+// === App harness ===========================================================
+
+async function buildApp() {
+  const { Hono } = await import('hono')
+  const { openaiProxy } = await import('../proxy/openai.js')
+  const app = new Hono()
+  app.route('/proxy/openai', openaiProxy)
+  installOnError(app)
+  return app
+}
+
+const CHAT_BODY = JSON.stringify({
+  model: 'gpt-4o-mini',
+  messages: [{ role: 'user', content: 'hi' }],
+})
+
+function chatRequest(app: Awaited<ReturnType<typeof buildApp>>, headers: Record<string, string> = {}, body: string = CHAT_BODY) {
+  return app.request('/proxy/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body,
+  })
+}
+
+// === Tests =================================================================
+
+beforeEach(() => {
+  resetProxyMocks()
+  cacheStore.clear()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('openai proxy — response cache miss → hit', () => {
+  test('first request is a miss (stored), identical second request is a hit that skips upstream', async () => {
+    mockUpstream(openAIChatResponse({ model: 'gpt-4o-mini-2024-07-18', promptTokens: 10, completionTokens: 5 }))
+    const app = await buildApp()
+
+    // ── First request: MISS ──────────────────────────────────────────────
+    const miss = await chatRequest(app, { 'x-spanlens-cache': 'true' })
+    await drainPendingTasks()
+
+    expect(miss.status).toBe(200)
+    expect(miss.headers.get('x-spanlens-cache')).toBe('miss')
+    expect(proxyState.fetchCalls).toHaveLength(1)
+    expect(cacheStore.size).toBe(1)
+    const missBody = await miss.text()
+
+    const storedRow = [...cacheStore.values()][0]!
+    expect(storedRow['api_key_id']).toBe(proxyState.apiKeyId)
+    expect(storedRow['provider']).toBe('openai')
+    expect(storedRow['response_body']).toBe(missBody)
+    expect(new Date(storedRow['expires_at'] as string).getTime()).toBeGreaterThan(Date.now())
+
+    const missLog = proxyState.loggerCalls[0]!
+    expect(missLog['cacheHit']).toBeUndefined()
+    expect(missLog['costUsd']).not.toBe(0)
+
+    // ── Second identical request: HIT ────────────────────────────────────
+    proxyState.loggerCalls = []
+    const hit = await chatRequest(app, { 'x-spanlens-cache': 'true' })
+    await drainPendingTasks()
+
+    expect(hit.status).toBe(200)
+    expect(hit.headers.get('x-spanlens-cache')).toBe('hit')
+    expect(hit.headers.get('content-type')).toBe('application/json')
+    // Upstream was NOT called again.
+    expect(proxyState.fetchCalls).toHaveLength(1)
+    // Byte-identical body.
+    expect(await hit.text()).toBe(missBody)
+
+    // The hit is still logged — with the cached tokens, zero cost, cacheHit.
+    expect(proxyState.loggerCalls).toHaveLength(1)
+    const hitLog = proxyState.loggerCalls[0]!
+    expect(hitLog['cacheHit']).toBe(true)
+    expect(hitLog['costUsd']).toBe(0)
+    expect(hitLog['model']).toBe('gpt-4o-mini-2024-07-18')
+    expect(hitLog['promptTokens']).toBe(10)
+    expect(hitLog['completionTokens']).toBe(5)
+    expect(hitLog['totalTokens']).toBe(15)
+    expect(hitLog['statusCode']).toBe(200)
+  })
+
+  test('a different Spanlens key does NOT see the cached entry (cross-key isolation)', async () => {
+    mockUpstream(openAIChatResponse())
+    const app = await buildApp()
+
+    await chatRequest(app, { 'x-spanlens-cache': 'true' })
+    await drainPendingTasks()
+    expect(proxyState.fetchCalls).toHaveLength(1)
+
+    // Same request, different authenticated key → must go upstream again.
+    proxyState.apiKeyId = 'key_other_tenant'
+    const res = await chatRequest(app, { 'x-spanlens-cache': 'true' })
+    await drainPendingTasks()
+
+    expect(res.headers.get('x-spanlens-cache')).toBe('miss')
+    expect(proxyState.fetchCalls).toHaveLength(2)
+    expect(cacheStore.size).toBe(2)
+  })
+
+  test('a different request body does not hit the cached entry (exact match)', async () => {
+    mockUpstream(openAIChatResponse())
+    const app = await buildApp()
+
+    await chatRequest(app, { 'x-spanlens-cache': 'true' })
+    await drainPendingTasks()
+
+    const otherBody = JSON.stringify({ model: 'gpt-4o-mini', messages: [{ role: 'user', content: 'bye' }] })
+    const res = await chatRequest(app, { 'x-spanlens-cache': 'true' }, otherBody)
+    await drainPendingTasks()
+
+    expect(res.headers.get('x-spanlens-cache')).toBe('miss')
+    expect(proxyState.fetchCalls).toHaveLength(2)
+  })
+})
+
+describe('openai proxy — response cache opt-in gating', () => {
+  test('without the header nothing is cached and no cache response header appears', async () => {
+    mockUpstream(openAIChatResponse())
+    const app = await buildApp()
+
+    const res = await chatRequest(app)
+    await drainPendingTasks()
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('x-spanlens-cache')).toBeNull()
+    expect(cacheStore.size).toBe(0)
+  })
+
+  test('malformed header value is treated as off', async () => {
+    mockUpstream(openAIChatResponse())
+    const app = await buildApp()
+
+    const res = await chatRequest(app, { 'x-spanlens-cache': 'forever' })
+    await drainPendingTasks()
+
+    expect(res.headers.get('x-spanlens-cache')).toBeNull()
+    expect(cacheStore.size).toBe(0)
+  })
+
+  test('stream:true bypasses the cache — header answers "bypass", nothing stored', async () => {
+    const sse = [
+      'data: {"id":"chatcmpl-s","choices":[{"delta":{"content":"hi"}}]}',
+      'data: [DONE]',
+      '',
+    ].join('\n')
+    mockUpstream(new Response(sse, {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    }))
+    const app = await buildApp()
+
+    const res = await chatRequest(
+      app,
+      { 'x-spanlens-cache': 'true' },
+      JSON.stringify({ model: 'gpt-4o-mini', stream: true, messages: [] }),
+    )
+    await res.text() // drain the stream so the pump completes
+    await drainPendingTasks()
+
+    expect(res.headers.get('x-spanlens-cache')).toBe('bypass')
+    expect(cacheStore.size).toBe(0)
+  })
+
+  test('upstream errors are never cached', async () => {
+    mockUpstream(new Response(JSON.stringify({ error: { message: 'boom' } }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    }))
+    const app = await buildApp()
+
+    const res = await chatRequest(app, { 'x-spanlens-cache': 'true' })
+    await drainPendingTasks()
+
+    expect(res.status).toBe(500)
+    expect(res.headers.get('x-spanlens-cache')).toBe('miss')
+    expect(cacheStore.size).toBe(0)
+  })
+
+  test('the x-spanlens-cache request header never reaches upstream', async () => {
+    mockUpstream(openAIChatResponse())
+    const app = await buildApp()
+
+    await chatRequest(app, { 'x-spanlens-cache': 'true' })
+    await drainPendingTasks()
+
+    const sent = proxyState.fetchCalls[0]!
+    expect(sent.headers.get('x-spanlens-cache')).toBeNull()
+  })
+})
+
+describe('openai proxy — expired cache entries', () => {
+  test('an expired row is a miss and gets cleaned up opportunistically', async () => {
+    mockUpstream(openAIChatResponse())
+    const app = await buildApp()
+
+    // Seed via a real miss, then force-expire the stored row.
+    await chatRequest(app, { 'x-spanlens-cache': 'true' })
+    await drainPendingTasks()
+    const [keyHash, row] = [...cacheStore.entries()][0]!
+    cacheStore.set(keyHash, { ...row, expires_at: new Date(Date.now() - 1_000).toISOString() })
+
+    const res = await chatRequest(app, { 'x-spanlens-cache': 'true' })
+    await drainPendingTasks()
+
+    expect(res.headers.get('x-spanlens-cache')).toBe('miss')
+    expect(proxyState.fetchCalls).toHaveLength(2)
+    // The second miss re-stored a fresh row (cleanup delete + upsert both ran).
+    const refreshed = cacheStore.get(keyHash)!
+    expect(new Date(refreshed['expires_at'] as string).getTime()).toBeGreaterThan(Date.now())
+  })
+})

--- a/apps/server/src/__tests__/weekly-digest-email.test.ts
+++ b/apps/server/src/__tests__/weekly-digest-email.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import { renderWeeklyDigestEmail } from '../lib/resend.js'
+
+function baseParams() {
+  return {
+    orgName: 'Acme Inc',
+    periodLabel: 'Jun 29 to Jul 5',
+    requestCount: 12345,
+    totalCostUsd: 42.5,
+    costChangePct: 25 as number | null,
+    errorCount: 12,
+    errorRatePct: 0.097,
+    topModels: [
+      { provider: 'openai', model: 'gpt-4o', costUsd: 30.25, requestCount: 4000 },
+      { provider: 'anthropic', model: 'claude-sonnet', costUsd: 12.25, requestCount: 8345 },
+    ],
+    anomalyCount: 3 as number | null,
+    recommendation: {
+      currentModel: 'gpt-4o',
+      suggestedModel: 'gpt-4o-mini',
+      estimatedMonthlySavingsUsd: 87.5,
+    } as { currentModel: string; suggestedModel: string; estimatedMonthlySavingsUsd: number } | null,
+    dashboardUrl: 'https://www.spanlens.io/dashboard',
+  }
+}
+
+describe('renderWeeklyDigestEmail', () => {
+  it('builds the "Your Spanlens week" subject from requests and cost', () => {
+    const { subject } = renderWeeklyDigestEmail(baseParams())
+    expect(subject).toBe('Your Spanlens week: 12,345 requests, $42.50')
+  })
+
+  it('rounds large dollar amounts in the subject', () => {
+    const { subject } = renderWeeklyDigestEmail({ ...baseParams(), totalCostUsd: 1234.56 })
+    expect(subject).toBe('Your Spanlens week: 12,345 requests, $1,235')
+  })
+
+  it('never contains an em dash or en dash (external-copy policy)', () => {
+    const variants = [
+      baseParams(),
+      { ...baseParams(), costChangePct: null, anomalyCount: null, recommendation: null, topModels: [] },
+      { ...baseParams(), costChangePct: -40, errorCount: 0, anomalyCount: 0 },
+    ]
+    for (const params of variants) {
+      const { subject, html } = renderWeeklyDigestEmail(params)
+      expect(subject).not.toMatch(/[—–]/)
+      expect(html).not.toMatch(/[—–]/)
+    }
+  })
+
+  it('describes the cost trend direction', () => {
+    expect(renderWeeklyDigestEmail(baseParams()).html).toContain(
+      'Spend is up 25% from the week before.',
+    )
+    expect(renderWeeklyDigestEmail({ ...baseParams(), costChangePct: -40 }).html).toContain(
+      'Spend is down 40% from the week before.',
+    )
+    expect(renderWeeklyDigestEmail({ ...baseParams(), costChangePct: 2 }).html).toContain(
+      'Spend is about the same as the week before.',
+    )
+    expect(renderWeeklyDigestEmail({ ...baseParams(), costChangePct: null }).html).toContain(
+      'There is no prior week to compare against yet.',
+    )
+  })
+
+  it('lists top models with per-model cost and request counts', () => {
+    const { html } = renderWeeklyDigestEmail(baseParams())
+    expect(html).toContain('gpt-4o')
+    expect(html).toContain('claude-sonnet')
+    expect(html).toContain('$30.25')
+    expect(html).toContain('8,345')
+  })
+
+  it('omits the models table when there are no model rows', () => {
+    const { html } = renderWeeklyDigestEmail({ ...baseParams(), topModels: [] })
+    expect(html).not.toContain('Top models by cost')
+  })
+
+  it('shows the error line, or a clean sentence when there were no failures', () => {
+    expect(renderWeeklyDigestEmail(baseParams()).html).toContain(
+      '12 failed requests (0.1% error rate).',
+    )
+    expect(renderWeeklyDigestEmail({ ...baseParams(), errorCount: 0 }).html).toContain(
+      'No failed requests this week.',
+    )
+  })
+
+  it('mentions anomalies only when at least one was detected', () => {
+    expect(renderWeeklyDigestEmail(baseParams()).html).toContain('3 anomalies were detected')
+    expect(renderWeeklyDigestEmail({ ...baseParams(), anomalyCount: 1 }).html).toContain(
+      '1 anomaly was detected',
+    )
+    expect(renderWeeklyDigestEmail({ ...baseParams(), anomalyCount: 0 }).html).not.toContain(
+      'detected this week',
+    )
+    expect(renderWeeklyDigestEmail({ ...baseParams(), anomalyCount: null }).html).not.toContain(
+      'detected this week',
+    )
+  })
+
+  it('includes the savings tip only when a recommendation exists', () => {
+    const withRec = renderWeeklyDigestEmail(baseParams()).html
+    expect(withRec).toContain('Savings tip')
+    expect(withRec).toContain('gpt-4o-mini')
+    expect(withRec).toContain('$87.50 per month')
+
+    const withoutRec = renderWeeklyDigestEmail({ ...baseParams(), recommendation: null }).html
+    expect(withoutRec).not.toContain('Savings tip')
+  })
+
+  it('links to the dashboard and escapes the org name', () => {
+    const { html } = renderWeeklyDigestEmail({
+      ...baseParams(),
+      orgName: '<script>alert(1)</script>',
+    })
+    expect(html).toContain('https://www.spanlens.io/dashboard')
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;')
+  })
+})

--- a/apps/server/src/__tests__/weekly-digest.test.ts
+++ b/apps/server/src/__tests__/weekly-digest.test.ts
@@ -1,0 +1,435 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockFrom = vi.hoisted(() => vi.fn())
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: { from: mockFrom },
+}))
+
+const mockChQuery = vi.hoisted(() => vi.fn())
+vi.mock('../lib/clickhouse.js', () => ({
+  unscopedClickhouse: () => ({ query: mockChQuery }),
+  // Real implementation is trivial — inline it so the module under test
+  // still produces ClickHouse-shaped timestamps (gotcha #18).
+  toClickhouseTimestamp: (d: Date) => d.toISOString().replace('T', ' ').replace('Z', ''),
+}))
+
+const mockSendEmail = vi.hoisted(() => vi.fn())
+const mockRenderEmail = vi.hoisted(() =>
+  vi.fn(() => ({ subject: 'test subject', html: '<p>test</p>' })),
+)
+vi.mock('../lib/resend.js', () => ({
+  sendEmail: mockSendEmail,
+  renderWeeklyDigestEmail: mockRenderEmail,
+}))
+
+const mockGetRecipients = vi.hoisted(() => vi.fn())
+vi.mock('../lib/digest-recipients.js', () => ({
+  getWeeklyDigestRecipients: mockGetRecipients,
+}))
+
+const mockRecommend = vi.hoisted(() => vi.fn())
+vi.mock('../lib/model-recommend.js', () => ({
+  recommendModelSwaps: mockRecommend,
+}))
+
+import {
+  computeDigestWindow,
+  isoWeekStartUtc,
+  formatPeriodLabel,
+  computeCostChangePct,
+  pickTopRecommendation,
+  topModelsByOrg,
+  runWeeklyDigestJob,
+  DIGEST_TOP_MODELS_LIMIT,
+} from '../lib/weekly-digest.js'
+import type { ModelRecommendation } from '../lib/model-recommend.js'
+
+// 2026-07-06 is a Monday.
+const MONDAY = new Date('2026-07-06T09:00:00.000Z')
+
+function rec(overrides: Partial<ModelRecommendation> = {}): ModelRecommendation {
+  return {
+    currentProvider: 'openai',
+    currentModel: 'gpt-4o',
+    sampleCount: 100,
+    avgPromptTokens: 500,
+    avgCompletionTokens: 200,
+    totalCostUsdLastNDays: 40,
+    suggestedProvider: 'openai',
+    suggestedModel: 'gpt-4o-mini',
+    estimatedMonthlySavingsUsd: 120,
+    reason: 'cheaper for small prompts',
+    maxPromptTokens: 4000,
+    maxCompletionTokens: 1000,
+    priorWindowCostUsd: null,
+    achieved: false,
+    actualMonthlySavingsUsd: null,
+    ...overrides,
+  }
+}
+
+// ── Pure helpers ───────────────────────────────────────────────────
+
+describe('computeDigestWindow', () => {
+  it('covers the last 7 full UTC days ending at today 00:00 UTC', () => {
+    const w = computeDigestWindow(MONDAY)
+    expect(w.weekEnd.toISOString()).toBe('2026-07-06T00:00:00.000Z')
+    expect(w.weekStart.toISOString()).toBe('2026-06-29T00:00:00.000Z')
+    expect(w.priorStart.toISOString()).toBe('2026-06-22T00:00:00.000Z')
+  })
+})
+
+describe('isoWeekStartUtc', () => {
+  it('returns the same day at midnight for a Monday', () => {
+    expect(isoWeekStartUtc(MONDAY).toISOString()).toBe('2026-07-06T00:00:00.000Z')
+  })
+
+  it('returns the previous Monday for a Sunday', () => {
+    const sunday = new Date('2026-07-05T23:59:00.000Z')
+    expect(isoWeekStartUtc(sunday).toISOString()).toBe('2026-06-29T00:00:00.000Z')
+  })
+})
+
+describe('formatPeriodLabel', () => {
+  it('labels the window with the first and last INCLUDED day', () => {
+    expect(formatPeriodLabel(computeDigestWindow(MONDAY))).toBe('Jun 29 to Jul 5')
+  })
+})
+
+describe('computeCostChangePct', () => {
+  it('computes the week-over-week percentage', () => {
+    expect(computeCostChangePct(110, 100, 500)).toBeCloseTo(10)
+    expect(computeCostChangePct(50, 100, 500)).toBeCloseTo(-50)
+  })
+
+  it('returns null when the prior week had no requests', () => {
+    expect(computeCostChangePct(100, 0, 0)).toBeNull()
+  })
+
+  it('returns null when the prior week had requests but zero recorded cost', () => {
+    expect(computeCostChangePct(100, 0, 42)).toBeNull()
+  })
+})
+
+describe('pickTopRecommendation', () => {
+  it('returns null for an empty list', () => {
+    expect(pickTopRecommendation([])).toBeNull()
+  })
+
+  it('picks the highest projected monthly savings', () => {
+    const best = pickTopRecommendation([
+      rec({ estimatedMonthlySavingsUsd: 10, currentModel: 'a' }),
+      rec({ estimatedMonthlySavingsUsd: 99, currentModel: 'b' }),
+      rec({ estimatedMonthlySavingsUsd: 40, currentModel: 'c' }),
+    ])
+    expect(best?.currentModel).toBe('b')
+  })
+})
+
+describe('topModelsByOrg', () => {
+  it('groups per org, sorts by cost desc, and keeps the top 3', () => {
+    const rows = [
+      { organization_id: 'org-1', provider: 'openai', model: 'm1', cost_usd: 1, request_count: 10 },
+      { organization_id: 'org-1', provider: 'openai', model: 'm2', cost_usd: 9, request_count: 5 },
+      { organization_id: 'org-1', provider: 'anthropic', model: 'm3', cost_usd: 4, request_count: 8 },
+      { organization_id: 'org-1', provider: 'gemini', model: 'm4', cost_usd: 2, request_count: 2 },
+      { organization_id: 'org-2', provider: 'openai', model: 'm5', cost_usd: 3, request_count: 1 },
+    ]
+    const grouped = topModelsByOrg(rows)
+    expect(grouped.get('org-1')).toHaveLength(DIGEST_TOP_MODELS_LIMIT)
+    expect(grouped.get('org-1')!.map((m) => m.model)).toEqual(['m2', 'm3', 'm4'])
+    expect(grouped.get('org-2')!.map((m) => m.model)).toEqual(['m5'])
+  })
+})
+
+// ── Job integration (mocked I/O) ───────────────────────────────────
+
+interface MockState {
+  claimError: null | { code?: string; message: string }
+  claimInserts: Record<string, unknown>[]
+  statsRows: Array<Record<string, unknown>>
+  modelRows: Array<Record<string, unknown>>
+  orgNames: Array<{ id: string; name: string | null }>
+  anomalyCount: number | null
+  anomalyError: null | { message: string }
+  auditInserts: Record<string, unknown>[]
+}
+
+let state: MockState
+
+function setupMocks(): void {
+  mockFrom.mockImplementation((table: string) => {
+    if (table === 'weekly_digest_runs') {
+      return {
+        insert: (row: Record<string, unknown>) => {
+          state.claimInserts.push(row)
+          return Promise.resolve({ error: state.claimError })
+        },
+      }
+    }
+    if (table === 'organizations') {
+      return {
+        select: () => ({
+          in: () => Promise.resolve({ data: state.orgNames, error: null }),
+        }),
+      }
+    }
+    if (table === 'anomaly_events') {
+      return {
+        select: () => ({
+          eq: () => ({
+            gte: () => ({
+              lt: () =>
+                Promise.resolve(
+                  state.anomalyError
+                    ? { count: null, error: state.anomalyError }
+                    : { count: state.anomalyCount, error: null },
+                ),
+            }),
+          }),
+        }),
+      }
+    }
+    if (table === 'audit_logs') {
+      return {
+        insert: (row: Record<string, unknown>) => {
+          state.auditInserts.push(row)
+          return Promise.resolve({ error: null })
+        },
+      }
+    }
+    throw new Error(`unexpected table ${table}`)
+  })
+
+  mockChQuery.mockImplementation((args: { query: string }) => {
+    const isTopModels = args.query.includes('GROUP BY organization_id, provider, model')
+    return Promise.resolve({
+      json: () => Promise.resolve(isTopModels ? state.modelRows : state.statsRows),
+    })
+  })
+}
+
+beforeEach(() => {
+  state = {
+    claimError: null,
+    claimInserts: [],
+    // JSONEachRow returns counts and Decimal sums as strings — the job must
+    // coerce every numeric at the boundary (gotcha #19).
+    statsRows: [
+      {
+        organization_id: 'org-1',
+        request_count: '1234',
+        total_cost_usd: '12.5',
+        error_count: '12',
+        prior_request_count: '900',
+        prior_cost_usd: '10.0',
+      },
+    ],
+    modelRows: [
+      { organization_id: 'org-1', provider: 'openai', model: 'gpt-4o', cost_usd: '9.5', request_count: '400' },
+      { organization_id: 'org-1', provider: 'openai', model: 'gpt-4o-mini', cost_usd: '3.0', request_count: '834' },
+    ],
+    orgNames: [{ id: 'org-1', name: 'Acme Inc' }],
+    anomalyCount: 2,
+    anomalyError: null,
+    auditInserts: [],
+  }
+  mockFrom.mockReset()
+  mockChQuery.mockReset()
+  mockSendEmail.mockReset()
+  mockRenderEmail.mockClear()
+  mockGetRecipients.mockReset()
+  mockRecommend.mockReset()
+  setupMocks()
+  mockGetRecipients.mockResolvedValue(['admin@acme.test', 'other@acme.test'])
+  mockSendEmail.mockResolvedValue({ sent: true })
+  mockRecommend.mockResolvedValue([rec()])
+})
+
+describe('runWeeklyDigestJob — happy path', () => {
+  it('sends one digest per active org with coerced numbers and writes an audit row', async () => {
+    const result = await runWeeklyDigestJob(MONDAY)
+
+    expect(result.skipped).toBe(false)
+    expect(result.completed).toBe(true)
+    expect(result.orgs_scanned).toBe(1)
+    expect(result.digests_sent).toBe(1)
+    expect(result.errors).toEqual([])
+
+    // Both recipients get the same rendered email.
+    expect(mockSendEmail).toHaveBeenCalledTimes(2)
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'admin@acme.test', subject: 'test subject' }),
+    )
+
+    expect(mockRenderEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgName: 'Acme Inc',
+        periodLabel: 'Jun 29 to Jul 5',
+        requestCount: 1234,
+        totalCostUsd: 12.5,
+        costChangePct: expect.closeTo(25, 5),
+        errorCount: 12,
+        errorRatePct: expect.closeTo((12 / 1234) * 100, 5),
+        anomalyCount: 2,
+        recommendation: expect.objectContaining({
+          currentModel: 'gpt-4o',
+          suggestedModel: 'gpt-4o-mini',
+          estimatedMonthlySavingsUsd: 120,
+        }),
+      }),
+    )
+
+    // Top models are cost-sorted numbers, not JSONEachRow strings.
+    const renderCalls = mockRenderEmail.mock.calls as unknown as Array<
+      [{ topModels: Array<{ model: string; costUsd: number }>; dashboardUrl: string }]
+    >
+    const call = renderCalls[0]![0]
+    expect(call.topModels.map((m) => m.model)).toEqual(['gpt-4o', 'gpt-4o-mini'])
+    expect(call.topModels[0]!.costUsd).toBe(9.5)
+    expect(call.dashboardUrl).toMatch(/\/dashboard$/)
+
+    expect(state.auditInserts).toHaveLength(1)
+    expect(state.auditInserts[0]).toMatchObject({
+      organization_id: 'org-1',
+      action: 'retention.weekly_digest_sent',
+    })
+  })
+
+  it('falls back to a generic org name when the lookup has no row', async () => {
+    state.orgNames = []
+    await runWeeklyDigestJob(MONDAY)
+    expect(mockRenderEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ orgName: 'your workspace' }),
+    )
+  })
+})
+
+describe('runWeeklyDigestJob — skip logic', () => {
+  it('claims the ISO week atomically before any email goes out', async () => {
+    const result = await runWeeklyDigestJob(MONDAY)
+    expect(result.skipped).toBe(false)
+    expect(state.claimInserts).toHaveLength(1)
+    // MONDAY fixture is inside the ISO week starting that same Monday.
+    expect(state.claimInserts[0]).toMatchObject({
+      week_start: MONDAY.toISOString().slice(0, 10),
+    })
+  })
+
+  it('skips entirely when another runner already claimed this ISO week', async () => {
+    state.claimError = { code: '23505', message: 'duplicate key value' }
+
+    const result = await runWeeklyDigestJob(MONDAY)
+    expect(result.skipped).toBe(true)
+    expect(result.completed).toBe(true)
+    expect(mockChQuery).not.toHaveBeenCalled()
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('still runs (best-effort) when the claim insert fails transiently', async () => {
+    state.claimError = { message: 'pg down' }
+
+    const result = await runWeeklyDigestJob(MONDAY)
+    expect(result.skipped).toBe(false)
+    expect(result.digests_sent).toBe(1)
+    expect(result.errors[0]).toMatch(/claim failed/)
+  })
+
+  it('skips orgs with zero requests in the window (no email at all)', async () => {
+    state.statsRows = [
+      {
+        organization_id: 'org-idle',
+        request_count: '0',
+        total_cost_usd: '0',
+        error_count: '0',
+        prior_request_count: '500',
+        prior_cost_usd: '5.0',
+      },
+    ]
+
+    const result = await runWeeklyDigestJob(MONDAY)
+    expect(result.completed).toBe(true)
+    expect(result.orgs_scanned).toBe(0)
+    expect(result.digests_sent).toBe(0)
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('counts orgs whose admins all opted out without treating them as errors', async () => {
+    mockGetRecipients.mockResolvedValue([])
+
+    const result = await runWeeklyDigestJob(MONDAY)
+    expect(result.orgs_no_recipients).toBe(1)
+    expect(result.digests_sent).toBe(0)
+    expect(result.errors).toEqual([])
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+})
+
+describe('runWeeklyDigestJob — degraded enrichments', () => {
+  it('still sends when the recommendation engine throws (recommendation null)', async () => {
+    mockRecommend.mockRejectedValue(new Error('CH busy'))
+
+    const result = await runWeeklyDigestJob(MONDAY)
+    expect(result.digests_sent).toBe(1)
+    expect(mockRenderEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ recommendation: null }),
+    )
+  })
+
+  it('passes recommendation null when no swaps qualify', async () => {
+    mockRecommend.mockResolvedValue([])
+    await runWeeklyDigestJob(MONDAY)
+    expect(mockRenderEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ recommendation: null }),
+    )
+  })
+
+  it('passes anomalyCount null when the anomaly_events lookup fails', async () => {
+    state.anomalyError = { message: 'pg down' }
+
+    const result = await runWeeklyDigestJob(MONDAY)
+    expect(result.digests_sent).toBe(1)
+    expect(mockRenderEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ anomalyCount: null }),
+    )
+  })
+
+  it('counts a dev-fallback send (RESEND_API_KEY unset) as not sent', async () => {
+    mockSendEmail.mockResolvedValue({ sent: false })
+
+    const result = await runWeeklyDigestJob(MONDAY)
+    expect(result.digests_sent).toBe(0)
+    expect(state.auditInserts).toEqual([])
+  })
+})
+
+describe('runWeeklyDigestJob — error handling', () => {
+  it('returns completed=false when ClickHouse is unreachable', async () => {
+    mockChQuery.mockRejectedValue(new Error('CH down'))
+
+    const result = await runWeeklyDigestJob(MONDAY)
+    expect(result.completed).toBe(false)
+    expect(result.errors).toContain('CH down')
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('continues processing other orgs when one org fails', async () => {
+    state.statsRows = [
+      { organization_id: 'org-a', request_count: '10', total_cost_usd: '1', error_count: '0', prior_request_count: '0', prior_cost_usd: '0' },
+      { organization_id: 'org-b', request_count: '20', total_cost_usd: '2', error_count: '0', prior_request_count: '0', prior_cost_usd: '0' },
+    ]
+    state.orgNames = [
+      { id: 'org-a', name: 'A' },
+      { id: 'org-b', name: 'B' },
+    ]
+    mockGetRecipients
+      .mockRejectedValueOnce(new Error('auth API down'))
+      .mockResolvedValueOnce(['admin@b.test'])
+
+    const result = await runWeeklyDigestJob(MONDAY)
+    expect(result.completed).toBe(true)
+    expect(result.digests_sent).toBe(1)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatch(/org org-a: auth API down/)
+  })
+})

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -8,6 +8,7 @@ import { runQuotaWarningsJob } from '../lib/quota-warnings.js'
 import { snapshotAnomaliesForAllOrgs } from '../lib/anomaly-snapshot.js'
 import { runStaleKeyDigestJob } from '../lib/stale-key-digest.js'
 import { runDataSilenceJob } from '../lib/data-silence.js'
+import { runWeeklyDigestJob } from '../lib/weekly-digest.js'
 import { runDueMigrations } from '../lib/background-migrations/runner.js'
 import { runReconciliationCron } from '../lib/events-reconciliation.js'
 import { runLeakDetectionJob } from '../lib/leak-detection.js'
@@ -187,6 +188,27 @@ cronRouter.get('/detect-data-silence', async (c) => {
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
     logCronRun('detect-data-silence', 'error', Date.now() - start, msg).catch(console.error)
+    throw new ApiError('INTERNAL_ERROR', msg)
+  }
+})
+
+// ── Weekly usage digest (Monday 09 UTC) ─────────────────────────
+cronRouter.get('/weekly-digest', async (c) => {
+  assertCronAuth(c.req.header('Authorization'))
+
+  const start = Date.now()
+  try {
+    const result = await runWeeklyDigestJob()
+    // `completed` = the aggregation phase ran; per-org email errors don't
+    // flip the status because the ISO-week dedup keys off an 'ok' row and a
+    // retry would double-send to every org that already succeeded.
+    const status = result.completed ? 'ok' : 'error'
+    const errSummary = result.errors.length > 0 ? result.errors.join('; ').slice(0, 500) : undefined
+    logCronRun('weekly-digest', status, Date.now() - start, errSummary).catch(console.error)
+    return c.json({ success: result.completed, ...result })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'unknown'
+    logCronRun('weekly-digest', 'error', Date.now() - start, msg).catch(console.error)
     throw new ApiError('INTERNAL_ERROR', msg)
   }
 })

--- a/apps/server/src/api/userNotificationPrefs.ts
+++ b/apps/server/src/api/userNotificationPrefs.ts
@@ -25,12 +25,14 @@ interface NotificationPrefs {
   security_alert_emails: boolean
   marketing_emails: boolean
   product_update_emails: boolean
+  weekly_digest_emails: boolean
 }
 
 const DEFAULT_PREFS: NotificationPrefs = {
   security_alert_emails: true,
   marketing_emails: true,
   product_update_emails: true,
+  weekly_digest_emails: true,
 }
 
 const PREF_KEYS = Object.keys(DEFAULT_PREFS) as (keyof NotificationPrefs)[]
@@ -40,7 +42,7 @@ userNotificationPrefsRouter.get('/', async (c) => {
 
   const { data, error } = await supabaseAdmin
     .from('user_notification_prefs')
-    .select('security_alert_emails, marketing_emails, product_update_emails')
+    .select('security_alert_emails, marketing_emails, product_update_emails, weekly_digest_emails')
     .eq('user_id', userId)
     .maybeSingle()
 
@@ -71,7 +73,7 @@ userNotificationPrefsRouter.patch('/', async (c) => {
   const { data, error } = await supabaseAdmin
     .from('user_notification_prefs')
     .upsert({ user_id: userId, ...updates }, { onConflict: 'user_id' })
-    .select('security_alert_emails, marketing_emails, product_update_emails')
+    .select('security_alert_emails, marketing_emails, product_update_emails, weekly_digest_emails')
     .single()
 
   if (error || !data) throw new ApiError('INTERNAL_ERROR', 'Failed to save notification preferences')

--- a/apps/server/src/lib/digest-recipients.ts
+++ b/apps/server/src/lib/digest-recipients.ts
@@ -1,0 +1,41 @@
+import { supabaseAdmin } from './db.js'
+
+/**
+ * Recipient resolver for the weekly usage digest (lib/weekly-digest.ts).
+ *
+ * Modeled on lib/admin-emails.ts getAdminEmails but keyed to the per-user
+ * `weekly_digest_emails` preference instead of `security_alert_emails` —
+ * the two switches are deliberately independent so opting out of a usage
+ * summary never silences security alerts (and vice versa). Kept as a
+ * separate module rather than a flag on getAdminEmails so that helper's
+ * security-alert semantics stay untouched.
+ *
+ * Same defaults as the rest of user_notification_prefs: a user with no
+ * prefs row is opted in; only an explicit `weekly_digest_emails = false`
+ * row excludes them.
+ */
+export async function getWeeklyDigestRecipients(orgId: string): Promise<string[]> {
+  const { data: members } = await supabaseAdmin
+    .from('org_members')
+    .select('user_id')
+    .eq('organization_id', orgId)
+    .eq('role', 'admin')
+
+  const userIds = (members ?? []).map((m) => m.user_id)
+  if (userIds.length === 0) return []
+
+  const { data: optedOut } = await supabaseAdmin
+    .from('user_notification_prefs')
+    .select('user_id')
+    .in('user_id', userIds)
+    .eq('weekly_digest_emails', false)
+  const optedOutSet = new Set((optedOut ?? []).map((r) => r.user_id as string))
+
+  const emails: string[] = []
+  for (const userId of userIds) {
+    if (optedOutSet.has(userId)) continue
+    const { data } = await supabaseAdmin.auth.admin.getUserById(userId)
+    if (data?.user?.email) emails.push(data.user.email)
+  }
+  return emails
+}

--- a/apps/server/src/lib/logger.ts
+++ b/apps/server/src/lib/logger.ts
@@ -93,6 +93,15 @@ export interface RequestLogData {
    * Empty string written to CH when unknown / unsupported (Anthropic).
    */
   serviceTier?: string | null | undefined
+  /**
+   * True when the response was served from the opt-in proxy response cache
+   * (x-spanlens-cache header) WITHOUT calling the upstream provider. The row
+   * keeps the original token counts and model but records cost_usd = 0 and
+   * cache_hit = 1 so cache savings are computable later.
+   *
+   * See lib/proxy-cache.ts for the cache semantics.
+   */
+  cacheHit?: boolean
 }
 
 /**
@@ -300,6 +309,12 @@ export async function logRequestAsync(data: RequestLogData): Promise<void> {
     // 0/1 because ClickHouse UInt8; never null even if the field was
     // never set (older rows backfill via DEFAULT 0 on the column).
     truncated: data.truncated ? 1 : 0,
+    // 0/1 UInt8, same convention as `truncated`. Served-from-cache rows carry
+    // cost_usd 0 — this flag is what separates them from genuinely-free rows.
+    // Column added by clickhouse/migrations/010_add_cache_hit.sql. The field
+    // rides inside `payload` on the requests_fallback path automatically
+    // (fallback-replay.ts re-inserts the payload verbatim — gotcha #23).
+    cache_hit: data.cacheHit ? 1 : 0,
     // Empty string when unknown — matches the column DEFAULT '' from migration
     // 003_add_service_tier.sql and keeps CH LowCardinality dictionary tight.
     service_tier: data.serviceTier ?? '',

--- a/apps/server/src/lib/proxy-cache.test.ts
+++ b/apps/server/src/lib/proxy-cache.test.ts
@@ -1,0 +1,353 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+// Programmable supabaseAdmin stub — the cache module only ever touches the
+// `proxy_response_cache` table via three chains:
+//   .select(...).eq('key_hash', x).maybeSingle()
+//   .upsert(row, { onConflict: 'key_hash' })
+//   .delete().eq('key_hash', x).lt('expires_at', now)
+const maybeSingleMock = vi.fn()
+const upsertMock = vi.fn()
+const deleteMock = vi.fn()
+
+vi.mock('./db.js', () => ({
+  supabaseAdmin: {
+    from: (table: string) => ({
+      select: (cols: string) => ({
+        eq: (col: string, val: string) => ({
+          maybeSingle: () => maybeSingleMock(table, cols, col, val),
+        }),
+      }),
+      upsert: (row: Record<string, unknown>, opts: Record<string, unknown>) =>
+        upsertMock(table, row, opts),
+      delete: () => ({
+        eq: (col: string, val: string) => ({
+          lt: (ltCol: string, ltVal: string) => deleteMock(table, col, val, ltCol, ltVal),
+        }),
+      }),
+    }),
+  },
+  supabaseClient: {},
+}))
+
+// Keep test output clean — cache failures log via the structured logger.
+vi.mock('./structured-logger.js', () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+}))
+
+import {
+  PROXY_CACHE_DEFAULT_TTL_SECONDS,
+  PROXY_CACHE_MAX_BODY_BYTES,
+  PROXY_CACHE_MAX_TTL_SECONDS,
+  computeCacheKeyHash,
+  deleteExpiredCacheEntry,
+  parseCacheTtlSeconds,
+  resolveProxyCache,
+  storeCachedProxyResponse,
+} from './proxy-cache.js'
+
+const KEY_INPUT = {
+  apiKeyId: 'a3f1c2d4-0000-4000-8000-000000000001',
+  provider: 'openai',
+  path: '/proxy/openai/v1/chat/completions',
+  rawBody: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}',
+}
+
+function freshRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    response_status: 200,
+    response_body: '{"id":"chatcmpl-1","usage":{"total_tokens":15}}',
+    usage: {
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      total_tokens: 15,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+    },
+    model: 'gpt-4o-mini-2024-07-18',
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  maybeSingleMock.mockReset()
+  upsertMock.mockReset()
+  deleteMock.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('parseCacheTtlSeconds — header parsing', () => {
+  test('absent / null / empty header → no caching', () => {
+    expect(parseCacheTtlSeconds(undefined)).toBeNull()
+    expect(parseCacheTtlSeconds(null)).toBeNull()
+    expect(parseCacheTtlSeconds('')).toBeNull()
+    expect(parseCacheTtlSeconds('   ')).toBeNull()
+  })
+
+  test('"true" (any case, trimmed) → default TTL 3600s', () => {
+    expect(parseCacheTtlSeconds('true')).toBe(PROXY_CACHE_DEFAULT_TTL_SECONDS)
+    expect(parseCacheTtlSeconds('TRUE')).toBe(PROXY_CACHE_DEFAULT_TTL_SECONDS)
+    expect(parseCacheTtlSeconds(' true ')).toBe(3600)
+  })
+
+  test('integer seconds pass through', () => {
+    expect(parseCacheTtlSeconds('600')).toBe(600)
+    expect(parseCacheTtlSeconds('1')).toBe(1)
+    expect(parseCacheTtlSeconds('86400')).toBe(86400)
+  })
+
+  test('TTL is capped at 86400s', () => {
+    expect(parseCacheTtlSeconds('86401')).toBe(PROXY_CACHE_MAX_TTL_SECONDS)
+    expect(parseCacheTtlSeconds('999999999')).toBe(PROXY_CACHE_MAX_TTL_SECONDS)
+  })
+
+  test('anything else → no caching (fail-safe)', () => {
+    expect(parseCacheTtlSeconds('false')).toBeNull()
+    expect(parseCacheTtlSeconds('yes')).toBeNull()
+    expect(parseCacheTtlSeconds('0')).toBeNull()
+    expect(parseCacheTtlSeconds('-5')).toBeNull()
+    expect(parseCacheTtlSeconds('1.5')).toBeNull()
+    expect(parseCacheTtlSeconds('600s')).toBeNull()
+    expect(parseCacheTtlSeconds('Infinity')).toBeNull()
+  })
+})
+
+describe('computeCacheKeyHash — key stability + isolation', () => {
+  test('same inputs → same 64-char hex hash (stable across calls)', async () => {
+    const a = await computeCacheKeyHash(KEY_INPUT)
+    const b = await computeCacheKeyHash({ ...KEY_INPUT })
+    expect(a).toBe(b)
+    expect(a).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  test('different api keys NEVER share a hash (cross-key isolation)', async () => {
+    const a = await computeCacheKeyHash(KEY_INPUT)
+    const b = await computeCacheKeyHash({
+      ...KEY_INPUT,
+      apiKeyId: 'a3f1c2d4-0000-4000-8000-000000000002',
+    })
+    expect(a).not.toBe(b)
+  })
+
+  test('provider, path, and body each change the hash', async () => {
+    const base = await computeCacheKeyHash(KEY_INPUT)
+    expect(await computeCacheKeyHash({ ...KEY_INPUT, provider: 'anthropic' })).not.toBe(base)
+    expect(
+      await computeCacheKeyHash({ ...KEY_INPUT, path: '/proxy/openai/v1/embeddings' }),
+    ).not.toBe(base)
+    expect(await computeCacheKeyHash({ ...KEY_INPUT, rawBody: '{"model":"gpt-4o"}' })).not.toBe(
+      base,
+    )
+  })
+})
+
+describe('resolveProxyCache — decision matrix', () => {
+  test('header absent → mode off, no DB lookup', async () => {
+    const result = await resolveProxyCache({
+      ...KEY_INPUT,
+      cacheHeader: undefined,
+      isStreaming: false,
+    })
+    expect(result.state.mode).toBe('off')
+    expect(result.expiredKeyHash).toBeNull()
+    expect(maybeSingleMock).not.toHaveBeenCalled()
+  })
+
+  test('malformed header → mode off (never caches by accident)', async () => {
+    const result = await resolveProxyCache({
+      ...KEY_INPUT,
+      cacheHeader: 'please',
+      isStreaming: false,
+    })
+    expect(result.state.mode).toBe('off')
+    expect(maybeSingleMock).not.toHaveBeenCalled()
+  })
+
+  test('stream:true bypasses the cache entirely (no DB lookup)', async () => {
+    const result = await resolveProxyCache({
+      ...KEY_INPUT,
+      cacheHeader: 'true',
+      isStreaming: true,
+    })
+    expect(result.state.mode).toBe('bypass')
+    expect(maybeSingleMock).not.toHaveBeenCalled()
+  })
+
+  test('no row → miss with keyHash + ttl', async () => {
+    maybeSingleMock.mockResolvedValueOnce({ data: null, error: null })
+    const result = await resolveProxyCache({
+      ...KEY_INPUT,
+      cacheHeader: '120',
+      isStreaming: false,
+    })
+    expect(result.state).toEqual({
+      mode: 'miss',
+      keyHash: await computeCacheKeyHash(KEY_INPUT),
+      ttlSeconds: 120,
+    })
+    expect(result.expiredKeyHash).toBeNull()
+    // Lookup keyed on key_hash against the cache table.
+    const [table, , col, val] = maybeSingleMock.mock.calls[0] ?? []
+    expect(table).toBe('proxy_response_cache')
+    expect(col).toBe('key_hash')
+    expect(val).toBe(await computeCacheKeyHash(KEY_INPUT))
+  })
+
+  test('fresh row → hit with numeric usage (jsonb values coerced via Number)', async () => {
+    maybeSingleMock.mockResolvedValueOnce({
+      data: freshRow({
+        // Simulate string-typed values sneaking through jsonb.
+        usage: { prompt_tokens: '10', completion_tokens: '5', total_tokens: '15' },
+      }),
+      error: null,
+    })
+    const result = await resolveProxyCache({
+      ...KEY_INPUT,
+      cacheHeader: 'true',
+      isStreaming: false,
+    })
+    expect(result.state.mode).toBe('hit')
+    if (result.state.mode !== 'hit') return
+    expect(result.state.entry.responseStatus).toBe(200)
+    expect(result.state.entry.model).toBe('gpt-4o-mini-2024-07-18')
+    expect(result.state.entry.usage).toEqual({
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      total_tokens: 15,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+    })
+  })
+
+  test('expired row → miss + expiredKeyHash set for opportunistic cleanup', async () => {
+    maybeSingleMock.mockResolvedValueOnce({
+      data: freshRow({ expires_at: new Date(Date.now() - 1_000).toISOString() }),
+      error: null,
+    })
+    const result = await resolveProxyCache({
+      ...KEY_INPUT,
+      cacheHeader: 'true',
+      isStreaming: false,
+    })
+    expect(result.state.mode).toBe('miss')
+    expect(result.expiredKeyHash).toBe(await computeCacheKeyHash(KEY_INPUT))
+  })
+
+  test('lookup error fails OPEN as a miss (cache outage never breaks the proxy)', async () => {
+    maybeSingleMock.mockResolvedValueOnce({ data: null, error: { message: 'db down' } })
+    const result = await resolveProxyCache({
+      ...KEY_INPUT,
+      cacheHeader: 'true',
+      isStreaming: false,
+    })
+    expect(result.state.mode).toBe('miss')
+    expect(result.expiredKeyHash).toBeNull()
+  })
+
+  test('lookup throw fails OPEN as a miss', async () => {
+    maybeSingleMock.mockRejectedValueOnce(new Error('network blip'))
+    const result = await resolveProxyCache({
+      ...KEY_INPUT,
+      cacheHeader: 'true',
+      isStreaming: false,
+    })
+    expect(result.state.mode).toBe('miss')
+  })
+})
+
+describe('storeCachedProxyResponse — write guards', () => {
+  const STORE_INPUT = {
+    keyHash: 'k'.repeat(64),
+    apiKeyId: KEY_INPUT.apiKeyId,
+    provider: 'openai',
+    ttlSeconds: 600,
+    responseStatus: 200,
+    responseBody: '{"id":"chatcmpl-1"}',
+    usage: {
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      total_tokens: 15,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+    },
+    model: 'gpt-4o-mini',
+  }
+
+  test('stores a 200 JSON response with expires_at = now + ttl', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-06T12:00:00Z'))
+    upsertMock.mockResolvedValueOnce({ error: null })
+
+    await storeCachedProxyResponse(STORE_INPUT)
+
+    expect(upsertMock).toHaveBeenCalledTimes(1)
+    const [table, row, opts] = upsertMock.mock.calls[0] ?? []
+    expect(table).toBe('proxy_response_cache')
+    expect(opts).toEqual({ onConflict: 'key_hash' })
+    expect(row).toMatchObject({
+      key_hash: STORE_INPUT.keyHash,
+      api_key_id: STORE_INPUT.apiKeyId,
+      provider: 'openai',
+      response_status: 200,
+      response_body: STORE_INPUT.responseBody,
+      model: 'gpt-4o-mini',
+    })
+    expect(row.expires_at).toBe(new Date('2026-07-06T12:10:00Z').toISOString())
+  })
+
+  test('non-200 responses are never stored', async () => {
+    await storeCachedProxyResponse({ ...STORE_INPUT, responseStatus: 401 })
+    await storeCachedProxyResponse({ ...STORE_INPUT, responseStatus: 500 })
+    expect(upsertMock).not.toHaveBeenCalled()
+  })
+
+  test('bodies over 256 KB are never stored', async () => {
+    const bigBody = `{"pad":"${'x'.repeat(PROXY_CACHE_MAX_BODY_BYTES)}"}`
+    await storeCachedProxyResponse({ ...STORE_INPUT, responseBody: bigBody })
+    expect(upsertMock).not.toHaveBeenCalled()
+  })
+
+  test('a body exactly at the limit IS stored', async () => {
+    upsertMock.mockResolvedValueOnce({ error: null })
+    const exactBody = 'x'.repeat(PROXY_CACHE_MAX_BODY_BYTES)
+    await storeCachedProxyResponse({ ...STORE_INPUT, responseBody: exactBody })
+    expect(upsertMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('upsert error / throw never propagates (fireAndForget-safe)', async () => {
+    upsertMock.mockResolvedValueOnce({ error: { message: 'db down' } })
+    await expect(storeCachedProxyResponse(STORE_INPUT)).resolves.toBeUndefined()
+
+    upsertMock.mockRejectedValueOnce(new Error('network blip'))
+    await expect(storeCachedProxyResponse(STORE_INPUT)).resolves.toBeUndefined()
+  })
+})
+
+describe('deleteExpiredCacheEntry — opportunistic cleanup', () => {
+  test('deletes only rows still expired (lt expires_at guard)', async () => {
+    deleteMock.mockResolvedValueOnce({ error: null })
+    await deleteExpiredCacheEntry('hash-1')
+
+    expect(deleteMock).toHaveBeenCalledTimes(1)
+    const [table, col, val, ltCol, ltVal] = deleteMock.mock.calls[0] ?? []
+    expect(table).toBe('proxy_response_cache')
+    expect(col).toBe('key_hash')
+    expect(val).toBe('hash-1')
+    expect(ltCol).toBe('expires_at')
+    // Guard timestamp must be a valid ISO string near "now" so a concurrently
+    // refreshed row is never deleted.
+    expect(new Date(ltVal as string).getTime()).toBeGreaterThan(0)
+  })
+
+  test('delete error / throw never propagates (fireAndForget-safe)', async () => {
+    deleteMock.mockResolvedValueOnce({ error: { message: 'db down' } })
+    await expect(deleteExpiredCacheEntry('hash-1')).resolves.toBeUndefined()
+
+    deleteMock.mockRejectedValueOnce(new Error('network blip'))
+    await expect(deleteExpiredCacheEntry('hash-1')).resolves.toBeUndefined()
+  })
+})

--- a/apps/server/src/lib/proxy-cache.ts
+++ b/apps/server/src/lib/proxy-cache.ts
@@ -1,0 +1,285 @@
+/**
+ * Opt-in exact-match proxy response cache (Helicone-style). OFF by default.
+ *
+ * Customers opt in per request with the `x-spanlens-cache` header:
+ *   - `true`          → cache with the default TTL (3600s)
+ *   - `<seconds>`     → integer TTL, capped at 86400s (24h)
+ *   - anything else   → no caching (fail-safe: a malformed header never caches)
+ *
+ * Scope + guards:
+ *   - Non-streaming only. `stream: true` requests bypass the cache entirely.
+ *   - Only HTTP 200 JSON upstream responses are stored.
+ *   - Bodies over 256 KB are never stored.
+ *   - The cache key is sha256(api_key_id + provider + path + raw request body),
+ *     so entries can never be served across Spanlens keys (and therefore never
+ *     across projects or organizations). Do not remove api_key_id from the key.
+ *
+ * Storage: Supabase table `proxy_response_cache` (RLS enabled, NO policies —
+ * server-only access via supabaseAdmin / service_role). Expired rows are
+ * removed opportunistically on the miss path (no cron): the proxy handler
+ * fires `deleteExpiredCacheEntry` via fireAndForget when a lookup finds a
+ * stale row.
+ *
+ * All read/write failures here fail OPEN — a cache outage must never break
+ * the proxy hot path. Errors are logged, never rethrown.
+ *
+ * The `x-spanlens-cache` request header is stripped before the upstream call
+ * by the STRIP_PREFIXES rule in proxy/utils.ts (every `x-spanlens-*` header).
+ */
+
+import { supabaseAdmin } from './db.js'
+import { sha256Hex } from './crypto.js'
+import { logError } from './structured-logger.js'
+
+export const PROXY_CACHE_HEADER = 'x-spanlens-cache'
+export const PROXY_CACHE_DEFAULT_TTL_SECONDS = 3600
+export const PROXY_CACHE_MAX_TTL_SECONDS = 86400
+export const PROXY_CACHE_MAX_BODY_BYTES = 256 * 1024
+
+const CACHE_TABLE = 'proxy_response_cache'
+
+/** Token usage snapshot stored alongside the cached body so HITs log real tokens. */
+export interface CachedUsage {
+  prompt_tokens: number
+  completion_tokens: number
+  total_tokens: number
+  cache_read_tokens: number
+  cache_write_tokens: number
+}
+
+export interface CachedProxyResponse {
+  responseStatus: number
+  responseBody: string
+  usage: CachedUsage
+  model: string
+}
+
+export type ProxyCacheState =
+  /** Header absent or invalid — caching not requested. No response header. */
+  | { mode: 'off' }
+  /** Header present but the request is streaming — respond `x-spanlens-cache: bypass`. */
+  | { mode: 'bypass' }
+  /** Caching requested, no fresh entry — store on 200 and respond `miss`. */
+  | { mode: 'miss'; keyHash: string; ttlSeconds: number }
+  /** Fresh entry found — serve it without calling upstream, respond `hit`. */
+  | { mode: 'hit'; keyHash: string; ttlSeconds: number; entry: CachedProxyResponse }
+
+export interface ResolvedProxyCache {
+  state: ProxyCacheState
+  /**
+   * Set when the lookup found an EXPIRED row for this key. The caller should
+   * pass `deleteExpiredCacheEntry(expiredKeyHash)` to fireAndForget so the
+   * cleanup never blocks the client response (CLAUDE.md gotcha #8).
+   */
+  expiredKeyHash: string | null
+}
+
+/**
+ * Parse the `x-spanlens-cache` request header into a TTL in seconds.
+ * Returns null when caching is not requested (absent / malformed / zero /
+ * negative / non-integer). `true` maps to the default TTL; integers are
+ * capped at PROXY_CACHE_MAX_TTL_SECONDS.
+ */
+export function parseCacheTtlSeconds(header: string | null | undefined): number | null {
+  if (header == null) return null
+  const value = header.trim().toLowerCase()
+  if (value === 'true') return PROXY_CACHE_DEFAULT_TTL_SECONDS
+  if (!/^\d+$/.test(value)) return null
+  const seconds = Number(value)
+  if (!Number.isSafeInteger(seconds) || seconds <= 0) return null
+  return Math.min(seconds, PROXY_CACHE_MAX_TTL_SECONDS)
+}
+
+export interface CacheKeyInput {
+  /** Spanlens key id — scopes the entry; cross-key reuse is impossible. */
+  apiKeyId: string
+  /** Provider tag from the URL path (openai / anthropic / gemini / ...). */
+  provider: string
+  /** Request path (e.g. /proxy/openai/v1/chat/completions). */
+  path: string
+  /** Raw (untransformed) request body text. */
+  rawBody: string
+}
+
+/**
+ * sha256 over (api_key_id + provider + path + raw request body).
+ * apiKeyId / provider / path never contain a newline, and rawBody is the
+ * last component, so the '\n' join is unambiguous.
+ *
+ * sha256Hex is async (Web Crypto) — ALWAYS await it (CLAUDE.md gotcha #12).
+ */
+export async function computeCacheKeyHash(input: CacheKeyInput): Promise<string> {
+  return sha256Hex(`${input.apiKeyId}\n${input.provider}\n${input.path}\n${input.rawBody}`)
+}
+
+interface CacheRow {
+  response_status: number | null
+  response_body: string | null
+  usage: Record<string, unknown> | null
+  model: string | null
+  expires_at: string
+}
+
+function toCachedUsage(raw: Record<string, unknown> | null): CachedUsage {
+  const num = (v: unknown): number => {
+    const n = Number(v ?? 0)
+    return Number.isFinite(n) ? n : 0
+  }
+  return {
+    prompt_tokens: num(raw?.['prompt_tokens']),
+    completion_tokens: num(raw?.['completion_tokens']),
+    total_tokens: num(raw?.['total_tokens']),
+    cache_read_tokens: num(raw?.['cache_read_tokens']),
+    cache_write_tokens: num(raw?.['cache_write_tokens']),
+  }
+}
+
+/**
+ * Look up a cache row by key hash. Fail-open: any Supabase error is treated
+ * as a miss. Returns `expired: true` when a row exists but is past its
+ * expires_at so the caller can schedule the opportunistic delete.
+ */
+async function lookupCacheRow(
+  keyHash: string,
+): Promise<{ entry: CachedProxyResponse | null; expired: boolean }> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from(CACHE_TABLE)
+      .select('response_status, response_body, usage, model, expires_at')
+      .eq('key_hash', keyHash)
+      .maybeSingle()
+
+    if (error || !data) {
+      if (error) {
+        logError('UNCATEGORIZED', { kind: 'proxy_cache_lookup_failed' }, error)
+      }
+      return { entry: null, expired: false }
+    }
+
+    const row = data as unknown as CacheRow
+    if (new Date(row.expires_at).getTime() <= Date.now()) {
+      return { entry: null, expired: true }
+    }
+    if (typeof row.response_body !== 'string' || row.response_body.length === 0) {
+      // Defensive: a row without a body is useless — treat as expired so the
+      // opportunistic cleanup removes it.
+      return { entry: null, expired: true }
+    }
+
+    return {
+      entry: {
+        responseStatus: Number(row.response_status ?? 200),
+        responseBody: row.response_body,
+        usage: toCachedUsage(row.usage),
+        model: row.model ?? '',
+      },
+      expired: false,
+    }
+  } catch (err) {
+    logError('UNCATEGORIZED', { kind: 'proxy_cache_lookup_failed' }, err)
+    return { entry: null, expired: false }
+  }
+}
+
+export interface ResolveProxyCacheInput extends CacheKeyInput {
+  /** Raw `x-spanlens-cache` request header value. */
+  cacheHeader: string | null | undefined
+  /** True when the request is streaming (body `stream: true`, or the Gemini
+   * `:streamGenerateContent` URL) — streaming requests always bypass. */
+  isStreaming: boolean
+}
+
+/**
+ * Single entry point for the proxy handlers: parses the header, applies the
+ * streaming bypass, computes the key, and performs the lookup. Runs at most
+ * one Supabase query, and only when caching was actually requested.
+ */
+export async function resolveProxyCache(
+  input: ResolveProxyCacheInput,
+): Promise<ResolvedProxyCache> {
+  const ttlSeconds = parseCacheTtlSeconds(input.cacheHeader)
+  if (ttlSeconds == null) return { state: { mode: 'off' }, expiredKeyHash: null }
+  if (input.isStreaming) return { state: { mode: 'bypass' }, expiredKeyHash: null }
+
+  const keyHash = await computeCacheKeyHash(input)
+  const { entry, expired } = await lookupCacheRow(keyHash)
+  if (entry) {
+    return { state: { mode: 'hit', keyHash, ttlSeconds, entry }, expiredKeyHash: null }
+  }
+  return {
+    state: { mode: 'miss', keyHash, ttlSeconds },
+    expiredKeyHash: expired ? keyHash : null,
+  }
+}
+
+/**
+ * Opportunistic cleanup for an expired row discovered on the miss path.
+ * The `.lt('expires_at', now)` guard means a fresh row written by a
+ * concurrent request between our lookup and this delete is left alone.
+ * Never throws — intended for fireAndForget.
+ */
+export async function deleteExpiredCacheEntry(keyHash: string): Promise<void> {
+  try {
+    const { error } = await supabaseAdmin
+      .from(CACHE_TABLE)
+      .delete()
+      .eq('key_hash', keyHash)
+      .lt('expires_at', new Date().toISOString())
+    if (error) {
+      logError('UNCATEGORIZED', { kind: 'proxy_cache_cleanup_failed' }, error)
+    }
+  } catch (err) {
+    logError('UNCATEGORIZED', { kind: 'proxy_cache_cleanup_failed' }, err)
+  }
+}
+
+export interface StoreProxyCacheInput {
+  keyHash: string
+  apiKeyId: string
+  provider: string
+  ttlSeconds: number
+  /** Upstream HTTP status — anything other than 200 is not stored. */
+  responseStatus: number
+  /** Raw upstream response body text (must be valid JSON — callers gate on
+   * a successful JSON.parse before storing). */
+  responseBody: string
+  usage: CachedUsage
+  model: string
+}
+
+/**
+ * Store a successful upstream response. Guards (non-200, oversized body) make
+ * this a silent no-op. Upsert on key_hash so two concurrent misses for the
+ * same request don't conflict — last writer wins, both bodies are identical
+ * by construction (exact-match key). Never throws — intended for fireAndForget.
+ */
+export async function storeCachedProxyResponse(input: StoreProxyCacheInput): Promise<void> {
+  if (input.responseStatus !== 200) return
+  const bodyBytes = new TextEncoder().encode(input.responseBody).byteLength
+  if (bodyBytes > PROXY_CACHE_MAX_BODY_BYTES) return
+
+  const now = Date.now()
+  try {
+    const { error } = await supabaseAdmin
+      .from(CACHE_TABLE)
+      .upsert(
+        {
+          key_hash: input.keyHash,
+          api_key_id: input.apiKeyId,
+          provider: input.provider,
+          response_status: input.responseStatus,
+          response_body: input.responseBody,
+          usage: input.usage,
+          model: input.model,
+          created_at: new Date(now).toISOString(),
+          expires_at: new Date(now + input.ttlSeconds * 1000).toISOString(),
+        },
+        { onConflict: 'key_hash' },
+      )
+    if (error) {
+      logError('UNCATEGORIZED', { kind: 'proxy_cache_store_failed' }, error)
+    }
+  } catch (err) {
+    logError('UNCATEGORIZED', { kind: 'proxy_cache_store_failed' }, err)
+  }
+}

--- a/apps/server/src/lib/resend.ts
+++ b/apps/server/src/lib/resend.ts
@@ -367,6 +367,139 @@ export function renderLeakAlertEmail(params: {
  *
  * Tone: calm reminder, not dunning. Most past_due is an expired card.
  */
+/** "$12.34" under $100, "$1,234" above — keeps subjects short and scannable. */
+function formatUsd(n: number): string {
+  if (n >= 100) return `$${Math.round(n).toLocaleString('en-US')}`
+  return `$${n.toFixed(2)}`
+}
+
+/**
+ * Weekly usage digest. Sent Monday 09:00 UTC by lib/weekly-digest.ts to org
+ * admins who keep the `weekly_digest_emails` preference on. Copy avoids em
+ * dashes entirely (external-text policy).
+ */
+export function renderWeeklyDigestEmail(params: {
+  orgName: string
+  /** Human window label, e.g. "Jun 29 to Jul 5". */
+  periodLabel: string
+  requestCount: number
+  totalCostUsd: number
+  /** Week-over-week cost change in percent; null = no prior week to compare. */
+  costChangePct: number | null
+  errorCount: number
+  errorRatePct: number
+  topModels: Array<{ provider: string; model: string; costUsd: number; requestCount: number }>
+  /** Anomalies persisted this week; null = lookup unavailable, omit the line. */
+  anomalyCount: number | null
+  recommendation: {
+    currentModel: string
+    suggestedModel: string
+    estimatedMonthlySavingsUsd: number
+  } | null
+  dashboardUrl: string
+}): { subject: string; html: string } {
+  const {
+    orgName, periodLabel, requestCount, totalCostUsd, costChangePct,
+    errorCount, errorRatePct, topModels, anomalyCount, recommendation, dashboardUrl,
+  } = params
+
+  const subject = `Your Spanlens week: ${requestCount.toLocaleString('en-US')} requests, ${formatUsd(totalCostUsd)}`
+
+  let trendLine: string
+  let trendColor = '#555'
+  if (costChangePct === null) {
+    trendLine = 'There is no prior week to compare against yet.'
+  } else if (Math.abs(costChangePct) < 5) {
+    trendLine = 'Spend is about the same as the week before.'
+  } else if (costChangePct > 0) {
+    trendLine = `Spend is up ${Math.round(costChangePct)}% from the week before.`
+    trendColor = '#9a3412'
+  } else {
+    trendLine = `Spend is down ${Math.abs(Math.round(costChangePct))}% from the week before.`
+    trendColor = '#166534'
+  }
+
+  const errorLine = errorCount === 0
+    ? 'No failed requests this week.'
+    : `${errorCount.toLocaleString('en-US')} failed request${errorCount === 1 ? '' : 's'} (${errorRatePct.toFixed(1)}% error rate).`
+
+  const modelRows = topModels
+    .map((m) => `
+      <tr>
+        <td style="padding: 8px 12px; border-bottom: 1px solid #eee; font-family: ui-monospace, monospace; font-size: 12.5px;">${escapeHtml(m.model)}</td>
+        <td style="padding: 8px 12px; border-bottom: 1px solid #eee; font-family: ui-monospace, monospace; font-size: 12px; color: #666;">${escapeHtml(m.provider)}</td>
+        <td style="padding: 8px 12px; border-bottom: 1px solid #eee; font-size: 12px; color: #666; text-align: right;">${m.requestCount.toLocaleString('en-US')}</td>
+        <td style="padding: 8px 12px; border-bottom: 1px solid #eee; font-size: 12px; color: #111; text-align: right;">${escapeHtml(formatUsd(m.costUsd))}</td>
+      </tr>`)
+    .join('')
+
+  const modelsTable = topModels.length === 0 ? '' : `
+      <p style="margin: 22px 0 8px; font-size: 13px; font-weight: 600; color: #111;">Top models by cost</p>
+      <table style="width: 100%; border-collapse: collapse; border: 1px solid #eee; border-radius: 6px; overflow: hidden;">
+        <thead>
+          <tr style="background: #fafafa;">
+            <th style="padding: 8px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: #888; border-bottom: 1px solid #eee;">Model</th>
+            <th style="padding: 8px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: #888; border-bottom: 1px solid #eee;">Provider</th>
+            <th style="padding: 8px 12px; text-align: right; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: #888; border-bottom: 1px solid #eee;">Requests</th>
+            <th style="padding: 8px 12px; text-align: right; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: #888; border-bottom: 1px solid #eee;">Cost</th>
+          </tr>
+        </thead>
+        <tbody>${modelRows}</tbody>
+      </table>`
+
+  const anomalyBlock = anomalyCount !== null && anomalyCount > 0 ? `
+      <p style="margin: 16px 0 0; font-size: 13px; color: #9a3412;">
+        ${anomalyCount.toLocaleString('en-US')} anomal${anomalyCount === 1 ? 'y was' : 'ies were'} detected this week. Details are on the anomalies page in your dashboard.
+      </p>` : ''
+
+  const recommendationBlock = recommendation ? `
+      <div style="background: #f0fdf4; border: 1px solid #bbf7d0; border-radius: 8px; padding: 14px 16px; margin: 20px 0 0;">
+        <div style="font-weight: 600; font-size: 13px; color: #166534; margin-bottom: 4px;">Savings tip</div>
+        <div style="font-size: 13px; color: #14532d; line-height: 1.55;">
+          Moving eligible traffic from <span style="font-family: ui-monospace, monospace;">${escapeHtml(recommendation.currentModel)}</span>
+          to <span style="font-family: ui-monospace, monospace;">${escapeHtml(recommendation.suggestedModel)}</span>
+          could save about <strong>${escapeHtml(formatUsd(recommendation.estimatedMonthlySavingsUsd))} per month</strong>.
+          See the savings page in your dashboard for details.
+        </div>
+      </div>` : ''
+
+  const html = `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 620px; margin: 0 auto; padding: 24px; color: #111;">
+      <h2 style="margin: 0 0 4px; font-size: 19px;">Your week on Spanlens</h2>
+      <p style="margin: 0 0 18px; color: #888; font-size: 13px;">${escapeHtml(orgName)} · ${escapeHtml(periodLabel)}</p>
+
+      <table style="width: 100%; border-collapse: separate; border-spacing: 8px 0; margin: 0 -8px 4px;">
+        <tr>
+          <td style="width: 50%; background: #fafafa; border: 1px solid #eee; border-radius: 8px; padding: 14px 16px;">
+            <div style="font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: #888;">Requests</div>
+            <div style="font-size: 22px; font-weight: 600; margin-top: 2px;">${requestCount.toLocaleString('en-US')}</div>
+          </td>
+          <td style="width: 50%; background: #fafafa; border: 1px solid #eee; border-radius: 8px; padding: 14px 16px;">
+            <div style="font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: #888;">Total cost</div>
+            <div style="font-size: 22px; font-weight: 600; margin-top: 2px;">${escapeHtml(formatUsd(totalCostUsd))}</div>
+          </td>
+        </tr>
+      </table>
+
+      <p style="margin: 12px 0 0; font-size: 13px; color: ${trendColor};">${escapeHtml(trendLine)}</p>
+      <p style="margin: 6px 0 0; font-size: 13px; color: #555;">${escapeHtml(errorLine)}</p>
+      ${anomalyBlock}
+      ${modelsTable}
+      ${recommendationBlock}
+
+      <p style="margin: 24px 0;">
+        <a href="${dashboardUrl}" style="display: inline-block; padding: 10px 18px; background: #111; color: #fff; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 13px;">Open your dashboard</a>
+      </p>
+      <p style="margin: 18px 0 0; color: #aaa; font-size: 11.5px;">
+        You receive this weekly summary because you admin this workspace.
+        To stop it, turn off Weekly digest under Settings, Notifications.
+      </p>
+    </div>
+  `.trim()
+
+  return { subject, html }
+}
+
 export function renderPastDueEmail(params: {
   orgName: string
   stage: 'warning-d3' | 'warning-d1' | 'downgraded'

--- a/apps/server/src/lib/weekly-digest.ts
+++ b/apps/server/src/lib/weekly-digest.ts
@@ -1,0 +1,443 @@
+/**
+ * Weekly usage digest email.
+ *
+ * Every Monday 09:00 UTC (/cron/weekly-digest) each org's admins get a
+ * summary of the last 7 full UTC days: request volume, spend, week-over-week
+ * cost change, error count, top models by cost, anomalies persisted by the
+ * daily snapshot job, and the single best model-swap recommendation.
+ *
+ * Orgs with zero requests in the window are skipped entirely — no
+ * "you did nothing this week" emails. Recipients honour the per-user
+ * `weekly_digest_emails` preference via lib/digest-recipients.ts (NOT the
+ * security_alert_emails switch used by getAdminEmails).
+ *
+ * Dedup: one digest per ISO week. Both schedulers (Vercel cron + the
+ * GitHub Actions backup in cron-server.yml) hit the same endpoint, so the
+ * job first checks cron_job_runs for a successful 'weekly-digest' run since
+ * Monday 00:00 UTC and no-ops if one exists. Best-effort: two runs starting
+ * in the same second could both pass the check, which is acceptable for a
+ * summary email (same trade-off as stale-key-digest.ts documents).
+ *
+ * Structure mirrors data-silence.ts / stale-key-digest.ts: global ClickHouse
+ * aggregation is allowed here (lib file) because organization_id is part of
+ * the GROUP BY and every downstream write/email is keyed per org.
+ */
+
+import { supabaseAdmin } from './db.js'
+import { unscopedClickhouse, toClickhouseTimestamp } from './clickhouse.js'
+import { sendEmail, renderWeeklyDigestEmail } from './resend.js'
+import { getWeeklyDigestRecipients } from './digest-recipients.js'
+import { recommendModelSwaps, type ModelRecommendation } from './model-recommend.js'
+
+/** Digest window length: the last 7 full UTC days. */
+export const DIGEST_WINDOW_DAYS = 7
+/** How many models the "top models by cost" table shows. */
+export const DIGEST_TOP_MODELS_LIMIT = 3
+
+export interface DigestWindow {
+  /** Start of the digest week (00:00 UTC, inclusive). */
+  weekStart: Date
+  /** End of the digest week = start of today UTC (exclusive). */
+  weekEnd: Date
+  /** Start of the comparison week immediately before (inclusive). */
+  priorStart: Date
+}
+
+/**
+ * The last 7 FULL UTC days ending at today's 00:00 UTC, plus the 7 days
+ * before that for the week-over-week comparison. Pure — no I/O.
+ */
+export function computeDigestWindow(now: Date = new Date()): DigestWindow {
+  const weekEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+  const weekStart = new Date(weekEnd.getTime() - DIGEST_WINDOW_DAYS * 86_400_000)
+  const priorStart = new Date(weekEnd.getTime() - 2 * DIGEST_WINDOW_DAYS * 86_400_000)
+  return { weekStart, weekEnd, priorStart }
+}
+
+/** Monday 00:00 UTC of the ISO week containing `now`. Pure — no I/O. */
+export function isoWeekStartUtc(now: Date = new Date()): Date {
+  const daysSinceMonday = (now.getUTCDay() + 6) % 7
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - daysSinceMonday),
+  )
+}
+
+/** Human label for the digest window, e.g. "Jun 29 to Jul 5". */
+export function formatPeriodLabel(window: DigestWindow): string {
+  const fmt = (d: Date): string =>
+    d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })
+  const lastDay = new Date(window.weekEnd.getTime() - 86_400_000)
+  return `${fmt(window.weekStart)} to ${fmt(lastDay)}`
+}
+
+export interface OrgWeekStats {
+  organization_id: string
+  request_count: number
+  total_cost_usd: number
+  error_count: number
+  prior_request_count: number
+  prior_cost_usd: number
+}
+
+export interface TopModel {
+  provider: string
+  model: string
+  cost_usd: number
+  request_count: number
+}
+
+/**
+ * Week-over-week cost change in percent. Pure — no I/O.
+ * Returns null when the prior week has no comparable data (zero requests
+ * or zero recorded cost), so the email can say "no prior week" instead of
+ * a misleading +Infinity%.
+ */
+export function computeCostChangePct(
+  currentCostUsd: number,
+  priorCostUsd: number,
+  priorRequestCount: number,
+): number | null {
+  if (priorRequestCount === 0) return null
+  if (priorCostUsd <= 0) return null
+  return ((currentCostUsd - priorCostUsd) / priorCostUsd) * 100
+}
+
+/** Highest projected-savings recommendation, or null. Pure — no I/O. */
+export function pickTopRecommendation(
+  recs: ModelRecommendation[],
+): ModelRecommendation | null {
+  if (recs.length === 0) return null
+  return recs.reduce((best, r) =>
+    r.estimatedMonthlySavingsUsd > best.estimatedMonthlySavingsUsd ? r : best,
+  )
+}
+
+/**
+ * Sort each org's model buckets by cost (desc) and keep the top N.
+ * Pure — no I/O.
+ */
+export function topModelsByOrg(
+  rows: Array<TopModel & { organization_id: string }>,
+  limit: number = DIGEST_TOP_MODELS_LIMIT,
+): Map<string, TopModel[]> {
+  const byOrg = new Map<string, TopModel[]>()
+  for (const row of rows) {
+    const list = byOrg.get(row.organization_id) ?? []
+    byOrg.set(row.organization_id, [
+      ...list,
+      {
+        provider: row.provider,
+        model: row.model,
+        cost_usd: row.cost_usd,
+        request_count: row.request_count,
+      },
+    ])
+  }
+  const trimmed = new Map<string, TopModel[]>()
+  for (const [orgId, list] of byOrg) {
+    trimmed.set(
+      orgId,
+      [...list].sort((a, b) => b.cost_usd - a.cost_usd).slice(0, limit),
+    )
+  }
+  return trimmed
+}
+
+/**
+ * One global ClickHouse round-trip covering both weeks: per-org request
+ * count, cost, and error count for the digest week plus the prior week's
+ * count and cost. organization_id is in the GROUP BY so every row is
+ * org-scoped.
+ */
+async function fetchOrgWeekStats(window: DigestWindow): Promise<OrgWeekStats[]> {
+  const result = await unscopedClickhouse().query({
+    query:
+      'SELECT organization_id, ' +
+      '  countIf(created_at >= parseDateTime64BestEffort({weekStart:String})) AS request_count, ' +
+      '  sumIf(cost_usd, created_at >= parseDateTime64BestEffort({weekStart:String})) AS total_cost_usd, ' +
+      '  countIf(created_at >= parseDateTime64BestEffort({weekStart:String}) AND status_code >= 400) AS error_count, ' +
+      '  countIf(created_at < parseDateTime64BestEffort({weekStart:String})) AS prior_request_count, ' +
+      '  sumIf(cost_usd, created_at < parseDateTime64BestEffort({weekStart:String})) AS prior_cost_usd ' +
+      'FROM requests ' +
+      'WHERE created_at >= parseDateTime64BestEffort({priorStart:String}) ' +
+      '  AND created_at < parseDateTime64BestEffort({weekEnd:String}) ' +
+      'GROUP BY organization_id',
+    query_params: {
+      weekStart: toClickhouseTimestamp(window.weekStart),
+      weekEnd: toClickhouseTimestamp(window.weekEnd),
+      priorStart: toClickhouseTimestamp(window.priorStart),
+    },
+    format: 'JSONEachRow',
+  })
+
+  // JSONEachRow returns UInt64 counts and Decimal sums as strings — coerce
+  // every numeric at the boundary (gotcha #19).
+  const raw = (await result.json()) as Array<{
+    organization_id: string
+    request_count: string | number
+    total_cost_usd: string | number | null
+    error_count: string | number
+    prior_request_count: string | number
+    prior_cost_usd: string | number | null
+  }>
+
+  return raw.map((r) => ({
+    organization_id: r.organization_id,
+    request_count: Number(r.request_count ?? 0),
+    total_cost_usd: Number(r.total_cost_usd ?? 0),
+    error_count: Number(r.error_count ?? 0),
+    prior_request_count: Number(r.prior_request_count ?? 0),
+    prior_cost_usd: Number(r.prior_cost_usd ?? 0),
+  }))
+}
+
+/**
+ * Global per-(org, provider, model) cost buckets for the digest week.
+ * Grouped/trimmed to the top 3 per org in JS via topModelsByOrg.
+ */
+async function fetchTopModels(window: DigestWindow): Promise<Map<string, TopModel[]>> {
+  const result = await unscopedClickhouse().query({
+    query:
+      'SELECT organization_id, provider, model, ' +
+      '  sum(cost_usd) AS cost_usd, ' +
+      '  count() AS request_count ' +
+      'FROM requests ' +
+      'WHERE created_at >= parseDateTime64BestEffort({weekStart:String}) ' +
+      '  AND created_at < parseDateTime64BestEffort({weekEnd:String}) ' +
+      "  AND model != '' " +
+      'GROUP BY organization_id, provider, model',
+    query_params: {
+      weekStart: toClickhouseTimestamp(window.weekStart),
+      weekEnd: toClickhouseTimestamp(window.weekEnd),
+    },
+    format: 'JSONEachRow',
+  })
+
+  const raw = (await result.json()) as Array<{
+    organization_id: string
+    provider: string
+    model: string
+    cost_usd: string | number | null
+    request_count: string | number
+  }>
+
+  return topModelsByOrg(
+    raw.map((r) => ({
+      organization_id: r.organization_id,
+      provider: r.provider,
+      model: r.model,
+      cost_usd: Number(r.cost_usd ?? 0),
+      request_count: Number(r.request_count ?? 0),
+    })),
+  )
+}
+
+/**
+ * Anomalies persisted this week by the daily snapshot cron
+ * (lib/anomaly-snapshot.ts → anomaly_events). One cheap indexed count per
+ * emailed org — no detection is recomputed. Returns null when the lookup
+ * fails so the email omits the line instead of showing a wrong zero.
+ */
+async function fetchAnomalyCount(
+  orgId: string,
+  window: DigestWindow,
+): Promise<number | null> {
+  const { count, error } = await supabaseAdmin
+    .from('anomaly_events')
+    .select('id', { count: 'exact', head: true })
+    .eq('organization_id', orgId)
+    .gte('detected_on', window.weekStart.toISOString().slice(0, 10))
+    .lt('detected_on', window.weekEnd.toISOString().slice(0, 10))
+
+  if (error) return null
+  return count ?? 0
+}
+
+/**
+ * Best model-swap recommendation for the org, or null. recommendModelSwaps
+ * is the same per-org engine the daily recommend-savings-alerts cron already
+ * runs, so a weekly call is cheap. Failures degrade to null — the digest
+ * still goes out without the recommendation block.
+ */
+async function fetchTopRecommendation(orgId: string): Promise<ModelRecommendation | null> {
+  try {
+    const recs = await recommendModelSwaps(orgId)
+    return pickTopRecommendation(recs)
+  } catch {
+    return null
+  }
+}
+
+async function fetchOrgNames(orgIds: string[]): Promise<Map<string, string>> {
+  const names = new Map<string, string>()
+  if (orgIds.length === 0) return names
+  const { data } = await supabaseAdmin
+    .from('organizations')
+    .select('id, name')
+    .in('id', orgIds)
+  for (const row of (data ?? []) as Array<{ id: string; name: string | null }>) {
+    if (row.name) names.set(row.id, row.name)
+  }
+  return names
+}
+
+/**
+ * Atomically claim this ISO week's digest run via the weekly_digest_runs
+ * primary key. Exactly one runner wins when Vercel cron and the GH Actions
+ * backup fire together (gotcha #32); the loser sees 23505 and skips. The
+ * claim happens BEFORE any email is sent, so the dedup window is closed for
+ * the job's whole runtime, not just after completion.
+ *
+ * Returns 'claimed' | 'already-claimed' | 'error'. Errors other than 23505
+ * are surfaced so the caller can decide (we fail open: a rare transient DB
+ * error risks a duplicate summary, which beats silently sending nothing).
+ */
+async function claimWeeklyDigestRun(now: Date): Promise<'claimed' | 'already-claimed' | 'error'> {
+  const weekStart = isoWeekStartUtc(now).toISOString().slice(0, 10)
+  const { error } = await supabaseAdmin
+    .from('weekly_digest_runs')
+    .insert({ week_start: weekStart })
+
+  if (!error) return 'claimed'
+  if (error.code === '23505') return 'already-claimed'
+  console.error('weekly-digest claim failed', error.message)
+  return 'error'
+}
+
+export interface WeeklyDigestRunResult {
+  /** True when a successful run this ISO week already exists — nothing sent. */
+  skipped: boolean
+  /** True when the aggregation phase ran (per-org errors may still exist). */
+  completed: boolean
+  /** Orgs with at least one request in the digest window. */
+  orgs_scanned: number
+  /** Orgs skipped because every admin opted out (or the org has no admins). */
+  orgs_no_recipients: number
+  /** Orgs where Resend accepted at least one recipient. Stays 0 without RESEND_API_KEY. */
+  digests_sent: number
+  errors: string[]
+}
+
+export async function runWeeklyDigestJob(now: Date = new Date()): Promise<WeeklyDigestRunResult> {
+  const result: WeeklyDigestRunResult = {
+    skipped: false,
+    completed: false,
+    orgs_scanned: 0,
+    orgs_no_recipients: 0,
+    digests_sent: 0,
+    errors: [],
+  }
+
+  // Dedup guard: one digest per ISO week even when both schedulers fire.
+  // The claim is atomic (PK insert) and taken before any email goes out.
+  // A transient claim error is non-fatal — worst case is a duplicate
+  // summary email, which beats silently sending nothing.
+  const claim = await claimWeeklyDigestRun(now)
+  if (claim === 'already-claimed') {
+    result.skipped = true
+    result.completed = true
+    return result
+  }
+  if (claim === 'error') {
+    result.errors.push('weekly_digest_runs claim failed, proceeding without dedup')
+  }
+
+  const window = computeDigestWindow(now)
+
+  let stats: OrgWeekStats[]
+  let topModels: Map<string, TopModel[]>
+  try {
+    ;[stats, topModels] = await Promise.all([
+      fetchOrgWeekStats(window),
+      fetchTopModels(window),
+    ])
+  } catch (err) {
+    result.errors.push(err instanceof Error ? err.message : 'unknown')
+    return result
+  }
+
+  // Orgs with zero requests this week never get an email. Rows can exist
+  // with request_count = 0 when only the PRIOR week had traffic.
+  const activeOrgs = stats.filter((s) => s.request_count > 0)
+  result.orgs_scanned = activeOrgs.length
+  if (activeOrgs.length === 0) {
+    result.completed = true
+    return result
+  }
+
+  const orgNames = await fetchOrgNames(activeOrgs.map((s) => s.organization_id))
+  const dashboardBase = process.env['WEB_URL'] ?? 'https://www.spanlens.io'
+  const periodLabel = formatPeriodLabel(window)
+
+  for (const org of activeOrgs) {
+    try {
+      const recipients = await getWeeklyDigestRecipients(org.organization_id)
+      if (recipients.length === 0) {
+        result.orgs_no_recipients++
+        continue
+      }
+
+      const [anomalyCount, recommendation] = await Promise.all([
+        fetchAnomalyCount(org.organization_id, window),
+        fetchTopRecommendation(org.organization_id),
+      ])
+
+      const { subject, html } = renderWeeklyDigestEmail({
+        orgName: orgNames.get(org.organization_id) ?? 'your workspace',
+        periodLabel,
+        requestCount: org.request_count,
+        totalCostUsd: org.total_cost_usd,
+        costChangePct: computeCostChangePct(
+          org.total_cost_usd,
+          org.prior_cost_usd,
+          org.prior_request_count,
+        ),
+        errorCount: org.error_count,
+        errorRatePct: (org.error_count / org.request_count) * 100,
+        topModels: (topModels.get(org.organization_id) ?? []).map((m) => ({
+          provider: m.provider,
+          model: m.model,
+          costUsd: m.cost_usd,
+          requestCount: m.request_count,
+        })),
+        anomalyCount,
+        recommendation: recommendation
+          ? {
+              currentModel: recommendation.currentModel,
+              suggestedModel: recommendation.suggestedModel,
+              estimatedMonthlySavingsUsd: recommendation.estimatedMonthlySavingsUsd,
+            }
+          : null,
+        dashboardUrl: `${dashboardBase}/dashboard`,
+      })
+
+      let sentToAtLeastOne = false
+      for (const to of recipients) {
+        const r = await sendEmail({ to, subject, html })
+        if (r.sent) sentToAtLeastOne = true
+      }
+
+      if (sentToAtLeastOne) {
+        result.digests_sent++
+        await supabaseAdmin.from('audit_logs').insert({
+          organization_id: org.organization_id,
+          action: 'retention.weekly_digest_sent',
+          resource_type: 'organization',
+          resource_id: org.organization_id,
+          metadata: {
+            requests: org.request_count,
+            cost_usd: org.total_cost_usd,
+            recipients: recipients.length,
+          },
+        })
+      }
+    } catch (err) {
+      result.errors.push(
+        `org ${org.organization_id}: ${err instanceof Error ? err.message : 'unknown'}`,
+      )
+    }
+  }
+
+  result.completed = true
+  return result
+}

--- a/apps/server/src/proxy/anthropic.ts
+++ b/apps/server/src/proxy/anthropic.ts
@@ -17,6 +17,12 @@ import { runSecurityGate } from './shared/security-gate.js'
 import { fetchUpstreamWithTimeout } from './shared/upstream-fetch.js'
 import { buildLogBase } from './shared/log-base.js'
 import { runLineBufferedStreamPump } from './shared/stream-pump.js'
+import {
+  PROXY_CACHE_HEADER,
+  resolveProxyCache,
+  deleteExpiredCacheEntry,
+  storeCachedProxyResponse,
+} from '../lib/proxy-cache.js'
 
 const ANTHROPIC_BASE = 'https://api.anthropic.com'
 
@@ -41,6 +47,51 @@ anthropicProxy.all('/*', async (c) => {
     parseProxyRequestBody(c),
   ])
   const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
+
+  // ── Opt-in response cache (x-spanlens-cache header) ────────────────────────
+  // Same wiring as proxy/openai.ts — see lib/proxy-cache.ts for semantics.
+  const cache = await resolveProxyCache({
+    cacheHeader: c.req.header(PROXY_CACHE_HEADER),
+    isStreaming: parsed.isStreaming,
+    apiKeyId,
+    provider: 'anthropic',
+    path: c.req.path,
+    rawBody: parsed.reqBodyText,
+  })
+  if (cache.expiredKeyHash) fireAndForget(c, deleteExpiredCacheEntry(cache.expiredKeyHash))
+  if (cache.state.mode === 'hit') {
+    const hit = cache.state.entry
+    const latencyMs = Date.now() - handlerStartMs
+    const hitLogBase = buildLogBase({
+      c, provider: 'anthropic',
+      organizationId, projectId, apiKeyId,
+      providerKey,
+      reqBodyJson: parsed.reqBodyJson,
+      requestFlags,
+      latencyMs, proxyOverheadMs: latencyMs,
+      statusCode: hit.responseStatus,
+    })
+    let cachedBodyJson: unknown = null
+    try { cachedBodyJson = JSON.parse(hit.responseBody) } catch { /* stored body is JSON by construction */ }
+    fireAndForget(c, logRequestAsync({
+      ...hitLogBase,
+      model: hit.model,
+      promptTokens: hit.usage.prompt_tokens,
+      completionTokens: hit.usage.completion_tokens,
+      totalTokens: hit.usage.total_tokens,
+      cacheReadTokens: hit.usage.cache_read_tokens,
+      cacheWriteTokens: hit.usage.cache_write_tokens,
+      serviceTier: null,
+      costUsd: 0,
+      cacheHit: true,
+      responseBody: cachedBodyJson,
+      errorMessage: null,
+    }))
+    return new Response(hit.responseBody, {
+      status: hit.responseStatus,
+      headers: { 'content-type': 'application/json', [PROXY_CACHE_HEADER]: 'hit' },
+    })
+  }
 
   const upstreamUrl = `${ANTHROPIC_BASE}${c.req.path.replace(/^\/proxy\/anthropic/, '')}`
   // Anthropic uses `x-api-key` (NOT Authorization Bearer) + anthropic-version.
@@ -75,6 +126,8 @@ anthropicProxy.all('/*', async (c) => {
 
   // ── Streaming path ────────────────────────────────────────────────────────
   if (parsed.isStreaming && upstreamRes.body) {
+    // Caching was requested but streaming responses are never cached.
+    if (cache.state.mode === 'bypass') c.header(PROXY_CACHE_HEADER, 'bypass')
     return runLineBufferedStreamPump({
       c, upstreamRes, handlerStartMs, provider: 'anthropic',
       onComplete: (lines, truncated) =>
@@ -114,6 +167,31 @@ anthropicProxy.all('/*', async (c) => {
   const cost = calculateCost('anthropic', resolvedModel, {
     promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
   })
+
+  // Cache MISS: store the successful JSON response off the response-critical
+  // path (fireAndForget — gotcha #8). storeCachedProxyResponse re-checks the
+  // 200 + size guards internally.
+  if (cache.state.mode === 'miss') {
+    downstreamHeaders.set(PROXY_CACHE_HEADER, 'miss')
+    if (upstreamRes.status === 200 && resBodyJson !== null) {
+      fireAndForget(c, storeCachedProxyResponse({
+        keyHash: cache.state.keyHash,
+        apiKeyId,
+        provider: 'anthropic',
+        ttlSeconds: cache.state.ttlSeconds,
+        responseStatus: upstreamRes.status,
+        responseBody: resBodyText,
+        usage: {
+          prompt_tokens: promptTokens,
+          completion_tokens: completionTokens,
+          total_tokens: totalTokens,
+          cache_read_tokens: cacheReadTokens,
+          cache_write_tokens: cacheWriteTokens,
+        },
+        model: resolvedModel,
+      }))
+    }
+  }
 
   fireAndForget(c, logRequestAsync({
     ...logBase,

--- a/apps/server/src/proxy/gemini.ts
+++ b/apps/server/src/proxy/gemini.ts
@@ -17,6 +17,12 @@ import { runSecurityGate } from './shared/security-gate.js'
 import { fetchUpstreamWithTimeout } from './shared/upstream-fetch.js'
 import { buildLogBase } from './shared/log-base.js'
 import { runChunkAccumulatedStreamPump } from './shared/stream-pump.js'
+import {
+  PROXY_CACHE_HEADER,
+  resolveProxyCache,
+  deleteExpiredCacheEntry,
+  storeCachedProxyResponse,
+} from '../lib/proxy-cache.js'
 
 const GEMINI_BASE = 'https://generativelanguage.googleapis.com'
 
@@ -45,6 +51,10 @@ geminiProxy.all('/*', async (c) => {
   // Build the upstream URL with our decrypted key in `?key=` (the caller's
   // ?key= is OVERWRITTEN — a customer can't smuggle their own credential).
   const originalPath = c.req.path.replace(/^\/proxy\/gemini/, '')
+  // Gemini streams are URL-selected (`:streamGenerateContent`), not body-flag
+  // selected like OpenAI/Anthropic — decide once, up front, so the cache
+  // bypass and the stream pump agree.
+  const isStreaming = /:streamGenerateContent/.test(originalPath)
   const upstreamUrlObj = new URL(`${GEMINI_BASE}${originalPath}`)
   const clientUrl = new URL(c.req.raw.url)
   clientUrl.searchParams.forEach((v, k) => {
@@ -61,6 +71,55 @@ geminiProxy.all('/*', async (c) => {
 
   const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
 
+  // Extract model name from the URL path (e.g.
+  // /v1/models/gemini-1.5-pro:streamGenerateContent).
+  const modelMatch = /\/models\/([^/:]+)/.exec(originalPath)
+
+  // ── Opt-in response cache (x-spanlens-cache header) ────────────────────────
+  // Same wiring as proxy/openai.ts — see lib/proxy-cache.ts for semantics.
+  const cache = await resolveProxyCache({
+    cacheHeader: c.req.header(PROXY_CACHE_HEADER),
+    isStreaming,
+    apiKeyId,
+    provider: 'gemini',
+    path: c.req.path,
+    rawBody: parsed.reqBodyText,
+  })
+  if (cache.expiredKeyHash) fireAndForget(c, deleteExpiredCacheEntry(cache.expiredKeyHash))
+  if (cache.state.mode === 'hit') {
+    const hit = cache.state.entry
+    const hitLatencyMs = Date.now() - handlerStartMs
+    const hitLogBase = buildLogBase({
+      c, provider: 'gemini',
+      organizationId, projectId, apiKeyId,
+      providerKey,
+      reqBodyJson: parsed.reqBodyJson,
+      requestFlags,
+      latencyMs: hitLatencyMs, proxyOverheadMs: hitLatencyMs,
+      statusCode: hit.responseStatus,
+    })
+    let cachedBodyJson: unknown = null
+    try { cachedBodyJson = JSON.parse(hit.responseBody) } catch { /* stored body is JSON by construction */ }
+    fireAndForget(c, logRequestAsync({
+      ...hitLogBase,
+      model: hit.model,
+      promptTokens: hit.usage.prompt_tokens,
+      completionTokens: hit.usage.completion_tokens,
+      totalTokens: hit.usage.total_tokens,
+      cacheReadTokens: hit.usage.cache_read_tokens,
+      cacheWriteTokens: hit.usage.cache_write_tokens,
+      serviceTier: null,
+      costUsd: 0,
+      cacheHit: true,
+      responseBody: cachedBodyJson,
+      errorMessage: null,
+    }))
+    return new Response(hit.responseBody, {
+      status: hit.responseStatus,
+      headers: { 'content-type': 'application/json', [PROXY_CACHE_HEADER]: 'hit' },
+    })
+  }
+
   const { upstreamRes, latencyMs, proxyOverheadMs } = await fetchUpstreamWithTimeout({
     url: upstreamUrlObj.toString(),
     method: c.req.method,
@@ -69,11 +128,6 @@ geminiProxy.all('/*', async (c) => {
     provider: 'gemini',
     handlerStartMs,
   })
-
-  // Extract model name from the URL path (e.g.
-  // /v1/models/gemini-1.5-pro:streamGenerateContent).
-  const modelMatch = /\/models\/([^/:]+)/.exec(originalPath)
-  const isStreaming = /:streamGenerateContent/.test(originalPath)
 
   const logBase = buildLogBase({
     c, provider: 'gemini',
@@ -89,6 +143,8 @@ geminiProxy.all('/*', async (c) => {
   // Gemini sends a JSON array (not line-delimited SSE), so the pump
   // accumulates raw chunks and the parser walks the full buffer.
   if (isStreaming && upstreamRes.body) {
+    // Caching was requested but streaming responses are never cached.
+    if (cache.state.mode === 'bypass') c.header(PROXY_CACHE_HEADER, 'bypass')
     return runChunkAccumulatedStreamPump({
       c, upstreamRes, handlerStartMs, provider: 'gemini',
       onComplete: async (buffer, truncated) => {
@@ -204,6 +260,33 @@ geminiProxy.all('/*', async (c) => {
 
   const cost = calculateCost('gemini', model, { promptTokens, completionTokens, serviceTier })
 
+  const downstreamHeaders = buildDownstreamHeaders(upstreamRes.headers)
+
+  // Cache MISS: store the successful JSON response off the response-critical
+  // path (fireAndForget — gotcha #8). storeCachedProxyResponse re-checks the
+  // 200 + size guards internally.
+  if (cache.state.mode === 'miss') {
+    downstreamHeaders.set(PROXY_CACHE_HEADER, 'miss')
+    if (upstreamRes.status === 200 && resBodyJson !== null) {
+      fireAndForget(c, storeCachedProxyResponse({
+        keyHash: cache.state.keyHash,
+        apiKeyId,
+        provider: 'gemini',
+        ttlSeconds: cache.state.ttlSeconds,
+        responseStatus: upstreamRes.status,
+        responseBody: resBodyText,
+        usage: {
+          prompt_tokens: promptTokens,
+          completion_tokens: completionTokens,
+          total_tokens: totalTokens,
+          cache_read_tokens: 0,
+          cache_write_tokens: 0,
+        },
+        model,
+      }))
+    }
+  }
+
   fireAndForget(c, logRequestAsync({
     ...logBase,
     model,
@@ -216,6 +299,6 @@ geminiProxy.all('/*', async (c) => {
 
   return new Response(resBodyText, {
     status: upstreamRes.status,
-    headers: buildDownstreamHeaders(upstreamRes.headers),
+    headers: downstreamHeaders,
   })
 })

--- a/apps/server/src/proxy/openai.ts
+++ b/apps/server/src/proxy/openai.ts
@@ -17,6 +17,12 @@ import { fetchUpstreamWithTimeout } from './shared/upstream-fetch.js'
 import { buildLogBase } from './shared/log-base.js'
 import { runLineBufferedStreamPump } from './shared/stream-pump.js'
 import { assertSafeProxyBase } from './shared/validate-base.js'
+import {
+  PROXY_CACHE_HEADER,
+  resolveProxyCache,
+  deleteExpiredCacheEntry,
+  storeCachedProxyResponse,
+} from '../lib/proxy-cache.js'
 
 // Overridable so E2E (apps/web/__e2e__/smoke.spec.ts via docker-compose
 // dev mock-openai) can point this at http://localhost:4000 without hitting
@@ -54,6 +60,53 @@ openaiProxy.all('/*', async (c) => {
   ])
   const requestFlags = await runSecurityGate(parsed.reqBodyJson, projectId)
 
+  // ── Opt-in response cache (x-spanlens-cache header) ────────────────────────
+  // Exact-match on (api key, provider, path, raw body). HIT skips upstream
+  // entirely; the row still logs with the cached tokens/model, cost_usd 0,
+  // and cache_hit 1. See lib/proxy-cache.ts.
+  const cache = await resolveProxyCache({
+    cacheHeader: c.req.header(PROXY_CACHE_HEADER),
+    isStreaming: parsed.isStreaming,
+    apiKeyId,
+    provider: 'openai',
+    path: c.req.path,
+    rawBody: parsed.reqBodyText,
+  })
+  if (cache.expiredKeyHash) fireAndForget(c, deleteExpiredCacheEntry(cache.expiredKeyHash))
+  if (cache.state.mode === 'hit') {
+    const hit = cache.state.entry
+    const latencyMs = Date.now() - handlerStartMs
+    const hitLogBase = buildLogBase({
+      c, provider: 'openai',
+      organizationId, projectId, apiKeyId,
+      providerKey,
+      reqBodyJson: parsed.reqBodyJson,
+      requestFlags,
+      latencyMs, proxyOverheadMs: latencyMs,
+      statusCode: hit.responseStatus,
+    })
+    let cachedBodyJson: unknown = null
+    try { cachedBodyJson = JSON.parse(hit.responseBody) } catch { /* stored body is JSON by construction */ }
+    fireAndForget(c, logRequestAsync({
+      ...hitLogBase,
+      model: hit.model,
+      promptTokens: hit.usage.prompt_tokens,
+      completionTokens: hit.usage.completion_tokens,
+      totalTokens: hit.usage.total_tokens,
+      cacheReadTokens: hit.usage.cache_read_tokens,
+      cacheWriteTokens: hit.usage.cache_write_tokens,
+      serviceTier: null,
+      costUsd: 0,
+      cacheHit: true,
+      responseBody: cachedBodyJson,
+      errorMessage: null,
+    }))
+    return new Response(hit.responseBody, {
+      status: hit.responseStatus,
+      headers: { 'content-type': 'application/json', [PROXY_CACHE_HEADER]: 'hit' },
+    })
+  }
+
   const upstreamUrl = `${OPENAI_BASE}${c.req.path.replace(/^\/proxy\/openai/, '')}`
   const headers = buildUpstreamHeaders(c.req.raw.headers, {
     Authorization: `Bearer ${providerKey.plaintext}`,
@@ -83,6 +136,8 @@ openaiProxy.all('/*', async (c) => {
 
   // ── Streaming path ────────────────────────────────────────────────────────
   if (parsed.isStreaming && upstreamRes.body) {
+    // Caching was requested but streaming responses are never cached.
+    if (cache.state.mode === 'bypass') c.header(PROXY_CACHE_HEADER, 'bypass')
     return runLineBufferedStreamPump({
       c, upstreamRes, handlerStartMs, provider: 'openai',
       onComplete: (lines, truncated) =>
@@ -122,6 +177,31 @@ openaiProxy.all('/*', async (c) => {
   const cost = calculateCost('openai', resolvedModel, {
     promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
   })
+
+  // Cache MISS: store the successful JSON response off the response-critical
+  // path (fireAndForget — gotcha #8). storeCachedProxyResponse re-checks the
+  // 200 + size guards internally.
+  if (cache.state.mode === 'miss') {
+    downstreamHeaders.set(PROXY_CACHE_HEADER, 'miss')
+    if (upstreamRes.status === 200 && resBodyJson !== null) {
+      fireAndForget(c, storeCachedProxyResponse({
+        keyHash: cache.state.keyHash,
+        apiKeyId,
+        provider: 'openai',
+        ttlSeconds: cache.state.ttlSeconds,
+        responseStatus: upstreamRes.status,
+        responseBody: resBodyText,
+        usage: {
+          prompt_tokens: promptTokens,
+          completion_tokens: completionTokens,
+          total_tokens: totalTokens,
+          cache_read_tokens: cacheReadTokens,
+          cache_write_tokens: cacheWriteTokens,
+        },
+        model: resolvedModel,
+      }))
+    }
+  }
 
   fireAndForget(c, logRequestAsync({
     ...logBase,

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -26,6 +26,7 @@
     { "path": "/cron/detect-orphan-spans",        "schedule": "17 * * * *" },
     { "path": "/cron/keep-warm",                  "schedule": "*/5 * * * *" },
     { "path": "/cron/prune-judge-cache",          "schedule": "0 3 * * *" },
-    { "path": "/cron/detect-data-silence",        "schedule": "30 */6 * * *" }
+    { "path": "/cron/detect-data-silence",        "schedule": "30 */6 * * *" },
+    { "path": "/cron/weekly-digest",              "schedule": "0 9 * * 1" }
   ]
 }

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -1760,7 +1760,7 @@ function SignInMethodsTab() {
 // ─── NOTIFICATIONS tab ────────────────────────────────────────────────────────
 
 interface NotificationPrefDef {
-  key: 'security_alert_emails' | 'marketing_emails' | 'product_update_emails'
+  key: 'security_alert_emails' | 'marketing_emails' | 'product_update_emails' | 'weekly_digest_emails'
   label: string
   hint: string
 }
@@ -1770,6 +1770,11 @@ const NOTIFICATION_PREFS: NotificationPrefDef[] = [
     key: 'security_alert_emails',
     label: 'Security alerts',
     hint: 'Stale-key reminders and leaked-key detection alerts for workspaces you admin.',
+  },
+  {
+    key: 'weekly_digest_emails',
+    label: 'Weekly digest',
+    hint: 'A Monday summary of last week’s requests, spend, and top models for workspaces you admin.',
   },
   {
     key: 'product_update_emails',

--- a/apps/web/app/docs/proxy/page.tsx
+++ b/apps/web/app/docs/proxy/page.tsx
@@ -390,6 +390,52 @@ res, _ := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
         See <a href="/docs/features/cost-tracking">cost tracking</a> for the full formula.
       </p>
 
+      <h2 id="response-caching">Response caching</h2>
+      <p>
+        Spanlens can serve repeated identical requests from a cache instead of calling the
+        provider again. Caching is <strong>off by default</strong> and opt-in per request with
+        the <code>X-Spanlens-Cache</code> header:
+      </p>
+      <CodeBlock>{`-H "X-Spanlens-Cache: true"    # cache with the default TTL (3600 seconds)
+-H "X-Spanlens-Cache: 600"     # cache for 600 seconds (max 86400 = 24h)`}</CodeBlock>
+      <p>
+        Accepted values are <code>true</code> (one hour TTL) or an integer number of seconds,
+        capped at <code>86400</code>. Any other value disables caching for that request, so a
+        malformed header never caches by accident. The header is internal Spanlens metadata
+        and is stripped before the request reaches the provider.
+      </p>
+      <p>
+        A cache entry matches only when the <strong>exact same request</strong> repeats: same
+        Spanlens API key, same provider, same path, and byte-identical request body. Entries
+        are scoped to your API key, so they are never shared across keys, projects, or
+        organizations.
+      </p>
+      <p>Rules and limits:</p>
+      <ul>
+        <li>
+          <strong>Non-streaming only.</strong> Requests with <code>stream: true</code> (or
+          Gemini&apos;s <code>:streamGenerateContent</code> endpoint) always go to the provider.
+        </li>
+        <li>Only successful (HTTP 200) JSON responses are stored.</li>
+        <li>Response bodies larger than 256 KB are not stored.</li>
+        <li>Expired entries are cleaned up automatically on the next miss for the same request.</li>
+      </ul>
+      <p>
+        Every response to a request that carried the header includes an{' '}
+        <code>x-spanlens-cache</code> response header telling you what happened:
+      </p>
+      <ul>
+        <li><code>hit</code>, served from the cache; the provider was not called.</li>
+        <li><code>miss</code>, the provider was called and a 200 JSON response was stored for next time.</li>
+        <li><code>bypass</code>, caching was requested but the request was streaming.</li>
+      </ul>
+      <p>
+        Cached hits still appear in <a href="/requests">/requests</a>: the row keeps the
+        original model and token counts but records <code>cost_usd</code> as{' '}
+        <strong>zero</strong> (the provider billed nothing) plus a <code>cache_hit</code>{' '}
+        flag, so you can compute exactly how much the cache saved you.
+      </p>
+
       <h2>Rate limits and response headers</h2>
       <p>
         Spanlens applies a high per-organization per-minute ceiling on{' '}

--- a/apps/web/app/docs/quick-start/page.tsx
+++ b/apps/web/app/docs/quick-start/page.tsx
@@ -6,7 +6,7 @@ export const metadata = {
   alternates: { canonical: '/docs/quick-start' },
   title: 'Quick start · Spanlens Docs',
   description:
-    'Get up and running with Spanlens in 30 seconds. Start from scratch or migrate existing OpenAI, Anthropic, or Gemini code with one command.',
+    'Get up and running with Spanlens in 30 seconds. Migrate existing OpenAI, Anthropic, or Gemini code with one command, or set up manually in four steps.',
 }
 
 export default function QuickStart() {
@@ -15,44 +15,99 @@ export default function QuickStart() {
       <DocsJsonLd meta={metadata} />
       <h1>Quick start</h1>
       <p className="lead">
-        Pick the path that matches your starting point. Both end with your LLM calls flowing through
-        Spanlens and showing up in <a href="/requests">your dashboard</a>.
+        Two ways to get your LLM calls flowing through Spanlens and showing up in{' '}
+        <a href="/requests">your dashboard</a>. If your code already calls OpenAI, Anthropic, or
+        Gemini directly, the CLI wires everything up in one command. Otherwise the manual path
+        takes four steps.
       </p>
 
-      <details className="not-prose my-6 rounded-lg border border-border/60 bg-bg-elev p-4 text-sm">
-        <summary className="cursor-pointer font-medium">
-          Need an account first? (signup → project → Spanlens key → provider key)
-        </summary>
-        <ol className="mt-3 ml-5 list-decimal space-y-1 text-muted-foreground">
-          <li><a className="underline" href="/signup">Sign up</a> and create a project at <a className="underline" href="/projects">/projects</a>.</li>
-          <li>Click <em>+ New Spanlens key</em> on the project card. You&apos;ll get a <code>sl_live_…</code> shown once — save it.</li>
-          <li>Click <em>+ Add provider key</em> next to the Spanlens key and paste your real OpenAI / Anthropic / Gemini key.</li>
-        </ol>
-        <p className="mt-2 text-muted-foreground">
-          One Spanlens key covers every provider key you register under it. You don&apos;t need separate keys per provider.
-        </p>
-      </details>
-
-      <h2 id="path-a">Path A — Starting from scratch (no CLI)</h2>
+      <h2 id="path-b">One command setup for existing code (CLI)</h2>
       <p>
-        If your code doesn&apos;t already call OpenAI / Anthropic / Gemini directly, this is the
-        simpler path. Three steps, never run the CLI.
+        If your codebase already has direct calls like{' '}
+        <code>new OpenAI(&#123; apiKey: ... &#125;)</code>, the CLI rewrites them in place in one
+        pass. Run it from your app root:
+      </p>
+      <CodeBlock language="bash">{`npx @spanlens/cli@latest init`}</CodeBlock>
+      <p>
+        Before you run it, set up three things at <a href="/projects">/projects</a>: a project, a
+        Spanlens key (<em>+ New Spanlens key</em>, the <code>sl_live_…</code> value is shown once,
+        so save it), and at least one provider key registered under that Spanlens key. The wizard
+        prompts you to paste the Spanlens key and automates the rest.
       </p>
 
-      <h3>Step 1: Install the SDK</h3>
-      <CodeBlock language="bash">{`pnpm add @spanlens/sdk
-# or: npm install @spanlens/sdk
-# or: yarn add @spanlens/sdk`}</CodeBlock>
+      <p>Here is exactly what it does to your project:</p>
+      <ol>
+        <li>Detects your framework (Next.js for now)</li>
+        <li>Validates your Spanlens key against the API and lists which providers you have keys registered for</li>
+        <li>
+          Writes <code>SPANLENS_API_KEY</code> to <code>.env.local</code> (asks before overwriting an existing value)
+        </li>
+        <li>Installs <code>@spanlens/sdk</code> with your package manager</li>
+        <li>
+          Patches every <code>new OpenAI(...)</code> / <code>new Anthropic(...)</code> /{' '}
+          <code>new GoogleGenerativeAI(...)</code> call to the matching{' '}
+          <code>createXxx()</code> helper, only for providers you have keys for
+        </li>
+        <li>Runs <code>tsc --noEmit</code> to verify the patch compiles</li>
+      </ol>
+      <p className="text-sm text-muted-foreground">
+        Want to see the changes before anything is written? Run{' '}
+        <code>npx @spanlens/cli init --dry-run</code>. Self-hosting? Add{' '}
+        <code>--server-url https://spanlens.yourcompany.com</code> to point the wizard at your own
+        instance instead of spanlens.io.
+      </p>
+
+      <p>Then deploy:</p>
+      <ol>
+        <li>Add <code>SPANLENS_API_KEY</code> to your production env (Vercel / Railway / Fly)</li>
+        <li>Redeploy, because new env values don&apos;t apply to existing deployments</li>
+      </ol>
+
+      <h3>When does the CLI need to run again?</h3>
+      <p>
+        Almost never. Once a file is patched it stays patched. Rotating, adding, or deactivating
+        provider keys in the dashboard doesn&apos;t require a re-run. The only time you re-run is
+        when:
+      </p>
+      <ul>
+        <li>
+          You add a <em>new provider type</em> (e.g. you had OpenAI before, now you&apos;re
+          adding Anthropic) <strong>and</strong> your codebase still has direct{' '}
+          <code>new Anthropic(...)</code> calls. Otherwise just write the helper directly
+          using the snippet from the manual path below.
+        </li>
+      </ul>
+
+      <h2 id="path-a">Manual setup in four steps</h2>
+      <p>
+        Starting from scratch, or your code doesn&apos;t call a provider directly yet? Four steps,
+        never run the CLI.
+      </p>
+
+      <h3>Step 1: Create your keys at /projects</h3>
+      <ol>
+        <li><a className="underline" href="/signup">Sign up</a> and create a project at <a className="underline" href="/projects">/projects</a>.</li>
+        <li>Click <em>+ New Spanlens key</em> on the project card. You&apos;ll get a <code>sl_live_…</code> value shown once, so save it now.</li>
+        <li>Click <em>+ Add provider key</em> next to the Spanlens key and paste your real OpenAI / Anthropic / Gemini key.</li>
+      </ol>
+      <p>
+        One Spanlens key covers every provider key you register under it. You don&apos;t need
+        separate keys per provider.
+      </p>
 
       <h3>Step 2: Add the env variable</h3>
       <p>
-        Copy the <code>sl_live_…</code> value shown when you issued the Spanlens key
-        (it&apos;s only displayed once) and put it in your env file:
+        Put the <code>sl_live_…</code> value you saved in Step 1 into your env file:
       </p>
       <CodeBlock language="env">{`# .env.local
 SPANLENS_API_KEY=sl_live_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`}</CodeBlock>
 
-      <h3>Step 3: Use the helper for each provider you registered</h3>
+      <h3>Step 3: Install the SDK</h3>
+      <CodeBlock language="bash">{`pnpm add @spanlens/sdk
+# or: npm install @spanlens/sdk
+# or: yarn add @spanlens/sdk`}</CodeBlock>
+
+      <h3>Step 4: Use the helper for each provider you registered</h3>
       <p>
         Each helper is a drop-in replacement for the provider&apos;s normal client: same methods,
         same return types. <code>SPANLENS_API_KEY</code> is read automatically.
@@ -97,9 +152,10 @@ const result = await model.generateContent('Hi')`}</CodeBlock>
         for the per-framework snippet.
       </p>
 
-      <h3>Adding new providers later — no CLI needed</h3>
+      <h3>Adding new providers later (no CLI needed)</h3>
       <p>
-        Once Steps 1 and 2 are done, adding a second or third provider is just:
+        Once Steps 2 and 3 are done (env variable set, SDK installed), adding a second or third
+        provider is just:
       </p>
       <ol>
         <li>Dashboard: <em>+ Add provider key</em> for the new provider</li>
@@ -110,59 +166,6 @@ const result = await model.generateContent('Hi')`}</CodeBlock>
         copy-paste straight into your project. Your <code>SPANLENS_API_KEY</code> already covers the
         new provider.
       </p>
-
-      <h2 id="path-b">Path B — Migrating existing OpenAI / Anthropic / Gemini code (CLI)</h2>
-      <p>
-        If your codebase already has direct calls like{' '}
-        <code>new OpenAI(&#123; apiKey: ... &#125;)</code>, the CLI rewrites them in place in one pass.
-      </p>
-      <CodeBlock language="bash">{`npx @spanlens/cli@latest init`}</CodeBlock>
-      <p className="text-sm text-muted-foreground">
-        Self-hosting? Add <code>--server-url https://spanlens.yourcompany.com</code> to point the
-        wizard at your own instance instead of spanlens.io.
-      </p>
-
-      <p>The wizard:</p>
-      <ol>
-        <li>Detects your framework (Next.js for now)</li>
-        <li>Validates your Spanlens key against the API and lists which providers you have keys registered for</li>
-        <li>
-          Writes <code>SPANLENS_API_KEY</code> to <code>.env.local</code> (asks before overwriting an existing value)
-        </li>
-        <li>Installs <code>@spanlens/sdk</code> with your package manager</li>
-        <li>
-          Patches every <code>new OpenAI(...)</code> / <code>new Anthropic(...)</code> /{' '}
-          <code>new GoogleGenerativeAI(...)</code> call to the matching{' '}
-          <code>createXxx()</code> helper, only for providers you have keys for
-        </li>
-        <li>Runs <code>tsc --noEmit</code> to verify the patch compiles</li>
-      </ol>
-
-      <p>Then deploy:</p>
-      <ol>
-        <li>Add <code>SPANLENS_API_KEY</code> to your production env (Vercel / Railway / Fly)</li>
-        <li>Redeploy — new env values don&apos;t apply to existing deployments</li>
-      </ol>
-
-      <p className="text-sm text-muted-foreground">
-        Preview the changes before applying:{' '}
-        <code>npx @spanlens/cli init --dry-run</code>
-      </p>
-
-      <h3>When does the CLI need to run again?</h3>
-      <p>
-        Almost never. Once a file is patched it stays patched. Rotating, adding, or deactivating
-        provider keys in the dashboard doesn&apos;t require a re-run. The only time you re-run is
-        when:
-      </p>
-      <ul>
-        <li>
-          You add a <em>new provider type</em> (e.g. you had OpenAI before, now you&apos;re
-          adding Anthropic) <strong>and</strong> your codebase still has direct{' '}
-          <code>new Anthropic(...)</code> calls. Otherwise just write the helper directly
-          using the snippet from Path A.
-        </li>
-      </ul>
 
       <h2 id="verify">Verify it works</h2>
       <p>
@@ -186,9 +189,9 @@ const result = await model.generateContent('Hi')`}</CodeBlock>
         </figcaption>
       </figure>
 
-      <h2>What about /traces?</h2>
+      <h2 id="tracing">What about /traces?</h2>
       <p>
-        The proxy setup above populates <a href="/requests">/requests</a> only —{' '}
+        The proxy setup above populates <a href="/requests">/requests</a> only, so{' '}
         <a href="/traces">/traces</a> will be empty. That&apos;s expected.
       </p>
       <p>
@@ -210,9 +213,9 @@ const result = await model.generateContent('Hi')`}</CodeBlock>
           Confirm <code>SPANLENS_API_KEY</code> is set in <em>both</em>{' '}
           <code>.env.local</code> AND your deployment environment
         </li>
-        <li>After adding env vars in Vercel, <strong>redeploy</strong> — new values don&apos;t apply retroactively</li>
+        <li>After adding env vars in Vercel, <strong>redeploy</strong>, because new values don&apos;t apply retroactively</li>
         <li>
-          Check the Network tab — your request should hit{' '}
+          Check the Network tab. Your request should hit{' '}
           <code>server.spanlens.io/proxy/*</code>, not <code>api.openai.com</code> directly
         </li>
       </ol>
@@ -221,7 +224,7 @@ const result = await model.generateContent('Hi')`}</CodeBlock>
       <p>
         You called a provider you haven&apos;t registered yet. Open{' '}
         <a href="/projects">/projects</a>, find the Spanlens key, and click{' '}
-        <em>+ Add provider key</em> — pick the matching provider (OpenAI / Anthropic / Gemini) and
+        <em>+ Add provider key</em>. Pick the matching provider (OpenAI / Anthropic / Gemini) and
         paste your AI key.
       </p>
 

--- a/apps/web/components/dashboard/welcome-banner.tsx
+++ b/apps/web/components/dashboard/welcome-banner.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
-import { Copy, Check, X, Terminal, CheckCircle2, Loader2, RefreshCw } from 'lucide-react'
+import { Copy, Check, X, Terminal, CheckCircle2, Loader2, RefreshCw, ShieldCheck } from 'lucide-react'
 import { createClient } from '@/lib/supabase/client'
 import { consumeWelcomeStash, clearWelcomeStash } from '@/lib/welcome-stash'
 import { useProviderKeys } from '@/lib/queries/use-provider-keys'
@@ -96,10 +96,34 @@ export function WelcomeBanner() {
   )
 }
 
+type KeyCheckState = 'idle' | 'checking' | 'ok' | 'failed'
+
 function WelcomeBannerInner({ apiKey, onDismiss }: { apiKey: string; onDismiss: () => void }) {
   const [copiedKey, setCopiedKey] = useState(false)
   const [copiedSnippet, setCopiedSnippet] = useState(false)
   const [copiedCurl, setCopiedCurl] = useState(false)
+
+  // Step 1 verification — introspects the freshly issued key against the
+  // server's key-info endpoint. Same-origin path: the Next.js rewrite in
+  // next.config.mjs forwards /api/* to spanlens-server, exactly like the
+  // banner's other queries (useProviderKeys / useRequests via lib/api.ts),
+  // so no CORS preflight and no hardcoded server host. Auth here is the
+  // sl_live_* key itself (authApiKey on the server), not the user JWT.
+  const [keyCheck, setKeyCheck] = useState<KeyCheckState>('idle')
+
+  async function verifyKey() {
+    if (keyCheck === 'checking') return
+    setKeyCheck('checking')
+    try {
+      const res = await fetch('/api/v1/me/key-info', {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        cache: 'no-store',
+      })
+      setKeyCheck(res.ok ? 'ok' : 'failed')
+    } catch {
+      setKeyCheck('failed')
+    }
+  }
 
   // Step 2 status — flips to a checkmark once any provider key exists.
   const providerKeys = useProviderKeys()
@@ -170,6 +194,31 @@ function WelcomeBannerInner({ apiKey, onDismiss }: { apiKey: string; onDismiss: 
             </code>{' '}
             (or your deployment&apos;s env settings, Vercel, Railway, etc.).
           </p>
+          <div className="flex items-center gap-2 mt-2">
+            <button
+              type="button"
+              onClick={() => void verifyKey()}
+              disabled={keyCheck === 'checking'}
+              className="font-mono text-[10.5px] px-[8px] py-[3px] border border-border rounded-[5px] text-text-muted hover:text-text hover:border-border-strong disabled:opacity-40 transition-colors inline-flex items-center gap-1"
+            >
+              {keyCheck === 'checking' ? (
+                <Loader2 className="w-3 h-3 animate-spin" />
+              ) : (
+                <ShieldCheck className="w-3 h-3" />
+              )}
+              Verify key
+            </button>
+            {keyCheck === 'ok' && (
+              <span className="inline-flex items-center gap-1 text-good font-mono text-[10.5px]">
+                <CheckCircle2 className="w-3.5 h-3.5" /> Key is active
+              </span>
+            )}
+            {keyCheck === 'failed' && (
+              <span className="font-mono text-[10.5px] text-bad">
+                Key check failed. Check the env var name and restart your dev server.
+              </span>
+            )}
+          </div>
         </div>
 
         {/* Step 2, register a provider key — checkmark once one exists */}

--- a/apps/web/lib/queries/types.ts
+++ b/apps/web/lib/queries/types.ts
@@ -415,6 +415,7 @@ export interface UserNotificationPrefs {
   security_alert_emails: boolean
   marketing_emails: boolean
   product_update_emails: boolean
+  weekly_digest_emails: boolean
 }
 
 export interface AlertDeliveryRow {

--- a/clickhouse/migrations/010_add_cache_hit.sql
+++ b/clickhouse/migrations/010_add_cache_hit.sql
@@ -1,0 +1,23 @@
+-- 010_add_cache_hit.sql
+-- Adds the `cache_hit` flag set when a proxy response was served from the
+-- opt-in exact-match response cache (x-spanlens-cache header) instead of
+-- calling the upstream provider.
+--
+-- WHY: cached hits are logged with the ORIGINAL token counts and model but
+-- cost_usd = 0 (nothing was billed by the provider). Without this flag those
+-- rows are indistinguishable from genuinely-free requests, so cache savings
+-- ("what would these tokens have cost?") cannot be computed later.
+--
+-- BACKFILL: existing rows default to 0 (not a cache hit). No rewrite needed —
+-- CH's MergeTree handles DEFAULT columns lazily on read.
+--
+-- ⚠️ DEPLOY ORDER (CLAUDE.md gotcha #21): apply this to production ClickHouse
+-- MANUALLY (Cloud SQL console) BEFORE the code that writes cache_hit deploys.
+-- input_format_skip_unknown_fields=1 protects the window (rows insert, the
+-- flag is silently dropped), but the flag data is lost until the column exists.
+--
+-- IDEMPOTENT (CLAUDE.md DB rule): IF NOT EXISTS for ALTER. CH treats this as
+-- a metadata-only change; safe to apply against a populated table.
+
+ALTER TABLE requests
+    ADD COLUMN IF NOT EXISTS cache_hit UInt8 DEFAULT 0;

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -355,38 +355,75 @@ process.exit(0)
 
 `flush()` resolves even if some requests failed. It uses `Promise.allSettled` internally so a network error won't hang the process.
 
-## Error handling
+## Troubleshooting and error handling
 
-Instrumentation is fire-and-forget by design, so **tracing never crashes your app**. Every ingest call is governed by two `SpanlensConfig` options:
+Instrumentation is fire-and-forget by design, so **observability never crashes your app**. Every ingest call is governed by two `SpanlensConfig` options:
 
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `silent` | `boolean` | `true` | When `true`, ingest failures are swallowed (the call resolves to `null`) so your hot path is never interrupted. When `false`, the failure is **re-thrown** so you can surface it in tests or fail-fast environments. |
-| `onError` | `(err, context) => void` | (none) | Called on **every** ingest failure, regardless of `silent`. `context` is the failing route, e.g. `"POST /ingest/traces"`. Use it to forward errors to your monitoring stack. |
+| `onError` | `(err, context) => void` | (none) | Called on **every** dropped or failed delivery, regardless of `silent`. `context` is the failing route, e.g. `"POST /ingest/traces"`. Use it to forward errors to your monitoring stack. |
 
 Even with the default `silent: true`, `onError` still fires, so you get full visibility without the risk of an unhandled rejection taking down a request.
 
-### `SpanlensApiError`
+```ts
+const client = new SpanlensClient({
+  apiKey: process.env.SPANLENS_API_KEY!,
+  onError: (err, context) => {
+    // err is a SpanlensTransportError for HTTP failures (status, code, endpoint)
+    // and the raw underlying error for network or timeout failures.
+    myLogger.warn('spanlens delivery dropped', { context, err })
+  },
+})
+```
+
+### Common failures and what to do
+
+For the misconfigurations customers hit most, the SDK also prints a single actionable `console.warn` prefixed with `[spanlens]` (deduped, one warning per failure kind), so a silently dropping integration is visible in your logs:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `401 UNAUTHORIZED` | Key not accepted | Check the three usual suspects: (1) the `SPANLENS_API_KEY` env var is actually loaded in the running process, (2) the key was not revoked in the dashboard, (3) no whitespace or quotes were pasted around the key. See the [quick start](https://www.spanlens.io/docs/quick-start). |
+| `403 PUBLIC_KEY_WRITE_FORBIDDEN` | A public key (`sl_live_pub_*`) was used for ingest or proxy | Public keys are read-only. Create a full `sl_live_` key on the Projects & Keys page for tracing. |
+| `429 RATE_LIMIT` | Monthly quota or rate limit hit | Review usage and upgrade at [spanlens.io/pricing](https://www.spanlens.io/pricing) or manage your plan on the billing page. |
+
+The SDK also warns once at `SpanlensClient` construction when the configured `apiKey` does not start with `sl_live_` (probably not a Spanlens key) or starts with `sl_live_pub_` (read-only, ingest will be rejected). The key itself is never printed.
+
+### Tuning `timeoutMs`
+
+Each ingest call has a `timeoutMs` deadline (default `3000` ms) covering the whole request, headers and body. The default is deliberately short: observability should not hold up user code. Raise it if you run in a region far from the ingest endpoint or behind a slow egress proxy; lower it (e.g. `1000`) in latency-critical paths where you would rather drop a span than wait. Timed-out calls are retried automatically (see below), then reported to `onError`.
+
+### Flush before process exit
+
+Ingest is fire-and-forget, so short-lived processes (scripts, CI jobs, serverless handlers) can exit before deliveries settle. Call `await client.flush()` before exit; see [Graceful shutdown with `client.flush()`](#graceful-shutdown-with-clientflush) above.
+
+### `SpanlensApiError` and `SpanlensTransportError`
 
 When the Spanlens server rejects a call with its standard error envelope (a `4xx`), the SDK surfaces a typed `SpanlensApiError` instead of a bare `Error`. This lets you branch on a stable `code` rather than string-matching a message. It reaches you either through `onError` (always) or as a thrown value (when `silent: false`).
 
 ```ts
-import { SpanlensApiError } from '@spanlens/sdk'
+import { SpanlensApiError, SpanlensTransportError } from '@spanlens/sdk'
 
-class SpanlensApiError extends Error {
-  code: string                              // stable machine code, e.g. 'PUBLIC_KEY_WRITE_FORBIDDEN'
-  status: number                            // HTTP status (4xx)
+class SpanlensTransportError extends Error {
+  code: string                              // stable machine code, or 'HTTP_<status>' when no envelope
+  status: number                            // HTTP status
+  endpoint: string                          // failing route, e.g. 'POST /ingest/traces'
+}
+
+class SpanlensApiError extends SpanlensTransportError {
   details?: Record<string, unknown>         // optional structured context
   requestId: string | null                  // server request id for support
 }
 ```
 
+`SpanlensTransportError` is the base class for every classified HTTP failure, including responses that do not carry the standard envelope (a CDN error page, for example). `instanceof SpanlensApiError` checks keep working unchanged.
+
 ### Automatic retries
 
-The transport retries **transient** failures on its own, so a brief network blip or a `429` doesn't lose a span:
+The transport retries **transient** failures on its own, so a brief network blip doesn't lose a span:
 
-- **Retried** (up to `3` attempts total) with exponential back-off `200 ms → 400 ms → 800 ms`: network errors, request timeouts (default `3000 ms`), `429`, and `5xx`.
-- **Not retried**: `4xx` client errors. These are your bug (bad key, missing scope, malformed body), so retrying wastes time. They go straight to `onError` (and throw when `silent: false`).
+- **Retried** (up to `3` attempts total) with exponential back-off `200 ms → 400 ms → 800 ms`: network errors, request timeouts (default `3000 ms`), and `5xx`.
+- **Not retried**: `4xx` client errors, including `429`. These indicate a configuration or quota problem (bad key, missing scope, malformed body, exhausted plan), so retrying wastes time. They go straight to `onError` (and throw when `silent: false`).
 
 Because every trace and span carries a **client-generated UUID**, retries are idempotent: the same UUID delivered twice is a no-op on the server.
 

--- a/packages/sdk/src/__tests__/error-ergonomics.test.ts
+++ b/packages/sdk/src/__tests__/error-ergonomics.test.ts
@@ -245,24 +245,25 @@ describe('SpanlensClient: apiKey format warnings at construction', () => {
     expect(warnSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('warns once when the key does not look like a Spanlens key, masking the value', () => {
+  it('warns once when the key does not look like a Spanlens key, without echoing the value', () => {
     new SpanlensClient({ apiKey: 'sk-proj-supersecretvalue' })
     expect(warnSpy).toHaveBeenCalledTimes(1)
     const msg = warnSpy.mock.calls[0]?.[0] as string
     expect(msg).toContain('does not look like a Spanlens key')
     expect(msg).toContain('sl_live_')
-    // Masked: short prefix only, never the secret part.
-    expect(msg).toContain('sk-pr')
+    // Nothing derived from the key value appears in the log, not even a
+    // masked prefix (CodeQL js/clear-text-logging flags any tainted substring).
+    expect(msg).not.toContain('sk-pr')
     expect(msg).not.toContain('supersecretvalue')
 
     new SpanlensClient({ apiKey: 'sk-proj-supersecretvalue' })
     expect(warnSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('fully masks very short keys', () => {
+  it('never echoes short keys either', () => {
     new SpanlensClient({ apiKey: 'abcdefg' })
     const msg = warnSpy.mock.calls[0]?.[0] as string
-    expect(msg).toContain('***')
+    expect(msg).toContain('does not look like a Spanlens key')
     expect(msg).not.toContain('abcdefg')
   })
 

--- a/packages/sdk/src/__tests__/error-ergonomics.test.ts
+++ b/packages/sdk/src/__tests__/error-ergonomics.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest'
+import {
+  createTransport,
+  SpanlensApiError,
+  SpanlensTransportError,
+} from '../transport.js'
+import { SpanlensClient, _resetKeyFormatWarningsForTests } from '../client.js'
+
+/**
+ * UX-retention batch 2: actionable SDK errors + observability of drops.
+ *
+ * Covers three things:
+ * 1. The transport emits a deduped, grep-friendly `[spanlens]` console.warn
+ *    with actionable guidance for the common integration failures
+ *    (401 bad key, 403 public key on a write endpoint, 429 quota).
+ * 2. onError fires on every dropped delivery even in silent mode, with a
+ *    typed SpanlensTransportError (status, code, message, endpoint).
+ * 3. SpanlensClient warns at construction when the apiKey prefix cannot
+ *    work for ingest, without ever printing the key itself.
+ *
+ * fetch mocking follows the transport-api-error.test.ts pattern:
+ * vi.stubGlobal + a fresh Response per call.
+ */
+
+function envelope(code: string, message: string): string {
+  return JSON.stringify({ error: { code, message, requestId: null } })
+}
+
+describe('transport: actionable error messages (silent mode)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let warnSpy: MockInstance
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('401: warns once with the three checks and the quick-start link, never throws', async () => {
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(
+        new Response(envelope('UNAUTHORIZED', 'Invalid API key'), { status: 401 }),
+      ),
+    )
+    const onError = vi.fn()
+    const transport = createTransport({ apiKey: 'sl_live_test', onError })
+
+    const result = await transport.post('/ingest/traces', { name: 't' })
+    expect(result).toBeNull() // silent default: user code never crashes
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const msg = warnSpy.mock.calls[0]?.[0] as string
+    expect(msg).toContain('[spanlens]')
+    expect(msg).toContain('401')
+    expect(msg).toContain('SPANLENS_API_KEY')
+    expect(msg).toContain('revoked')
+    expect(msg).toContain('whitespace')
+    expect(msg).toContain('https://www.spanlens.io/docs/quick-start')
+
+    // Deduped: a second failing call does not warn again...
+    await transport.post('/ingest/traces', { name: 't2' })
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    // ...but onError still fires once per dropped delivery.
+    expect(onError).toHaveBeenCalledTimes(2)
+  })
+
+  it('401: onError receives a typed error with status, code, message, endpoint', async () => {
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(
+        new Response(envelope('UNAUTHORIZED', 'Invalid API key'), { status: 401 }),
+      ),
+    )
+    const onError = vi.fn()
+    const transport = createTransport({ apiKey: 'sl_live_test', onError })
+    await transport.post('/ingest/traces', {})
+
+    const [err, ctx] = onError.mock.calls[0] as [unknown, string]
+    expect(err).toBeInstanceOf(SpanlensTransportError)
+    expect(err).toBeInstanceOf(SpanlensApiError)
+    const typed = err as SpanlensApiError
+    expect(typed.status).toBe(401)
+    expect(typed.code).toBe('UNAUTHORIZED')
+    expect(typed.message).toBe('Invalid API key')
+    expect(typed.endpoint).toBe('POST /ingest/traces')
+    expect(ctx).toBe('POST /ingest/traces')
+  })
+
+  it('401 without the standard envelope still warns and yields a SpanlensTransportError', async () => {
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(new Response('unauthorized', { status: 401 })),
+    )
+    const onError = vi.fn()
+    const transport = createTransport({ apiKey: 'sl_live_test', onError })
+    await transport.post('/ingest/traces', {})
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0] as string).toContain('SPANLENS_API_KEY')
+
+    const [err] = onError.mock.calls[0] as [unknown, string]
+    expect(err).toBeInstanceOf(SpanlensTransportError)
+    expect(err).not.toBeInstanceOf(SpanlensApiError)
+    const typed = err as SpanlensTransportError
+    expect(typed.status).toBe(401)
+    expect(typed.code).toBe('HTTP_401')
+    expect(typed.endpoint).toBe('POST /ingest/traces')
+  })
+
+  it('403 PUBLIC_KEY_WRITE_FORBIDDEN: explains public keys are read-only, links docs', async () => {
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          envelope(
+            'PUBLIC_KEY_WRITE_FORBIDDEN',
+            'Public scope keys cannot use proxy, ingest, or OTLP endpoints',
+          ),
+          { status: 403 },
+        ),
+      ),
+    )
+    const onError = vi.fn()
+    const transport = createTransport({ apiKey: 'sl_live_pub_x', onError })
+    await transport.post('/ingest/events', {})
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const msg = warnSpy.mock.calls[0]?.[0] as string
+    expect(msg).toContain('PUBLIC_KEY_WRITE_FORBIDDEN')
+    expect(msg).toContain('read-only')
+    expect(msg).toContain('sl_live_')
+    expect(msg).toContain('https://www.spanlens.io/docs/quick-start')
+
+    const [err] = onError.mock.calls[0] as [unknown, string]
+    expect((err as SpanlensApiError).code).toBe('PUBLIC_KEY_WRITE_FORBIDDEN')
+    expect((err as SpanlensApiError).status).toBe(403)
+  })
+
+  it('plain 403 FORBIDDEN (not public-key) does not emit the public-key hint', async () => {
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(new Response(envelope('FORBIDDEN', 'Forbidden'), { status: 403 })),
+    )
+    const transport = createTransport({ apiKey: 'sl_live_test' })
+    await transport.post('/ingest/events', {})
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('429 RATE_LIMIT: says quota or rate limit was hit and links pricing + billing', async () => {
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(
+        new Response(envelope('RATE_LIMIT', 'Monthly request quota exceeded'), {
+          status: 429,
+        }),
+      ),
+    )
+    const onError = vi.fn()
+    const transport = createTransport({ apiKey: 'sl_live_test', onError })
+    const result = await transport.post('/ingest/traces', {})
+    expect(result).toBeNull()
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const msg = warnSpy.mock.calls[0]?.[0] as string
+    expect(msg).toContain('429')
+    expect(msg.toLowerCase()).toContain('quota')
+    expect(msg).toContain('https://www.spanlens.io/pricing')
+    expect(msg).toContain('https://www.spanlens.io/billing')
+
+    const [err] = onError.mock.calls[0] as [unknown, string]
+    expect(err).toBeInstanceOf(SpanlensApiError)
+    expect((err as SpanlensApiError).status).toBe(429)
+    expect((err as SpanlensApiError).code).toBe('RATE_LIMIT')
+    expect((err as SpanlensApiError).endpoint).toBe('POST /ingest/traces')
+  })
+
+  it('silent:false throws the same typed error it reported to onError', async () => {
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(
+        new Response(envelope('UNAUTHORIZED', 'Invalid API key'), { status: 401 }),
+      ),
+    )
+    const onError = vi.fn()
+    const transport = createTransport({
+      apiKey: 'sl_live_test',
+      silent: false,
+      onError,
+    })
+    let thrown: unknown
+    try {
+      await transport.post('/ingest/traces', {})
+    } catch (err) {
+      thrown = err
+    }
+    expect(thrown).toBeInstanceOf(SpanlensTransportError)
+    expect(onError.mock.calls[0]?.[0]).toBe(thrown)
+  })
+
+  it('network errors in silent mode keep the raw error in onError (unchanged behavior)', async () => {
+    const boom = new TypeError('fetch failed')
+    fetchMock.mockImplementation(() => Promise.reject(boom))
+    const onError = vi.fn()
+    const transport = createTransport({ apiKey: 'sl_live_test', onError })
+    const result = await transport.post('/ingest/traces', {})
+    expect(result).toBeNull()
+    // Retried 3 times, onError fires on each occurrence, raw error passthrough.
+    expect(onError).toHaveBeenCalledTimes(3)
+    expect(onError.mock.calls[0]?.[0]).toBe(boom)
+    // No actionable console hint for network failures.
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('SpanlensClient: apiKey format warnings at construction', () => {
+  let warnSpy: MockInstance
+
+  beforeEach(() => {
+    _resetKeyFormatWarningsForTests()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(() =>
+        Promise.resolve(new Response('{}', { status: 200 })),
+      ),
+    )
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('warns once for a public key (sl_live_pub_*) and never prints the key body', () => {
+    new SpanlensClient({ apiKey: 'sl_live_pub_abc123def456' })
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const msg = warnSpy.mock.calls[0]?.[0] as string
+    expect(msg).toContain('[spanlens]')
+    expect(msg).toContain('read-only')
+    expect(msg).toContain('403')
+    expect(msg).toContain('PUBLIC_KEY_WRITE_FORBIDDEN')
+    expect(msg).not.toContain('abc123def456')
+
+    // Once per process: a second client does not warn again.
+    new SpanlensClient({ apiKey: 'sl_live_pub_abc123def456' })
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('warns once when the key does not look like a Spanlens key, masking the value', () => {
+    new SpanlensClient({ apiKey: 'sk-proj-supersecretvalue' })
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const msg = warnSpy.mock.calls[0]?.[0] as string
+    expect(msg).toContain('does not look like a Spanlens key')
+    expect(msg).toContain('sl_live_')
+    // Masked: short prefix only, never the secret part.
+    expect(msg).toContain('sk-pr')
+    expect(msg).not.toContain('supersecretvalue')
+
+    new SpanlensClient({ apiKey: 'sk-proj-supersecretvalue' })
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('fully masks very short keys', () => {
+    new SpanlensClient({ apiKey: 'abcdefg' })
+    const msg = warnSpy.mock.calls[0]?.[0] as string
+    expect(msg).toContain('***')
+    expect(msg).not.toContain('abcdefg')
+  })
+
+  it('does not warn for a normal full key', () => {
+    new SpanlensClient({ apiKey: 'sl_live_0123456789abcdef' })
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -40,10 +40,11 @@ function warnOnKeyFormat(apiKey: string): void {
   if (!apiKey.startsWith('sl_live_')) {
     if (warnedKeyFormats.has('format')) return
     warnedKeyFormats.add('format')
-    // Mask everything except a short prefix; never log the key itself.
-    const masked = apiKey.length > 8 ? `${apiKey.slice(0, 5)}...` : '***'
+    // Deliberately logs nothing derived from the key value, not even a
+    // masked prefix (js/clear-text-logging flags any tainted substring).
     console.warn(
-      `[spanlens] apiKey "${masked}" does not look like a Spanlens key (expected sl_live_ prefix). ` +
+      '[spanlens] apiKey does not look like a Spanlens key (expected sl_live_ prefix). ' +
+        'A pasted provider key (sk-...) is the usual mixup. ' +
         'Check that SPANLENS_API_KEY holds the key from your Spanlens dashboard. ' +
         'Docs: https://www.spanlens.io/docs/quick-start',
     )

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -5,6 +5,52 @@ import { createEvalsApi, type EvalsApi } from './evals.js'
 import type { SpanlensConfig, TraceOptions } from './types.js'
 
 /**
+ * Key-format warnings fire at most once per process per category so a
+ * client constructed in a hot path (per-request factories are common in
+ * serverless code) cannot flood the console. Module-level on purpose:
+ * the misconfiguration is process-wide, not per-client.
+ */
+const warnedKeyFormats = new Set<'public' | 'format'>()
+
+/** Test-only helper. Production never calls this. */
+export function _resetKeyFormatWarningsForTests(): void {
+  warnedKeyFormats.clear()
+}
+
+/**
+ * Warn (once) when the configured apiKey cannot work for ingest:
+ * - `sl_live_pub_*` keys are read-only, so every ingest/proxy call will be
+ *   rejected with 403 PUBLIC_KEY_WRITE_FORBIDDEN.
+ * - Anything without the `sl_live_` prefix is not a Spanlens key at all
+ *   (a pasted provider key like `sk-...` is the classic mixup).
+ * Never prints the key itself; only a short masked prefix.
+ */
+function warnOnKeyFormat(apiKey: string): void {
+  if (apiKey.startsWith('sl_live_pub_')) {
+    if (warnedKeyFormats.has('public')) return
+    warnedKeyFormats.add('public')
+    console.warn(
+      '[spanlens] apiKey is a public key (sl_live_pub_*). Public keys are read-only: ' +
+        'ingest and proxy calls will be rejected with 403 PUBLIC_KEY_WRITE_FORBIDDEN. ' +
+        'Create a full sl_live_ key on the Projects & Keys page for tracing. ' +
+        'Docs: https://www.spanlens.io/docs/quick-start',
+    )
+    return
+  }
+  if (!apiKey.startsWith('sl_live_')) {
+    if (warnedKeyFormats.has('format')) return
+    warnedKeyFormats.add('format')
+    // Mask everything except a short prefix; never log the key itself.
+    const masked = apiKey.length > 8 ? `${apiKey.slice(0, 5)}...` : '***'
+    console.warn(
+      `[spanlens] apiKey "${masked}" does not look like a Spanlens key (expected sl_live_ prefix). ` +
+        'Check that SPANLENS_API_KEY holds the key from your Spanlens dashboard. ' +
+        'Docs: https://www.spanlens.io/docs/quick-start',
+    )
+  }
+}
+
+/**
  * Spanlens SDK client — single entry point.
  *
  * @example
@@ -30,6 +76,7 @@ export class SpanlensClient {
     if (!config.apiKey || config.apiKey.trim().length === 0) {
       throw new Error('[spanlens] apiKey is required')
     }
+    warnOnKeyFormat(config.apiKey)
     this.config = config
     this.sampleRate = validateSampleRate(config.sampleRate)
     this.transport = createTransport(config)

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -15,7 +15,9 @@ export {
 export { parseOpenAIUsage, parseAnthropicUsage, parseGeminiUsage } from './parsers.js'
 // Sprint 7 R-15 + R-20: typed exception thrown on Spanlens server errors
 // that follow the standard envelope. See transport.ts for the shape.
-export { SpanlensApiError } from './transport.js'
+// SpanlensTransportError is the base class covering every classified HTTP
+// failure (status, code, message, endpoint) handed to onError.
+export { SpanlensApiError, SpanlensTransportError } from './transport.js'
 
 // Evals API (CI / script-driven prompt evaluation — "prompt CI").
 export { EvalsApi, scoreConfidenceInterval } from './evals.js'

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -9,20 +9,57 @@
 
 import type { SpanlensConfig } from './types.js'
 
+const DOCS_QUICK_START_URL = 'https://www.spanlens.io/docs/quick-start'
+const PRICING_URL = 'https://www.spanlens.io/pricing'
+const BILLING_URL = 'https://www.spanlens.io/billing'
+
+/**
+ * Base typed error for every non-2xx delivery failure the transport can
+ * classify. Carries the four fields callers need to branch without string
+ * matching: `status` (HTTP status), `code` (server error code when the
+ * standard envelope was parseable, `HTTP_<status>` otherwise), `message`,
+ * and `endpoint` (e.g. `"POST /ingest/traces"`).
+ *
+ * This is the value handed to `onError` for HTTP failures (network and
+ * timeout failures still pass the raw underlying error, unchanged, so
+ * existing `instanceof TypeError` / AbortError handlers keep working).
+ */
+export class SpanlensTransportError extends Error {
+  public readonly code: string
+  public readonly status: number
+  public readonly endpoint: string
+
+  constructor(args: {
+    code: string
+    message: string
+    status: number
+    endpoint?: string
+  }) {
+    super(args.message)
+    this.name = 'SpanlensTransportError'
+    this.code = args.code
+    this.status = args.status
+    this.endpoint = args.endpoint ?? ''
+  }
+}
+
 /**
  * Sprint 7 R-15 + R-20: typed exception thrown when the Spanlens server
  * responds with the standard error envelope. Callers running with
  * `silent: false` can `instanceof SpanlensApiError` to branch on
  * `error.code` rather than parsing a string message.
  *
+ * Extends `SpanlensTransportError` so a single `instanceof
+ * SpanlensTransportError` check covers both envelope and non-envelope
+ * HTTP failures; existing `instanceof SpanlensApiError` checks keep
+ * working unchanged.
+ *
  * The shape mirrors `@spanlens/api-types`'s `ApiErrorEnvelope` but is
  * defined here so the SDK has zero dependencies. When `@spanlens/api-types`
  * gets published to npm (currently a workspace-private package) we will
  * switch this file to import the shared interface and drop the duplicate.
  */
-export class SpanlensApiError extends Error {
-  public readonly code: string
-  public readonly status: number
+export class SpanlensApiError extends SpanlensTransportError {
   public readonly details: Record<string, unknown> | undefined
   public readonly requestId: string | null
 
@@ -32,14 +69,44 @@ export class SpanlensApiError extends Error {
     status: number
     details?: Record<string, unknown>
     requestId: string | null
+    endpoint?: string
   }) {
-    super(args.message)
+    super(args)
     this.name = 'SpanlensApiError'
-    this.code = args.code
-    this.status = args.status
     this.details = args.details
     this.requestId = args.requestId
   }
+}
+
+/**
+ * Actionable, grep-friendly guidance for the failure modes customers hit
+ * during integration. Returned text is appended to a `[spanlens]`-prefixed
+ * console.warn (deduped per transport) so a misconfigured key or exhausted
+ * quota is visible even under the default `silent: true`.
+ */
+function actionableHint(status: number, code: string | null): string | null {
+  if (status === 401) {
+    return (
+      'Check: (1) the SPANLENS_API_KEY env var is actually loaded in this process, ' +
+      '(2) the key was not revoked in the Spanlens dashboard, ' +
+      '(3) no whitespace or quotes were pasted around the key. ' +
+      `Docs: ${DOCS_QUICK_START_URL}`
+    )
+  }
+  if (status === 403 && code === 'PUBLIC_KEY_WRITE_FORBIDDEN') {
+    return (
+      'Public keys (sl_live_pub_*) are read-only. Ingest and proxy calls require a full ' +
+      'sl_live_ key from the Projects & Keys page. ' +
+      `Docs: ${DOCS_QUICK_START_URL}`
+    )
+  }
+  if (status === 429) {
+    return (
+      'Monthly quota or rate limit hit. ' +
+      `Upgrade at ${PRICING_URL} or manage billing at ${BILLING_URL}`
+    )
+  }
+  return null
 }
 
 interface ApiErrorEnvelopeLike {
@@ -59,6 +126,7 @@ interface ApiErrorEnvelopeLike {
 function tryParseApiError(
   text: string,
   status: number,
+  endpoint: string,
 ): SpanlensApiError | null {
   if (!text) return null
   let parsed: unknown
@@ -82,6 +150,7 @@ function tryParseApiError(
     status,
     ...(env.error.details ? { details: env.error.details } : {}),
     requestId: env.error.requestId ?? null,
+    endpoint,
   })
 }
 
@@ -132,12 +201,29 @@ export function createTransport(config: SpanlensConfig): Transport {
   // Set of Promises for all in-flight calls — used by flush().
   const pending = new Set<Promise<unknown>>()
 
+  // Actionable-hint dedupe: a broken key fails on EVERY span, so without
+  // dedupe a single misconfiguration floods the console. One warn per
+  // (status, code) pair per transport instance is enough to be seen.
+  const warnedHints = new Set<string>()
+
+  function warnActionable(status: number, code: string | null, endpoint: string): void {
+    const hint = actionableHint(status, code)
+    if (!hint) return
+    const dedupeKey = `${status}:${code ?? ''}`
+    if (warnedHints.has(dedupeKey)) return
+    warnedHints.add(dedupeKey)
+    console.warn(
+      `[spanlens] ${endpoint} failed with ${status}${code ? ` ${code}` : ''}. ${hint}`,
+    )
+  }
+
   async function callWithRetry(
     method: 'POST' | 'PATCH',
     path: string,
     body: unknown,
   ): Promise<unknown> {
     let lastErr: unknown
+    const endpoint = `${method} ${path}`
 
     // Serialize once, before the retry loop. A circular reference (or any
     // non-serializable value) in user-supplied metadata makes JSON.stringify
@@ -179,31 +265,46 @@ export function createTransport(config: SpanlensConfig): Transport {
         // timer is cleared only after the body is fully consumed (on every
         // return path) or in the catch block.
 
-        // 4xx = client error, don't retry
+        // 4xx = client error (including 429 quota blocks), don't retry
         if (res.status >= 400 && res.status < 500) {
           const text = await res.text().catch(() => '')
           clearTimeout(timer)
           // If the server speaks the standard error envelope (post Sprint 7
           // R-15), give callers the typed exception so they can branch on
           // error.code without string-comparing the message.
-          const apiError = tryParseApiError(text, res.status)
-          const err = apiError
+          const apiError = tryParseApiError(text, res.status, endpoint)
+          const err: SpanlensTransportError = apiError
             ? apiError
-            : new Error(`[spanlens] ${method} ${path} -> ${res.status} ${text.slice(0, 200)}`)
-          safeOnError(onError, err, `${method} ${path}`)
+            : new SpanlensTransportError({
+                code: `HTTP_${res.status}`,
+                status: res.status,
+                endpoint,
+                message: `[spanlens] ${method} ${path} -> ${res.status} ${text.slice(0, 200)}`,
+              })
+          // Surface an actionable, deduped console.warn for the common
+          // misconfiguration cases (401 bad key, 403 public key on a write
+          // endpoint, 429 quota). Under the default silent:true these drops
+          // are otherwise invisible.
+          warnActionable(res.status, apiError ? apiError.code : null, endpoint)
+          safeOnError(onError, err, endpoint)
           if (!silent) throw err
           return null
         }
 
-        // 5xx / 429 — retryable
+        // 5xx — retryable
         if (!res.ok) {
           clearTimeout(timer)
-          lastErr = new Error(`[spanlens] ${method} ${path} → ${res.status}`)
+          lastErr = new SpanlensTransportError({
+            code: `HTTP_${res.status}`,
+            status: res.status,
+            endpoint,
+            message: `[spanlens] ${method} ${path} → ${res.status}`,
+          })
           if (attempt < MAX_RETRIES) {
             await sleep(retryDelayMs(attempt))
             continue
           }
-          safeOnError(onError, lastErr, `${method} ${path}`)
+          safeOnError(onError, lastErr, endpoint)
           if (!silent) throw lastErr
           return null
         }
@@ -216,30 +317,21 @@ export function createTransport(config: SpanlensConfig): Transport {
         try { return JSON.parse(text) } catch { return null }
       } catch (err) {
         clearTimeout(timer)
-        // Re-throw immediately for 4xx errors. The 4xx branch above
-        // intentionally throws (when silent=false) to break out of the
-        // retry loop. Without this guard the catch would treat the
-        // structured 4xx as a transient network error and retry,
-        // exhausting the mock and producing a TypeError on the next
-        // undefined `res.status` read. SpanlensApiError plus the
-        // plain "[spanlens] ... -> 4xx" Error both originate from
-        // the no-retry branch, so a single `instanceof` check on the
-        // typed class plus a string check on the plain prefix covers
-        // them. Using a sentinel property would be cleaner; defer to a
-        // follow-up since it touches the existing Error shape that
-        // user code may already match on.
-        if (err instanceof SpanlensApiError) throw err
-        if (
-          err instanceof Error &&
-          err.message.startsWith(`[spanlens] ${method} ${path} -> 4`)
-        ) {
-          throw err
-        }
+        // Re-throw immediately for structured HTTP errors. The 4xx branch
+        // above intentionally throws (when silent=false) to break out of
+        // the retry loop; the 5xx branch throws its final-attempt error.
+        // Without this guard the catch would treat those as a transient
+        // network error and retry, exhausting the mock and producing a
+        // TypeError on the next undefined `res.status` read. Every HTTP
+        // failure is now a SpanlensTransportError (SpanlensApiError
+        // included, since it extends it), so one instanceof check covers
+        // all no-retry throws.
+        if (err instanceof SpanlensTransportError) throw err
         // AbortError (timeout) or network failure — retryable.
         // Call onError on every occurrence so callers receive the notification
         // promptly rather than only after all retries are exhausted.
         lastErr = err
-        safeOnError(onError, err, `${method} ${path}`)
+        safeOnError(onError, err, endpoint)
         if (attempt < MAX_RETRIES) {
           await sleep(retryDelayMs(attempt))
           continue

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -24,7 +24,11 @@ export type Status = 'running' | 'completed' | 'error'
 export type LogBodyMode = 'full' | 'meta' | 'none'
 
 export interface SpanlensConfig {
-  /** Spanlens API key created in the dashboard (sl_live_... or sl_test_...). */
+  /**
+   * Spanlens API key created in the dashboard (`sl_live_...`). Public keys
+   * (`sl_live_pub_...`) are read-only and cannot ingest; the client warns
+   * at construction if one is configured.
+   */
   apiKey: string
   /** API base URL — default https://spanlens-server.vercel.app. */
   baseUrl?: string
@@ -35,7 +39,15 @@ export interface SpanlensConfig {
   timeoutMs?: number
   /** Swallow all errors so instrumentation never crashes user code. Default true. */
   silent?: boolean
-  /** Custom error hook — called when an ingest call fails. */
+  /**
+   * Custom error hook — called on every dropped or failed delivery, even
+   * under the default `silent: true`. For HTTP failures `err` is a
+   * `SpanlensTransportError` (or its `SpanlensApiError` subclass when the
+   * server returned its standard envelope) carrying `status`, `code`,
+   * `message`, and `endpoint`. Network and timeout failures pass the raw
+   * underlying error unchanged. `context` is the failing endpoint, e.g.
+   * `"POST /ingest/traces"`.
+   */
   onError?: (err: unknown, context: string) => void
   /**
    * Fraction of traces to ingest, in `[0.0, 1.0]`. Default `1.0` (no sampling).

--- a/supabase/migrations/20260706150000_weekly_digest_pref.sql
+++ b/supabase/migrations/20260706150000_weekly_digest_pref.sql
@@ -1,0 +1,17 @@
+-- Migration: weekly_digest_pref
+--
+-- Adds the per-user opt-out toggle for the weekly usage digest email
+-- (Monday 09:00 UTC cron /cron/weekly-digest, lib/weekly-digest.ts).
+--
+-- Defaults to true so every existing admin is opted in on deploy, matching
+-- the convention of the other user_notification_prefs columns (see
+-- 20260529000100_user_notification_prefs.sql). The digest sender resolves
+-- recipients through lib/digest-recipients.ts, which excludes only users
+-- who explicitly set this to false. Distinct from security_alert_emails on
+-- purpose: opting out of a usage summary must not silence security alerts,
+-- and vice versa.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, safe to re-run.
+
+ALTER TABLE user_notification_prefs
+  ADD COLUMN IF NOT EXISTS weekly_digest_emails BOOLEAN NOT NULL DEFAULT true;

--- a/supabase/migrations/20260706160000_proxy_response_cache.sql
+++ b/supabase/migrations/20260706160000_proxy_response_cache.sql
@@ -1,0 +1,34 @@
+-- 20260706160000_proxy_response_cache.sql
+-- Opt-in exact-match proxy response cache (x-spanlens-cache header).
+--
+-- key_hash is sha256(api_key_id + provider + request path + raw request body),
+-- computed server-side in apps/server/src/lib/proxy-cache.ts. Because the
+-- Spanlens key id is part of the hash AND stored on the row, an entry can
+-- never be served across keys (and therefore never across projects or orgs).
+--
+-- Access model: server-only via supabaseAdmin (service_role). RLS is enabled
+-- with NO policies so anon/authenticated clients can never read cached
+-- provider responses. Do not add client-facing policies to this table.
+--
+-- Cleanup: expired rows are deleted opportunistically on cache misses
+-- (proxy-cache.ts deleteExpiredCacheEntry) — no cron. The expires_at index
+-- supports any future bulk cleanup job.
+--
+-- Idempotent per CLAUDE.md DB rules (IF NOT EXISTS everywhere).
+
+CREATE TABLE IF NOT EXISTS proxy_response_cache (
+  key_hash text PRIMARY KEY,
+  api_key_id uuid NOT NULL REFERENCES api_keys(id) ON DELETE CASCADE,
+  provider text NOT NULL,
+  response_status int,
+  response_body text,
+  usage jsonb,
+  model text,
+  created_at timestamptz DEFAULT now(),
+  expires_at timestamptz NOT NULL
+);
+
+ALTER TABLE proxy_response_cache ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_proxy_response_cache_expires_at
+  ON proxy_response_cache (expires_at);

--- a/supabase/migrations/20260706170000_weekly_digest_runs.sql
+++ b/supabase/migrations/20260706170000_weekly_digest_runs.sql
@@ -1,0 +1,13 @@
+-- Atomic per-week claim for the weekly digest cron. Both schedulers
+-- (Vercel cron + GH Actions backup, gotcha #32) can fire around the same
+-- time; the cron_job_runs "success this week" lookup only closes the race
+-- after the whole job finishes, which can take minutes across many orgs.
+-- A primary-key INSERT claim closes it before the first email is sent:
+-- exactly one runner wins the 23505 race for a given week_start.
+CREATE TABLE IF NOT EXISTS weekly_digest_runs (
+  week_start  DATE        PRIMARY KEY,
+  claimed_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE weekly_digest_runs ENABLE ROW LEVEL SECURITY;
+-- Server-only via service_role (supabaseAdmin); no client policies.


### PR DESCRIPTION
## Summary

Second batch from the product review: the four strategic bets. Weekly digest (habit loop), proxy response caching (closes the biggest gap vs Helicone), CLI-first onboarding with key verification, and actionable SDK errors.

### 1. Weekly digest email
- Monday 09:00 UTC per-org summary to admins: requests, cost with WoW change, error rate, top 3 models, anomaly count, best model-swap recommendation. Zero-traffic orgs are skipped.
- New `weekly_digest_emails` pref (default on) with a settings toggle; recipients resolve through a dedicated helper so the security-alert opt-out is not overloaded.
- Atomic per-week claim table (`weekly_digest_runs`, PK insert) taken before any email goes out, so the Vercel cron and GH Actions backup cannot double-send even mid-run. This addresses the one HIGH finding from code review.

### 2. Opt-in proxy response caching
- `x-spanlens-cache: true | <seconds>` (cap 86400), off by default, non-streaming only, 200-only, 256 KB guard.
- Cache key is sha256(api_key_id + provider + path + body) and rows are scoped by api_key_id, so cross-key or cross-org leakage is structurally impossible.
- Hits skip upstream entirely, return `x-spanlens-cache: hit`, and are logged with cached usage tokens, zero cost, and the new `cache_hit` ClickHouse flag (rides through the fallback queue verbatim).
- Documented in /docs/proxy. SDK `withCache()` helper and /docs/sdk coverage deferred to a follow-up.

### 3. CLI-first quick-start + key verification
- Quick-start now leads with the one-command CLI path, manual path is explicitly four steps, and key creation is step 1 (fixes the old copy-a-key-you-do-not-have-yet sequencing). All anchors preserved, missing #tracing anchor added.
- Welcome banner step 1 gains a Verify key button hitting GET /api/v1/me/key-info same-origin; key never logged or rendered.

### 4. SDK error ergonomics
- New exported `SpanlensTransportError` (status, code, endpoint); `SpanlensApiError` extends it, non-breaking.
- Deduped actionable warnings for 401 / 403 PUBLIC_KEY_WRITE_FORBIDDEN / 429, matched to the real server error envelope. Constructor warns on non-Spanlens-looking or public keys, masked to a 5-char prefix.
- README gains a Troubleshooting section (silent mode, onError, timeoutMs, flush). Corrected the stale claim that 429 retries.

## Code review
Dedicated review pass: 0 critical, 1 high (digest double-send race, fixed in this branch via the atomic claim), 2 medium accepted for now (sequential per-admin lookups in the digest loop, O(n^2) list building in topModelsByOrg; both negligible at current scale, revisit before large org counts), 2 low noted.

## Test plan
- [x] `pnpm typecheck` / `lint` / `test` / `build` all pass locally (server 1493 tests, sdk 169 tests)
- [x] New tests: weekly-digest (25) + digest email (10), proxy-cache unit (21) + integration (9), sdk error-ergonomics (12)
- [ ] **BEFORE merge: apply `clickhouse/migrations/010_add_cache_hit.sql` to production ClickHouse manually** (CH migrations are not in the deploy pipeline; skip_unknown_fields protects rows in the gap but cache_hit values are dropped until the column exists)
- [ ] After deploy: `supabase gen types --lang typescript --local > supabase/types.ts` regeneration commit (three new/changed tables: weekly_digest_runs, proxy_response_cache, user_notification_prefs column)
- [ ] After deploy: verify `cron_job_runs` shows `weekly-digest` on Monday (gotcha 32); Better Stack monitor if it under-fires
- [ ] Manual smoke: `curl -H "x-spanlens-cache: true"` twice against the proxy, confirm second response has `x-spanlens-cache: hit` and appears in /requests with zero cost
