### PR TITLE
fix(web): soft-fail IndexNow ping on ownership-verification 403

### DIFF
--- a/apps/web/scripts/indexnow-ping.mjs
+++ b/apps/web/scripts/indexnow-ping.mjs
@@ -31,8 +31,25 @@ async function fetchSitemapUrls() {
   return urls
 }
 
-async function ping(urlList) {
-  const res = await fetch(ENDPOINT, {
+/**
+ * Confirm our own key file is live and world-readable before we ask
+ * IndexNow to verify it. If this fails the fault is ours (key file
+ * missing, wrong contents, deploy not live) and the job must fail loudly.
+ */
+async function assertKeyFileLive() {
+  const keyUrl = `https://${HOST}/${KEY}.txt`
+  const res = await fetch(keyUrl)
+  if (!res.ok) {
+    throw new Error(`key file not reachable: ${res.status} ${res.statusText} at ${keyUrl}`)
+  }
+  const body = (await res.text()).trim()
+  if (body !== KEY) {
+    throw new Error(`key file contents mismatch at ${keyUrl}: expected ${KEY}, got "${body.slice(0, 64)}"`)
+  }
+}
+
+async function postPing(urlList) {
+  return fetch(ENDPOINT, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json; charset=utf-8' },
     body: JSON.stringify({
@@ -42,14 +59,47 @@ async function ping(urlList) {
       urlList,
     }),
   })
-  // 200 = submitted, 202 = key validation pending — both are success.
-  if (res.status !== 200 && res.status !== 202) {
+}
+
+/**
+ * Submit URLs. Return values:
+ * - { ok: true, status }  submitted (200) or validation pending (202)
+ * - { ok: false, softFail: true }  IndexNow could not verify ownership
+ *   yet (403) even though our key file is live. This is IndexNow's own
+ *   verification-cache lag, not our bug; it self-heals on a later push,
+ *   so we warn and exit 0 rather than reporting a false failure.
+ * Any other non-2xx (400/422 malformed payload, 429, 5xx) throws.
+ */
+async function ping(urlList) {
+  // One retry on 403, since the lag is usually brief.
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const res = await postPing(urlList)
+    if (res.status === 200 || res.status === 202) {
+      return { ok: true, status: res.status }
+    }
     const body = await res.text().catch(() => '')
+    if (res.status === 403) {
+      if (attempt === 1) {
+        console.warn(`IndexNow returned 403 on attempt ${attempt}, retrying once...`)
+        continue
+      }
+      console.warn(
+        `IndexNow could not verify ownership yet (403) despite the key file being live. ` +
+          `This is IndexNow verification lag, not a site problem. Skipping without failure. ${body}`,
+      )
+      return { ok: false, softFail: true }
+    }
     throw new Error(`IndexNow ping failed: ${res.status} ${res.statusText} ${body}`)
   }
-  return res.status
+  // Unreachable: the loop returns or throws on every path.
+  return { ok: false, softFail: true }
 }
 
 const urls = await fetchSitemapUrls()
-const status = await ping(urls)
-console.log(`IndexNow: submitted ${urls.length} URLs (HTTP ${status})`)
+await assertKeyFileLive()
+const result = await ping(urls)
+if (result.ok) {
+  console.log(`IndexNow: submitted ${urls.length} URLs (HTTP ${result.status})`)
+} else {
+  console.log(`IndexNow: skipped ${urls.length} URLs (verification pending on IndexNow side)`)
+}


### PR DESCRIPTION
## Problem

The IndexNow ping workflow has failed on every push to main since the key was registered (#396 onward, four consecutive red runs today). It returns `403 UserForbiddedToAccessSite` even though the key file at https://www.spanlens.io/b15c20f4975a1540622713bffea2a6d0.txt is live and correct (verified 200 with matching contents).

This is IndexNow''s own verification-cache lag, not a site misconfiguration. The impact is limited (Google does not use IndexNow, and Bing still crawls on its normal cycle), but a red workflow on every push buries genuine CI failures.

## Fix

- **Self-verify the key file first.** Before pinging, fetch `/<key>.txt` and check it is reachable and matches. A missing or wrong key file is our bug and still fails the job loudly.
- **Soft-fail the 403.** When the key file is live but IndexNow returns 403, retry once, then warn and exit 0. The submission self-heals on a later push once IndexNow revalidates ownership.
- **Everything else still hard-fails.** Malformed payload (400/422), rate limiting (429), and 5xx continue to throw.

## Test

Ran locally against production while IndexNow is currently 403ing:
```
IndexNow returned 403 on attempt 1, retrying once...
IndexNow could not verify ownership yet (403) despite the key file being live. ...
IndexNow: skipped 91 URLs (verification pending on IndexNow side)
EXIT CODE: 0
```
Key-file self-check passed (91 sitemap URLs parsed). When IndexNow''s verification catches up, the same code returns 200/202 and logs a normal submission.

Note: supersedes the unused `fix/indexnow-validation-grace` branch (no commits), which can be deleted.