### PR TITLE
fix(server): reset ClickHouse idle timer with real SELECT 1 in health probes and keep-warm

### DIFF
--- a/apps/server/src/__tests__/clickhouse-warm.test.ts
+++ b/apps/server/src/__tests__/clickhouse-warm.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+/**
+ * warmClickhouse / warmClickhouseWithRetry tests.
+ *
+ * Why these exist: the status-page "Spanlens Proxy (Deep)" monitor sat at
+ * 98.2% uptime because /health/deep probed ClickHouse with HTTP /ping,
+ * which wakes a suspended ClickHouse Cloud service but does NOT count as
+ * query activity — so the Development tier kept idle-suspending between
+ * probes. The fix routes health probes and /cron/keep-warm through a real
+ * `SELECT 1`. These tests pin the two behaviors the fix depends on:
+ *
+ *   - warmClickhouse issues an actual query (not ping) and maps
+ *     success/failure to boolean without throwing.
+ *   - warmClickhouseWithRetry retries exactly once, so a transient blip
+ *     (or an in-flight cold wake) doesn't 503 the monitor while a real
+ *     outage still resolves to false.
+ */
+
+const queryMock = vi.fn()
+
+vi.mock('@clickhouse/client', () => ({
+  createClient: () => ({ query: queryMock }),
+}))
+
+let warmClickhouse: typeof import('../lib/clickhouse.js').warmClickhouse
+let warmClickhouseWithRetry: typeof import('../lib/clickhouse.js').warmClickhouseWithRetry
+
+const ENV_KEYS = ['CLICKHOUSE_URL', 'CLICKHOUSE_USER', 'CLICKHOUSE_PASSWORD'] as const
+const origEnv = new Map(ENV_KEYS.map((k) => [k, process.env[k]]))
+
+beforeEach(async () => {
+  vi.resetModules()
+  queryMock.mockReset()
+  process.env['CLICKHOUSE_URL'] = 'http://localhost:8123'
+  process.env['CLICKHOUSE_USER'] = 'default'
+  process.env['CLICKHOUSE_PASSWORD'] = 'test'
+  const mod = await import('../lib/clickhouse.js')
+  mod.resetClickhouseClient()
+  ;({ warmClickhouse, warmClickhouseWithRetry } = mod)
+})
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const orig = origEnv.get(key)
+    if (orig === undefined) delete process.env[key]
+    else process.env[key] = orig
+  }
+})
+
+function queryOk() {
+  return Promise.resolve({ json: () => Promise.resolve([{ 1: 1 }]) })
+}
+
+describe('warmClickhouse', () => {
+  test('returns true when SELECT 1 succeeds', async () => {
+    queryMock.mockImplementation(queryOk)
+
+    await expect(warmClickhouse()).resolves.toBe(true)
+
+    expect(queryMock).toHaveBeenCalledTimes(1)
+    const arg = queryMock.mock.calls[0]?.[0] as { query: string; abort_signal: AbortSignal }
+    expect(arg.query).toBe('SELECT 1')
+    expect(arg.abort_signal).toBeInstanceOf(AbortSignal)
+  })
+
+  test('returns false (never throws) when the query rejects', async () => {
+    queryMock.mockRejectedValue(new Error('Timeout error.'))
+
+    await expect(warmClickhouse()).resolves.toBe(false)
+  })
+})
+
+describe('warmClickhouseWithRetry', () => {
+  test('first attempt succeeds → no retry', async () => {
+    queryMock.mockImplementation(queryOk)
+
+    await expect(warmClickhouseWithRetry()).resolves.toBe(true)
+    expect(queryMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('first attempt fails, retry succeeds → true (transient blip absorbed)', async () => {
+    queryMock.mockRejectedValueOnce(new Error('socket hang up')).mockImplementation(queryOk)
+
+    await expect(warmClickhouseWithRetry()).resolves.toBe(true)
+    expect(queryMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('both attempts fail → false (real outage still surfaces)', async () => {
+    queryMock.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    await expect(warmClickhouseWithRetry()).resolves.toBe(false)
+    expect(queryMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/server/src/__tests__/health.test.ts
+++ b/apps/server/src/__tests__/health.test.ts
@@ -44,6 +44,11 @@ vi.mock('../lib/db.js', () => ({
 
 vi.mock('../lib/clickhouse.js', () => ({
   pingClickhouse: () => pingClickhouseMock(),
+  // health.ts moved to the SELECT-1-based probe (keeps ClickHouse Cloud's
+  // idle timer reset). Retry semantics are covered by clickhouse-warm.test.ts;
+  // here it drives the same mock so every existing scenario still applies.
+  warmClickhouse: () => pingClickhouseMock(),
+  warmClickhouseWithRetry: () => pingClickhouseMock(),
   getClickhouse: () => ({}),
   unscopedClickhouse: () => ({}),
   getOrgClickhouse: () => ({}),

--- a/apps/server/src/api/health.ts
+++ b/apps/server/src/api/health.ts
@@ -68,7 +68,7 @@ healthRouter.get('/health', (c) =>
 
 healthRouter.get('/health/ready', async (c) => {
   const { supabaseAdmin } = await import('../lib/db.js')
-  const { pingClickhouse } = await import('../lib/clickhouse.js')
+  const { warmClickhouseWithRetry } = await import('../lib/clickhouse.js')
   // Lazy import keeps the cold-start cheap when the Redis singleton hasn't
   // been touched yet. getRedis() falls through to null when env is missing,
   // which is the local-dev / preview-without-KV path — reported as
@@ -81,15 +81,18 @@ healthRouter.get('/health/ready', async (c) => {
     // Cheapest indexed read against an existing table — same pattern as
     // /cron/keep-warm step 1.
     supabaseAdmin.from('organizations').select('id', { count: 'exact', head: true }).limit(1),
-    pingClickhouse(),
+    // Real SELECT 1 with 5s fast-fail + one retry (not HTTP /ping): resets
+    // ClickHouse Cloud's idle timer on every probe and stops a transient
+    // blip from 503ing the monitor. See warmClickhouse docs.
+    warmClickhouseWithRetry(),
     redis ? redis.ping?.() ?? Promise.resolve('OK') : Promise.resolve('skipped'),
   ])
   const totalMs = Date.now() - start
 
   const pgOk = pgResult.status === 'fulfilled' && !pgResult.value.error
-  // pingClickhouse swallows errors and resolves to false — same pitfall as
-  // gotcha #14, fixed in R-Q6 keep-warm. Check the resolved value, not the
-  // settled status.
+  // warmClickhouseWithRetry swallows errors and resolves to false — same
+  // pitfall as gotcha #14, fixed in R-Q6 keep-warm. Check the resolved
+  // value, not the settled status.
   const chOk = chResult.status === 'fulfilled' && chResult.value === true
 
   let redisStatus: 'ok' | 'skipped' | 'fail'
@@ -122,7 +125,7 @@ healthRouter.get('/health/ready', async (c) => {
 
 healthRouter.get('/health/deep', async (c) => {
   const { supabaseAdmin } = await import('../lib/db.js')
-  const { pingClickhouse } = await import('../lib/clickhouse.js')
+  const { warmClickhouseWithRetry } = await import('../lib/clickhouse.js')
   const { fallbackQueueSize, eventsFallbackQueueSize } = await import(
     '../lib/fallback-replay.js'
   )
@@ -133,7 +136,10 @@ healthRouter.get('/health/deep', async (c) => {
   // the slowest dependency, not the sum.
   const [chOk, fallbackQueue, eventsFallback, cronMaxRuntime, webhookBacklog, webhookDlq] =
     await Promise.all([
-      pingClickhouse().catch(() => false),
+      // Real SELECT 1 + retry: Better Stack hits this every 3 minutes, so
+      // the probe itself keeps the ClickHouse Development tier from idle-
+      // suspending — the very thing that was flapping this monitor.
+      warmClickhouseWithRetry().catch(() => false),
       fallbackQueueSize().catch(() => null),
       eventsFallbackQueueSize().catch(() => null),
       // crons.max_runtime_ms: MAX(duration_ms) over last 24h. R-11 trigger

--- a/apps/server/src/lib/clickhouse.ts
+++ b/apps/server/src/lib/clickhouse.ts
@@ -121,6 +121,44 @@ export async function pingClickhouse(): Promise<boolean> {
 }
 
 /**
+ * Warm probe — runs a real `SELECT 1` so ClickHouse Cloud's idle timer
+ * resets. The HTTP /ping behind pingClickhouse() wakes a suspended
+ * service but does NOT count as query activity, so a ping-only probe
+ * lets the Development tier auto-suspend between checks. Observed as
+ * the /health/deep 503 → self-heal → 503 cycle on the status page
+ * (98.2% uptime, 2026-07-13) while liveness sat at 99.98%.
+ *
+ * Aborts after timeoutMs: a cold instance can take minutes to wake and
+ * the caller shouldn't hang for that. The aborted request still
+ * triggers the wake server-side, so a follow-up probe succeeds.
+ */
+export async function warmClickhouse(timeoutMs = 5_000): Promise<boolean> {
+  try {
+    const result = await unscopedClickhouse().query({
+      query: 'SELECT 1',
+      format: 'JSONEachRow',
+      abort_signal: AbortSignal.timeout(timeoutMs),
+    })
+    await result.json()
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * warmClickhouse with one retry — health probes use this so a single
+ * transient blip (or an in-flight cold wake) doesn't 503 the monitor.
+ * A real outage fails both attempts and still surfaces as 503. Worst
+ * case adds 2 × timeoutMs to the probe, which is fine for the 3-minute
+ * Better Stack cadence and the 30s docker healthcheck loop alike.
+ */
+export async function warmClickhouseWithRetry(timeoutMs = 5_000): Promise<boolean> {
+  if (await warmClickhouse(timeoutMs)) return true
+  return warmClickhouse(timeoutMs)
+}
+
+/**
  * Returns the raw ClickHouse client scoped to a specific organization.
  *
  * This is a thin helper that pairs `unscopedClickhouse()` with the caller's

--- a/apps/server/src/lib/cron-jobs/keep-warm.ts
+++ b/apps/server/src/lib/cron-jobs/keep-warm.ts
@@ -9,7 +9,7 @@
  * No logCronRun call: every-5-min cadence would flood cron_job_runs.
  */
 
-import { pingClickhouse } from '../clickhouse.js'
+import { warmClickhouse } from '../clickhouse.js'
 import { supabaseAdmin } from '../db.js'
 
 export interface KeepWarmResult {
@@ -23,11 +23,15 @@ export async function runKeepWarmJob(): Promise<KeepWarmResult> {
   const started = Date.now()
   const results = await Promise.allSettled([
     supabaseAdmin.from('organizations').select('id', { count: 'exact', head: true }).limit(1),
-    pingClickhouse(),
+    // Real `SELECT 1`, not HTTP /ping: ClickHouse Cloud only resets its
+    // idle-suspend timer on query activity, so a ping-only warmup let the
+    // Development tier suspend anyway. Generous timeout rides out a cold
+    // wake (minutes) — this runs as a cron, nobody is waiting on it.
+    warmClickhouse(30_000),
   ])
 
   const supabaseOk = results[0].status === 'fulfilled'
-  // pingClickhouse swallows its own errors and resolves to false — read
+  // warmClickhouse swallows its own errors and resolves to false — read
   // the value, not the settled status.
   const clickhouseOk =
     results[1].status === 'fulfilled' && results[1].value === true


### PR DESCRIPTION
## Problem

Status page **Spanlens Proxy (Deep)** monitor shows 98.2% uptime (Liveness: 99.98%). Root cause chain:

1. ClickHouse Cloud Development tier auto-suspends on **query** inactivity.
2. `pingClickhouse()` uses HTTP `/ping` — wakes a suspended service but does **not** count as query activity, so it never resets the idle timer.
3. `/cron/keep-warm` (ping-based) also barely fires: GH Actions throttles the `*/5` schedule (observed **2h24m gap**), Vercel cron sync is unreliable (CLAUDE.md gotcha #32), and no Better Stack monitor covers it.
4. Result: suspend → Better Stack `/health/deep` probe hangs 30s → 503 incident → cold wake → 200 → suspend again. Hundreds of short incidents.
5. Same root cause behind recurring `Timeout error.` failures in `detect-missing-model-prices` (4/16 runs), `aggregate-usage`, `detect-data-silence` crons.

## Fix

- **lib/clickhouse.ts**: add `warmClickhouse` (real `SELECT 1`, abortable via `AbortSignal.timeout`) + `warmClickhouseWithRetry` (one retry — transient blip or in-flight cold wake doesn't 503 the monitor; real outages fail both attempts and still 503).
- **lib/cron-jobs/keep-warm.ts**: `warmClickhouse(30_000)` instead of ping — a keep-warm run now actually resets the idle timer.
- **api/health.ts**: `/health/ready` + `/health/deep` probe via `warmClickhouseWithRetry()` (5s fast-fail instead of 30s hang). Side effect: the existing 3-minute Better Stack deep monitor now doubles as the warmer, independent of the flaky cron schedulers.

## Test plan

- [x] `clickhouse-warm.test.ts` (new): SELECT 1 issued with abort signal, false-not-throw on failure, retry-once semantics (blip absorbed / outage surfaces)
- [x] `health.test.ts`: mock updated to the new probe, all existing ready/deep scenarios green
- [x] `pnpm --filter server typecheck && lint && test` — 1506 tests pass
- [ ] Post-deploy: watch status page Deep monitor over 24h — expect incidents to stop; `cron_job_runs` Timeout errors to disappear