### PR TITLE
feat(server): add api.spanlens.io to CORS allowlist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,7 @@ PORT=3001 (server), 3000 (web)
 현재 등록된 origins:
 - `https://spanlens.io` (apex, canonical로 리다이렉트됨)
 - `https://www.spanlens.io` (primary canonical)
+- `https://api.spanlens.io` (server 프로젝트 alias — 프록시/REST 공식 주소, 2026-07-13 등록)
 - `https://spanlens-web.vercel.app` (Vercel default)
 - `http://localhost:3000` (local dev)
 - `https://spanlens-*-sunes26s-projects.vercel.app` (preview — 정규식 매치)

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -82,6 +82,7 @@ app.use('*', cors({
     const allowed = [
       'https://spanlens.io',
       'https://www.spanlens.io',
+      'https://api.spanlens.io',
       'https://spanlens-web.vercel.app',
       'http://localhost:3000',
     ]


### PR DESCRIPTION
## Summary
- Registers `https://api.spanlens.io` in the server CORS allowlist (`apps/server/src/app.ts`)
- Syncs the CLAUDE.md domain policy list

## Context
Public pages (faq, integrations/openai|anthropic|gemini, docs/integrations/flowise, docs/concepts/llm-observability) and marketing drafts instruct users to point their baseURL at `api.spanlens.io`, but the domain had no DNS record. Decision: register the domain (standard proxy naming, keeps published drafts valid) instead of rewriting docs to `server.spanlens.io`.

Done alongside this PR:
- Vercel: `api.spanlens.io` added to the `spanlens-server` project (Production)
- Gabia DNS: CNAME `api` -> `eecbf2820f5a078b.vercel-dns-017.com` (manual)

## Test plan
- [x] pnpm --filter server typecheck
- [x] pnpm --filter server lint
- [x] pnpm --filter server test (1501 passed)
- [ ] After DNS propagation: `curl https://api.spanlens.io/health` returns 200
- [ ] Integrations page curl example works end-to-end