### PR TITLE
fix(sdk): mcp-server 0.2.1 — send params the REST API actually reads

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -87,7 +87,7 @@ The agent will discover seven tools and use them automatically when relevant.
 | `query_requests` | Individual LLM requests with cost, latency, model, error message. Filter by `model`, `provider`, `status`, `userId`, `since`, `limit`. |
 | `list_traces` | Agent trace summaries (name, status, duration, span count, total tokens, total cost) for discovering trace IDs. Filter by `limit`, `status`, `since`, `query`. Pair with `get_trace` for the full span tree. |
 | `get_trace` | Full agent span tree for a trace ID — every LLM/tool/retrieval span with timing, tokens, cost. |
-| `get_anomalies` | Cost / latency / error-rate anomalies the platform has detected. Optional `severity`. |
+| `get_anomalies` | Cost / latency / error-rate anomalies the platform has detected. Optional `since` (observation window) and `sigma` (sensitivity). |
 | `get_savings` | Model-swap recommendations with projected monthly savings and adoption status. |
 | `get_user_analytics` | Per-end-user usage breakdown — total cost, request count, models touched, recent calls. |
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/mcp-server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "mcpName": "io.github.spanlens/mcp-server",
   "description": "MCP server for Spanlens — query LLM cost, anomalies, traces, and per-user analytics from inside Cursor, Continue, or Claude Desktop.",
   "type": "module",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -7,12 +7,12 @@
     "source": "github",
     "subfolder": "packages/mcp-server"
   },
-  "version": "0.2.0",
+  "version": "0.2.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@spanlens/mcp-server",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/__tests__/tools.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { SpanlensClient } from '../client.js'
+import {
+  registerTools,
+  timeframeToHours,
+  hoursAgoIso,
+  sinceToObservationHours,
+} from '../tools.js'
+
+/**
+ * Param-contract tests: every tool is a thin shim over a REST endpoint, so
+ * the only thing that can break silently is the (path, query) pair it sends.
+ * v0.2.0 shipped exactly that class of bug — get_stats sent a `window` param
+ * no endpoint reads, so "spend this week" returned retention-wide totals.
+ * These tests pin each tool's outgoing request against the params the server
+ * actually parses (apps/server/src/api/{stats,requests,traces,anomalies,
+ * recommendations,users}.ts).
+ */
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<unknown>
+
+function captureTools(client: SpanlensClient): Map<string, ToolHandler> {
+  const handlers = new Map<string, ToolHandler>()
+  const fakeServer = {
+    tool: (name: string, _desc: string, _schema: unknown, handler: ToolHandler) => {
+      handlers.set(name, handler)
+    },
+  } as unknown as McpServer
+  registerTools(fakeServer, client)
+  return handlers
+}
+
+function fakeClient(): { client: SpanlensClient; calls: Array<{ path: string; query?: Record<string, unknown> }> } {
+  const calls: Array<{ path: string; query?: Record<string, unknown> }> = []
+  const client = {
+    get: async (path: string, query?: Record<string, unknown>) => {
+      calls.push({ path, query })
+      return { ok: true }
+    },
+  } as unknown as SpanlensClient
+  return { client, calls }
+}
+
+const NOW = new Date('2026-07-13T12:00:00.000Z').getTime()
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('get_stats param contract', () => {
+  test('overview: timeframe becomes a `from` ISO bound, never `window`', async () => {
+    const { client, calls } = fakeClient()
+    const handlers = captureTools(client)
+    await handlers.get('get_stats')!({ timeframe: '7d' })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].path).toBe('/api/v1/stats/overview')
+    expect(calls[0].query).toEqual({ from: new Date(NOW - 168 * 3_600_000).toISOString() })
+    expect(calls[0].query).not.toHaveProperty('window')
+  })
+
+  test('groupBy: models endpoint gets `hours`, never `window`', async () => {
+    const { client, calls } = fakeClient()
+    const handlers = captureTools(client)
+    await handlers.get('get_stats')!({ timeframe: '24h', groupBy: 'model' })
+
+    expect(calls[0].path).toBe('/api/v1/stats/models')
+    expect(calls[0].query).toEqual({ hours: 24 })
+  })
+
+  test('default timeframe is 7d', async () => {
+    const { client, calls } = fakeClient()
+    const handlers = captureTools(client)
+    await handlers.get('get_stats')!({})
+
+    expect(calls[0].query).toEqual({ from: new Date(NOW - 168 * 3_600_000).toISOString() })
+  })
+})
+
+describe('get_anomalies param contract', () => {
+  test('since maps to observationHours; sigma passes through', async () => {
+    const { client, calls } = fakeClient()
+    const handlers = captureTools(client)
+    const sixHoursAgo = new Date(NOW - 6 * 3_600_000).toISOString()
+    await handlers.get('get_anomalies')!({ since: sixHoursAgo, sigma: 2 })
+
+    expect(calls[0].path).toBe('/api/v1/anomalies')
+    expect(calls[0].query).toEqual({ observationHours: 6, sigma: 2 })
+    // v0.2.0 sent `severity`/`from`, which the endpoint never read.
+    expect(calls[0].query).not.toHaveProperty('severity')
+    expect(calls[0].query).not.toHaveProperty('from')
+  })
+
+  test('no args sends no params (server defaults apply)', async () => {
+    const { client, calls } = fakeClient()
+    const handlers = captureTools(client)
+    await handlers.get('get_anomalies')!({})
+
+    expect(calls[0].query).toEqual({ observationHours: undefined, sigma: undefined })
+  })
+})
+
+describe('other tools keep server-parsed param names', () => {
+  test('query_requests sends from (not since) + supported filters', async () => {
+    const { client, calls } = fakeClient()
+    const handlers = captureTools(client)
+    await handlers.get('query_requests')!({
+      limit: 5,
+      provider: 'groq',
+      status: 'error',
+      since: '2026-07-01T00:00:00Z',
+    })
+
+    expect(calls[0].path).toBe('/api/v1/requests')
+    expect(calls[0].query).toMatchObject({
+      limit: 5,
+      provider: 'groq',
+      status: 'error',
+      from: '2026-07-01T00:00:00Z',
+    })
+  })
+
+  test('list_traces sends from/q', async () => {
+    const { client, calls } = fakeClient()
+    const handlers = captureTools(client)
+    await handlers.get('list_traces')!({ since: '2026-07-01T00:00:00Z', query: 'agent' })
+
+    expect(calls[0].path).toBe('/api/v1/traces')
+    expect(calls[0].query).toMatchObject({ from: '2026-07-01T00:00:00Z', q: 'agent' })
+  })
+
+  test('get_savings sends hours/minSavings', async () => {
+    const { client, calls } = fakeClient()
+    const handlers = captureTools(client)
+    await handlers.get('get_savings')!({ hours: 24, minSavings: 10 })
+
+    expect(calls[0].path).toBe('/api/v1/recommendations')
+    expect(calls[0].query).toEqual({ hours: 24, minSavings: 10 })
+  })
+})
+
+describe('helpers', () => {
+  test('timeframeToHours maps all enum values', () => {
+    expect(timeframeToHours('1h')).toBe(1)
+    expect(timeframeToHours('24h')).toBe(24)
+    expect(timeframeToHours('7d')).toBe(168)
+    expect(timeframeToHours('30d')).toBe(720)
+    expect(timeframeToHours(undefined)).toBe(168)
+  })
+
+  test('hoursAgoIso subtracts from now', () => {
+    expect(hoursAgoIso(1)).toBe(new Date(NOW - 3_600_000).toISOString())
+  })
+
+  test('sinceToObservationHours clamps to the server range 0.25–72', () => {
+    const oneWeekAgo = new Date(NOW - 168 * 3_600_000).toISOString()
+    expect(sinceToObservationHours(oneWeekAgo)).toBe(72)
+    const oneMinuteAgo = new Date(NOW - 60_000).toISOString()
+    expect(sinceToObservationHours(oneMinuteAgo)).toBe(0.25)
+    expect(sinceToObservationHours('not-a-date')).toBeUndefined()
+  })
+})

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -26,19 +26,42 @@ const formatError = (
   return { content: [{ type: 'text', text: `Error: ${msg}` }], isError: true }
 }
 
