### PR TITLE
fix(server): close viewer/API-key gaps on dual-auth write routes

### DIFF
--- a/apps/server/src/__tests__/require-edit-dual-auth.test.ts
+++ b/apps/server/src/__tests__/require-edit-dual-auth.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import { authJwtOrApiKey, type DualAuthContext } from '../middleware/authJwtOrApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
+import { requireEditDualAuth } from '../middleware/requireEditDualAuth.js'
+import { _clearAuthCacheForTests } from '../middleware/authJwt.js'
+import { installOnError } from './helpers/install-on-error.js'
+
+/**
+ * Pins the auth matrix for dual-auth WRITE routes that use the shared
+ * requireEditDualAuth gate (evals evaluator CRUD/run trigger, anomalies ack):
+ *
+ *   authJwtOrApiKey + requireFullScope + requireEditDualAuth:
+ *     full sl_live_ key       → allowed (null role passes the gate)
+ *     public sl_live_pub_ key → 403 PUBLIC_KEY_WRITE_FORBIDDEN
+ *     admin / editor JWT      → allowed
+ *     viewer JWT              → 403 FORBIDDEN
+ *
+ * Regression guard for two bugs found 2026-07-13: DELETE /evaluators/:id was
+ * missing the edit gate (viewer could archive), and anomalies /ack used plain
+ * requireRole (full API keys could not ack).
+ */
+
+const FULL_KEY = 'sl_live_fullkey0123456789abcdef'
+const PUBLIC_KEY = 'sl_live_pub_publickey0123456789'
+const JWT_TOKEN = 'fake-jwt-token-12345'
+
+const FULL_HASH = 'full-hash'
+const PUBLIC_HASH = 'public-hash'
+
+// Role returned for the JWT path — mutated per test.
+let jwtRole = 'admin'
+
+vi.mock('../lib/crypto.js', () => ({
+  sha256Hex: async (raw: string) => {
+    if (raw === FULL_KEY) return FULL_HASH
+    if (raw === PUBLIC_KEY) return PUBLIC_HASH
+    return 'invalid'
+  },
+}))
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: (table: string) => ({
+      select: (_cols: string) => ({
+        eq: (col: string, val: string) => ({
+          eq: (_col2: string, _val2: unknown) => ({
+            single: async () => {
+              if (table === 'api_keys' && col === 'key_hash') {
+                if (val === FULL_HASH) {
+                  return {
+                    data: {
+                      id: 'api-key-full',
+                      project_id: 'proj-1',
+                      organization_id: null,
+                      scope: 'full',
+                      projects: { organization_id: 'org-full', organizations: { plan: 'pro' } },
+                      organizations: null,
+                    },
+                    error: null,
+                  }
+                }
+                if (val === PUBLIC_HASH) {
+                  return {
+                    data: {
+                      id: 'api-key-public',
+                      project_id: null,
+                      organization_id: 'org-public',
+                      scope: 'public',
+                      projects: null,
+                      organizations: { plan: 'pro' },
+                    },
+                    error: null,
+                  }
+                }
+              }
+              return { data: null, error: { message: 'not found' } }
+            },
+            maybeSingle: async () => ({ data: null }),
+          }),
+          order: () => ({
+            limit: () => ({
+              maybeSingle: async () => ({
+                data: { organization_id: 'org-from-jwt', role: jwtRole },
+              }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  },
+  supabaseClient: {
+    auth: {
+      getUser: async (token: string) =>
+        token === JWT_TOKEN
+          ? { data: { user: { id: 'user-1', email: 'jwt@example.com' } }, error: null }
+          : { data: { user: null }, error: { message: 'invalid token' } },
+    },
+  },
+}))
+
+function buildApp() {
+  const app = new Hono<DualAuthContext>()
+  app.use('*', authJwtOrApiKey)
+  // Mirrors the write-route composition in evals.ts and anomalies.ts.
+  app.post('/write', requireFullScope, requireEditDualAuth, (c) =>
+    c.json({ ok: true, orgId: c.get('orgId'), role: c.get('role') ?? null }),
+  )
+  installOnError(app)
+  return app
+}
+
+describe('requireEditDualAuth write gate', () => {
+  beforeEach(() => {
+    _clearAuthCacheForTests()
+    jwtRole = 'admin'
+  })
+
+  test('full sl_live_ key passes (null role is the CI/SDK path)', async () => {
+    const res = await buildApp().request('/write', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${FULL_KEY}` },
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { orgId: string; role: string | null }
+    expect(body.orgId).toBe('org-full')
+    expect(body.role).toBeNull()
+  })
+
+  test('public sl_live_pub_ key is rejected by requireFullScope', async () => {
+    const res = await buildApp().request('/write', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${PUBLIC_KEY}` },
+    })
+    expect(res.status).toBe(403)
+    const body = (await res.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('PUBLIC_KEY_WRITE_FORBIDDEN')
+  })
+
+  test('admin JWT passes', async () => {
+    jwtRole = 'admin'
+    const res = await buildApp().request('/write', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${JWT_TOKEN}` },
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { role: string | null }
+    expect(body.role).toBe('admin')
+  })
+
+  test('editor JWT passes', async () => {
+    jwtRole = 'editor'
+    const res = await buildApp().request('/write', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${JWT_TOKEN}` },
+    })
+    expect(res.status).toBe(200)
+  })
+
+  test('viewer JWT is rejected with FORBIDDEN', async () => {
+    jwtRole = 'viewer'
+    const res = await buildApp().request('/write', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${JWT_TOKEN}` },
+    })
+    expect(res.status).toBe(403)
+    const body = (await res.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('FORBIDDEN')
+  })
+})
+
+// Source-level guard: the 2026-07-13 bug was a ROUTE missing the gate, which
+// the middleware-composition tests above cannot catch. Pin that every dual-auth
+// write route in evals.ts and anomalies.ts mounts both guards.
+describe('dual-auth write routes mount requireFullScope + requireEdit', () => {
+  const routes: Array<{ file: string; pattern: RegExp; label: string }> = [
+    {
+      file: 'evals.ts',
+      label: 'POST /evaluators',
+      pattern: /post\('\/evaluators', requireFullScope, requireEdit,/,
+    },
+    {
+      file: 'evals.ts',
+      label: 'DELETE /evaluators/:id',
+      pattern: /delete\('\/evaluators\/:id', requireFullScope, requireEdit,/,
+    },
+    {
+      file: 'evals.ts',
+      label: 'POST /eval-runs',
+      pattern: /post\('\/eval-runs', requireFullScope, requireEdit,/,
+    },
+    {
+      file: 'anomalies.ts',
+      label: 'POST /ack',
+      pattern: /post\('\/ack', requireFullScope, requireEdit,/,
+    },
+    {
+      file: 'anomalies.ts',
+      label: 'DELETE /ack',
+      pattern: /delete\('\/ack', requireFullScope, requireEdit,/,
+    },
+  ]
+
+  for (const { file, pattern, label } of routes) {
+    test(`${file} ${label}`, async () => {
+      const { readFile } = await import('node:fs/promises')
+      const { fileURLToPath } = await import('node:url')
+      const path = fileURLToPath(new URL(`../api/${file}`, import.meta.url))
+      const source = await readFile(path, 'utf8')
+      expect(source).toMatch(pattern)
+    })
+  }
+})

--- a/apps/server/src/api/anomalies.ts
+++ b/apps/server/src/api/anomalies.ts
@@ -1,14 +1,18 @@
 import { Hono, type Context } from 'hono'
-import type { JwtContext } from '../middleware/authJwt.js'
-import { authJwtOrApiKey } from '../middleware/authJwtOrApiKey.js'
-import { requireRole } from '../middleware/requireRole.js'
+import { authJwtOrApiKey, type DualAuthContext } from '../middleware/authJwtOrApiKey.js'
+import { requireFullScope } from '../middleware/requireFullScope.js'
+import { requireEditDualAuth } from '../middleware/requireEditDualAuth.js'
 import { detectAnomalies, fetchContributingFactors } from '../lib/anomaly.js'
 import { getAnomalyHistory } from '../lib/anomaly-snapshot.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { parsePositiveFloat, parseClampedFloat } from '../lib/params.js'
 import { ApiError } from '../lib/errors.js'
 
-const requireEdit = requireRole('admin', 'editor')
+// Dual-auth write gate for ack/un-ack: plain requireRole('admin','editor')
+// would reject the null-role API-key path, which the handlers deliberately
+// support (`acknowledged_by: userId ?? null`). requireFullScope keeps public
+// (sl_live_pub_*) keys read-only.
+const requireEdit = requireEditDualAuth
 
 /**
  * Anomaly endpoints.
@@ -19,7 +23,7 @@ const requireEdit = requireRole('admin', 'editor')
  *   DELETE /api/v1/anomalies/ack          un-acknowledge
  */
 
-export const anomaliesRouter = new Hono<JwtContext>()
+export const anomaliesRouter = new Hono<DualAuthContext>()
 
 anomaliesRouter.use('*', authJwtOrApiKey)
 
@@ -133,7 +137,7 @@ anomaliesRouter.get('/history', async (c) => {
 })
 
 async function parseAckBody(
-  c: Context<JwtContext>,
+  c: Context<DualAuthContext>,
 ): Promise<{ error: string } | { provider: string; model: string; kind: string; projectId?: string }> {
   let body: { provider?: unknown; model?: unknown; kind?: unknown; projectId?: unknown }
   try {
@@ -162,7 +166,7 @@ async function parseAckBody(
 }
 
 // POST /api/v1/anomalies/ack — acknowledge (upsert)
-anomaliesRouter.post('/ack', requireEdit, async (c) => {
+anomaliesRouter.post('/ack', requireFullScope, requireEdit, async (c) => {
   const orgId = c.get('orgId')
   const userId = c.get('userId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
@@ -198,7 +202,7 @@ anomaliesRouter.post('/ack', requireEdit, async (c) => {
 })
 
 // DELETE /api/v1/anomalies/ack?provider=X&model=Y&kind=Z[&projectId=P] — un-acknowledge
-anomaliesRouter.delete('/ack', requireEdit, async (c) => {
+anomaliesRouter.delete('/ack', requireFullScope, requireEdit, async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 

--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
-import { createMiddleware } from 'hono/factory'
 import { authJwtOrApiKey, type DualAuthContext } from '../middleware/authJwtOrApiKey.js'
 import { requireFullScope } from '../middleware/requireFullScope.js'
+import { requireEditDualAuth } from '../middleware/requireEditDualAuth.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { runEvalRun, estimateJudgeCostUsd } from '../lib/eval-runner.js'
 import { EMBEDDING_PROVIDERS } from '../lib/eval-runners/embedding.js'
@@ -25,15 +25,9 @@ evalsRouter.use('*', authJwtOrApiKey)
 //     sl_live_* key" flow (see header comment), so allow it through.
 //   - JWT (dashboard) path: require admin/editor so a viewer-role member can't
 //     create evaluators or trigger billable eval runs.
-// Plain requireRole('admin','editor') would reject the null-role API-key path
-// and break CI, so this variant only enforces the role check when a role is set.
-const requireEdit = createMiddleware<DualAuthContext>(async (c, next) => {
-  const role = c.get('role')
-  if (role != null && role !== 'admin' && role !== 'editor') {
-    throw ApiError.from('FORBIDDEN', { required: ['admin', 'editor'], actual: role })
-  }
-  return next()
-})
+// Extracted to middleware/requireEditDualAuth.ts so anomalies.ts (and future
+// dual-auth writers) share the exact same gate.
+const requireEdit = requireEditDualAuth
 
 // ── Evaluators (定義) ────────────────────────────────────────────────────────
 
@@ -386,7 +380,7 @@ evalsRouter.get('/evaluator-templates', async (c) => {
 })
 
 // DELETE /api/v1/evaluators/:id — soft delete (archive)
-evalsRouter.delete('/evaluators/:id', requireFullScope, async (c) => {
+evalsRouter.delete('/evaluators/:id', requireFullScope, requireEdit, async (c) => {
   const orgId = c.get('orgId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 

--- a/apps/server/src/middleware/requireEditDualAuth.ts
+++ b/apps/server/src/middleware/requireEditDualAuth.ts
@@ -1,0 +1,24 @@
+import { createMiddleware } from 'hono/factory'
+import type { DualAuthContext } from './authJwtOrApiKey.js'
+import { ApiError } from '../lib/errors.js'
+
+/**
+ * Write gate for DUAL-AUTH routers (authJwtOrApiKey), where plain
+ * `requireRole('admin','editor')` must not be used: the API-key path has a
+ * null role and would be rejected, breaking CI/SDK callers (`sl_live_*`).
+ *
+ *   - JWT (dashboard) path: role is set → require admin/editor so a
+ *     viewer-role member cannot write.
+ *   - API-key path: role is null → pass through. Mount `requireFullScope`
+ *     BEFORE this middleware so a public (sl_live_pub_*) key stays read-only.
+ *
+ * Usage (order matters):
+ *   router.post('/thing', requireFullScope, requireEditDualAuth, handler)
+ */
+export const requireEditDualAuth = createMiddleware<DualAuthContext>(async (c, next) => {
+  const role = c.get('role')
+  if (role != null && role !== 'admin' && role !== 'editor') {
+    throw ApiError.from('FORBIDDEN', { required: ['admin', 'editor'], actual: role })
+  }
+  return next()
+})


### PR DESCRIPTION
## Summary
Security/consistency fixes found in a full-codebase review (2026-07-13).

1. **DELETE /api/v1/evaluators/:id missing edit gate (HIGH)** — the route mounted only `requireFullScope`, which is a no-op on the JWT path, so a **viewer-role member could archive any evaluator**. POST /evaluators and POST /eval-runs in the same file already had the gate; only DELETE was missing it.
2. **POST/DELETE /api/v1/anomalies/ack used plain `requireRole` on a dual-auth router** — the CLAUDE.md-banned pattern. `requireRole` rejects the null-role API-key path, so full `sl_live_*` keys could never ack an anomaly, even though the handlers deliberately support it (`acknowledged_by: userId ?? null`). Now uses the null-tolerant gate + `requireFullScope` so public keys stay read-only.
3. **Extracted the shared gate** into `middleware/requireEditDualAuth.ts` (was inlined in evals.ts) so both routers use the exact same middleware and future dual-auth writers don't re-derive it.

## Auth matrix (write routes, after this PR)
| Caller | Result |
|---|---|
| full `sl_live_*` key | allowed |
| public `sl_live_pub_*` key | 403 PUBLIC_KEY_WRITE_FORBIDDEN |
| admin / editor JWT | allowed |
| viewer JWT | 403 FORBIDDEN |

## Test plan
- [x] New `require-edit-dual-auth.test.ts`: full auth matrix through real `authJwtOrApiKey` + `requireFullScope` + `requireEditDualAuth`
- [x] Source-level route guard test pinning that all 5 dual-auth write routes (evals x3, anomalies x2) mount both middlewares — catches the route-omission class of bug directly
- [x] `pnpm --filter server typecheck && lint && test` (1516 tests green)