### PR TITLE
feat(web): link Helicone compare + migrate pages to acquisition blog post

### DIFF
--- a/apps/web/app/compare/helicone/page.tsx
+++ b/apps/web/app/compare/helicone/page.tsx
@@ -172,6 +172,18 @@ export default function VsHeliconePage() {
       whyCompetitor={whyCompetitor}
       groups={groups}
       closing="If you want a battle-tested proxy with a focused feature set, Helicone is a strong choice. If you want the same proxy ergonomics plus deeper agent analytics, statistical A/B, and log durability, try Spanlens."
+      relatedNote={
+        <>
+          Deciding whether to move at all?{' '}
+          <a
+            href="https://blog.spanlens.io/helicone-mintlify-migration-checklist/"
+            className="underline hover:text-text-muted"
+          >
+            Helicone was acquired by Mintlify: a migration checklist
+          </a>{' '}
+          walks through what changed and what to check before picking any replacement.
+        </>
+      }
     />
   )
 }

--- a/apps/web/app/docs/migrate/from-helicone/page.tsx
+++ b/apps/web/app/docs/migrate/from-helicone/page.tsx
@@ -252,7 +252,13 @@ const openai = new OpenAI({ baseURL, apiKey })`}</CodeBlock>
       <hr />
       <p className="text-sm text-muted-foreground">
         Next: <a href="/docs/proxy">Direct proxy reference</a> for headers and auth, or{' '}
-        <a href="/docs/concepts/data-model">data model</a> for the full schema.
+        <a href="/docs/concepts/data-model">data model</a> for the full schema. For the
+        background on why teams are moving and what to check before picking any
+        replacement, see{' '}
+        <a href="https://blog.spanlens.io/helicone-mintlify-migration-checklist/">
+          Helicone was acquired by Mintlify: a migration checklist
+        </a>
+        .
       </p>
     </div>
   )

--- a/apps/web/components/marketing/compare-template.tsx
+++ b/apps/web/components/marketing/compare-template.tsx
@@ -38,6 +38,8 @@ export interface CompareTemplateProps {
   groups: CompareGroup[]
   /** Short closing line above the CTA */
   closing?: string
+  /** Optional related-reading node rendered under the closing line (e.g. a link to a deeper blog post). */
+  relatedNote?: React.ReactNode
   /** Year shown next to the H1 and used in the FAQ canonical URL. Defaults to the current year. */
   year?: number
 }
@@ -152,6 +154,7 @@ export function CompareTemplate({
   whyCompetitor,
   groups,
   closing,
+  relatedNote,
   year,
 }: CompareTemplateProps) {
   const resolvedYear = year ?? new Date().getUTCFullYear()
@@ -379,6 +382,9 @@ export function CompareTemplate({
         <div className="rounded-xl border border-border bg-bg-elev p-8 text-center">
           {closing && (
             <p className="text-[15px] text-text-muted mb-5 max-w-[640px] mx-auto leading-relaxed">{closing}</p>
+          )}
+          {relatedNote && (
+            <p className="text-[13px] text-text-faint mb-5 max-w-[640px] mx-auto leading-relaxed">{relatedNote}</p>
           )}
           <div className="flex flex-col sm:flex-row gap-3 justify-center items-center">
             <Link


### PR DESCRIPTION
## Summary
Internal links from the two strongest Helicone-intent pages to the newly published blog post [Helicone was acquired by Mintlify: a migration checklist](https://blog.spanlens.io/helicone-mintlify-migration-checklist/).

- `/docs/migrate/from-helicone` — adds the post to the closing "Next" line.
- `/compare/helicone` — adds a related-reading note under the closing CTA via a new optional `relatedNote` prop on `CompareTemplate` (other compare pages unaffected).

## Why
The post lives on `blog.spanlens.io` (a fresh subdomain with almost no organic pull). These two marketing pages already draw Helicone-intent impressions in GSC. Linking from them passes link equity to the new post and gives migration-intent readers the fuller acquisition context.

## Test plan
- [x] `pnpm --filter web lint` clean
- [x] typecheck clean for touched files (the unrelated `app/refund/page.js` validator error is a stale local artifact of an uncommitted route deletion, not in this branch)
- [ ] Preview: confirm both links render and resolve to the live post

🤖 Generated with [Claude Code](https://claude.com/claude-code)