### PR TITLE
fix(web): add fetch-error states, pin date locales, add missing route loading skeletons

### DIFF
--- a/apps/web/app/(dashboard)/admin/feedback/loading.tsx
+++ b/apps/web/app/(dashboard)/admin/feedback/loading.tsx
@@ -1,0 +1,4 @@
+import { PageSkeleton } from '@/components/layout/page-skeleton'
+export default function Loading() {
+  return <PageSkeleton />
+}

--- a/apps/web/app/(dashboard)/datasets/[id]/loading.tsx
+++ b/apps/web/app/(dashboard)/datasets/[id]/loading.tsx
@@ -1,0 +1,4 @@
+import { PageDetailSkeleton } from '@/components/layout/page-skeleton'
+export default function Loading() {
+  return <PageDetailSkeleton />
+}

--- a/apps/web/app/(dashboard)/datasets/datasets-client.tsx
+++ b/apps/web/app/(dashboard)/datasets/datasets-client.tsx
@@ -732,6 +732,19 @@ export function DatasetsClient() {
           <div className="p-[22px] space-y-2">
             {[1, 2].map((i) => <div key={i} className="h-14 bg-bg-elev rounded animate-pulse" />)}
           </div>
+        ) : datasets.isError ? (
+          // Don't fall through to the "create your first dataset" empty state on
+          // a load failure — a workspace with existing datasets would look brand-new.
+          <div className="flex flex-col items-center gap-3 text-text-muted py-20 px-6 text-center">
+            <p className="text-[13px] text-accent">Couldn&apos;t load datasets.</p>
+            <button
+              type="button"
+              onClick={() => void datasets.refetch()}
+              className="font-mono text-[11.5px] px-2.5 py-1 border border-border rounded text-text-muted hover:text-text hover:border-border-strong transition-colors"
+            >
+              Retry
+            </button>
+          </div>
         ) : list.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-64 gap-3 text-text-muted">
             <FileText className="h-10 w-10 text-text-faint" />

--- a/apps/web/app/(dashboard)/experiments/[id]/loading.tsx
+++ b/apps/web/app/(dashboard)/experiments/[id]/loading.tsx
@@ -1,0 +1,4 @@
+import { PageDetailSkeleton } from '@/components/layout/page-skeleton'
+export default function Loading() {
+  return <PageDetailSkeleton />
+}

--- a/apps/web/app/(dashboard)/prompts/prompts-client.tsx
+++ b/apps/web/app/(dashboard)/prompts/prompts-client.tsx
@@ -211,7 +211,7 @@ export function PromptsClient() {
   }, [callsMenuOpen, dateMenuOpen, exportOpen])
 
   const hours = DATE_RANGE_HOURS[dateRange]
-  const { data: prompts, isLoading, isFetching, refetch } = usePrompts(undefined, hours)
+  const { data: prompts, isLoading, isError, isFetching, refetch } = usePrompts(undefined, hours)
   const createMutation = useCreatePromptVersion()
 
   const all = prompts ?? []
