### PR TITLE
docs: fix inaccurate API docs, OTEL example, env template (2026-07 audit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/spanlens.svg)](https://pypi.org/project/spanlens/)
 [![npm downloads](https://img.shields.io/npm/dm/@spanlens/sdk.svg)](https://www.npmjs.com/package/@spanlens/sdk)
 
-**Open-source LLM observability and monitoring.** Record every OpenAI / Anthropic / Gemini / Mistral / OpenRouter / Azure OpenAI / Ollama call with one line of code. Plugs into Vercel AI SDK, LangChain, and LlamaIndex too. Query the same data directly from Cursor, Claude Desktop, or Continue via the bundled [MCP server](https://www.npmjs.com/package/@spanlens/mcp-server). Get cost, latency, tokens, traces, anomalies, PII scan, and model-swap suggestions out of the box. Self-hostable. MIT.
+**Open-source LLM observability and monitoring.** Record every OpenAI / Anthropic / Gemini / Mistral / OpenRouter / Groq / DeepSeek / xAI / Cohere / Azure OpenAI / Ollama call with one line of code. Plugs into Vercel AI SDK, LangChain, and LlamaIndex too. Query the same data directly from Cursor, Claude Desktop, or Continue via the bundled [MCP server](https://www.npmjs.com/package/@spanlens/mcp-server). Get cost, latency, tokens, traces, anomalies, PII scan, and model-swap suggestions out of the box. Self-hostable. MIT.
 
 > ⭐ **If Spanlens is useful to you, please [star the repo](https://github.com/spanlens/Spanlens). It takes a second and helps other developers find it.**
 
@@ -239,7 +239,7 @@ Spanlens uses **two databases**, each for what it's good at.
 ### Projects, unified keys, and headers
 
 - A workspace can hold **multiple projects** (e.g. `dev` / `staging` / `prod`, or one per app). Each project gets its own quota slice, provider keys, and prompt namespace.
-- **Unified API keys** give you one `sl_live_*` key per project that is provider-agnostic. Spanlens infers the provider from the request path (`/proxy/openai/*`, `/proxy/anthropic/*`, `/proxy/gemini/*`, `/proxy/mistral/*`, `/proxy/openrouter/*`, `/proxy/azure/*`), so you only need one Spanlens key even if you call multiple model vendors.
+- **Unified API keys** give you one `sl_live_*` key per project that is provider-agnostic. Spanlens infers the provider from the request path (`/proxy/openai/*`, `/proxy/anthropic/*`, `/proxy/gemini/*`, `/proxy/mistral/*`, `/proxy/openrouter/*`, `/proxy/groq/*`, `/proxy/deepseek/*`, `/proxy/xai/*`, `/proxy/cohere/*`, `/proxy/azure/*`), so you only need one Spanlens key even if you call multiple model vendors.
 - **`X-Spanlens-*` headers** (set automatically by the SDK helpers `withUser()`, `withSession()`, `withPromptVersion()`, `withLogBody()`): tag a request with end-user / session IDs, link it to a prompt-version experiment, or limit how much body Spanlens stores. Full list in [`/docs/proxy`](https://www.spanlens.io/docs/proxy).
 - **Streaming safety** ensures proxy responses are gracefully closed at 290s with a `truncated=true` flag in the log, so long streams never silently disappear.
 

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -18,8 +18,15 @@ CRON_SECRET=
 # Resend (email notifications).
 # If unset, invitation links are printed to console (local dev only).
 RESEND_API_KEY=
+# Sender shown on outgoing email. Default: Spanlens <notifications@spanlens.io>.
+# Use a verified Resend domain or mail lands in spam.
+RESEND_FROM=
 # Base URL for invitation accept links. Production: https://www.spanlens.io
 WEB_URL=http://localhost:3000
+
+# Internal operator allowlist for /api/v1/admin/* (comma-separated emails).
+# Fail-closed: when unset, every admin route returns 403.
+SPANLENS_ADMIN_EMAILS=
 
 # GitGuardian HasMySecretLeaked (provider key leak detection — required only when leak_detection_enabled is on).
 # Sign up: https://dashboard.gitguardian.com → Settings → API → Personal Access Tokens
@@ -35,6 +42,15 @@ PADDLE_API_KEY=
 PADDLE_NOTIFICATION_SECRET=
 # 'sandbox' for Paddle Sandbox, 'production' for live billing.
 PADDLE_ENVIRONMENT=sandbox
+# Paddle price IDs (Dashboard → Catalog → Products). Checkout rejects every
+# plan as "unconfigured" without the plan prices; overage billing is skipped
+# without the overage ones.
+# Sandbox and production use DIFFERENT price IDs — keep them per-environment.
+PADDLE_PRICE_STARTER=
+PADDLE_PRICE_TEAM=
+PADDLE_PRICE_ENTERPRISE=
+PADDLE_PRICE_STARTER_OVERAGE=
+PADDLE_PRICE_TEAM_OVERAGE=
 
 # Sentry — error monitoring (https://sentry.io).
 # Create two projects: spanlens-server (Node) + spanlens-web (Next.js).

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,36 +1,36 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# apps/web — Spanlens dashboard
 
-## Getting Started
+Next.js 16 (App Router) frontend for [Spanlens](https://spanlens.io): the dashboard at `www.spanlens.io`, the marketing pages, and the docs at `/docs`.
 
-First, run the development server:
+This package never talks to Supabase for data — all reads and writes go through the Hono server (`apps/server`) via `fetch('/api/v1/...')`. The only Supabase usage here is auth/session plumbing (middleware, login callback).
+
+## Develop
+
+From the **repo root** (pnpm workspace — do not use npm or yarn):
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+cp apps/server/.env.example apps/server/.env   # server env (see root README)
+cp apps/web/.env.example apps/web/.env.local   # web env
+pnpm install
+pnpm dev        # web on :3000, server on :3001
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+The dashboard is useless without the server running; `pnpm dev` at the root starts both.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Verify changes
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+pnpm --filter web typecheck
+pnpm --filter web lint
+```
 
-## Learn More
+## Conventions
 
-To learn more about Next.js, take a look at the following resources:
+- Tailwind only — no inline styles.
+- Server components fetch data; client components own interaction (`useState`, `onClick`).
+- SSR-rendered dates go through `lib/utils.ts` (`formatDate` / `formatDateTime` / `formatTime`) — locale-free `toLocaleString()` causes hydration mismatches.
+- See the root [CLAUDE.md](../../CLAUDE.md) for the full convention list and known gotchas.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Deploy
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Deployed to Vercel via git integration on pushes to `main` (project `spanlens-web`). No manual step.

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -2436,7 +2436,7 @@ function DestinationsTab() {
 
 // ─── OPENTELEMETRY tab ────────────────────────────────────────────────────────
 
-const OTEL_ENDPOINT = 'https://spanlens-server.vercel.app/ingest/traces'
+const OTEL_ENDPOINT = 'https://api.spanlens.io/v1/traces'
 
 const OTEL_CODE_EXAMPLE = `import { NodeSDK } from '@opentelemetry/sdk-node'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'

--- a/apps/web/app/docs/api/page.tsx
+++ b/apps/web/app/docs/api/page.tsx
@@ -19,9 +19,11 @@ export default function ApiReferencePage() {
       <h1>REST API Reference</h1>
       <p className="lead">
         The Spanlens REST API backs the dashboard and is stable for direct
-        use. All authenticated endpoints require a Supabase JWT in{' '}
-        <code>Authorization: Bearer …</code>. Proxy endpoints use a Spanlens
-        API key.
+        use. Dashboard endpoints accept a Supabase JWT in{' '}
+        <code>Authorization: Bearer …</code>; the read endpoints (requests,
+        stats, traces, anomalies, recommendations, users, evals) also accept
+        a Spanlens API key, which is how the MCP server and BI integrations
+        query your data. Proxy and ingest endpoints use a Spanlens API key.
       </p>
 
       <div className="flex flex-wrap gap-3 my-5 not-prose">
@@ -63,6 +65,14 @@ export default function ApiReferencePage() {
             <td><strong>ApiKey</strong></td>
             <td><code>Authorization: Bearer sl_live_…</code></td>
             <td>Proxy endpoints (<code>/proxy/*</code>) and SDK ingest (<code>/ingest/*</code>)</td>
+          </tr>
+          <tr>
+            <td><strong>Either</strong></td>
+            <td><code>Authorization: Bearer &lt;jwt | sl_live_… | sl_live_pub_…&gt;</code></td>
+            <td>
+              Dual-auth read endpoints, marked &quot;JWT or API key&quot; below. Public-scope
+              keys (<code>sl_live_pub_…</code>) work here and are read-only everywhere else.
+            </td>
           </tr>
         </tbody>
       </table>
@@ -115,32 +125,46 @@ export default function ApiReferencePage() {
           <tr><td>Projects</td><td><code>/api/v1/projects</code></td><td>JWT</td></tr>
           <tr><td>API keys</td><td><code>/api/v1/api-keys</code></td><td>JWT</td></tr>
           <tr><td>Provider keys</td><td><code>/api/v1/provider-keys</code></td><td>JWT</td></tr>
-          <tr><td>Requests</td><td><code>/api/v1/requests</code></td><td>JWT</td></tr>
-          <tr><td>Stats</td><td><code>/api/v1/stats</code></td><td>JWT</td></tr>
-          <tr><td>Traces</td><td><code>/api/v1/traces</code></td><td>JWT</td></tr>
+          <tr><td>Key introspection</td><td><code>/api/v1/me/key-info</code></td><td>API key</td></tr>
+          <tr><td>Requests</td><td><code>/api/v1/requests</code></td><td>JWT or API key</td></tr>
+          <tr><td>Stats</td><td><code>/api/v1/stats</code></td><td>JWT or API key</td></tr>
+          <tr><td>Traces</td><td><code>/api/v1/traces</code></td><td>JWT or API key</td></tr>
+          <tr><td>Users (end-user analytics)</td><td><code>/api/v1/users</code></td><td>JWT or API key</td></tr>
+          <tr><td>Sessions</td><td><code>/api/v1/sessions</code></td><td>JWT</td></tr>
           <tr><td>Prompts</td><td><code>/api/v1/prompts</code></td><td>JWT</td></tr>
-          <tr><td>Anomalies</td><td><code>/api/v1/anomalies</code></td><td>JWT</td></tr>
+          <tr><td>Anomalies</td><td><code>/api/v1/anomalies</code></td><td>JWT or API key</td></tr>
           <tr><td>Security</td><td><code>/api/v1/security</code></td><td>JWT</td></tr>
           <tr><td>Alerts</td><td><code>/api/v1/alerts</code></td><td>JWT</td></tr>
-          <tr><td>Recommendations</td><td><code>/api/v1/recommendations</code></td><td>JWT</td></tr>
-          <tr><td>Evals</td><td><code>/api/v1/evaluators</code></td><td>JWT</td></tr>
+          <tr><td>Recommendations</td><td><code>/api/v1/recommendations</code></td><td>JWT or API key</td></tr>
+          <tr><td>Evals</td><td><code>/api/v1/evaluators</code>, <code>/api/v1/eval-runs</code></td><td>JWT or API key (writes need a full key or admin/editor)</td></tr>
           <tr><td>Datasets</td><td><code>/api/v1/datasets</code></td><td>JWT</td></tr>
           <tr><td>Experiments</td><td><code>/api/v1/experiments</code></td><td>JWT</td></tr>
           <tr><td>Prompt experiments (A/B)</td><td><code>/api/v1/prompt-experiments</code></td><td>JWT</td></tr>
-          <tr><td>Prompt playground</td><td><code>/api/v1/prompts-playground/run</code></td><td>JWT</td></tr>
+          <tr><td>Prompt playground</td><td><code>/api/v1/prompts/playground/run</code></td><td>JWT</td></tr>
           <tr><td>Human evals</td><td><code>/api/v1/human-evals</code></td><td>JWT</td></tr>
           <tr><td>Annotation queue</td><td><code>/api/v1/annotation/queue</code></td><td>JWT</td></tr>
+          <tr><td>Score configs</td><td><code>/api/v1/score-configs</code></td><td>JWT (admin/editor for writes)</td></tr>
           <tr><td>Webhooks</td><td><code>/api/v1/webhooks</code></td><td>JWT (admin/editor for writes)</td></tr>
           <tr><td>Audit logs</td><td><code>/api/v1/audit-logs</code></td><td>JWT</td></tr>
           <tr><td>Saved filters</td><td><code>/api/v1/saved-filters</code></td><td>JWT</td></tr>
           <tr><td>Exports</td><td><code>/api/v1/exports/*</code></td><td>JWT</td></tr>
+          <tr><td>Rate limits</td><td><code>/api/v1/rate-limits</code></td><td>JWT</td></tr>
+          <tr><td>Billing</td><td><code>/api/v1/billing</code></td><td>JWT</td></tr>
+          <tr><td>Shares</td><td><code>/api/v1/shares</code></td><td>JWT</td></tr>
           <tr><td>Members</td><td><code>/api/v1/organizations/:orgId/members</code></td><td>JWT (admin for writes)</td></tr>
           <tr><td>Invitations</td><td><code>/api/v1/organizations/:orgId/invitations</code></td><td>JWT (admin)</td></tr>
-          <tr><td>Proxy, OpenAI</td><td><code>/proxy/openai/v1/*</code></td><td>API key</td></tr>
-          <tr><td>Proxy, Anthropic</td><td><code>/proxy/anthropic/v1/*</code></td><td>API key</td></tr>
-          <tr><td>Proxy, Gemini</td><td><code>/proxy/gemini/v1/*</code></td><td>API key</td></tr>
-          <tr><td>Proxy, Azure OpenAI</td><td><code>/proxy/azure/*</code></td><td>API key</td></tr>
-          <tr><td>SDK Ingest</td><td><code>/ingest/*</code></td><td>API key</td></tr>
+          <tr><td>Proxy, OpenAI</td><td><code>/proxy/openai/v1/*</code></td><td>API key (full)</td></tr>
+          <tr><td>Proxy, Anthropic</td><td><code>/proxy/anthropic/v1/*</code></td><td>API key (full)</td></tr>
+          <tr><td>Proxy, Gemini</td><td><code>/proxy/gemini/v1/*</code></td><td>API key (full)</td></tr>
+          <tr><td>Proxy, Azure OpenAI</td><td><code>/proxy/azure/*</code></td><td>API key (full)</td></tr>
+          <tr><td>Proxy, Mistral</td><td><code>/proxy/mistral/*</code></td><td>API key (full)</td></tr>
+          <tr><td>Proxy, OpenRouter</td><td><code>/proxy/openrouter/*</code></td><td>API key (full)</td></tr>
+          <tr><td>Proxy, Groq</td><td><code>/proxy/groq/*</code></td><td>API key (full)</td></tr>
+          <tr><td>Proxy, DeepSeek</td><td><code>/proxy/deepseek/*</code></td><td>API key (full)</td></tr>
+          <tr><td>Proxy, xAI</td><td><code>/proxy/xai/*</code></td><td>API key (full)</td></tr>
+          <tr><td>Proxy, Cohere</td><td><code>/proxy/cohere/*</code></td><td>API key (full)</td></tr>
+          <tr><td>SDK Ingest</td><td><code>/ingest/*</code></td><td>API key (full)</td></tr>
+          <tr><td>OTLP traces</td><td><code>POST /v1/traces</code></td><td>API key (full)</td></tr>
         </tbody>
       </table>
 

--- a/apps/web/app/docs/features/projects/page.tsx
+++ b/apps/web/app/docs/features/projects/page.tsx
@@ -229,16 +229,11 @@ GET    /api/v1/pending-deletions             # active queue
 GET    /api/v1/pending-deletions/history     # terminal rows (executed or cancelled)
 POST   /api/v1/pending-deletions/:id/restore # cancel + flip is_active back to true`}</CodeBlock>
 
-      <h3>Tagging requests with a project from client code</h3>
+      <h3>How requests get their project</h3>
       <p>
-        By default, a request&apos;s project is determined by <strong>which Spanlens key</strong>{' '}
-        was used. One key = one project. If you want to override per-request, pass:
-      </p>
-      <CodeBlock language="bash">{`X-Spanlens-Project: my-project-slug`}</CodeBlock>
-      <p>
-        … in the proxy request headers. The SDK also accepts a <code>project</code> option on{' '}
-        <code>createOpenAI()</code> / <code>createAnthropic()</code> /{' '}
-        <code>createGemini()</code>.
+        A request&apos;s project is determined by <strong>which Spanlens key</strong> was used.
+        One key = one project. To send traffic to a different project, issue a key under that
+        project and use it for those calls. There is no per-request project override header.
       </p>
 
       <h2>Security design</h2>

--- a/apps/web/app/docs/features/requests/page.tsx
+++ b/apps/web/app/docs/features/requests/page.tsx
@@ -92,7 +92,7 @@ export default function RequestsDocs() {
           </tr>
           <tr>
             <td><code>project_id</code></td>
-            <td>Scoped to the API key used (or <code>X-Spanlens-Project</code> header)</td>
+            <td>Scoped to the API key used (one key = one project)</td>
           </tr>
           <tr>
             <td><code>provider_key_id</code></td>

--- a/apps/web/app/docs/proxy/page.tsx
+++ b/apps/web/app/docs/proxy/page.tsx
@@ -307,11 +307,20 @@ res, _ := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
         is negligible (10–50ms).
       </p>
 
-      <h2>Passing project / metadata</h2>
+      <h2>Passing metadata</h2>
       <p>
-        Add an <code>X-Spanlens-Project</code> header to tag requests with a project scope:
+        Project scoping needs no header. Every <code>sl_live_*</code> key is issued for a single
+        project, so requests are attributed to that project automatically.
       </p>
-      <CodeBlock>{`-H "X-Spanlens-Project: my-backend-service"`}</CodeBlock>
+      <p>
+        Add <code>X-Trace-Id</code> and <code>X-Span-Id</code> headers (UUIDs) to link a proxy call
+        to an <a href="/docs/agents">agent trace</a> so it appears inside the span tree with its
+        cost and tokens. The SDK sets these for you via{' '}
+        <code>trace.headers()</code> / <code>span.headers()</code>; raw HTTP callers can pass them
+        directly. Non-UUID values are ignored rather than rejected:
+      </p>
+      <CodeBlock>{`-H "X-Trace-Id: 7f0d2ab8-6a3e-4d0f-9c1b-2e8a51f0c123"
+-H "X-Span-Id: 1b9c4e02-3f7d-4a58-8e21-6c0d9b7a4f56"`}</CodeBlock>
 
       <p>
         Add an <code>X-Spanlens-Prompt-Version</code> header to link the request to a specific{' '}

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spanlens/cli changelog
 
+## 0.3.3
+
+### Added
+
+- Post-init welcome message with a GitHub star CTA and a docs link, shown once after a successful `spanlens init`.
+
 ## 0.3.2
 
 Metadata + dependency refresh. No CLI behavior changes; same wizard flow, same prompts, same code patches.


### PR DESCRIPTION
## Summary
Documentation accuracy fixes from the 2026-07-13 full-codebase audit. Every item was verified against the actual server code before changing the doc.

### User-breaking inaccuracies
1. **Settings → OpenTelemetry tab**: the copy-paste exporter example pointed at `spanlens-server.vercel.app/ingest/traces` — wrong host (legacy) AND wrong route (`/ingest/traces` expects the native SDK payload, not OTLP). Anyone copying it got silent trace loss. Now `https://api.spanlens.io/v1/traces`.
2. **`X-Spanlens-Project` header documented as functional** in /docs/proxy, /docs/features/projects, /docs/features/requests — the server strips it and never reads it (project scope comes from the key under the unified-key model). Docs now state the one-key-one-project truth, and the freed section documents `X-Trace-Id`/`X-Span-Id` trace-linking headers for raw-HTTP callers (previously only in SDK docs).
3. **/docs/api**: `/api/v1/prompts-playground/run` does not exist (actual: `/api/v1/prompts/playground/run`); dual-auth read endpoints (requests/stats/traces/anomalies/recommendations/users/evals) were marked JWT-only — contradicting our own MCP server which queries them with public keys.

### Coverage gaps
4. /docs/api endpoint table: added the 6 missing proxy providers (mistral/openrouter/groq/deepseek/xai/cohere) + missing groups (users, sessions, rate-limits, billing, shares, score-configs, me/key-info, OTLP).
5. `.env.example`: added `SPANLENS_ADMIN_EMAILS` (fail-closed — all /admin routes 403 without it), `RESEND_FROM`, and the 5 `PADDLE_PRICE_*` ids without which checkout rejects every plan.
6. Root README provider lists now include Groq/DeepSeek/xAI/Cohere; apps/web/README.md replaced (was create-next-app boilerplate recommending npm/yarn against the pnpm-only rule); CLI CHANGELOG got its missing 0.3.3 entry.

### Deliberately NOT changed
- `PROXY_RATE_LIMIT_OVERAGE` was flagged as missing from the error reference, but it's a server-side log code (the middleware passes through, no 4xx) — it doesn't belong on a client-facing error page. The `X-Spanlens-RateLimit-Overage` header is already documented in /docs/proxy.

## Test plan
- [x] `pnpm --filter web typecheck && lint`
- [x] Every endpoint/auth claim cross-checked against `apps/server/src/app.ts` mounts and router middlewares