### PR TITLE
feat: unify API host to api.spanlens.io (web docs + SDK v0.16.0)

### DIFF
--- a/apps/web/app/(dashboard)/projects/projects-client.tsx
+++ b/apps/web/app/(dashboard)/projects/projects-client.tsx
@@ -140,7 +140,7 @@ const model = genAI.getGenerativeModel({ model: 'gemini-2.5-flash' })
 // Azure resource URL is stored on the Spanlens provider key — your client
 // just talks to /proxy/azure and Spanlens forwards to the right Azure endpoint.
 const azure = new OpenAI({
-  baseURL: 'https://server.spanlens.io/proxy/azure',
+  baseURL: 'https://api.spanlens.io/proxy/azure',
   apiKey: process.env.SPANLENS_API_KEY,
 })
 // await azure.chat.completions.create({ model: 'gpt-4o', messages: [...] })`,
@@ -149,7 +149,7 @@ const azure = new OpenAI({
 // Mistral exposes an OpenAI-compatible API — point the OpenAI SDK at the
 // Spanlens proxy and use any Mistral model id.
 const mistral = new OpenAI({
-  baseURL: 'https://server.spanlens.io/proxy/mistral/v1',
+  baseURL: 'https://api.spanlens.io/proxy/mistral/v1',
   apiKey: process.env.SPANLENS_API_KEY,
 })
 // await mistral.chat.completions.create({ model: 'mistral-large-latest', messages: [...] })`,
@@ -158,7 +158,7 @@ const mistral = new OpenAI({
 // OpenRouter is OpenAI-compatible and gives you 100+ models behind one key.
 // Use the vendor-prefixed model id (e.g. 'openai/gpt-4o', 'anthropic/claude-sonnet-4').
 const openrouter = new OpenAI({
-  baseURL: 'https://server.spanlens.io/proxy/openrouter/v1',
+  baseURL: 'https://api.spanlens.io/proxy/openrouter/v1',
   apiKey: process.env.SPANLENS_API_KEY,
 })
 // await openrouter.chat.completions.create({ model: 'anthropic/claude-sonnet-4', messages: [...] })`,

--- a/apps/web/app/(dashboard)/requests/empty-requests-hint.tsx
+++ b/apps/web/app/(dashboard)/requests/empty-requests-hint.tsx
@@ -11,7 +11,7 @@ import { Copy, Check, Terminal } from 'lucide-react'
  * the request list polls on its own, so the row appears here automatically
  * once the call lands.
  */
-const TEST_CURL = `curl https://server.spanlens.io/proxy/openai/v1/chat/completions \\
+const TEST_CURL = `curl https://api.spanlens.io/proxy/openai/v1/chat/completions \\
   -H "Authorization: Bearer $SPANLENS_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hello from Spanlens"}]}'`

--- a/apps/web/app/demo/settings/page.tsx
+++ b/apps/web/app/demo/settings/page.tsx
@@ -516,7 +516,7 @@ function OtelTab() {
       <TabHeader title="OpenTelemetry" description="Export Spanlens traces to your existing OTel collector." />
       <Section title="OTLP endpoint">
         <FormRow label="Endpoint">
-          <DemoInput value="https://server.spanlens.io/v1/traces" mono />
+          <DemoInput value="https://api.spanlens.io/v1/traces" mono />
         </FormRow>
         <FormRow label="Headers">
           <DemoInput value="Authorization: Bearer sl_live_…" mono />

--- a/apps/web/app/docs/api/errors/page.tsx
+++ b/apps/web/app/docs/api/errors/page.tsx
@@ -246,7 +246,7 @@ try {
 }`}</pre>
 
       <h3>Raw fetch</h3>
-      <pre>{`const res = await fetch('https://server.spanlens.io/api/v1/foo', {
+      <pre>{`const res = await fetch('https://api.spanlens.io/api/v1/foo', {
   headers: { Authorization: 'Bearer ' + apiKey }
 })
 if (!res.ok) {

--- a/apps/web/app/docs/api/page.tsx
+++ b/apps/web/app/docs/api/page.tsx
@@ -7,7 +7,7 @@ export const metadata = {
     'Interactive OpenAPI 3.0 reference for the Spanlens REST API. Authentication, requests, stats, traces, anomalies, members, and proxy endpoints.',
 }
 
-const SERVER_URL = process.env.NEXT_PUBLIC_API_URL ?? 'https://server.spanlens.io'
+const SERVER_URL = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.spanlens.io'
 
 export default function ApiReferencePage() {
   const swaggerUiUrl = `${SERVER_URL}/api/v1/docs`
@@ -87,7 +87,7 @@ export default function ApiReferencePage() {
         <tbody>
           <tr>
             <td>Production (hosted)</td>
-            <td><code>https://server.spanlens.io</code></td>
+            <td><code>https://api.spanlens.io</code></td>
           </tr>
           <tr>
             <td>Local dev</td>

--- a/apps/web/app/docs/features/annotation/page.tsx
+++ b/apps/web/app/docs/features/annotation/page.tsx
@@ -153,7 +153,7 @@ export default function AnnotationDocs() {
 
       <h3>Example, save a rating</h3>
       <CodeBlock language="bash">{`# 4 stars + comment
-curl https://server.spanlens.io/api/v1/human-evals \\
+curl https://api.spanlens.io/api/v1/human-evals \\
   -H "Authorization: Bearer $SPANLENS_JWT" \\
   -H "Content-Type: application/json" \\
   -d '{

--- a/apps/web/app/docs/features/audit-logs/page.tsx
+++ b/apps/web/app/docs/features/audit-logs/page.tsx
@@ -296,15 +296,15 @@ GET /api/v1/audit-logs/actions`}</CodeBlock>
 
       <h2>curl examples</h2>
       <CodeBlock language="bash">{`# Fetch the 20 most recent entries
-curl "https://server.spanlens.io/api/v1/audit-logs?limit=20" \\
+curl "https://api.spanlens.io/api/v1/audit-logs?limit=20" \\
   -H "Authorization: Bearer <JWT>"
 
 # Filter to provider key events only
-curl "https://server.spanlens.io/api/v1/audit-logs?action=provider_key.add&limit=50" \\
+curl "https://api.spanlens.io/api/v1/audit-logs?action=provider_key.add&limit=50" \\
   -H "Authorization: Bearer <JWT>"
 
 # Second page (entries 51–100)
-curl "https://server.spanlens.io/api/v1/audit-logs?limit=50&offset=50" \\
+curl "https://api.spanlens.io/api/v1/audit-logs?limit=50&offset=50" \\
   -H "Authorization: Bearer <JWT>"`}</CodeBlock>
 
       <h2>Limitations</h2>

--- a/apps/web/app/docs/features/datasets/page.tsx
+++ b/apps/web/app/docs/features/datasets/page.tsx
@@ -81,7 +81,7 @@ export default function DatasetsDocs() {
       </ul>
 
       <h3>2. Import from production requests (API)</h3>
-      <CodeBlock language="bash">{`curl https://server.spanlens.io/api/v1/datasets/<dataset-id>/items/import-requests \\
+      <CodeBlock language="bash">{`curl https://api.spanlens.io/api/v1/datasets/<dataset-id>/items/import-requests \\
   -H "Authorization: Bearer $SPANLENS_JWT" \\
   -H "Content-Type: application/json" \\
   -d '{ "requestIds": ["uuid-1", "uuid-2", ...] }'`}</CodeBlock>
@@ -91,7 +91,7 @@ export default function DatasetsDocs() {
       </p>
 
       <h3>3. Single item (API)</h3>
-      <CodeBlock language="bash">{`curl https://server.spanlens.io/api/v1/datasets/<dataset-id>/items \\
+      <CodeBlock language="bash">{`curl https://api.spanlens.io/api/v1/datasets/<dataset-id>/items \\
   -H "Authorization: Bearer $SPANLENS_JWT" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -139,7 +139,7 @@ What is the capital of France?,Paris
         </li>
       </ul>
       <p>Behind the scenes the upload calls:</p>
-      <CodeBlock language="bash">{`curl https://server.spanlens.io/api/v1/datasets/<dataset-id>/items/bulk \\
+      <CodeBlock language="bash">{`curl https://api.spanlens.io/api/v1/datasets/<dataset-id>/items/bulk \\
   -H "Authorization: Bearer $SPANLENS_JWT" \\
   -H "Content-Type: application/json" \\
   -d '{ "items": [ { "input": { "messages": [...] } }, ... ] }'`}</CodeBlock>

--- a/apps/web/app/docs/features/evals/page.tsx
+++ b/apps/web/app/docs/features/evals/page.tsx
@@ -324,7 +324,7 @@ export default function EvalsDocs() {
 
       <h2>Example, create and run an evaluator</h2>
       <CodeBlock language="bash">{`# 1. Define the evaluator
-curl https://server.spanlens.io/api/v1/evaluators \\
+curl https://api.spanlens.io/api/v1/evaluators \\
   -H "Authorization: Bearer $SPANLENS_JWT" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -341,7 +341,7 @@ curl https://server.spanlens.io/api/v1/evaluators \\
   }'
 
 # 2. Score v2 with 50 samples from the last 7 days
-curl https://server.spanlens.io/api/v1/eval-runs \\
+curl https://api.spanlens.io/api/v1/eval-runs \\
   -H "Authorization: Bearer $SPANLENS_JWT" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -354,7 +354,7 @@ curl https://server.spanlens.io/api/v1/eval-runs \\
 
 # 2b. Dataset mode also accepts runProvider + runModel.
 #     The runner generates a response per item before scoring.
-curl https://server.spanlens.io/api/v1/eval-runs \\
+curl https://api.spanlens.io/api/v1/eval-runs \\
   -H "Authorization: Bearer $SPANLENS_JWT" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -368,7 +368,7 @@ curl https://server.spanlens.io/api/v1/eval-runs \\
   }'
 
 # 3. Poll for results (status: pending → running → completed)
-curl https://server.spanlens.io/api/v1/eval-runs/<run-id> \\
+curl https://api.spanlens.io/api/v1/eval-runs/<run-id> \\
   -H "Authorization: Bearer $SPANLENS_JWT"`}</CodeBlock>
 
       <h2>Run from CI (prompt CI)</h2>

--- a/apps/web/app/docs/features/experiments/page.tsx
+++ b/apps/web/app/docs/features/experiments/page.tsx
@@ -146,7 +146,7 @@ export default function ExperimentsDocs() {
       </table>
 
       <h3>Example</h3>
-      <CodeBlock language="bash">{`curl https://server.spanlens.io/api/v1/experiments \\
+      <CodeBlock language="bash">{`curl https://api.spanlens.io/api/v1/experiments \\
   -H "Authorization: Bearer $SPANLENS_JWT" \\
   -H "Content-Type: application/json" \\
   -d '{

--- a/apps/web/app/docs/features/export/page.tsx
+++ b/apps/web/app/docs/features/export/page.tsx
@@ -331,28 +331,28 @@ export default function ExportDocs() {
 
       <h3>CSV download</h3>
       <CodeBlock language="bash">{`# Request logs, specific date range, GPT-4o only, CSV
-curl "https://server.spanlens.io/api/v1/exports/requests?from=2026-05-01T00:00:00Z&to=2026-05-15T23:59:59Z&provider=openai&model=gpt-4o&format=csv" \\
+curl "https://api.spanlens.io/api/v1/exports/requests?from=2026-05-01T00:00:00Z&to=2026-05-15T23:59:59Z&provider=openai&model=gpt-4o&format=csv" \\
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \\
   -o spanlens-requests.csv
 
 # Traces, last 7 days, JSON
-curl "https://server.spanlens.io/api/v1/exports/traces?from=2026-05-08T00:00:00Z&format=json" \\
+curl "https://api.spanlens.io/api/v1/exports/traces?from=2026-05-08T00:00:00Z&format=json" \\
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \\
   -o spanlens-traces.json
 
 # Anomaly history, defaults (30 days, CSV)
-curl "https://server.spanlens.io/api/v1/exports/anomalies" \\
+curl "https://api.spanlens.io/api/v1/exports/anomalies" \\
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \\
   -o spanlens-anomalies.csv
 
 # Security flags, from a specific date
-curl "https://server.spanlens.io/api/v1/exports/security?from=2026-05-01T00:00:00Z" \\
+curl "https://api.spanlens.io/api/v1/exports/security?from=2026-05-01T00:00:00Z" \\
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \\
   -o spanlens-security.csv`}</CodeBlock>
 
       <h3>JSONL download (large exports)</h3>
       <CodeBlock language="bash">{`# One million rows, streamed. Pipe straight into jq for filtering.
-curl "https://server.spanlens.io/api/v1/exports/requests?format=jsonl&from=2026-01-01T00:00:00Z&limit=1000000" \\
+curl "https://api.spanlens.io/api/v1/exports/requests?format=jsonl&from=2026-01-01T00:00:00Z&limit=1000000" \\
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \\
   | jq -c 'select(.cost_usd != null and (.cost_usd | tonumber) > 0.01)' \\
   > expensive-requests.jsonl
@@ -362,7 +362,7 @@ curl "https://server.spanlens.io/api/v1/exports/requests?format=jsonl&from=2026-
 # {"id":"req_yyy","provider":"anthropic","model":"claude-sonnet-4-5",...}`}</CodeBlock>
 
       <h3>JSON download (small, wrapped)</h3>
-      <CodeBlock language="bash">{`curl "https://server.spanlens.io/api/v1/exports/requests?format=json&limit=1000" \\
+      <CodeBlock language="bash">{`curl "https://api.spanlens.io/api/v1/exports/requests?format=json&limit=1000" \\
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN"
 
 # Response shape (buffered, capped at 10,000 rows):
@@ -397,12 +397,12 @@ curl "https://server.spanlens.io/api/v1/exports/requests?format=jsonl&from=2026-
 token = "YOUR_SUPABASE_ACCESS_TOKEN"
 
 # Small / medium, CSV, single response.
-url = "https://server.spanlens.io/api/v1/exports/requests?from=2026-05-01T00:00:00Z&format=csv"
+url = "https://api.spanlens.io/api/v1/exports/requests?from=2026-05-01T00:00:00Z&format=csv"
 df = pd.read_csv(url, storage_options={"Authorization": f"Bearer {token}"})
 
 # Million-row pipeline, JSONL, streamed line-by-line. Pandas reads it in
 # chunks so peak memory stays bounded.
-url = "https://server.spanlens.io/api/v1/exports/requests?format=jsonl&limit=1000000"
+url = "https://api.spanlens.io/api/v1/exports/requests?format=jsonl&limit=1000000"
 chunks = pd.read_json(url, lines=True, chunksize=50_000,
                       storage_options={"Authorization": f"Bearer {token}"})
 totals = pd.concat(chunk.groupby("model")["cost_usd"].sum() for chunk in chunks).groupby(level=0).sum()

--- a/apps/web/app/docs/features/prompt-ab/page.tsx
+++ b/apps/web/app/docs/features/prompt-ab/page.tsx
@@ -147,7 +147,7 @@ export default function PromptAbDocs() {
       </div>
 
       <h3>Example</h3>
-      <CodeBlock language="bash">{`curl https://server.spanlens.io/api/v1/prompt-experiments \\
+      <CodeBlock language="bash">{`curl https://api.spanlens.io/api/v1/prompt-experiments \\
   -H "Authorization: Bearer $SPANLENS_JWT" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -233,7 +233,7 @@ export default function PromptAbDocs() {
       </p>
       <CodeBlock language="bash">{`PATCH /api/v1/prompt-experiments/:id
 
-curl -X PATCH https://server.spanlens.io/api/v1/prompt-experiments/<experiment-id> \\
+curl -X PATCH https://api.spanlens.io/api/v1/prompt-experiments/<experiment-id> \\
   -H "Authorization: Bearer $SPANLENS_JWT" \\
   -H "Content-Type: application/json" \\
   -d '{

--- a/apps/web/app/docs/features/prompts-playground/page.tsx
+++ b/apps/web/app/docs/features/prompts-playground/page.tsx
@@ -213,7 +213,7 @@ export default function PromptsPlaygroundDocs() {
       <p>Auth: JWT (<code>Authorization: Bearer $SPANLENS_JWT</code>)</p>
 
       <h3>Request example</h3>
-      <CodeBlock language="bash">{`curl https://server.spanlens.io/api/v1/prompts-playground/run \\
+      <CodeBlock language="bash">{`curl https://api.spanlens.io/api/v1/prompts-playground/run \\
   -H "Authorization: Bearer $SPANLENS_JWT" \\
   -H "Content-Type: application/json" \\
   -d '{

--- a/apps/web/app/docs/features/prompts/page.tsx
+++ b/apps/web/app/docs/features/prompts/page.tsx
@@ -113,7 +113,7 @@ export default function PromptsDocs() {
       </ol>
 
       <h3>Creating via API</h3>
-      <CodeBlock language="bash">{`curl https://server.spanlens.io/api/v1/prompts \\
+      <CodeBlock language="bash">{`curl https://api.spanlens.io/api/v1/prompts \\
   -H "Authorization: Bearer $SPANLENS_JWT" \\
   -H "Content-Type: application/json" \\
   -d '{

--- a/apps/web/app/docs/features/saved-filters/page.tsx
+++ b/apps/web/app/docs/features/saved-filters/page.tsx
@@ -154,17 +154,17 @@ Content-Type: application/json
 
       <h2>curl examples</h2>
       <CodeBlock language="bash">{`# List saved filters
-curl https://server.spanlens.io/api/v1/saved-filters \\
+curl https://api.spanlens.io/api/v1/saved-filters \\
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN"
 
 # Save a filter
-curl -X POST https://server.spanlens.io/api/v1/saved-filters \\
+curl -X POST https://api.spanlens.io/api/v1/saved-filters \\
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \\
   -H "Content-Type: application/json" \\
   -d '{"name":"Anthropic 429 errors","filters":{"provider":"anthropic","status":"4xx"}}'
 
 # Delete a filter
-curl -X DELETE https://server.spanlens.io/api/v1/saved-filters/sf_xxxxxxxx \\
+curl -X DELETE https://api.spanlens.io/api/v1/saved-filters/sf_xxxxxxxx \\
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN"`}</CodeBlock>
 
       <h2>Limitations</h2>

--- a/apps/web/app/docs/features/shares/page.tsx
+++ b/apps/web/app/docs/features/shares/page.tsx
@@ -152,11 +152,11 @@ export default function SharesDocs() {
         grab from your browser session.
       </p>
       <CodeBlock language="bash">{`# List every active share in the workspace, sorted by view count
-curl 'https://server.spanlens.io/api/v1/shares?scope=org&sort=views' \\
+curl 'https://api.spanlens.io/api/v1/shares?scope=org&sort=views' \\
   -H "Authorization: Bearer $SPANLENS_JWT"
 
 # Create a share with the Marketing redaction preset
-curl -X POST https://server.spanlens.io/api/v1/shares \\
+curl -X POST https://api.spanlens.io/api/v1/shares \\
   -H "Authorization: Bearer $SPANLENS_JWT" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -169,7 +169,7 @@ curl -X POST https://server.spanlens.io/api/v1/shares \\
   }'
 
 # Revoke a share immediately (soft delete, view_count preserved)
-curl -X DELETE https://server.spanlens.io/api/v1/shares/<token> \\
+curl -X DELETE https://api.spanlens.io/api/v1/shares/<token> \\
   -H "Authorization: Bearer $SPANLENS_JWT"`}</CodeBlock>
 
       <h2>Security model</h2>

--- a/apps/web/app/docs/features/webhooks/page.tsx
+++ b/apps/web/app/docs/features/webhooks/page.tsx
@@ -98,7 +98,7 @@ GET    /api/v1/webhooks/:id/deliveries    # Last 10 delivery records`}</CodeBloc
         </tbody>
       </table>
 
-      <CodeBlock language="bash">{`curl -X POST https://server.spanlens.io/api/v1/webhooks \\
+      <CodeBlock language="bash">{`curl -X POST https://api.spanlens.io/api/v1/webhooks \\
   -H "Authorization: Bearer <JWT>" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -199,7 +199,7 @@ app.post('/hooks/spanlens', express.raw({ type: 'application/json' }), (req, res
         and the delivery timestamp. If you see repeated 4xx or 5xx responses, check your server
         logs alongside the delivery history.
       </p>
-      <CodeBlock language="bash">{`curl https://server.spanlens.io/api/v1/webhooks/wh_01j9abc.../deliveries \\
+      <CodeBlock language="bash">{`curl https://api.spanlens.io/api/v1/webhooks/wh_01j9abc.../deliveries \\
   -H "Authorization: Bearer <JWT>"`}</CodeBlock>
       <CodeBlock language="json">{`[
   {
@@ -217,7 +217,7 @@ app.post('/hooks/spanlens', express.raw({ type: 'application/json' }), (req, res
         Use this to verify your endpoint URL and signature verification logic without waiting for
         a real event.
       </p>
-      <CodeBlock language="bash">{`curl -X POST https://server.spanlens.io/api/v1/webhooks/wh_01j9abc.../test \\
+      <CodeBlock language="bash">{`curl -X POST https://api.spanlens.io/api/v1/webhooks/wh_01j9abc.../test \\
   -H "Authorization: Bearer <JWT>"`}</CodeBlock>
 
       <h2>Permissions</h2>

--- a/apps/web/app/docs/integrations/langgraph/page.tsx
+++ b/apps/web/app/docs/integrations/langgraph/page.tsx
@@ -164,7 +164,7 @@ await trace.end()   // caller owns lifecycle when trace is passed in`}</CodeBloc
 const llm = new ChatOpenAI({
   model: 'gpt-4o-mini',
   configuration: {
-    baseURL: 'https://server.spanlens.io/proxy/openai/v1',
+    baseURL: 'https://api.spanlens.io/proxy/openai/v1',
     apiKey: process.env.SPANLENS_API_KEY,
   },
 })`}</CodeBlock>
@@ -184,7 +184,7 @@ const llm = new ChatOpenAI({
       <CodeBlock language="ts">{`const llm = new ChatOpenAI({
   model: 'gpt-4o-mini',
   configuration: {
-    baseURL: 'https://server.spanlens.io/proxy/openai/v1',
+    baseURL: 'https://api.spanlens.io/proxy/openai/v1',
     apiKey: process.env.SPANLENS_API_KEY,
     defaultHeaders: {
       'x-spanlens-prompt-version': 'agent-system@7',

--- a/apps/web/app/docs/integrations/llamaindex/page.tsx
+++ b/apps/web/app/docs/integrations/llamaindex/page.tsx
@@ -153,7 +153,7 @@ trace.end(status="completed")   # caller owns lifecycle when trace is passed in`
 
 llm = OpenAI(
     model="gpt-4o-mini",
-    api_base="https://server.spanlens.io/proxy/openai/v1",
+    api_base="https://api.spanlens.io/proxy/openai/v1",
     api_key=os.environ["SPANLENS_API_KEY"],
 )
 
@@ -173,7 +173,7 @@ Settings.llm = llm`}</CodeBlock>
 
 llm = OpenAI(
     model="gpt-4o-mini",
-    api_base="https://server.spanlens.io/proxy/openai/v1",
+    api_base="https://api.spanlens.io/proxy/openai/v1",
     api_key=os.environ["SPANLENS_API_KEY"],
     default_headers={"x-spanlens-prompt-version": "rag-system@7"},
 )`}</CodeBlock>

--- a/apps/web/app/docs/integrations/vercel-ai/page.tsx
+++ b/apps/web/app/docs/integrations/vercel-ai/page.tsx
@@ -143,7 +143,7 @@ await trace.end({ status: 'completed' })`}</CodeBlock>
 
 const openai = createOpenAI({
   apiKey: process.env.SPANLENS_API_KEY!,
-  baseURL: 'https://server.spanlens.io/proxy/openai/v1',
+  baseURL: 'https://api.spanlens.io/proxy/openai/v1',
 })
 
 const result = await generateText({
@@ -167,7 +167,7 @@ const result = await generateText({
       </p>
       <CodeBlock language="ts">{`const openai = createOpenAI({
   apiKey: process.env.SPANLENS_API_KEY!,
-  baseURL: 'https://server.spanlens.io/proxy/openai/v1',
+  baseURL: 'https://api.spanlens.io/proxy/openai/v1',
   headers: { 'x-spanlens-prompt-version': 'chatbot-system@3' },
 })`}</CodeBlock>
 

--- a/apps/web/app/docs/migrate/from-helicone/page.tsx
+++ b/apps/web/app/docs/migrate/from-helicone/page.tsx
@@ -61,7 +61,7 @@ export default function MigrateFromHelicone() {
       <p>
         Helicone routes through <code>https://ai-gateway.helicone.ai</code> (or the older
         <code>https://oai.helicone.ai/v1</code>). Spanlens routes through{' '}
-        <code>https://server.spanlens.io/proxy/&lt;provider&gt;</code>. The auth header
+        <code>https://api.spanlens.io/proxy/&lt;provider&gt;</code>. The auth header
         stays the same shape; only the key value changes.
       </p>
 
@@ -79,7 +79,7 @@ const openai = new OpenAI({
       <CodeBlock language="ts">{`import OpenAI from 'openai'
 
 const openai = new OpenAI({
-  baseURL: 'https://server.spanlens.io/proxy/openai/v1',
+  baseURL: 'https://api.spanlens.io/proxy/openai/v1',
   apiKey: process.env.SPANLENS_API_KEY,
 })`}</CodeBlock>
       <p className="text-sm text-muted-foreground">After (Spanlens, SDK helper):</p>
@@ -89,10 +89,10 @@ const openai = createOpenAI() // reads SPANLENS_API_KEY from env`}</CodeBlock>
 
       <h3>Anthropic, Gemini, Azure OpenAI</h3>
       <p>Different base path per provider. The dashboard shows the exact URL after you register a provider key.</p>
-      <CodeBlock language="text">{`OpenAI    : https://server.spanlens.io/proxy/openai/v1
-Anthropic : https://server.spanlens.io/proxy/anthropic
-Gemini    : https://server.spanlens.io/proxy/gemini/v1beta
-Azure     : https://server.spanlens.io/proxy/azure`}</CodeBlock>
+      <CodeBlock language="text">{`OpenAI    : https://api.spanlens.io/proxy/openai/v1
+Anthropic : https://api.spanlens.io/proxy/anthropic
+Gemini    : https://api.spanlens.io/proxy/gemini/v1beta
+Azure     : https://api.spanlens.io/proxy/azure`}</CodeBlock>
 
       <h2>Step 3. Replace Helicone headers with Spanlens equivalents</h2>
       <p>
@@ -226,7 +226,7 @@ const res = await openai.chat.completions.create(
       </p>
       <CodeBlock language="ts">{`// Read from env so you can flip per environment
 const baseURL = process.env.LLM_PROXY === 'spanlens'
-  ? 'https://server.spanlens.io/proxy/openai/v1'
+  ? 'https://api.spanlens.io/proxy/openai/v1'
   : 'https://ai-gateway.helicone.ai'
 
 const apiKey = process.env.LLM_PROXY === 'spanlens'

--- a/apps/web/app/docs/otel/page.tsx
+++ b/apps/web/app/docs/otel/page.tsx
@@ -29,7 +29,7 @@ export default function OtelDocs() {
       </p>
 
       <h2>Endpoint</h2>
-      <CodeBlock language="text">{`POST https://server.spanlens.io/v1/traces
+      <CodeBlock language="text">{`POST https://api.spanlens.io/v1/traces
 Content-Type: application/json
 Authorization: Bearer sl_live_<your-key>`}</CodeBlock>
       <p>
@@ -46,7 +46,7 @@ Authorization: Bearer sl_live_<your-key>`}</CodeBlock>
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
 exporter = OTLPSpanExporter(
-    endpoint="https://server.spanlens.io",
+    endpoint="https://api.spanlens.io",
     headers={"Authorization": "Bearer sl_live_YOUR_KEY"},
 )
 `}</CodeBlock>
@@ -145,7 +145,7 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 
 # Configure the OTLP exporter
 exporter = OTLPSpanExporter(
-    endpoint="https://server.spanlens.io",
+    endpoint="https://api.spanlens.io",
     headers={"Authorization": "Bearer sl_live_YOUR_KEY"},
 )
 
@@ -183,7 +183,7 @@ from agents.tracing.otlp import OTLPTraceProcessor
 
 set_trace_processor(
     OTLPTraceProcessor(
-        endpoint="https://server.spanlens.io/v1/traces",
+        endpoint="https://api.spanlens.io/v1/traces",
         headers={"Authorization": "Bearer sl_live_YOUR_KEY"},
     )
 )
@@ -195,7 +195,7 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 
 const sdk = new NodeSDK({
   traceExporter: new OTLPTraceExporter({
-    url: 'https://server.spanlens.io/v1/traces',
+    url: 'https://api.spanlens.io/v1/traces',
     headers: { Authorization: 'Bearer sl_live_YOUR_KEY' },
   }),
 })

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -27,7 +27,7 @@ res = client.chat.completions.create(
     messages=[{"role": "user", "content": "Hi"}],
 )`
 
-const CURL_SNIPPET = `curl https://server.spanlens.io/proxy/openai/v1/chat/completions \\
+const CURL_SNIPPET = `curl https://api.spanlens.io/proxy/openai/v1/chat/completions \\
   -H "Authorization: Bearer $SPANLENS_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{

--- a/apps/web/app/docs/production/disaster-recovery/page.tsx
+++ b/apps/web/app/docs/production/disaster-recovery/page.tsx
@@ -92,7 +92,7 @@ export default function DisasterRecoveryDocs() {
         </li>
         <li>
           Trigger a drain by hand:
-          <CodeBlock language="bash">{`curl -X GET https://server.spanlens.io/cron/replay-fallback \\
+          <CodeBlock language="bash">{`curl -X GET https://api.spanlens.io/cron/replay-fallback \\
   -H "Authorization: Bearer $CRON_SECRET"`}</CodeBlock>
         </li>
         <li>
@@ -209,7 +209,7 @@ ORDER BY created_at;`}</CodeBlock>
           to make the cron fire again.
         </li>
         <li>Trigger one run by hand to resume:
-          <CodeBlock language="bash">{`curl -X GET https://server.spanlens.io/cron/run-background-migrations \\
+          <CodeBlock language="bash">{`curl -X GET https://api.spanlens.io/cron/run-background-migrations \\
   -H "Authorization: Bearer $CRON_SECRET"`}</CodeBlock>
         </li>
       </ol>

--- a/apps/web/app/docs/production/reliability/page.tsx
+++ b/apps/web/app/docs/production/reliability/page.tsx
@@ -206,12 +206,12 @@ export default function ReliabilityDocs() {
       <ol>
         <li>Check <a href="https://status.spanlens.io" rel="noopener noreferrer" target="_blank">status.spanlens.io</a>.</li>
         <li>
-          <code>curl https://server.spanlens.io/health/deep</code>. If <code>fallback.queue &gt; 0</code>,
+          <code>curl https://api.spanlens.io/health/deep</code>. If <code>fallback.queue &gt; 0</code>,
           the rows are queued and will replay automatically; no action needed.
         </li>
         <li>
           Verify your application is hitting the proxy (Network tab in the browser, or
-          your APM trace). If requests are not reaching <code>server.spanlens.io</code>,
+          your APM trace). If requests are not reaching <code>api.spanlens.io</code>,
           the gap is on your side.
         </li>
         <li>

--- a/apps/web/app/docs/proxy/page.tsx
+++ b/apps/web/app/docs/proxy/page.tsx
@@ -35,16 +35,16 @@ export default function ProxyDocs() {
       <p>
         Spanlens exposes a 1:1 compatible proxy at:
       </p>
-      <CodeBlock>{`https://server.spanlens.io/proxy/openai/v1
-https://server.spanlens.io/proxy/anthropic
-https://server.spanlens.io/proxy/gemini/v1beta
-https://server.spanlens.io/proxy/azure
-https://server.spanlens.io/proxy/mistral/v1
-https://server.spanlens.io/proxy/openrouter/v1
-https://server.spanlens.io/proxy/groq/v1
-https://server.spanlens.io/proxy/deepseek/v1
-https://server.spanlens.io/proxy/xai/v1
-https://server.spanlens.io/proxy/cohere/v1`}</CodeBlock>
+      <CodeBlock>{`https://api.spanlens.io/proxy/openai/v1
+https://api.spanlens.io/proxy/anthropic
+https://api.spanlens.io/proxy/gemini/v1beta
+https://api.spanlens.io/proxy/azure
+https://api.spanlens.io/proxy/mistral/v1
+https://api.spanlens.io/proxy/openrouter/v1
+https://api.spanlens.io/proxy/groq/v1
+https://api.spanlens.io/proxy/deepseek/v1
+https://api.spanlens.io/proxy/xai/v1
+https://api.spanlens.io/proxy/cohere/v1`}</CodeBlock>
       <p>
         Send requests exactly as you would to the real provider, with two changes:
       </p>
@@ -113,7 +113,7 @@ https://server.spanlens.io/proxy/cohere/v1`}</CodeBlock>
 
 client = OpenAI(
     api_key=os.environ["SPANLENS_API_KEY"],
-    base_url="https://server.spanlens.io/proxy/openai/v1",
+    base_url="https://api.spanlens.io/proxy/openai/v1",
 )
 
 res = client.chat.completions.create(
@@ -126,7 +126,7 @@ res = client.chat.completions.create(
 
 client = Anthropic(
     api_key=os.environ["SPANLENS_API_KEY"],
-    base_url="https://server.spanlens.io/proxy/anthropic",
+    base_url="https://api.spanlens.io/proxy/anthropic",
 )
 
 msg = client.messages.create(
@@ -147,7 +147,7 @@ msg = client.messages.create(
 
 client = OpenAI(
     api_key=os.environ["SPANLENS_API_KEY"],
-    base_url="https://server.spanlens.io/proxy/azure",
+    base_url="https://api.spanlens.io/proxy/azure",
 )
 
 # 'model' is your Azure deployment name, not the underlying model id.
@@ -176,7 +176,7 @@ res = client.chat.completions.create(
 
 client = OpenAI(
     api_key=os.environ["SPANLENS_API_KEY"],
-    base_url="https://server.spanlens.io/proxy/mistral/v1",
+    base_url="https://api.spanlens.io/proxy/mistral/v1",
 )
 
 res = client.chat.completions.create(
@@ -205,7 +205,7 @@ res = client.chat.completions.create(
 
 client = OpenAI(
     api_key=os.environ["SPANLENS_API_KEY"],
-    base_url="https://server.spanlens.io/proxy/openrouter/v1",
+    base_url="https://api.spanlens.io/proxy/openrouter/v1",
 )
 
 # Model id carries a vendor prefix
@@ -264,7 +264,7 @@ const cohere   = createCohere()    // model: 'command-a-03-2025' (Cohere ids, no
       </p>
 
       <h2 id="curl">curl, raw HTTP</h2>
-      <CodeBlock language="bash">{`curl https://server.spanlens.io/proxy/openai/v1/chat/completions \\
+      <CodeBlock language="bash">{`curl https://api.spanlens.io/proxy/openai/v1/chat/completions \\
   -H "Authorization: Bearer $SPANLENS_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -277,7 +277,7 @@ const cohere   = createCohere()    // model: 'command-a-03-2025' (Cohere ids, no
 
 client = OpenAI::Client.new(
   access_token: ENV["SPANLENS_API_KEY"],
-  uri_base: "https://server.spanlens.io/proxy/openai",
+  uri_base: "https://api.spanlens.io/proxy/openai",
 )
 
 res = client.chat(parameters: {
@@ -289,7 +289,7 @@ res = client.chat(parameters: {
       <CodeBlock language="go">{`import "github.com/sashabaranov/go-openai"
 
 config := openai.DefaultConfig(os.Getenv("SPANLENS_API_KEY"))
-config.BaseURL = "https://server.spanlens.io/proxy/openai/v1"
+config.BaseURL = "https://api.spanlens.io/proxy/openai/v1"
 
 client := openai.NewClientWithConfig(config)
 

--- a/apps/web/app/docs/quick-start/page.tsx
+++ b/apps/web/app/docs/quick-start/page.tsx
@@ -216,7 +216,7 @@ const result = await model.generateContent('Hi')`}</CodeBlock>
         <li>After adding env vars in Vercel, <strong>redeploy</strong>, because new values don&apos;t apply retroactively</li>
         <li>
           Check the Network tab. Your request should hit{' '}
-          <code>server.spanlens.io/proxy/*</code>, not <code>api.openai.com</code> directly
+          <code>api.spanlens.io/proxy/*</code>, not <code>api.openai.com</code> directly
         </li>
       </ol>
 

--- a/apps/web/app/docs/sdk/page.tsx
+++ b/apps/web/app/docs/sdk/page.tsx
@@ -235,7 +235,7 @@ import openai
 
 client = openai.OpenAI(
     api_key=os.environ["SPANLENS_API_KEY"],
-    base_url="https://server.spanlens.io/proxy/openai/v1",
+    base_url="https://api.spanlens.io/proxy/openai/v1",
     default_headers={
         "x-spanlens-user": current_user_id,
         "x-spanlens-session": session_id,
@@ -323,12 +323,12 @@ from openai import OpenAI
 
 openai = OpenAI(
     api_key=os.environ['SPANLENS_API_KEY'],
-    base_url='https://server.spanlens.io/proxy/openai/v1',
+    base_url='https://api.spanlens.io/proxy/openai/v1',
     default_headers={'x-spanlens-log-body': 'meta'},
 )`}
       />
       <p>Raw curl:</p>
-      <CodeBlock>{`curl https://server.spanlens.io/proxy/openai/v1/chat/completions \\
+      <CodeBlock>{`curl https://api.spanlens.io/proxy/openai/v1/chat/completions \\
   -H "Authorization: Bearer $SPANLENS_API_KEY" \\
   -H "x-spanlens-log-body: meta" \\
   -H "Content-Type: application/json" \\
@@ -407,12 +407,12 @@ from openai import OpenAI
 
 openai = OpenAI(
     api_key=os.environ['SPANLENS_API_KEY'],
-    base_url='https://server.spanlens.io/proxy/openai/v1',
+    base_url='https://api.spanlens.io/proxy/openai/v1',
     default_headers={'x-spanlens-cache': '600'},
 )`}
       />
       <p>Raw curl:</p>
-      <CodeBlock>{`curl https://server.spanlens.io/proxy/openai/v1/chat/completions \\
+      <CodeBlock>{`curl https://api.spanlens.io/proxy/openai/v1/chat/completions \\
   -H "Authorization: Bearer $SPANLENS_API_KEY" \\
   -H "x-spanlens-cache: true" \\
   -H "Content-Type: application/json" \\

--- a/apps/web/app/docs/troubleshooting/page.tsx
+++ b/apps/web/app/docs/troubleshooting/page.tsx
@@ -255,7 +255,7 @@ Gemini           x-goog-api-key: sl_live_...`}</pre>
         <li>
           <strong>The request is still going to the provider directly.</strong> In your
           Network tab the call should hit{' '}
-          <code>server.spanlens.io/proxy/*</code>, not <code>api.openai.com</code> (or the
+          <code>api.spanlens.io/proxy/*</code>, not <code>api.openai.com</code> (or the
           equivalent). If it is not, the client is constructed with the upstream{' '}
           <code>baseURL</code>; use the SDK helper or set <code>base_url</code> to the proxy.
         </li>
@@ -278,7 +278,7 @@ Gemini           x-goog-api-key: sl_live_...`}</pre>
         entirely and hit the proxy directly. A row should appear in{' '}
         <a href="/requests">/requests</a> within a few seconds:
       </p>
-      <pre>{`curl https://server.spanlens.io/proxy/openai/v1/chat/completions \\
+      <pre>{`curl https://api.spanlens.io/proxy/openai/v1/chat/completions \\
   -H "Authorization: Bearer $SPANLENS_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{

--- a/apps/web/app/docs/tutorials/nightly-evals/page.tsx
+++ b/apps/web/app/docs/tutorials/nightly-evals/page.tsx
@@ -92,10 +92,10 @@ Reply with: {"score": <1-5>, "reasoning": "<one sentence>"}`}</CodeBlock>
       </p>
       <CodeBlock language="bash">{`# Look up the evaluator id once
 curl -H "Authorization: Bearer $SPANLENS_API_KEY" \\
-  https://server.spanlens.io/api/v1/evaluators
+  https://api.spanlens.io/api/v1/evaluators
 
 # Trigger a new run
-curl -X POST https://server.spanlens.io/api/v1/eval-runs \\
+curl -X POST https://api.spanlens.io/api/v1/eval-runs \\
   -H "Authorization: Bearer $SPANLENS_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -143,7 +143,7 @@ export async function GET(req: Request) {
   const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000)
   const isoDay = (d: Date) => d.toISOString()
 
-  const res = await fetch('https://server.spanlens.io/api/v1/eval-runs', {
+  const res = await fetch('https://api.spanlens.io/api/v1/eval-runs', {
     method: 'POST',
     headers: {
       'Authorization': \`Bearer \${process.env.SPANLENS_API_KEY}\`,
@@ -182,7 +182,7 @@ jobs:
         run: |
           NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           FROM=$(date -u -d '1 day ago' +"%Y-%m-%dT%H:%M:%SZ")
-          curl -sf -X POST https://server.spanlens.io/api/v1/eval-runs \\
+          curl -sf -X POST https://api.spanlens.io/api/v1/eval-runs \\
             -H "Authorization: Bearer $SPANLENS_API_KEY" \\
             -H "Content-Type: application/json" \\
             -d "{

--- a/apps/web/components/dashboard/welcome-banner.tsx
+++ b/apps/web/components/dashboard/welcome-banner.tsx
@@ -42,7 +42,7 @@ const openai = createOpenAI()
 
 /** Copy-paste test call through the Spanlens proxy, pre-filled with the key. */
 function buildTestCurl(apiKey: string): string {
-  return `curl https://server.spanlens.io/proxy/openai/v1/chat/completions \\
+  return `curl https://api.spanlens.io/proxy/openai/v1/chat/completions \\
   -H "Authorization: Bearer ${apiKey}" \\
   -H "Content-Type: application/json" \\
   -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hello from Spanlens"}]}'`

--- a/apps/web/lib/changelog/entries.ts
+++ b/apps/web/lib/changelog/entries.ts
@@ -158,7 +158,7 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
     title: 'Mistral and OpenRouter are now first-class providers',
     tags: ['feature'],
     body: [
-      'Two new proxies join OpenAI, Anthropic, Gemini, and Azure. Point the OpenAI SDK at `https://server.spanlens.io/proxy/mistral/v1` or `/proxy/openrouter/v1` with your Spanlens key and Mistral chat completions or any of OpenRouter\'s 100+ models route through Spanlens with cost, latency, and token counts on every row in /requests. Both APIs are OpenAI-compatible, so existing client code only needs a baseURL swap.',
+      'Two new proxies join OpenAI, Anthropic, Gemini, and Azure. Point the OpenAI SDK at `https://api.spanlens.io/proxy/mistral/v1` or `/proxy/openrouter/v1` with your Spanlens key and Mistral chat completions or any of OpenRouter\'s 100+ models route through Spanlens with cost, latency, and token counts on every row in /requests. Both APIs are OpenAI-compatible, so existing client code only needs a baseURL swap.',
       'OpenRouter is a meta-provider that fronts models from 30+ vendors behind one key — `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`, `meta-llama/llama-3.3-70b-instruct`, `deepseek/deepseek-r1`, and so on. For these calls Spanlens prefers the `usage.cost` field on OpenRouter\'s response (the authoritative billed amount, which captures any volume discount or upstream-provider margin we don\'t see) over our local price-table lookup. Streaming responses get the same treatment via the final SSE chunk.',
       'Register a provider key from /projects and the dropdown now lists both. Evaluators and experiments can also use Mistral or OpenRouter as the judge or run model — the New Evaluator dialog reads the live model catalog, so any new model in `model_prices` shows up automatically. See [the proxy guide](/docs/proxy) for code samples in TypeScript, Python, and curl.',
     ].join('\n\n'),
@@ -489,7 +489,7 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
     tags: ['reliability'],
     body: [
       'When the ClickHouse insert fails, the request row is queued in a Supabase fallback table instead of dropped. A cron drains the queue every 5 minutes once ClickHouse recovers.',
-      'You can monitor the queue depth from [GET /health/deep](https://server.spanlens.io/health/deep) as `fallback.queue`.',
+      'You can monitor the queue depth from [GET /health/deep](https://api.spanlens.io/health/deep) as `fallback.queue`.',
     ].join('\n\n'),
   },
   {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @spanlens/sdk changelog
 
+## 0.16.0
+
+Default API host moved to the official `api.spanlens.io` domain.
+
+### Changed
+
+- All default base URLs now point at `https://api.spanlens.io` instead of `https://spanlens-server.vercel.app`: the transport (`baseUrl`), `runEvals`, and every provider proxy default (`openai`, `anthropic`, `gemini`, `groq`, `deepseek`, `xai`, `cohere`). Both hosts serve the same deployment, so previously released SDK versions keep working unchanged. Explicit `baseUrl` / `baseURL` overrides are unaffected.
+
 ## 0.15.1
 
 Reliability fixes for observe(), the transport, and the framework trackers. No API changes beyond a new optional onError handler on the Vercel AI tracker.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -23,7 +23,7 @@ For the common case where you **just want to route your LLM calls through Spanle
 import OpenAI from 'openai'
 const openai = new OpenAI({
   apiKey: process.env.SPANLENS_API_KEY,
-  baseURL: 'https://spanlens-server.vercel.app/proxy/openai/v1',
+  baseURL: 'https://api.spanlens.io/proxy/openai/v1',
 })
 
 // After ⚡
@@ -130,7 +130,7 @@ try {
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `apiKey` | `string` | (required) | Spanlens API key (`sl_live_...`). |
-| `baseUrl` | `string` | `https://spanlens-server.vercel.app` | API base URL. |
+| `baseUrl` | `string` | `https://api.spanlens.io` | API base URL. |
 | `timeoutMs` | `number` | `3000` | Request timeout for ingest calls. |
 | `silent` | `boolean` | `true` | Swallow network errors so instrumentation never crashes user code. |
 | `onError` | `(err, ctx) => void` | (none) | Called on every ingest failure (even when `silent`). |
@@ -181,7 +181,7 @@ const spanlens = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
 // back to your spans.
 const openai = new OpenAI({
   apiKey: process.env.SPANLENS_API_KEY!,
-  baseURL: 'https://spanlens-server.vercel.app/proxy/openai/v1',
+  baseURL: 'https://api.spanlens.io/proxy/openai/v1',
 })
 
 const trace = spanlens.startTrace({ name: 'support_chat' })
@@ -205,7 +205,7 @@ import { SpanlensClient, observeAnthropic } from '@spanlens/sdk'
 const spanlens = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
 const anthropic = new Anthropic({
   apiKey: process.env.SPANLENS_API_KEY!,
-  baseURL: 'https://spanlens-server.vercel.app/proxy/anthropic',
+  baseURL: 'https://api.spanlens.io/proxy/anthropic',
 })
 
 const trace = spanlens.startTrace({ name: 'agent_run' })

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/evals.ts
+++ b/packages/sdk/src/evals.ts
@@ -20,7 +20,7 @@
 
 import { SpanlensApiError } from './transport.js'
 
-const DEFAULT_BASE_URL = 'https://spanlens-server.vercel.app'
+const DEFAULT_BASE_URL = 'https://api.spanlens.io'
 const DEFAULT_POLL_INTERVAL_MS = 2000
 const DEFAULT_TIMEOUT_MS = 300_000
 

--- a/packages/sdk/src/integrations/anthropic.ts
+++ b/packages/sdk/src/integrations/anthropic.ts
@@ -23,7 +23,7 @@ export const CACHE_DEFAULT_TTL_SECONDS = 3600
 export const CACHE_MAX_TTL_SECONDS = 86400
 
 export const DEFAULT_SPANLENS_ANTHROPIC_PROXY =
-  'https://spanlens-server.vercel.app/proxy/anthropic'
+  'https://api.spanlens.io/proxy/anthropic'
 
 export function createAnthropic(options: ClientOptions = {}): Anthropic {
   const apiKey = options.apiKey ?? readEnv('SPANLENS_API_KEY')

--- a/packages/sdk/src/integrations/cohere.ts
+++ b/packages/sdk/src/integrations/cohere.ts
@@ -35,7 +35,7 @@ import { makeSpanlensProxyClient } from './_proxy-client.js'
 
 /** Default Spanlens Cohere proxy URL. Override for self-hosted deployments. */
 export const DEFAULT_SPANLENS_COHERE_PROXY =
-  'https://spanlens-server.vercel.app/proxy/cohere/v1'
+  'https://api.spanlens.io/proxy/cohere/v1'
 
 /** Build an OpenAI-compatible client whose requests flow through the Spanlens Cohere proxy. */
 export function createCohere(options: ClientOptions = {}): OpenAI {

--- a/packages/sdk/src/integrations/deepseek.ts
+++ b/packages/sdk/src/integrations/deepseek.ts
@@ -34,7 +34,7 @@ import { makeSpanlensProxyClient } from './_proxy-client.js'
 
 /** Default Spanlens DeepSeek proxy URL. Override for self-hosted deployments. */
 export const DEFAULT_SPANLENS_DEEPSEEK_PROXY =
-  'https://spanlens-server.vercel.app/proxy/deepseek/v1'
+  'https://api.spanlens.io/proxy/deepseek/v1'
 
 /** Build an OpenAI-compatible client whose requests flow through the Spanlens DeepSeek proxy. */
 export function createDeepSeek(options: ClientOptions = {}): OpenAI {

--- a/packages/sdk/src/integrations/gemini.ts
+++ b/packages/sdk/src/integrations/gemini.ts
@@ -18,7 +18,7 @@
 import { GoogleGenerativeAI, type GenerativeModel } from '@google/generative-ai'
 
 export const DEFAULT_SPANLENS_GEMINI_PROXY =
-  'https://spanlens-server.vercel.app/proxy/gemini'
+  'https://api.spanlens.io/proxy/gemini'
 
 export interface CreateGeminiOptions {
   /** Spanlens API key. Defaults to `process.env.SPANLENS_API_KEY`. */

--- a/packages/sdk/src/integrations/groq.ts
+++ b/packages/sdk/src/integrations/groq.ts
@@ -34,7 +34,7 @@ import { makeSpanlensProxyClient } from './_proxy-client.js'
 
 /** Default Spanlens Groq proxy URL. Override for self-hosted deployments. */
 export const DEFAULT_SPANLENS_GROQ_PROXY =
-  'https://spanlens-server.vercel.app/proxy/groq/v1'
+  'https://api.spanlens.io/proxy/groq/v1'
 
 /** Build an OpenAI-compatible client whose requests flow through the Spanlens Groq proxy. */
 export function createGroq(options: ClientOptions = {}): OpenAI {

--- a/packages/sdk/src/integrations/openai.ts
+++ b/packages/sdk/src/integrations/openai.ts
@@ -4,7 +4,7 @@
  * Replaces:
  *   const openai = new OpenAI({
  *     apiKey: process.env.SPANLENS_API_KEY,
- *     baseURL: 'https://spanlens-server.vercel.app/proxy/openai/v1',
+ *     baseURL: 'https://api.spanlens.io/proxy/openai/v1',
  *   })
  *
  * With:
@@ -25,7 +25,7 @@ import type { LogBodyMode } from '../types.js'
 
 /** Default Spanlens proxy URL. Override for self-hosted deployments. */
 export const DEFAULT_SPANLENS_OPENAI_PROXY =
-  'https://spanlens-server.vercel.app/proxy/openai/v1'
+  'https://api.spanlens.io/proxy/openai/v1'
 
 export const PROMPT_VERSION_HEADER = 'x-spanlens-prompt-version'
 export const USER_HEADER = 'x-spanlens-user'

--- a/packages/sdk/src/integrations/xai.ts
+++ b/packages/sdk/src/integrations/xai.ts
@@ -34,7 +34,7 @@ import { makeSpanlensProxyClient } from './_proxy-client.js'
 
 /** Default Spanlens xAI proxy URL. Override for self-hosted deployments. */
 export const DEFAULT_SPANLENS_XAI_PROXY =
-  'https://spanlens-server.vercel.app/proxy/xai/v1'
+  'https://api.spanlens.io/proxy/xai/v1'
 
 /** Build an OpenAI-compatible client whose requests flow through the Spanlens xAI proxy. */
 export function createXai(options: ClientOptions = {}): OpenAI {

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -193,7 +193,7 @@ function safeOnError(
 }
 
 export function createTransport(config: SpanlensConfig): Transport {
-  const baseUrl = (config.baseUrl ?? 'https://spanlens-server.vercel.app').replace(/\/$/, '')
+  const baseUrl = (config.baseUrl ?? 'https://api.spanlens.io').replace(/\/$/, '')
   const timeoutMs = config.timeoutMs ?? 3000
   const silent = config.silent ?? true
   const onError = config.onError

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -30,7 +30,7 @@ export interface SpanlensConfig {
    * at construction if one is configured.
    */
   apiKey: string
-  /** API base URL — default https://spanlens-server.vercel.app. */
+  /** API base URL — default https://api.spanlens.io. */
   baseUrl?: string
   /**
    * Request timeout in ms for ingest calls. Default 3000ms.


### PR DESCRIPTION
## Summary

Follow-up to #409 (api.spanlens.io registered as the server alias). Unifies all customer-facing addresses on the official domain.

**apps/web (32 files)**
- Replaced `server.spanlens.io` with `api.spanlens.io` across all docs pages, dashboard components (projects page, empty-requests hint, welcome banner), and changelog entries.
- `server.spanlens.io` keeps working, so this is consistency only, no behavior change.

**packages/sdk (v0.15.1 → v0.16.0)**
- Default base URLs moved from `https://spanlens-server.vercel.app` to `https://api.spanlens.io`: transport `baseUrl`, `runEvals`, and all 7 provider proxy integrations (openai, anthropic, gemini, groq, deepseek, xai, cohere).
- README examples updated, CHANGELOG entry added. Old CHANGELOG history left untouched.
- Not breaking: both hosts serve the same deployment, previously released SDK versions keep working, explicit `baseUrl`/`baseURL` overrides unaffected.

**Out of scope** (old address still referenced, intentionally)
- `supabase/migrations/20260601000000_*.sql` (migration files immutable)
- `packages/mcp-server` (separate package, needs its own version bump/publish)
- Root README, `apps/server/.env.example`, `apps/server/src/lib/internal-tracing.ts`, docs/plans, docs/CODEMAPS

## Test plan
- [x] `pnpm --filter web typecheck` / `lint`
- [x] `pnpm --filter @spanlens/sdk build` / `typecheck` / `test` (180/180 passed)
- [ ] After merge: tag `sdk-v0.16.0` publish flow (npm)