### PR TITLE
feat: saved-view discovery, replay/export feedback, a11y, cache purge cron, SDK withCache

### DIFF
--- a/.github/workflows/cron-server.yml
+++ b/.github/workflows/cron-server.yml
@@ -69,6 +69,7 @@ on:
     - cron: '0 9 * * *'        # daily 09:00 — recommend-savings-alerts
     - cron: '0 10 * * *'       # daily 10:00 — check-past-due-downgrades
     - cron: '0 3 * * *'        # daily 03:00 — prune-judge-cache
+    - cron: '15 3 * * *'       # daily 03:15 — purge-proxy-cache
     - cron: '0 9 * * 1'        # weekly Monday 09:00 — stale-key-reminders + weekly-digest
     - cron: '30 */6 * * *'     # every 6h at :30 — detect-data-silence
   workflow_dispatch:
@@ -258,6 +259,24 @@ jobs:
           STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
             -H "Authorization: Bearer $CRON_SECRET" \
             "$BASE_URL/cron/prune-judge-cache")
+          echo "Status: $STATUS"
+          cat /tmp/body
+          if [ "$STATUS" -ge 400 ]; then exit 1; fi
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+
+  daily-03-15:
+    name: Daily 03:15 UTC (purge-proxy-cache)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '15 3 * * *' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: POST /cron/purge-proxy-cache
+        run: |
+          BASE_URL='https://spanlens-server.vercel.app'
+          STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            "$BASE_URL/cron/purge-proxy-cache")
           echo "Status: $STATUS"
           cat /tmp/body
           if [ "$STATUS" -ge 400 ]; then exit 1; fi

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -14,6 +14,7 @@ import { runReconciliationCron } from '../lib/events-reconciliation.js'
 import { runLeakDetectionJob } from '../lib/leak-detection.js'
 import { sendHighConfidenceRecommendationAlerts } from '../lib/recommendation-notify.js'
 import { logCronRun } from '../lib/cron-logger.js'
+import { purgeExpiredProxyCache } from '../lib/proxy-cache.js'
 import { replayFallbackQueue, replayEventsFallbackQueue, alertOnFallbackBacklog } from '../lib/fallback-replay.js'
 import { runDowngradeCheck } from '../lib/billing-downgrade.js'
 import { executePendingDeletions } from './pendingDeletions.js'
@@ -440,4 +441,19 @@ cronRouter.get('/keep-warm', async (c) => {
   assertCronAuth(c.req.header('Authorization'))
   const result = await runKeepWarmJob()
   return c.json(result)
+})
+
+// ── /purge-proxy-cache (daily 03:15 UTC) — reclaim expired opt-in
+// proxy_response_cache rows. The opportunistic miss-path cleanup only
+// reclaims rows for keys that are still being hit; keys that go quiet
+// leave their expired rows behind, so this sweep collects the rest.
+cronRouter.get('/purge-proxy-cache', async (c) => {
+  assertCronAuth(c.req.header('Authorization'))
+
+  const start = Date.now()
+  // purgeExpiredProxyCache is fail-open: it never throws and returns the
+  // count deleted so far, so this handler always logs 'ok'.
+  const deleted = await purgeExpiredProxyCache()
+  logCronRun('purge-proxy-cache', 'ok', Date.now() - start).catch(console.error)
+  return c.json({ deleted })
 })

--- a/apps/server/src/lib/proxy-cache.test.ts
+++ b/apps/server/src/lib/proxy-cache.test.ts
@@ -1,13 +1,17 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
-// Programmable supabaseAdmin stub — the cache module only ever touches the
-// `proxy_response_cache` table via three chains:
-//   .select(...).eq('key_hash', x).maybeSingle()
-//   .upsert(row, { onConflict: 'key_hash' })
-//   .delete().eq('key_hash', x).lt('expires_at', now)
+// Programmable supabaseAdmin stub — the cache module touches the
+// `proxy_response_cache` table via these chains:
+//   .select(...).eq('key_hash', x).maybeSingle()             (lookup)
+//   .upsert(row, { onConflict: 'key_hash' })                 (store)
+//   .delete().eq('key_hash', x).lt('expires_at', now)        (opportunistic)
+//   .select('key_hash').lt('expires_at', now).limit(n)       (purge page)
+//   .delete().in('key_hash', [...]).lt('expires_at', now)    (purge delete)
 const maybeSingleMock = vi.fn()
 const upsertMock = vi.fn()
 const deleteMock = vi.fn()
