### PR TITLE
fix(sdk): sdk-python 0.8.1 — default host to api.spanlens.io

### DIFF
--- a/packages/cli/src/__tests__/code-patcher.test.ts
+++ b/packages/cli/src/__tests__/code-patcher.test.ts
@@ -56,7 +56,7 @@ describe('planPatches / applyPatches end-to-end', () => {
         ``,
         `const openai = new OpenAI({`,
         `  apiKey: process.env.SPANLENS_API_KEY,`,
-        `  baseURL: 'https://spanlens-server.vercel.app/proxy/openai/v1',`,
+        `  baseURL: 'https://api.spanlens.io/proxy/openai/v1',`,
         `  timeout: 30_000,`,
         `})`,
         ``,

--- a/packages/sdk-python/CHANGELOG.md
+++ b/packages/sdk-python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.1
+
+### Changed
+
+- Default API host is now `https://api.spanlens.io` (was the legacy `https://spanlens-server.vercel.app`, which continues to work). Affects `DEFAULT_BASE_URL` and the `observe_openai` / `observe_anthropic` / `observe_gemini` default proxy URLs. Set `SPANLENS_BASE_URL` or pass `base_url=` to override either way.
+
 ## 0.8.0
 
 FastAPI / ASGI auto-instrumentation — one line traces every HTTP request.

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -309,7 +309,7 @@ async def chat(body: dict, request: Request):
 ```python
 SpanlensClient(
     api_key="sl_live_...",        # required
-    base_url=None,                 # default: https://spanlens-server.vercel.app
+    base_url=None,                 # default: https://api.spanlens.io
     timeout_ms=3000,               # ingest timeout per call
     silent=True,                   # swallow errors so observability never crashes user code
     on_error=None,                 # callback (err, context) for non-silent monitoring

--- a/packages/sdk-python/examples/e2e_smoke.py
+++ b/packages/sdk-python/examples/e2e_smoke.py
@@ -12,7 +12,7 @@ Usage::
     export SPANLENS_API_KEY="sl_live_..."   # from your /projects page
     export OPENAI_API_KEY="sk-..."          # your real OpenAI key
     # Optional — only needed when using a non-default Spanlens deployment.
-    # export SPANLENS_BASE_URL="https://spanlens-server.vercel.app"
+    # export SPANLENS_BASE_URL="https://api.spanlens.io"
 
     python examples/e2e_smoke.py
 

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "spanlens"
-version = "0.8.0"
+version = "0.8.1"
 description = "Spanlens SDK for Python. Agent tracing, LLM usage capture, and cost observability."
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/sdk-python/spanlens/__init__.py
+++ b/packages/sdk-python/spanlens/__init__.py
@@ -38,7 +38,7 @@ from .parsers import parse_anthropic_usage, parse_gemini_usage, parse_openai_usa
 from .span import SpanHandle
 from .trace import TraceHandle
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 __all__ = [
     "SpanHandle",

--- a/packages/sdk-python/spanlens/integrations/anthropic.py
+++ b/packages/sdk-python/spanlens/integrations/anthropic.py
@@ -5,7 +5,7 @@ Replaces::
     from anthropic import Anthropic
     client = Anthropic(
         api_key=os.environ["SPANLENS_API_KEY"],
-        base_url="https://spanlens-server.vercel.app/proxy/anthropic",
+        base_url="https://api.spanlens.io/proxy/anthropic",
     )
 
 With::
@@ -22,7 +22,7 @@ from __future__ import annotations
 import os
 from typing import Any, Optional
 
-DEFAULT_SPANLENS_ANTHROPIC_PROXY = "https://spanlens-server.vercel.app/proxy/anthropic"
+DEFAULT_SPANLENS_ANTHROPIC_PROXY = "https://api.spanlens.io/proxy/anthropic"
 PROMPT_VERSION_HEADER = "x-spanlens-prompt-version"
 
 

--- a/packages/sdk-python/spanlens/integrations/gemini.py
+++ b/packages/sdk-python/spanlens/integrations/gemini.py
@@ -26,7 +26,7 @@ from typing import Any, Optional
 
 import httpx
 
-DEFAULT_SPANLENS_GEMINI_PROXY = "https://spanlens-server.vercel.app/proxy/gemini"
+DEFAULT_SPANLENS_GEMINI_PROXY = "https://api.spanlens.io/proxy/gemini"
 
 
 def create_gemini(

--- a/packages/sdk-python/spanlens/integrations/openai.py
+++ b/packages/sdk-python/spanlens/integrations/openai.py
@@ -5,7 +5,7 @@ Replaces::
     from openai import OpenAI
     client = OpenAI(
         api_key=os.environ["SPANLENS_API_KEY"],
-        base_url="https://spanlens-server.vercel.app/proxy/openai/v1",
+        base_url="https://api.spanlens.io/proxy/openai/v1",
     )
 
 With::
@@ -27,7 +27,7 @@ from __future__ import annotations
 import os
 from typing import Any, Optional
 
-DEFAULT_SPANLENS_OPENAI_PROXY = "https://spanlens-server.vercel.app/proxy/openai/v1"
+DEFAULT_SPANLENS_OPENAI_PROXY = "https://api.spanlens.io/proxy/openai/v1"
 PROMPT_VERSION_HEADER = "x-spanlens-prompt-version"
 
 

--- a/packages/sdk-python/spanlens/transport.py
+++ b/packages/sdk-python/spanlens/transport.py
@@ -32,7 +32,7 @@ from .types import SpanlensConfig
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_BASE_URL = "https://spanlens-server.vercel.app"
+DEFAULT_BASE_URL = "https://api.spanlens.io"
 DEFAULT_TIMEOUT_MS = 3000
 # Small pool — one trace might fan out to a handful of concurrent spans, but
 # we never need many workers: each task is a short-lived HTTP call.

--- a/packages/sdk-python/spanlens/types.py
+++ b/packages/sdk-python/spanlens/types.py
@@ -35,7 +35,7 @@ class SpanlensConfig(TypedDict, total=False):
     Attributes:
         api_key: Spanlens API key created in the dashboard
             (``sl_live_...`` or ``sl_test_...``). **Required.**
-        base_url: API base URL — default ``https://spanlens-server.vercel.app``.
+        base_url: API base URL — default ``https://api.spanlens.io``.
         timeout_ms: Request timeout in ms for ingest calls (default 3000).
             Observability calls should not block user code indefinitely.
         silent: Swallow all errors so instrumentation never crashes user code


### PR DESCRIPTION
## Summary
The 2026-07-13 host unification (#409-413) covered sdk@0.16.0 and mcp-server@0.2.0 but **missed sdk-python** — 0.8.0 still defaults to the legacy `https://spanlens-server.vercel.app` in:
- `spanlens/transport.py` `DEFAULT_BASE_URL`
- `observe_openai` / `observe_anthropic` / `observe_gemini` default proxy URLs
- `types.py` docstring, README, e2e example

All now default to `https://api.spanlens.io`. The old host keeps resolving, so nothing breaks for existing installs; this aligns new installs with the canonical host. Also updates the stale host in the CLI code-patcher test fixture (inert sample input).

## Release
Version 0.8.1 (pyproject.toml + `__init__.py` + CHANGELOG entry). After merge, publish via the existing publish-sdk-python workflow.

## Test plan
- [x] `python -m pytest` — 164 passed
- [x] `ruff check` — clean
- [x] `pnpm --filter @spanlens/cli test` — 31 passed