### PR TITLE
feat(web): harden email-verification signup UX

### DIFF
--- a/apps/web/app/forgot-password/page.tsx
+++ b/apps/web/app/forgot-password/page.tsx
@@ -95,13 +95,13 @@ export default function ForgotPasswordPage() {
         <div className="w-[360px] max-w-full">
           {sent ? (
             <div className="text-center">
-              <div className="w-9 h-9 rounded-full bg-accent-bg border border-accent-border flex items-center justify-center mx-auto mb-3 font-mono text-[14px] text-accent">✉</div>
-              <div className="text-[16px] font-medium tracking-[-0.2px] mb-1.5">Check your inbox.</div>
-              <div className="text-[12.5px] text-text-muted leading-[1.55]">
+              <div className="w-14 h-14 rounded-full bg-accent-bg border border-accent-border flex items-center justify-center mx-auto mb-4 font-mono text-[24px] text-accent">✉</div>
+              <div className="text-[24px] font-medium tracking-[-0.2px] mb-2">Check your inbox.</div>
+              <div className="text-[18px] text-text-muted leading-[1.55]">
                 If an account exists for{' '}
                 <span className="font-mono text-text">{email}</span>, we sent a password reset link. It expires in 60 minutes.
               </div>
-              <div className="text-[12.5px] text-text-muted mt-4">
+              <div className="text-[18px] text-text-muted mt-4">
                 <Link href="/login" className="text-text font-medium hover:opacity-80 transition-opacity">
                   ← Back to sign in
                 </Link>

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -76,6 +76,16 @@ export default function LoginPage() {
     const supabase = createClient()
     const { error: authError } = await supabase.auth.signInWithPassword({ email, password })
     if (authError) {
+      // A user who signed up but never clicked the confirmation link gets
+      // "Email not confirmed" from GoTrue. Raw wording is a dead end — route
+      // them to /verify-email where they can resend the link. Match on the
+      // stable `code` first (SDK ≥ 2.x) with a message fallback for older
+      // error shapes. Carry the email so the page can prefill the resend.
+      const code = (authError as { code?: string }).code
+      if (code === 'email_not_confirmed' || /email not confirmed/i.test(authError.message)) {
+        window.location.href = `/verify-email?email=${encodeURIComponent(email)}`
+        return
+      }
       setError(authError.message)
       setLoading(false)
       return

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -216,11 +216,12 @@ function SignupPageInner() {
         <div className="w-[360px] max-w-full">
           {sent ? (
             <div className="text-center">
-              <div className="w-9 h-9 rounded-full bg-accent-bg border border-accent-border flex items-center justify-center mx-auto mb-3 font-mono text-[14px] text-accent">✉</div>
-              <div className="text-[16px] font-medium tracking-[-0.2px] mb-1.5">Check your inbox.</div>
-              <div className="text-[12.5px] text-text-muted leading-[1.55]">
-                We sent a sign-in link to{' '}
-                <span className="font-mono text-text">{email}</span>. It expires in 10 minutes.
+              <div className="w-14 h-14 rounded-full bg-accent-bg border border-accent-border flex items-center justify-center mx-auto mb-4 font-mono text-[24px] text-accent">✉</div>
+              <div className="text-[24px] font-medium tracking-[-0.2px] mb-2">Check your inbox.</div>
+              <div className="text-[18px] text-text-muted leading-[1.55]">
+                We sent a confirmation link to{' '}
+                <span className="font-mono text-text">{email}</span>. Click it to activate your
+                account and finish setting up your workspace.
               </div>
             </div>
           ) : (

--- a/apps/web/app/verify-email/page.tsx
+++ b/apps/web/app/verify-email/page.tsx
@@ -55,12 +55,21 @@ function VerifyEmailInner() {
     setSent(false)
 
     const supabase = createClient()
-    const { error: otpError } = await supabase.auth.signInWithOtp({ email })
+    // Resend the signup confirmation email (not a fresh magic link). The
+    // user already created an account with a password; `resend` reissues
+    // the original confirmation link, which lands on /auth/callback and
+    // completes sign-in. `emailRedirectTo` must match the signup call so
+    // the callback receives the code on the same route.
+    const { error: resendError } = await supabase.auth.resend({
+      type: 'signup',
+      email,
+      options: { emailRedirectTo: `${window.location.origin}/auth/callback` },
+    })
 
     setSending(false)
 
-    if (otpError) {
-      setError(otpError.message)
+    if (resendError) {
+      setError(resendError.message)
       return
     }
 
@@ -87,12 +96,13 @@ function VerifyEmailInner() {
 
         <h1 className="text-[20px] font-medium tracking-[-0.3px] mb-2">Check your inbox</h1>
         <p className="text-[13px] text-text-muted leading-relaxed mb-6">
-          We sent a magic link to{' '}
-          <span className="font-mono text-text">{displayEmail}</span>. It expires in 10 minutes.
+          We sent a confirmation link to{' '}
+          <span className="font-mono text-text">{displayEmail}</span>. Click it to activate your
+          account. The link expires after a while, so use it soon.
         </p>
 
         {sent && (
-          <p className="text-[12.5px] text-accent mb-3">Magic link resent successfully.</p>
+          <p className="text-[12.5px] text-accent mb-3">Confirmation email resent successfully.</p>
         )}
         {error && <p className="text-[12.5px] text-bad mb-3">{error}</p>}
 

--- a/apps/web/lib/oauth-consent.ts
+++ b/apps/web/lib/oauth-consent.ts
@@ -1,17 +1,23 @@
-import { TERMS_VERSION, PRIVACY_VERSION } from './legal-versions'
+import { TERMS_VERSION, PRIVACY_VERSION, DPA_VERSION } from './legal-versions'
 
 /**
  * Server-side helper invoked from the OAuth callback route handler.
  *
- * The email signup flow records Terms + Privacy consent client-side
- * (signup/page.tsx:19-37) before calling signUp. The OAuth flow skips
- * that step — the user clicks "Continue with Google/GitHub" and bounces
- * straight to the provider. By the time we see them again in the
- * callback we've already implicitly accepted their consent.
+ * The email signup flow records Terms + Privacy + DPA consent client-side
+ * (signup/page.tsx:21-40) before calling signUp — but only when signUp
+ * returns a session inline. When email confirmation is enabled the session
+ * is null until the user clicks the confirmation link, which lands on
+ * /auth/callback (emailRedirectTo). So both the OAuth flow AND the
+ * email-confirmation flow reach this helper without consent recorded yet.
  *
- * This helper closes the gap: after exchangeCodeForSession succeeds we
+ * The OAuth flow skips the client-side step entirely — the user clicks
+ * "Continue with Google/GitHub" and bounces straight to the provider.
+ * By the time we see them again in the callback we've already implicitly
+ * accepted their consent (the notice next to the SSO buttons covers it).
+ *
+ * This helper closes both gaps: after exchangeCodeForSession succeeds we
  * check whether this user has already accepted the current TERMS /
- * PRIVACY versions, and POST any missing rows to /api/v1/me/consent.
+ * PRIVACY / DPA versions, and POST any missing rows to /api/v1/me/consent.
  * Idempotent — safe to call on every callback (including OAuth
  * re-logins for users who accepted long ago).
  *
@@ -35,7 +41,7 @@ import { TERMS_VERSION, PRIVACY_VERSION } from './legal-versions'
  */
 
 interface ConsentRow {
-  document: 'terms' | 'privacy'
+  document: 'terms' | 'privacy' | 'dpa'
   version: string
 }
 
@@ -77,6 +83,7 @@ export async function recordOAuthConsentIfMissing(
   const required: ConsentRow[] = [
     { document: 'terms', version: TERMS_VERSION },
     { document: 'privacy', version: PRIVACY_VERSION },
+    { document: 'dpa', version: DPA_VERSION },
   ]
 
   const missing = required.filter(


### PR DESCRIPTION
## Summary

Production already requires email confirmation (Supabase **Confirm email** toggle is ON) and now sends auth mail through a verified **Resend custom SMTP** relay (rate limit 2/h → 30/h). This PR closes the app-side gaps around that flow.

## Changes

- **login** ([login/page.tsx](apps/web/app/login/page.tsx)): a user who signed up but never confirmed hit a dead-end raw `Email not confirmed` error. Now routes them to `/verify-email?email=...` where they can resend. Matches on the stable `code` (`email_not_confirmed`) with a message-regex fallback for older SDK error shapes.
- **verify-email** ([verify-email/page.tsx](apps/web/app/verify-email/page.tsx)): resend now uses `auth.resend({ type: 'signup' })` (correct API for reissuing a signup confirmation) instead of `signInWithOtp` (magic link). `emailRedirectTo` matches the signup call so the link lands on `/auth/callback`. Copy corrected from "magic link" to "confirmation link".
- **oauth-consent** ([oauth-consent.ts](apps/web/lib/oauth-consent.ts)): the callback backfill recorded only terms + privacy. **DPA was missing** for both the email-confirmation and OAuth signup paths (signup records all three inline only when a session is returned). Added DPA so every path records the full set.
- **signup / forgot-password**: accurate confirmation-link copy, removed a hardcoded expiry we can't guarantee (production Dashboard controls it), and enlarged the "Check your inbox" success block (icon 36→56px, glyph 14→24px, heading 16→24px, body 12.5→18px).

## Test plan

- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint`
- [x] End-to-end email delivery verified in prod: `/forgot-password` → GoTrue `/recover` 200 (no `535`) → Resend shows **Delivered** to the inbox.
- [x] "Check your inbox" resize verified via local preview render.
- [ ] Reviewer: confirm the `/verify-email` redirect fires on a real unconfirmed-user login.