@@ -633,6 +633,19 @@ export function PromptsClient() {
         {isLoading ? (
           <div className="p-6 space-y-2">
             {[1, 2, 3].map((i) => <div key={i} className="h-10 bg-bg-elev rounded animate-pulse" />)}
+          </div>
+        ) : isError ? (
+          // Don't fall through to the "register first prompt" empty state on a
+          // load failure — a workspace with existing prompts would look brand-new.
+          <div className="flex flex-col items-center gap-3 text-text-muted py-20 px-6 text-center">
+            <p className="text-[13px] text-accent">Couldn&apos;t load prompts.</p>
+            <button
+              type="button"
+              onClick={() => void refetch()}
+              className="font-mono text-[11.5px] px-2.5 py-1 border border-border rounded text-text-muted hover:text-text hover:border-border-strong transition-colors"
+            >
+              Retry
+            </button>
           </div>
         ) : filtered.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-20 gap-3 text-text-muted">

--- a/apps/web/app/(dashboard)/sessions/[sessionId]/loading.tsx
+++ b/apps/web/app/(dashboard)/sessions/[sessionId]/loading.tsx
@@ -1,0 +1,4 @@
+import { PageDetailSkeleton } from '@/components/layout/page-skeleton'
+export default function Loading() {
+  return <PageDetailSkeleton />
+}

--- a/apps/web/app/(dashboard)/settings/alerts/loading.tsx
+++ b/apps/web/app/(dashboard)/settings/alerts/loading.tsx
@@ -1,0 +1,4 @@
+import { PageSkeleton } from '@/components/layout/page-skeleton'
+export default function Loading() {
+  return <PageSkeleton />
+}

--- a/apps/web/app/(dashboard)/settings/background-migrations/background-migrations-client.tsx
+++ b/apps/web/app/(dashboard)/settings/background-migrations/background-migrations-client.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { useState } from 'react'
 import { Play, Square, RotateCcw, AlertTriangle, CheckCircle, Loader2 } from 'lucide-react'
 import { Topbar } from '@/components/layout/topbar'
-import { cn } from '@/lib/utils'
+import { cn, formatDateTime } from '@/lib/utils'
 import {
   useBackgroundMigrations,
   useCancelBackgroundMigration,
@@ -186,7 +186,7 @@ export function BackgroundMigrationsClient() {
                   <Field label="attempts" value={String(row.attempts)} />
                   <Field
                     label="started"
-                    value={row.started_at ? new Date(row.started_at).toLocaleString() : '—'}
+                    value={formatDateTime(row.started_at)}
                   />
                 </div>
 

--- a/apps/web/app/(dashboard)/settings/background-migrations/loading.tsx
+++ b/apps/web/app/(dashboard)/settings/background-migrations/loading.tsx
@@ -1,0 +1,4 @@
+import { PageSkeleton } from '@/components/layout/page-skeleton'
+export default function Loading() {
+  return <PageSkeleton />
+}

--- a/apps/web/app/(dashboard)/settings/pending-deletions/loading.tsx
+++ b/apps/web/app/(dashboard)/settings/pending-deletions/loading.tsx
@@ -1,0 +1,4 @@
+import { PageSkeleton } from '@/components/layout/page-skeleton'
+export default function Loading() {
+  return <PageSkeleton />
+}

--- a/apps/web/app/(dashboard)/settings/score-configs/loading.tsx
+++ b/apps/web/app/(dashboard)/settings/score-configs/loading.tsx
@@ -1,0 +1,4 @@
+import { PageSkeleton } from '@/components/layout/page-skeleton'
+export default function Loading() {
+  return <PageSkeleton />
+}

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -1964,7 +1964,7 @@ function DeliveryHistory({ webhookId }: { webhookId: string }) {
       {deliveries.map((d) => (
         <div key={d.id} className="grid grid-cols-[140px_80px_80px_1fr] gap-4 px-6 py-2 items-center">
           <span className="font-mono text-[11px] text-text-muted">
-            {new Date(d.delivered_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })}
+            {new Date(d.delivered_at).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })}
           </span>
           <MonoPill variant={d.status === 'success' ? 'good' : 'faint'} dot>
             {d.status}

--- a/apps/web/app/(dashboard)/shares/loading.tsx
+++ b/apps/web/app/(dashboard)/shares/loading.tsx
@@ -1,0 +1,4 @@
+import { PageSkeleton } from '@/components/layout/page-skeleton'
+export default function Loading() {
+  return <PageSkeleton />
+}

--- a/apps/web/app/(dashboard)/users/[userId]/loading.tsx
+++ b/apps/web/app/(dashboard)/users/[userId]/loading.tsx
@@ -1,0 +1,4 @@
+import { PageDetailSkeleton } from '@/components/layout/page-skeleton'
+export default function Loading() {
+  return <PageDetailSkeleton />
+}

--- a/apps/web/app/demo/users/[userId]/page.tsx
+++ b/apps/web/app/demo/users/[userId]/page.tsx
@@ -101,7 +101,7 @@ export default async function DemoUserDetailPage({ params }: { params: Promise<{
                   className="grid grid-cols-[1fr,1fr,1fr,1fr,1fr] gap-3 items-center px-4 py-2.5 font-mono text-[12px] text-text hover:bg-bg-elev transition-colors"
                 >
                   <span className="text-text-muted">
-                    {new Date(r.created_at).toLocaleString(undefined, {
+                    {new Date(r.created_at).toLocaleString('en-US', {
                       month: 'short',
                       day: 'numeric',
                       hour: '2-digit',


### PR DESCRIPTION
## Summary

UX fixes from the 2026-07-13 apps/web audit.

### 1. Failed fetches no longer masquerade as empty states
- **Datasets** (`datasets-client.tsx`): the list rendered `isLoading ? skeleton : "No datasets yet."` with no error branch, so a failed fetch told users with real data that they had none (and pushed the "Create your first dataset" CTA at them). Added an `isError` branch with a Retry button, matching the established pattern in `traces-client.tsx` / `anomalies-client.tsx`.
- **Prompts** (`prompts-client.tsx`): same bug, same fix. `refetch` was already destructured from the query hook.

### 2. Locale-less date formatting (hydration gotcha #22A)
- `settings/background-migrations`: `new Date(row.started_at).toLocaleString()` replaced with the `formatDateTime()` helper from `lib/utils.ts` (en-US pinned, handles null with an em-dash placeholder).
- `demo/users/[userId]/page.tsx`: `toLocaleString(undefined, {...})` pinned to `'en-US'`, consistent with the rest of the demo subsystem (same option object kept).
- `settings-client.tsx` webhook deliveries: `toLocaleTimeString([], {...})` pinned to `'en-US'` (options kept as-is since the display includes seconds, which `formatTime()` does not).

### 3. Missing route-level loading.tsx
Added minimal skeletons matching the 21 existing siblings (`PageDetailSkeleton` for detail routes, `PageSkeleton` for list/settings routes):

- `sessions/[sessionId]`, `users/[userId]`, `datasets/[id]`, `experiments/[id]` (detail)
- `shares`, `admin/feedback`, `settings/{alerts,background-migrations,pending-deletions,score-configs}` (list)

## Test plan
- [x] `pnpm --filter web typecheck` passes
- [x] `pnpm --filter web lint` passes
- [ ] Manual: kill the API server and load `/datasets` and `/prompts` — error + Retry shown instead of the onboarding empty state
- [ ] Manual: navigate to a session/user/dataset/experiment detail page and confirm the route skeleton flashes instead of a blank frame