+const purgeSelectMock = vi.fn()
+const purgeDeleteMock = vi.fn()
 
 vi.mock('./db.js', () => ({
   supabaseAdmin: {
@@ -16,12 +20,20 @@ vi.mock('./db.js', () => ({
         eq: (col: string, val: string) => ({
           maybeSingle: () => maybeSingleMock(table, cols, col, val),
         }),
+        // Purge page: .select('key_hash').lt('expires_at', now).limit(n)
+        lt: (ltCol: string, ltVal: string) => ({
+          limit: (n: number) => purgeSelectMock(table, cols, ltCol, ltVal, n),
+        }),
       }),
       upsert: (row: Record<string, unknown>, opts: Record<string, unknown>) =>
         upsertMock(table, row, opts),
       delete: () => ({
         eq: (col: string, val: string) => ({
           lt: (ltCol: string, ltVal: string) => deleteMock(table, col, val, ltCol, ltVal),
+        }),
+        // Purge delete: .delete().in('key_hash', [...]).lt('expires_at', now)
+        in: (col: string, vals: string[]) => ({
+          lt: (ltCol: string, ltVal: string) => purgeDeleteMock(table, col, vals, ltCol, ltVal),
         }),
       }),
     }),
@@ -39,9 +51,11 @@ import {
   PROXY_CACHE_DEFAULT_TTL_SECONDS,
   PROXY_CACHE_MAX_BODY_BYTES,
   PROXY_CACHE_MAX_TTL_SECONDS,
+  PROXY_CACHE_PURGE_BATCH_SIZE,
   computeCacheKeyHash,
   deleteExpiredCacheEntry,
   parseCacheTtlSeconds,
+  purgeExpiredProxyCache,
   resolveProxyCache,
   storeCachedProxyResponse,
 } from './proxy-cache.js'
@@ -74,6 +88,8 @@ beforeEach(() => {
   maybeSingleMock.mockReset()
   upsertMock.mockReset()
   deleteMock.mockReset()
+  purgeSelectMock.mockReset()
+  purgeDeleteMock.mockReset()
 })
 
 afterEach(() => {
@@ -349,5 +365,104 @@ describe('deleteExpiredCacheEntry — opportunistic cleanup', () => {
 
     deleteMock.mockRejectedValueOnce(new Error('network blip'))
     await expect(deleteExpiredCacheEntry('hash-1')).resolves.toBeUndefined()
+  })
+})
+
+describe('purgeExpiredProxyCache — periodic sweep', () => {
+  function keyRows(n: number): Array<{ key_hash: string }> {
+    return Array.from({ length: n }, (_, i) => ({ key_hash: `k${i}` }))
+  }
+
+  test('deletes only expired rows and returns the count (single short batch)', async () => {
+    purgeSelectMock.mockResolvedValueOnce({ data: keyRows(3), error: null })
+    purgeDeleteMock.mockResolvedValueOnce({ error: null })
+
+    const now = new Date('2026-07-06T03:15:00Z')
+    const deleted = await purgeExpiredProxyCache(now)
+
+    expect(deleted).toBe(3)
+    // Select pages expired rows on the cache table with the now cutoff + batch limit.
+    expect(purgeSelectMock).toHaveBeenCalledTimes(1)
+    const [table, cols, ltCol, ltVal, limit] = purgeSelectMock.mock.calls[0] ?? []
+    expect(table).toBe('proxy_response_cache')
+    expect(cols).toBe('key_hash')
+    expect(ltCol).toBe('expires_at')
+    expect(ltVal).toBe(now.toISOString())
+    expect(limit).toBe(PROXY_CACHE_PURGE_BATCH_SIZE)
+
+    // Delete targets exactly the selected key hashes, still guarded by expires_at < now
+    // so a row refreshed concurrently between select and delete is left alone.
+    expect(purgeDeleteMock).toHaveBeenCalledTimes(1)
+    const [dTable, dCol, dVals, dLtCol, dLtVal] = purgeDeleteMock.mock.calls[0] ?? []
+    expect(dTable).toBe('proxy_response_cache')
+    expect(dCol).toBe('key_hash')
+    expect(dVals).toEqual(['k0', 'k1', 'k2'])
+    expect(dLtCol).toBe('expires_at')
+    expect(dLtVal).toBe(now.toISOString())
+  })
+
+  test('empty result → no delete, returns 0', async () => {
+    purgeSelectMock.mockResolvedValueOnce({ data: [], error: null })
+
+    const deleted = await purgeExpiredProxyCache(new Date())
+
+    expect(deleted).toBe(0)
+    expect(purgeSelectMock).toHaveBeenCalledTimes(1)
+    expect(purgeDeleteMock).not.toHaveBeenCalled()
+  })
+
+  test('batches: a full page loops for another, stops on the short page', async () => {
+    // First page is exactly a full batch → loop; second page is short → stop.
+    purgeSelectMock
+      .mockResolvedValueOnce({ data: keyRows(PROXY_CACHE_PURGE_BATCH_SIZE), error: null })
+      .mockResolvedValueOnce({ data: keyRows(2), error: null })
+    purgeDeleteMock.mockResolvedValue({ error: null })
+
+    const deleted = await purgeExpiredProxyCache(new Date())
+
+    expect(deleted).toBe(PROXY_CACHE_PURGE_BATCH_SIZE + 2)
+    expect(purgeSelectMock).toHaveBeenCalledTimes(2)
+    expect(purgeDeleteMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('rows with null/blank key_hash are skipped', async () => {
+    purgeSelectMock.mockResolvedValueOnce({
+      data: [{ key_hash: 'k0' }, { key_hash: null }, { key_hash: '' }, { key_hash: 'k1' }],
+      error: null,
+    })
+    purgeDeleteMock.mockResolvedValueOnce({ error: null })
+
+    const deleted = await purgeExpiredProxyCache(new Date())
+
+    expect(deleted).toBe(2)
+    const [, , dVals] = purgeDeleteMock.mock.calls[0] ?? []
+    expect(dVals).toEqual(['k0', 'k1'])
+  })
+
+  test('select error fails OPEN — returns count so far, never throws', async () => {
+    purgeSelectMock
+      .mockResolvedValueOnce({ data: keyRows(PROXY_CACHE_PURGE_BATCH_SIZE), error: null })
+      .mockResolvedValueOnce({ data: null, error: { message: 'db down' } })
+    purgeDeleteMock.mockResolvedValueOnce({ error: null })
+
+    const deleted = await purgeExpiredProxyCache(new Date())
+
+    // First batch deleted, second select failed → returns the first batch count.
+    expect(deleted).toBe(PROXY_CACHE_PURGE_BATCH_SIZE)
+    expect(purgeDeleteMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('delete error fails OPEN — returns count so far, never throws', async () => {
+    purgeSelectMock.mockResolvedValueOnce({ data: keyRows(3), error: null })
+    purgeDeleteMock.mockResolvedValueOnce({ error: { message: 'db down' } })
+
+    const deleted = await purgeExpiredProxyCache(new Date())
+
+    expect(deleted).toBe(0)
+  })
+
+  test('select throw fails OPEN — resolves, never throws', async () => {
+    purgeSelectMock.mockRejectedValueOnce(new Error('network blip'))
+    await expect(purgeExpiredProxyCache(new Date())).resolves.toBe(0)
   })
 })

--- a/apps/server/src/lib/proxy-cache.ts
+++ b/apps/server/src/lib/proxy-cache.ts
@@ -213,6 +213,99 @@ export async function resolveProxyCache(
 }
 
 /**
+ * Batch size for the periodic sweep. Each pass selects up to this many expired
+ * key hashes, deletes exactly those, and loops until a short page is returned.
+ * Keeps every statement bounded so the sweep can never run away on a table that
+ * has accumulated a large backlog of expired rows.
+ */
+export const PROXY_CACHE_PURGE_BATCH_SIZE = 500
+
+/**
+ * Hard cap on the number of batches a single sweep run will process, so one
+ * cron invocation can never loop unbounded (e.g. against a clock skew or a
+ * pathological backlog). 200 batches * 500 rows = up to 100k rows per run,
+ * which the next daily run picks up if any remain.
+ */
+const PROXY_CACHE_PURGE_MAX_BATCHES = 200
+
+interface ExpiredKeyRow {
+  key_hash: string | null
+}
+
+/**
+ * Periodic sweep that reclaims every `proxy_response_cache` row whose
+ * `expires_at` is in the past. Complements the opportunistic miss-path cleanup:
+ * rows for API keys that go quiet are never revisited on a miss, so without this
+ * they would linger until manually purged.
+ *
+ * Bounded by design — instead of one unbounded `DELETE ... WHERE expires_at <
+ * now()`, it pages the expired key hashes in batches of
+ * PROXY_CACHE_PURGE_BATCH_SIZE and deletes exactly those keys per pass. Every
+ * delete carries the same `.lt('expires_at', now)` guard as the opportunistic
+ * path, so a row refreshed by a concurrent request between the select and the
+ * delete is left alone.
+ *
+ * Fail-open: never throws. On any Supabase error it stops and returns the count
+ * deleted so far, so the cron handler always gets a summary.
+ */
+export async function purgeExpiredProxyCache(
+  now: Date = new Date(),
+): Promise<number> {
+  const cutoff = now.toISOString()
+  let deleted = 0
+
+  try {
+    for (let batch = 0; batch < PROXY_CACHE_PURGE_MAX_BATCHES; batch++) {
+      const { data, error } = await supabaseAdmin
+        .from(CACHE_TABLE)
+        .select('key_hash')
+        .lt('expires_at', cutoff)
+        .limit(PROXY_CACHE_PURGE_BATCH_SIZE)
+
+      if (error) {
+        logError('UNCATEGORIZED', { kind: 'proxy_cache_purge_failed' }, error)
+        return deleted
+      }
+
+      const rows = (data ?? []) as unknown as ExpiredKeyRow[]
+      const keyHashes = rows
+        .map((r) => r.key_hash)
+        .filter((k): k is string => typeof k === 'string' && k.length > 0)
+
+      if (keyHashes.length === 0) return deleted
+
+      const { error: deleteError } = await supabaseAdmin
+        .from(CACHE_TABLE)
+        .delete()
+        .in('key_hash', keyHashes)
+        .lt('expires_at', cutoff)
+
+      if (deleteError) {
+        logError('UNCATEGORIZED', { kind: 'proxy_cache_purge_failed' }, deleteError)
+        return deleted
+      }
+
+      deleted += keyHashes.length
+
+      // Short page → the table is drained; stop before an empty round-trip.
+      if (rows.length < PROXY_CACHE_PURGE_BATCH_SIZE) return deleted
+
+      // Full page but some rows had no deletable key_hash (null/blank). Those
+      // rows still match the select and would be re-returned on every pass,
+      // so we cannot make progress on this page. Stop rather than spin the
+      // remaining batches. Today `key_hash` is the table PRIMARY KEY so this
+      // is unreachable, but the guard keeps termination correct independent of
+      // the schema (finding from the batch-3 review).
+      if (keyHashes.length < rows.length) return deleted
+    }
+    return deleted
+  } catch (err) {
+    logError('UNCATEGORIZED', { kind: 'proxy_cache_purge_failed' }, err)
+    return deleted
+  }
+}
+
+/**
  * Opportunistic cleanup for an expired row discovered on the miss path.
  * The `.lt('expires_at', now)` guard means a fresh row written by a
  * concurrent request between our lookup and this delete is left alone.

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -27,6 +27,7 @@
     { "path": "/cron/keep-warm",                  "schedule": "*/5 * * * *" },
     { "path": "/cron/prune-judge-cache",          "schedule": "0 3 * * *" },
     { "path": "/cron/detect-data-silence",        "schedule": "30 */6 * * *" },
-    { "path": "/cron/weekly-digest",              "schedule": "0 9 * * 1" }
+    { "path": "/cron/weekly-digest",              "schedule": "0 9 * * 1" },
+    { "path": "/cron/purge-proxy-cache",          "schedule": "15 3 * * *" }
   ]
 }

--- a/apps/web/app/(dashboard)/requests/[id]/request-detail-client.tsx
+++ b/apps/web/app/(dashboard)/requests/[id]/request-detail-client.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { ArrowLeft, Check, Copy, Play, RotateCw } from 'lucide-react'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -260,6 +260,18 @@ function ReplayButton({ requestId, originalModel, provider }: ReplayButtonProps)
   const run = useRunReplay()
   const { data: modelsCatalog } = useModels()
 
+  // Scroll the result card into view once per completed replay. Keyed on the
+  // mutation result identity, which only changes when a new replay resolves,
+  // so unrelated re-renders (e.g. a useModels refetch on window focus) never
+  // re-trigger the scroll and yank the viewport. No setState here, so this
+  // stays clear of the react-hooks/set-state-in-effect rule.
+  const resultRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (run.data) {
+      resultRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    }
+  }, [run.data])
+
   // Model options: provider list from the live catalog + original if not
   // already included. Falls back to just the original while the catalog
   // is loading so the dropdown isn't empty.
@@ -381,11 +393,16 @@ function ReplayButton({ requestId, originalModel, provider }: ReplayButtonProps)
           </button>
         </div>
 
-        {/* Run result card */}
+        {/* Run result card. A mount-only effect above scrolls it into view
+            when a replay completes so the outcome is surfaced even on short
+            viewports. */}
         {run.data && (
-          <div className="rounded-[6px] border border-border bg-bg-elev px-4 py-3 space-y-3">
+          <div
+            ref={resultRef}
+            className="rounded-[6px] border border-border bg-bg-elev px-4 py-3 space-y-3"
+          >
             <div className="font-mono text-[10px] uppercase tracking-[0.05em] text-text-faint">
-              Result · HTTP {run.data.statusCode}
+              {run.data.statusCode < 400 ? 'Replay complete' : 'Replay finished with errors'} · HTTP {run.data.statusCode}
             </div>
             <div className="grid grid-cols-2 gap-x-6 gap-y-2">
               {[

--- a/apps/web/app/(dashboard)/requests/saved-views-bar.tsx
+++ b/apps/web/app/(dashboard)/requests/saved-views-bar.tsx
@@ -45,9 +45,13 @@ export function SavedViewsBar({ current, onApply, canSave }: SavedViewsBarProps)
   const [error, setError] = useState<string | null>(null)
 
   const hasViews = (views?.length ?? 0) > 0
-  // Nothing to show: no saved views and nothing to save from. Keep the row
-  // out of the layout entirely so a fresh account isn't cluttered.
+  // Nothing to show and nothing to save: keep the row out of the layout
+  // entirely so a fresh account isn't cluttered. When the user has an active
+  // filter set but no saved views yet (canSave && !hasViews), we still render
+  // the bar so the "Save view" affordance is discoverable, with a one-line
+  // hint explaining what it does.
   if (!hasViews && !canSave) return null
+  const showDiscoveryHint = !hasViews && canSave && !naming
 
   async function save() {
     const trimmed = name.trim()
@@ -146,6 +150,14 @@ export function SavedViewsBar({ current, onApply, canSave }: SavedViewsBarProps)
             <Plus className="w-3 h-3" /> Save view
           </button>
         )
+      )}
+
+      {/* First-time hint: only when there are no saved views yet, so it
+          disappears once the user has bookmarked at least one combination. */}
+      {showDiscoveryHint && (
+        <span className="font-mono text-[10.5px] text-text-faint">
+          Save this filter combination to jump back into it later.
+        </span>
       )}
     </div>
   )

--- a/apps/web/app/(dashboard)/traces/[id]/trace-detail-client.tsx
+++ b/apps/web/app/(dashboard)/traces/[id]/trace-detail-client.tsx
@@ -21,6 +21,10 @@ export function TraceDetailClient({ id }: { id: string }) {
   const router = useRouter()
   // Lazy init reads sessionStorage on client mount (SSR-safe via typeof check).
   const [navIds] = useState<string[]>(loadNavIds)
+  // Transient acknowledgement for the OTLP download. The anchor click hands
+  // off to the browser silently, so we flip the button label to "Exported"
+  // for a moment. Same inline-feedback pattern as CopyPermalink (no toast lib).
+  const [otlpExported, setOtlpExported] = useState(false)
 
   const navIdx = navIds.indexOf(id)
   const prevId = navIdx > 0 ? navIds[navIdx - 1] : null
@@ -105,11 +109,13 @@ export function TraceDetailClient({ id }: { id: string }) {
                 document.body.appendChild(a)
                 a.click()
                 a.remove()
+                setOtlpExported(true)
+                setTimeout(() => setOtlpExported(false), 1800)
               }}
               title="Download this trace as OTLP JSON. Upload to Datadog / Honeycomb / Jaeger / Tempo."
               className="font-mono text-[11px] px-[9px] py-1 border border-border rounded-[5px] text-text-muted hover:border-border-strong transition-colors"
             >
-              ↓ OTLP
+              {otlpExported ? 'Exported' : '↓ OTLP'}
             </button>
             <ShareDialog scope="trace" targetId={id} variant="primary" />
           </div>

--- a/apps/web/app/docs/proxy/page.tsx
+++ b/apps/web/app/docs/proxy/page.tsx
@@ -435,6 +435,14 @@ res, _ := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
         <strong>zero</strong> (the provider billed nothing) plus a <code>cache_hit</code>{' '}
         flag, so you can compute exactly how much the cache saved you.
       </p>
+      <p>
+        From the SDK, use the <a href="/docs/sdk#with-cache"><code>withCache()</code></a> helper
+        instead of setting the header by hand: <code>withCache()</code> for the default TTL or{' '}
+        <code>withCache(seconds)</code> for a custom one. It is exported from{' '}
+        <code>@spanlens/sdk/openai</code> and <code>@spanlens/sdk/anthropic</code>, and the same
+        directive is available as the <code>cache</code> option on{' '}
+        <a href="/docs/sdk#observe-openai"><code>observeOpenAI()</code></a>.
+      </p>
 
       <h2>Rate limits and response headers</h2>
       <p>

--- a/apps/web/app/docs/sdk/page.tsx
+++ b/apps/web/app/docs/sdk/page.tsx
@@ -339,6 +339,90 @@ openai = OpenAI(
         the bodies.
       </p>
 
+      <h2 id="with-cache">withCache(), response caching</h2>
+      <p>
+        Opt a single request into the Spanlens proxy response cache. When the exact same request
+        repeats (same API key, provider, path, and byte-identical body), Spanlens serves the stored
+        response instead of calling the provider again, so the repeat returns in milliseconds and
+        costs nothing. Caching is off by default and only applies to non-streaming requests whose
+        upstream response is a 200 JSON body under 256 KB. See the{' '}
+        <a href="/docs/proxy#response-caching">proxy caching reference</a> for the full rules,
+        response headers, and how hits show up in <a href="/requests">/requests</a>.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Argument</th>
+            <th>Header emitted</th>
+            <th>Effect</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>withCache()</code> or <code>withCache(true)</code></td>
+            <td><code>x-spanlens-cache: true</code></td>
+            <td>Cache with the default TTL (3600 seconds / 1 hour)</td>
+          </tr>
+          <tr>
+            <td><code>withCache(600)</code></td>
+            <td><code>x-spanlens-cache: 600</code></td>
+            <td>Cache for 600 seconds. The server caps TTL at 86400 (24h) and the helper clamps to the same ceiling</td>
+          </tr>
+          <tr>
+            <td>Invalid (zero, negative, non-integer)</td>
+            <td><em>none</em></td>
+            <td>No header is emitted, so the request is not cached (fail-safe, matches the server)</td>
+          </tr>
+        </tbody>
+      </table>
+      <LangTabs
+        ts={`import { createOpenAI, withCache, withUser } from '@spanlens/sdk/openai'
+
+const openai = createOpenAI()
+
+// Default TTL (1 hour)
+const res = await openai.chat.completions.create(
+  { model: 'gpt-4o-mini', messages: [{ role: 'user', content: 'Ping' }] },
+  withCache(),
+)
+
+// Custom TTL (10 minutes)
+const res2 = await openai.chat.completions.create(
+  { model: 'gpt-4o-mini', messages: [...] },
+  withCache(600),
+)
+
+// Combine with other helpers
+const res3 = await openai.chat.completions.create(
+  { model: 'gpt-4o-mini', messages: [...] },
+  {
+    headers: {
+      ...withCache(600).headers,
+      ...withUser(currentUser.id).headers,
+    },
+  },
+)`}
+        py={`# Python helper coming soon, set the header directly
+from openai import OpenAI
+
+openai = OpenAI(
+    api_key=os.environ['SPANLENS_API_KEY'],
+    base_url='https://server.spanlens.io/proxy/openai/v1',
+    default_headers={'x-spanlens-cache': '600'},
+)`}
+      />
+      <p>Raw curl:</p>
+      <CodeBlock>{`curl https://server.spanlens.io/proxy/openai/v1/chat/completions \\
+  -H "Authorization: Bearer $SPANLENS_API_KEY" \\
+  -H "x-spanlens-cache: true" \\
+  -H "Content-Type: application/json" \\
+  -d '{"model": "gpt-4o-mini", "messages": [...]}'`}</CodeBlock>
+      <p className="text-sm text-muted-foreground">
+        The same helper is exported from <code>@spanlens/sdk/anthropic</code> with identical
+        behavior. For agent tracing, pass <code>cache</code> on the{' '}
+        <a href="#observe-openai"><code>observeOpenAI()</code></a> options object instead.
+      </p>
+
       <h2 id="sample-rate">sampleRate, trace sampling (v0.3.x+)</h2>
       <p>
         Cap the volume of trace + span ingestion without changing your application code. The
@@ -544,10 +628,10 @@ const res = await observeOpenAI(trace, 'greeting', (headers) =>
   ),
 )
 
-// Options object — pass logBody to opt out of body storage per call
+// Options object — pass logBody / cache alongside promptVersion per call
 const res2 = await observeOpenAI(
   trace,
-  { name: 'pii-heavy-call', logBody: 'meta', promptVersion: 'greeter@latest' },
+  { name: 'pii-heavy-call', logBody: 'meta', cache: 600, promptVersion: 'greeter@latest' },
   (headers) => openai.chat.completions.create({ ... }, { headers }),
 )`}
         py={`from spanlens import observe_openai
@@ -564,7 +648,9 @@ res = observe_openai(trace, "greeting", lambda headers:
         Same pattern works with <code>observeAnthropic()</code> / <code>observe_anthropic()</code>{' '}
         and <code>observeGemini()</code> / <code>observe_gemini()</code>. The{' '}
         <code>logBody</code> option on the options form maps 1:1 to the{' '}
-        <a href="#with-log-body"><code>withLogBody()</code></a> helper.
+        <a href="#with-log-body"><code>withLogBody()</code></a> helper, and the{' '}
+        <code>cache</code> option maps 1:1 to{' '}
+        <a href="#with-cache"><code>withCache()</code></a>.
       </p>
 
       <h2 id="observe-ollama">observeOllama(), self-hosted LLMs (v0.5.0+ / 0.4.0+)</h2>

--- a/apps/web/components/dashboard/welcome-banner.tsx
+++ b/apps/web/components/dashboard/welcome-banner.tsx
@@ -237,18 +237,34 @@ function WelcomeBannerInner({ apiKey, onDismiss }: { apiKey: string; onDismiss: 
               Provider key registered. Spanlens stores it encrypted and uses it on your behalf.
             </p>
           ) : (
-            <p className="text-[11.5px] text-text-muted leading-relaxed">
-              Open{' '}
-              <Link
-                href="/projects"
-                className="text-accent hover:opacity-80 transition-opacity underline underline-offset-2"
-              >
-                /projects
-              </Link>
-              , find your Spanlens key, click <em>+ Add provider key</em>, and paste your AI
-              provider&apos;s API key. Spanlens stores it encrypted and uses it on your
-              behalf, your app never sees it again.
-            </p>
+            <>
+              <p className="text-[11.5px] text-text-muted leading-relaxed">
+                Open{' '}
+                <Link
+                  href="/projects"
+                  className="text-accent hover:opacity-80 transition-opacity underline underline-offset-2"
+                >
+                  /projects
+                </Link>
+                , find your Spanlens key, click <em>+ Add provider key</em>, and paste your AI
+                provider&apos;s API key. Spanlens stores it encrypted and uses it on your
+                behalf, your app never sees it again.
+              </p>
+              {/* Immediate refetch so the checkmark flips right after the user
+                  adds a key at /projects, rather than waiting on the ~30s
+                  provider-keys poll. Mirrors step 4's "Check now" button. */}
+              <div className="flex items-center gap-2 mt-2">
+                <button
+                  type="button"
+                  onClick={() => void providerKeys.refetch()}
+                  disabled={providerKeys.isFetching}
+                  className="font-mono text-[10.5px] px-[8px] py-[3px] border border-border rounded-[5px] text-text-muted hover:text-text hover:border-border-strong disabled:opacity-40 transition-colors inline-flex items-center gap-1"
+                >
+                  <RefreshCw className={providerKeys.isFetching ? 'w-3 h-3 animate-spin' : 'w-3 h-3'} />
+                  Check now
+                </button>
+              </div>
+            </>
           )}
         </div>
 
@@ -370,6 +386,19 @@ function WelcomeBannerInner({ apiKey, onDismiss }: { apiKey: string; onDismiss: 
             </>
           )}
         </div>
+
+        {/* Free-tier footnote — sets expectations on the monthly allowance so
+            new users aren't surprised by the quota. Kept muted, not a callout. */}
+        <p className="text-[11px] text-text-faint mt-4 leading-relaxed">
+          Free tier includes 50,000 requests per month. You can upgrade anytime from{' '}
+          <Link
+            href="/billing"
+            className="text-accent hover:opacity-80 transition-opacity underline underline-offset-2"
+          >
+            Billing
+          </Link>
+          .
+        </p>
       </div>
     </div>
   )

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -137,6 +137,9 @@ function WorkspaceSwitcher() {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Switch workspace"
         className="w-full flex items-center justify-between px-[10px] py-[7px] rounded-[5px] border border-border bg-bg-muted text-[12px] font-mono text-text-muted hover:bg-bg-muted/80 transition-colors"
       >
         <span className="truncate text-text">{orgName}</span>
@@ -488,6 +491,7 @@ export function Sidebar() {
                 <Link
                   key={href}
                   href={href}
+                  aria-current={active ? 'page' : undefined}
                   // All sidebar links skip prefetch entirely. Production
                   // measurement showed 18 sibling-page RSC requests firing on
                   // every dashboard mount, each costing ~327ms middleware
@@ -574,6 +578,9 @@ export function Sidebar() {
         <Link
           href="/feedback"
           prefetch={false}
+          aria-current={
+            pathname === '/feedback' || pathname.startsWith('/feedback/') ? 'page' : undefined
+          }
           className={cn(
             'flex w-full items-center gap-2 px-[10px] py-[6px] rounded-[5px] text-[13px] transition-colors',
             pathname === '/feedback' || pathname.startsWith('/feedback/')

--- a/packages/sdk/src/__tests__/cache.test.ts
+++ b/packages/sdk/src/__tests__/cache.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import {
+  withCache as withCacheOpenAI,
+  withUser as withUserOpenAI,
+  CACHE_HEADER as OPENAI_CACHE_HEADER,
+  CACHE_DEFAULT_TTL_SECONDS as OPENAI_CACHE_DEFAULT_TTL,
+  CACHE_MAX_TTL_SECONDS as OPENAI_CACHE_MAX_TTL,
+} from '../integrations/openai.js'
+import {
+  withCache as withCacheAnthropic,
+  CACHE_HEADER as ANTHROPIC_CACHE_HEADER,
+  CACHE_MAX_TTL_SECONDS as ANTHROPIC_CACHE_MAX_TTL,
+} from '../integrations/anthropic.js'
+
+describe('withCache', () => {
+  it('openai helper defaults to x-spanlens-cache: true', () => {
+    expect(withCacheOpenAI()).toEqual({
+      headers: { 'x-spanlens-cache': 'true' },
+    })
+    expect(withCacheOpenAI(true)).toEqual({
+      headers: { 'x-spanlens-cache': 'true' },
+    })
+  })
+
+  it('anthropic helper has identical shape', () => {
+    expect(withCacheAnthropic()).toEqual({
+      headers: { 'x-spanlens-cache': 'true' },
+    })
+  })
+
+  it('emits an integer TTL in seconds', () => {
+    expect(withCacheOpenAI(600)).toEqual({
+      headers: { 'x-spanlens-cache': '600' },
+    })
+    expect(withCacheOpenAI(3600).headers['x-spanlens-cache']).toBe('3600')
+  })
+
+  it('clamps a TTL above the cap to the max (24h)', () => {
+    expect(withCacheOpenAI(999_999).headers[OPENAI_CACHE_HEADER]).toBe(
+      String(OPENAI_CACHE_MAX_TTL),
+    )
+    expect(withCacheAnthropic(999_999).headers[ANTHROPIC_CACHE_HEADER]).toBe(
+      String(ANTHROPIC_CACHE_MAX_TTL),
+    )
+  })
+
+  it('accepts exactly the cap without clamping past it', () => {
+    expect(withCacheOpenAI(86400).headers['x-spanlens-cache']).toBe('86400')
+  })
+
+  it('emits no header for invalid values (fail-safe, matches server)', () => {
+    // zero, negative, non-integer, NaN, Infinity — all "no caching"
+    expect(withCacheOpenAI(0)).toEqual({ headers: {} })
+    expect(withCacheOpenAI(-10)).toEqual({ headers: {} })
+    expect(withCacheOpenAI(1.5)).toEqual({ headers: {} })
+    expect(withCacheOpenAI(Number.NaN)).toEqual({ headers: {} })
+    expect(withCacheOpenAI(Number.POSITIVE_INFINITY)).toEqual({ headers: {} })
+  })
+
+  it('header + default TTL constants are stable across both integrations', () => {
+    expect(OPENAI_CACHE_HEADER).toBe('x-spanlens-cache')
+    expect(ANTHROPIC_CACHE_HEADER).toBe('x-spanlens-cache')
+    expect(OPENAI_CACHE_DEFAULT_TTL).toBe(3600)
+    expect(OPENAI_CACHE_MAX_TTL).toBe(86400)
+    expect(ANTHROPIC_CACHE_MAX_TTL).toBe(86400)
+  })
+
+  it('merges with other helpers via header spread', () => {
+    const merged = {
+      headers: {
+        ...withCacheOpenAI(600).headers,
+        ...withUserOpenAI('u1').headers,
+      },
+    }
+    expect(merged.headers).toEqual({
+      'x-spanlens-cache': '600',
+      'x-spanlens-user': 'u1',
+    })
+  })
+})

--- a/packages/sdk/src/__tests__/observe-providers.test.ts
+++ b/packages/sdk/src/__tests__/observe-providers.test.ts
@@ -149,6 +149,85 @@ describe('observeOpenAI / observeAnthropic / observeGemini', () => {
     expect(receivedHeaders!['x-spanlens-log-body']).toBeUndefined()
   })
 
+  it('forwards cache: true option as x-spanlens-cache header', async () => {
+    const client = new SpanlensClient({ apiKey: 'k', baseUrl: 'http://x' })
+    const trace = client.startTrace({ name: 't' })
+
+    let receivedHeaders: Record<string, string> | null = null
+    await observeOpenAI(
+      trace,
+      { name: 'call', cache: true },
+      async (headers) => {
+        receivedHeaders = headers
+        return {
+          model: 'gpt-4o',
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }
+      },
+    )
+
+    expect(receivedHeaders!['x-spanlens-cache']).toBe('true')
+  })
+
+  it('forwards an integer cache TTL and clamps it to the 86400 cap', async () => {
+    const client = new SpanlensClient({ apiKey: 'k', baseUrl: 'http://x' })
+    const trace = client.startTrace({ name: 't' })
+
+    let seconds: Record<string, string> | null = null
+    await observeAnthropic(
+      trace,
+      { name: 'call', cache: 600 },
+      async (headers) => {
+        seconds = headers
+        return { model: 'claude-3-5-sonnet-20241022', usage: { input_tokens: 1, output_tokens: 1 } }
+      },
+    )
+    expect(seconds!['x-spanlens-cache']).toBe('600')
+
+    let capped: Record<string, string> | null = null
+    await observeOpenAI(
+      trace,
+      { name: 'call', cache: 999999 },
+      async (headers) => {
+        capped = headers
+        return {
+          model: 'gpt-4o',
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }
+      },
+    )
+    expect(capped!['x-spanlens-cache']).toBe('86400')
+  })
+
+  it('omits cache header for invalid or absent values', async () => {
+    const client = new SpanlensClient({ apiKey: 'k', baseUrl: 'http://x' })
+    const trace = client.startTrace({ name: 't' })
+
+    let absent: Record<string, string> | null = null
+    await observeOpenAI(trace, 'call', async (headers) => {
+      absent = headers
+      return {
+        model: 'gpt-4o',
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }
+    })
+    expect(absent!['x-spanlens-cache']).toBeUndefined()
+
+    let invalid: Record<string, string> | null = null
+    await observeOpenAI(
+      trace,
+      { name: 'call', cache: 0 },
+      async (headers) => {
+        invalid = headers
+        return {
+          model: 'gpt-4o',
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }
+      },
+    )
+    expect(invalid!['x-spanlens-cache']).toBeUndefined()
+  })
+
   it('observeOpenAI auto-parses usage into span.end', async () => {
     const client = new SpanlensClient({ apiKey: 'k', baseUrl: 'http://x' })
     const trace = client.startTrace({ name: 't' })

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -12,6 +12,7 @@ export {
   observeXai,
   observeCohere,
 } from './observe.js'
+export type { ProviderObserveOptions } from './observe.js'
 export { parseOpenAIUsage, parseAnthropicUsage, parseGeminiUsage } from './parsers.js'
 // Sprint 7 R-15 + R-20: typed exception thrown on Spanlens server errors
 // that follow the standard envelope. See transport.ts for the shape.

--- a/packages/sdk/src/integrations/anthropic.ts
+++ b/packages/sdk/src/integrations/anthropic.ts
@@ -15,6 +15,12 @@ export const PROMPT_VERSION_HEADER = 'x-spanlens-prompt-version'
 export const USER_HEADER = 'x-spanlens-user'
 export const SESSION_HEADER = 'x-spanlens-session'
 export const LOG_BODY_HEADER = 'x-spanlens-log-body'
+export const CACHE_HEADER = 'x-spanlens-cache'
+
+/** Default TTL applied server-side when the cache header is `true`. */
+export const CACHE_DEFAULT_TTL_SECONDS = 3600
+/** Server caps any requested TTL at this many seconds (24h). */
+export const CACHE_MAX_TTL_SECONDS = 86400
 
 export const DEFAULT_SPANLENS_ANTHROPIC_PROXY =
   'https://spanlens-server.vercel.app/proxy/anthropic'
@@ -87,4 +93,37 @@ export function withSession(sessionId: string): { headers: Record<string, string
  */
 export function withLogBody(mode: LogBodyMode): { headers: Record<string, string> } {
   return { headers: { [LOG_BODY_HEADER]: mode } }
+}
+
+/**
+ * Serialize a `withCache` argument into the `x-spanlens-cache` header value,
+ * or `null` when the input is not a valid cache directive. Same semantics as
+ * the OpenAI helper.
+ */
+export function cacheHeaderValue(ttl?: number | true): string | null {
+  if (ttl === undefined || ttl === true) return 'true'
+  if (typeof ttl !== 'number' || !Number.isInteger(ttl) || ttl <= 0) return null
+  return String(Math.min(ttl, CACHE_MAX_TTL_SECONDS))
+}
+
+/**
+ * Opt a single Anthropic request into the Spanlens proxy response cache. See
+ * the OpenAI helper for full semantics — behavior is identical.
+ *
+ * @param ttl `true` (or omitted) uses the default TTL
+ *   ({@link CACHE_DEFAULT_TTL_SECONDS}, 1 hour); a positive integer sets seconds,
+ *   clamped to {@link CACHE_MAX_TTL_SECONDS} (24h). Invalid values emit no header.
+ *
+ * @example
+ *   import { createAnthropic, withCache } from '@spanlens/sdk/anthropic'
+ *   const anthropic = createAnthropic()
+ *
+ *   const msg = await anthropic.messages.create(
+ *     { model: 'claude-3-5-sonnet-20241022', max_tokens: 1024, messages },
+ *     withCache(600),
+ *   )
+ */
+export function withCache(ttl?: number | true): { headers: Record<string, string> } {
+  const value = cacheHeaderValue(ttl)
+  return { headers: value == null ? {} : { [CACHE_HEADER]: value } }
 }

--- a/packages/sdk/src/integrations/openai.ts
+++ b/packages/sdk/src/integrations/openai.ts
@@ -31,6 +31,12 @@ export const PROMPT_VERSION_HEADER = 'x-spanlens-prompt-version'
 export const USER_HEADER = 'x-spanlens-user'
 export const SESSION_HEADER = 'x-spanlens-session'
 export const LOG_BODY_HEADER = 'x-spanlens-log-body'
+export const CACHE_HEADER = 'x-spanlens-cache'
+
+/** Default TTL applied server-side when the cache header is `true`. */
+export const CACHE_DEFAULT_TTL_SECONDS = 3600
+/** Server caps any requested TTL at this many seconds (24h). */
+export const CACHE_MAX_TTL_SECONDS = 86400
 
 /**
  * Build an OpenAI client whose requests flow through the Spanlens proxy.
@@ -151,4 +157,63 @@ export function withSession(sessionId: string): { headers: Record<string, string
  */
 export function withLogBody(mode: LogBodyMode): { headers: Record<string, string> } {
   return { headers: { [LOG_BODY_HEADER]: mode } }
+}
+
+/**
+ * Serialize a `withCache` argument into the `x-spanlens-cache` header value,
+ * or `null` when the input is not a valid cache directive.
+ *
+ * Semantics mirror the server (`apps/server/src/lib/proxy-cache.ts`):
+ *   - `true` (or omitted) → `'true'` (server applies the default 3600s TTL).
+ *   - a positive integer  → the integer as a string, clamped to
+ *     CACHE_MAX_TTL_SECONDS (86400) so the emitted value is never rejected.
+ *   - anything else (non-integer, zero, negative, NaN) → `null`. The helper
+ *     emits no header, matching how the server treats a malformed value as
+ *     "no caching" rather than throwing.
+ */
+export function cacheHeaderValue(ttl?: number | true): string | null {
+  if (ttl === undefined || ttl === true) return 'true'
+  if (typeof ttl !== 'number' || !Number.isInteger(ttl) || ttl <= 0) return null
+  return String(Math.min(ttl, CACHE_MAX_TTL_SECONDS))
+}
+
+/**
+ * Opt a single request into the Spanlens proxy response cache — repeated,
+ * byte-identical requests are served from the cache instead of calling the
+ * provider again, so they cost nothing and return in milliseconds.
+ *
+ * Caching is off by default and only applies to non-streaming requests whose
+ * upstream response is a 200 JSON body under 256 KB. Entries are scoped to your
+ * Spanlens API key, so they are never shared across keys, projects, or orgs.
+ * See the {@link https://spanlens.io/docs/proxy#response-caching proxy caching docs}
+ * for the full rules.
+ *
+ * @param ttl `true` (or omitted) caches with the default TTL
+ *   ({@link CACHE_DEFAULT_TTL_SECONDS}, 1 hour). A positive integer sets the TTL
+ *   in seconds; the server caps it at {@link CACHE_MAX_TTL_SECONDS} (24h) and
+ *   this helper clamps to the same ceiling. Invalid values (non-integer, zero,
+ *   negative) emit no header, matching the server's fail-safe.
+ *
+ * @example
+ *   import { createOpenAI, withCache } from '@spanlens/sdk/openai'
+ *   const openai = createOpenAI()
+ *
+ *   // Default TTL (1 hour)
+ *   const res = await openai.chat.completions.create(
+ *     { model: 'gpt-4o-mini', messages: [...] },
+ *     withCache(),
+ *   )
+ *
+ *   // Custom TTL (10 minutes)
+ *   const res2 = await openai.chat.completions.create(
+ *     { model: 'gpt-4o-mini', messages: [...] },
+ *     withCache(600),
+ *   )
+ *
+ * Combine with other helpers by merging headers:
+ *   { headers: { ...withCache(600).headers, ...withUser(u).headers } }
+ */
+export function withCache(ttl?: number | true): { headers: Record<string, string> } {
+  const value = cacheHeaderValue(ttl)
+  return { headers: value == null ? {} : { [CACHE_HEADER]: value } }
 }

--- a/packages/sdk/src/observe.ts
+++ b/packages/sdk/src/observe.ts
@@ -96,6 +96,23 @@ const OPENAI_SHAPED = new Set<Usage>([
 
 const PROMPT_VERSION_HEADER = 'x-spanlens-prompt-version'
 const LOG_BODY_HEADER = 'x-spanlens-log-body'
+const CACHE_HEADER = 'x-spanlens-cache'
+/** Server caps any requested cache TTL at this many seconds (24h). */
+const CACHE_MAX_TTL_SECONDS = 86400
+
+/**
+ * Serialize the `cache` observe option into the `x-spanlens-cache` header
+ * value, or `null` when it is not a valid directive. Mirrors the `withCache`
+ * helpers and the server (`apps/server/src/lib/proxy-cache.ts`): `true` maps to
+ * `'true'`, a positive integer is clamped to CACHE_MAX_TTL_SECONDS, and any
+ * other value emits no header.
+ */
+function cacheHeaderValue(ttl: number | true | undefined): string | null {
+  if (ttl === undefined) return null
+  if (ttl === true) return 'true'
+  if (typeof ttl !== 'number' || !Number.isInteger(ttl) || ttl <= 0) return null
+  return String(Math.min(ttl, CACHE_MAX_TTL_SECONDS))
+}
 
 /** Provider-observe options — narrower than SpanOptions; adds optional promptVersion + logBody. */
 export type ProviderObserveOptions = Omit<SpanOptions, 'spanType'> & {
@@ -107,6 +124,13 @@ export type ProviderObserveOptions = Omit<SpanOptions, 'spanType'> & {
    * Override to `'meta'` or `'none'` for stricter data minimization — see LogBodyMode docs.
    */
   logBody?: LogBodyMode
+  /**
+   * Opt this single call into the Spanlens proxy response cache. `true` uses the
+   * default TTL (1 hour); a positive integer sets the TTL in seconds, capped at
+   * 86400 (24h) server-side. Non-streaming 200 JSON responses only. Maps 1:1 to
+   * the `withCache()` helper. See the proxy caching docs for the full rules.
+   */
+  cache?: number | true
   /**
    * Override the provider tag on this span's metadata. Useful when calling an
    * OpenAI-compatible endpoint that isn't actually OpenAI (Ollama, vLLM,
@@ -125,6 +149,7 @@ function splitArgs(
   spanOptions: SpanOptions
   promptVersion: string | undefined
   logBody: LogBodyMode | undefined
+  cache: number | true | undefined
   providerOverride: string | undefined
 } {
   if (typeof nameOrOptions === 'string') {
@@ -132,14 +157,16 @@ function splitArgs(
       spanOptions: { name: nameOrOptions, spanType: 'llm' },
       promptVersion: undefined,
       logBody: undefined,
+      cache: undefined,
       providerOverride: undefined,
     }
   }
-  const { promptVersion, logBody, provider: providerOverride, ...rest } = nameOrOptions
+  const { promptVersion, logBody, cache, provider: providerOverride, ...rest } = nameOrOptions
   return {
     spanOptions: { ...rest, spanType: 'llm' },
     promptVersion,
     logBody,
+    cache,
     providerOverride,
   }
 }
@@ -150,7 +177,7 @@ async function observeProvider<T>(
   nameOrOptions: string | ProviderObserveOptions,
   fn: (headers: Record<string, string>) => Promise<T>,
 ): Promise<T> {
-  const { spanOptions, promptVersion, logBody, providerOverride } = splitArgs(nameOrOptions)
+  const { spanOptions, promptVersion, logBody, cache, providerOverride } = splitArgs(nameOrOptions)
 
   const span =
     'span' in parent && typeof parent.span === 'function'
@@ -160,6 +187,8 @@ async function observeProvider<T>(
   const headers: Record<string, string> = { ...span.traceHeaders() }
   if (promptVersion) headers[PROMPT_VERSION_HEADER] = promptVersion
   if (logBody) headers[LOG_BODY_HEADER] = logBody
+  const cacheValue = cacheHeaderValue(cache)
+  if (cacheValue != null) headers[CACHE_HEADER] = cacheValue
 
   try {
     const result = await fn(headers)


### PR DESCRIPTION
## Summary

Third batch from the product review: the remaining small UX polish items plus the two caching follow-ups. Nothing here is a big bet; it is the long tail of "small win, quick" items and closing loops opened by #400.

### Web UX polish
- **Saved views discovery**: the saved-views bar now shows a "Save view" affordance with a one-line hint when a filter set is active but no views exist yet, so users discover the feature instead of it staying invisible until they somehow save one. Still hides entirely when there is nothing to save.
- **Export and replay feedback**: OTLP trace export flips its button to "Exported" briefly; model replay shows a "Replay complete" / "Replay finished with errors" acknowledgement and scrolls the result into view. Uses the existing inline setTimeout feedback pattern (the repo deliberately ships no toast library).
- **Banner "Check now" on step 2**: reuses the existing provider-keys refetch so users do not wait up to 30s for the poll.
- **Free tier note in banner**: subtle line stating 50,000 requests per month (verified against quota.ts) with a Billing link.
- **Sidebar a11y**: aria-current on the active nav link, aria-haspopup/aria-expanded/aria-label on the workspace switcher.

Two review items (pagination indicators, PII mask reset on row change) turned out to already be handled in the codebase (the drawer remounts by key, and both lists already render "Showing N of M"), so they were intentionally left untouched rather than churned.

### Cache purge cron
- Daily 03:15 UTC sweep of expired proxy_response_cache rows, complementing the opportunistic miss-path cleanup. Batched, bounded, fail-open, with the same expires_at guard on the delete so concurrently refreshed rows are never touched. Registered in vercel.json and the GH Actions backup scheduler. No migration (table exists from #400).

### SDK withCache
- withCache(ttl?) helper and observe cache option, closing the 4-place rule for the response-cache header (server and /docs/proxy shipped in #400). Validation matches the server parseCacheTtlSeconds exactly (clamp 86400, invalid emits no header). /docs/sdk gains a caching subsection.

## Code review
Dedicated review pass: 0 critical, 1 high (fixed), 1 medium (fixed), 2 low (accepted).
- HIGH (fixed): the replay result scroll used an inline ref callback that re-fired on any re-render, including a useModels refetch on window focus, yanking the viewport. Replaced with a mount-keyed useEffect on the mutation result so it scrolls once per completed replay.
- MEDIUM (fixed): the purge loop's termination relied implicitly on key_hash being a non-null primary key. Added a guard so a full page of undeletable rows stops the loop instead of re-selecting the same page, making termination correct independent of the schema.
- LOW (accepted): cacheHeaderValue is implemented in three places (openai/anthropic integrations and observe) with an intentional, test-verified difference in how undefined is treated; and the purge null-key filter is dead code given the PK constraint. Both are defensive and covered by tests; noted for a future consolidation rather than churned now.

## Test plan
- [x] `pnpm typecheck` / `lint` / `test` / `build` all pass locally
- [x] New tests: proxy-cache purge (8), SDK withCache + observe option (11)
- [x] Review fixes re-validated: web typecheck/lint clean, proxy-cache suite 39 tests pass
- [ ] After deploy: verify cron_job_runs shows purge-proxy-cache firing at 03:15 UTC (gotcha 32)