-/** Translate the MCP-friendly enum into the REST API's window param shape. */
-function timeframeToWindow(tf?: string): string {
+/**
+ * Translate the MCP-friendly timeframe enum into hours.
+ *
+ * The REST API has no `window` param: /stats/overview takes `from`/`to`
+ * ISO dates and /stats/models takes `hours`. (v0.2.0 sent `window`, which
+ * the server silently ignored — stats came back for the wrong period.)
+ */
+export function timeframeToHours(tf?: string): number {
   switch (tf) {
     case '1h':
-      return '1h'
+      return 1
     case '24h':
-      return '24h'
+      return 24
     case '30d':
-      return '30d'
+      return 30 * 24
     case '7d':
     default:
-      return '7d'
+      return 7 * 24
   }
+}
+
+/** ISO timestamp `hours` ago — the `from` bound for /stats/overview. */
+export function hoursAgoIso(hours: number): string {
+  return new Date(Date.now() - hours * 3_600_000).toISOString()
+}
+
+/**
+ * Map an ISO `since` bound onto /api/v1/anomalies' `observationHours`
+ * param (the server compares the last N hours against a reference window;
+ * it has no `from` param). Clamped to the server's accepted 0.25–72 range.
+ */
+export function sinceToObservationHours(since: string): number | undefined {
+  const t = Date.parse(since)
+  if (Number.isNaN(t)) return undefined
+  const hours = (Date.now() - t) / 3_600_000
+  return Math.min(72, Math.max(0.25, hours))
 }
 
 export function registerTools(server: McpServer, client: SpanlensClient): void {
@@ -60,14 +83,13 @@ export function registerTools(server: McpServer, client: SpanlensClient): void {
     },
     async ({ timeframe, groupBy }) => {
       try {
+        const hours = timeframeToHours(timeframe)
         if (groupBy === 'model' || groupBy === 'provider') {
-          const data = await client.get('/api/v1/stats/models', {
-            window: timeframeToWindow(timeframe),
-          })
+          const data = await client.get('/api/v1/stats/models', { hours })
           return formatJson(data)
         }
         const data = await client.get('/api/v1/stats/overview', {
-          window: timeframeToWindow(timeframe),
+          from: hoursAgoIso(hours),
         })
         return formatJson(data)
       } catch (err) {
@@ -90,7 +112,18 @@ export function registerTools(server: McpServer, client: SpanlensClient): void {
         .describe('Max rows to return. Default 20, max 100.'),
       model: z.string().optional().describe('Filter to a specific model substring.'),
       provider: z
-        .enum(['openai', 'anthropic', 'gemini', 'azure'])
+        .enum([
+          'openai',
+          'anthropic',
+          'gemini',
+          'azure',
+          'mistral',
+          'openrouter',
+          'groq',
+          'deepseek',
+          'xai',
+          'cohere',
+        ])
         .optional()
         .describe('Filter to a specific provider.'),
       status: z
@@ -191,20 +224,27 @@ export function registerTools(server: McpServer, client: SpanlensClient): void {
   // ── 5. get_anomalies ────────────────────────────────────────────────────
   server.tool(
     'get_anomalies',
-    'List unacknowledged cost / latency / error-rate anomalies the platform has detected. Use when the user asks "anything weird going on?", "any spikes?", or wants a quick health check.',
+    'List unacknowledged cost / latency / error-rate anomalies the platform has detected. Each anomaly carries a `deviations` field (how many sigmas off baseline). Use when the user asks "anything weird going on?", "any spikes?", or wants a quick health check.',
     {
-      severity: z
-        .enum(['low', 'medium', 'high'])
-        .optional()
-        .describe('Filter to anomalies at or above this severity.'),
       since: z
         .string()
         .optional()
-        .describe('ISO 8601 timestamp lower bound. Only return anomalies first seen at or after this time.'),
+        .describe(
+          'ISO 8601 timestamp. Sets the observation window: behaviour since this time is compared against the preceding baseline. Clamped to the last 15 minutes – 72 hours; default is the last hour.',
+        ),
+      sigma: z
+        .number()
+        .min(1)
+        .max(10)
+        .optional()
+        .describe('Minimum deviations (in sigmas) to flag. Default 3. Lower = more sensitive.'),
     },
-    async ({ severity, since }) => {
+    async ({ since, sigma }) => {
       try {
-        const data = await client.get('/api/v1/anomalies', { severity, from: since })
+        const data = await client.get('/api/v1/anomalies', {
+          observationHours: since ? sinceToObservationHours(since) : undefined,
+          sigma,
+        })
         return formatJson(data)
       } catch (err) {
         return formatError(err)

--- a/packages/mcp-server/src/version.ts
+++ b/packages/mcp-server/src/version.ts
@@ -1,4 +1,4 @@
 // Kept in a separate module so package.json doesn't have to be read at runtime
 // (avoids resolveJsonModule pulling the whole manifest into the bundle).
 // Bumped manually with each release; package.json stays canonical for npm.
-export const SERVER_VERSION = '0.2.0'
+export const SERVER_VERSION = '0.2.1'


### PR DESCRIPTION
## Summary
Full-codebase review (2026-07-13) found the MCP server's tools advertising and sending parameters the REST API never parses — the worst failure mode for an LLM-facing tool because the data comes back plausible but wrong.

1. **get_stats (HIGH)**: sent `window=7d` etc. `/api/v1/stats/overview` reads `from`/`to` and `/stats/models` reads `hours` — neither reads `window`. So "spend this week" returned **retention-window-wide totals** regardless of timeframe. Now: timeframe → `from` ISO bound (overview) / `hours` (models).
2. **get_anomalies (MEDIUM)**: advertised `severity` + `since`, sent `severity`/`from` — `/api/v1/anomalies` reads neither, and anomalies have no severity field at all (only sigma `deviations`). Replaced with `since` → `observationHours` (clamped 0.25–72h) and `sigma` (1–10), both actually parsed by the endpoint.
3. **query_requests (MEDIUM)**: provider enum only allowed 4 of the 10 proxied providers. Widened to include mistral, openrouter, groq, deepseek, xai, cohere.

## Tests
New `tools.test.ts` (11 tests) pins each tool's outgoing (path, query) pair against the params the server parses — a param-contract regression guard for exactly this bug class. `get_stats`/`get_anomalies` tests assert the dead params are gone.

## Release
Version bumped to 0.2.1 in package.json, server.json (x2), src/version.ts. After merge: `git tag mcp-server-v0.2.1 && git push --tags` publishes npm + MCP Registry automatically.

## Test plan
- [x] `pnpm --filter @spanlens/mcp-server typecheck && test && build` (17 tests green)