### PR TITLE
feat: finish api.spanlens.io migration (mcp-server v0.2.0 + remaining docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Spanlens is multi-user out of the box. Invite teammates, hand out roles, and spi
 Spanlens/
 ├── apps/
 │   ├── web/             — Next.js 16 dashboard (www.spanlens.io)
-│   └── server/          — Hono LLM proxy + REST API (server.spanlens.io)
+│   └── server/          — Hono LLM proxy + REST API (api.spanlens.io)
 ├── packages/
 │   ├── sdk/             — @spanlens/sdk:  TypeScript / JavaScript SDK
 │   ├── sdk-python/      — spanlens (PyPI): Python SDK

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -64,7 +64,7 @@ CLICKHOUSE_DB=spanlens
 # /traces alongside customer data. Leave blank locally and in CI — the
 # tracing helper degrades to no-op so nothing leaks to production.
 #
-# SPANLENS_INTERNAL_BASE_URL=https://server.spanlens.io
+# SPANLENS_INTERNAL_BASE_URL=https://api.spanlens.io
 # SPANLENS_INTERNAL_API_KEY=sl_live_<hex>
 SPANLENS_INTERNAL_BASE_URL=
 SPANLENS_INTERNAL_API_KEY=

--- a/apps/server/src/lib/internal-tracing.ts
+++ b/apps/server/src/lib/internal-tracing.ts
@@ -32,7 +32,7 @@
  *
  * Env vars (read once at module load):
  *
- *   SPANLENS_INTERNAL_BASE_URL  https://server.spanlens.io  (or local)
+ *   SPANLENS_INTERNAL_BASE_URL  https://api.spanlens.io  (or local)
  *   SPANLENS_INTERNAL_API_KEY   sl_live_<hex>               (full-scope key
  *                                                            of the
  *                                                            spanlens-team

--- a/docs/CODEMAPS/dependencies.md
+++ b/docs/CODEMAPS/dependencies.md
@@ -69,7 +69,7 @@ tailwindcss 4 + @tailwindcss/typography
 apps/web → @spanlens/api-types, server (devDep, for E2E)
 apps/server → @spanlens/api-types
 packages/cli → @spanlens/sdk
-packages/mcp-server → (none — talks to server.spanlens.io REST API)
+packages/mcp-server → (none — talks to api.spanlens.io REST API)
 ```
 
 ## Build / CI

--- a/docs/plans/vercel-marketplace.md
+++ b/docs/plans/vercel-marketplace.md
@@ -116,7 +116,7 @@ Fields verified from
 | Overview | 768 chars, markdown | (draft below) |
 | Additional info | 1024 chars | Self-host with Docker, SaaS at spanlens.io. SDKs for JS / Python. OpenTelemetry + MCP supported. |
 | Website / Docs / EULA / Privacy / Support URLs | — | spanlens.io, /docs, /eula, /privacy, mailto:hi@spanlens.io |
-| Redirect URL | OAuth callback | `https://server.spanlens.io/oauth/callback/vercel` |
+| Redirect URL | OAuth callback | `https://api.spanlens.io/oauth/callback/vercel` |
 | Logo / Feature media | — | (Phase 1.C) |
 
 Overview draft (under 768 chars):

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -103,7 +103,7 @@ This server is designed for the IDE-config use case, where the credential sits i
 | Environment variable | Default | Notes |
 |---|---|---|
 | `SPANLENS_API_KEY` | _required_ | A `sl_live_pub_*` key from the **Public Keys** card on `/projects`. The server refuses to start without one, and refuses to start with a `sl_live_*` (full) key. |
-| `SPANLENS_BASE_URL` | `https://server.spanlens.io` | Override for self-hosted Spanlens. Trailing slashes are normalised. |
+| `SPANLENS_BASE_URL` | `https://api.spanlens.io` | Override for self-hosted Spanlens. Trailing slashes are normalised. |
 
 ## Self-hosted Spanlens
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/mcp-server",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "mcpName": "io.github.spanlens/mcp-server",
   "description": "MCP server for Spanlens — query LLM cost, anomalies, traces, and per-user analytics from inside Cursor, Continue, or Claude Desktop.",
   "type": "module",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -7,12 +7,12 @@
     "source": "github",
     "subfolder": "packages/mcp-server"
   },
-  "version": "0.1.4",
+  "version": "0.2.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@spanlens/mcp-server",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "transport": {
         "type": "stdio"
       },
@@ -26,10 +26,10 @@
         },
         {
           "name": "SPANLENS_BASE_URL",
-          "description": "Override the API endpoint for self-hosted Spanlens. Default: https://server.spanlens.io",
+          "description": "Override the API endpoint for self-hosted Spanlens. Default: https://api.spanlens.io",
           "isRequired": false,
           "format": "string",
-          "default": "https://server.spanlens.io"
+          "default": "https://api.spanlens.io"
         }
       ]
     }

--- a/packages/mcp-server/src/__tests__/client.test.ts
+++ b/packages/mcp-server/src/__tests__/client.test.ts
@@ -38,7 +38,7 @@ describe('SpanlensClient', () => {
     // Verify Authorization header + URL composition.
     const url = fetchMock.mock.calls[0]?.[0] as string
     const init = fetchMock.mock.calls[0]?.[1] as RequestInit
-    expect(url).toBe('https://server.spanlens.io/api/v1/stats/overview')
+    expect(url).toBe('https://api.spanlens.io/api/v1/stats/overview')
     expect(
       (init.headers as Record<string, string>)['Authorization'],
     ).toBe('Bearer sl_live_pub_test1234567890ab')

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -13,7 +13,7 @@
  * proxy spend on the user's behalf.
  */
 
-const DEFAULT_BASE_URL = 'https://server.spanlens.io'
+const DEFAULT_BASE_URL = 'https://api.spanlens.io'
 
 export interface SpanlensClientOptions {
   apiKey: string

--- a/packages/mcp-server/src/version.ts
+++ b/packages/mcp-server/src/version.ts
@@ -1,4 +1,4 @@
 // Kept in a separate module so package.json doesn't have to be read at runtime
 // (avoids resolveJsonModule pulling the whole manifest into the bundle).
 // Bumped manually with each release; package.json stays canonical for npm.
-export const SERVER_VERSION = '0.1.4'
+export const SERVER_VERSION = '0.2.0'


### PR DESCRIPTION
## Summary

Completes the address unification started in #410.

**packages/mcp-server (v0.1.4 → v0.2.0)**
- `DEFAULT_BASE_URL` in `src/client.ts`, `server.json` metadata (env var description + default), README, and tests now use `https://api.spanlens.io`.
- Version bumped in all three places (package.json, server.json x2, src/version.ts).
- Not breaking: both hosts serve the same deployment; `SPANLENS_BASE_URL` overrides unaffected.

**Remaining docs/comments (5 files)**
- Root README, `apps/server/.env.example`, `internal-tracing.ts` doc comment, `docs/plans/vercel-marketplace.md`, `docs/CODEMAPS/dependencies.md`.

**Still intentionally untouched**
- `supabase/migrations/20260601000000_*.sql` (migrations immutable)
- SDK CHANGELOG history entries

## Test plan
- [x] `pnpm --filter @spanlens/mcp-server build` / `typecheck` / `test`
- [x] `pnpm --filter server typecheck` / `lint`
- [ ] After merge: tag `mcp-server-v0.2.0` (npm publish workflow)
- [ ] MCP Registry re-publish is manual (`mcp-publisher login github && mcp-publisher publish`) — needs OAuth, run locally