### PR TITLE
refactor(server): mount /api/v1 wildcard routers last in app.ts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ apps/web/app/demo/_client-guard.tsx — `DemoClientGuard`. demo subsystem 전용
    - read API인데 user identity 필요 (audit, members 등) → `authJwt`만
    - write API (`/proxy/*`, `/ingest/*`, OTLP) → `authApiKey` + `requireFullScope`
    - write API가 org-role 제약 필요 (viewer 차단) → authJwt 뒤에 `requireRole('admin','editor')`. dual-auth write면 evals.ts의 `requireEdit` + `requireFullScope` 조합 재사용.
-   - app.ts에서 mount 순서 주의: `/api/v1` wildcard 라우터(evalsRouter/humanEvalsRouter) **뒤**에 mount하면 wildcard authJwt가 먼저 잡아 dual-auth 무력화 (recommendations 사고 패턴, 2026-06-04 발견)
+   - app.ts mount 순서 invariant (2026-07-13 reorder): `/api/v1` wildcard 라우터(evalsRouter/humanEvalsRouter)는 **/api/v1 섹션 맨 마지막**에 mount됨. 새 specific 라우터는 "Wildcard /api/v1 routers — MUST STAY LAST" 주석 블록 **위**에 추가 — wildcard 뒤에 mount하면 wildcard authJwt가 먼저 잡아 dual-auth/public 라우트 무력화 (recommendations 2026-06-04 + feedback PR #304, 두 번 실사고). `src/__tests__/api-v1-mount-order.test.ts` source-guard가 순서 위반을 CI에서 잡음.
 4. UI → apps/web에서 fetch('/api/v1/...') 또는 TanStack Query
 5. 검증 → pnpm typecheck && lint && test
 ## 환경변수 (필수)

--- a/apps/server/src/__tests__/api-v1-mount-order.test.ts
+++ b/apps/server/src/__tests__/api-v1-mount-order.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Source-level guard for the /api/v1 mount-order invariant in app.ts.
+ *
+ * evalsRouter and humanEvalsRouter mount at the broad `/api/v1` prefix and
+ * register `.use('*', ...)` auth middleware. Hono matches in registration
+ * order, so any /api/v1 route mounted AFTER those wildcards first passes
+ * through their auth middleware. For routes with their own auth that is a
+ * wasted duplicate Supabase round-trip; for dual-auth or public routes it is
+ * an outright break — the wildcard's authJwt 401s the request before the
+ * route's own middleware ever runs. This shipped twice: recommendations
+ * (2026-06-04) and public feedback (PR #304).
+ *
+ * The fix is structural: the wildcard routers mount LAST among /api/v1
+ * routes. This test pins that ordering so a new router added below them
+ * fails CI instead of silently breaking in production.
+ *
+ * (Same source-guard pattern as require-edit-dual-auth.test.ts — behavior
+ * cannot be asserted cheaply here because "auth ran twice" is invisible in
+ * the response, so we pin the registration order in the source instead.)
+ */
+
+const WILDCARD_ROUTERS = ['evalsRouter', 'humanEvalsRouter'] as const
+
+async function readAppSource(): Promise<string> {
+  const path = fileURLToPath(new URL('../app.ts', import.meta.url))
+  return readFile(path, 'utf8')
+}
+
+/** All `app.route('/api/v1...', xRouter)` mounts, in registration order. */
+function apiV1Mounts(source: string): Array<{ path: string; router: string }> {
+  const re = /^app\.route\('(\/api\/v1[^']*)',\s*(\w+)\)/gm
+  const mounts: Array<{ path: string; router: string }> = []
+  for (const m of source.matchAll(re)) {
+    mounts.push({ path: m[1]!, router: m[2]! })
+  }
+  return mounts
+}
+
+describe('/api/v1 mount order in app.ts', () => {
+  test('wildcard routers (evals, human-evals) are the LAST /api/v1 mounts', async () => {
+    const mounts = apiV1Mounts(await readAppSource())
+    expect(mounts.length).toBeGreaterThan(10) // sanity: regex still matches app.ts
+
+    const lastTwo = mounts.slice(-WILDCARD_ROUTERS.length).map((m) => m.router)
+    expect(lastTwo).toEqual([...WILDCARD_ROUTERS])
+  })
+
+  test('each wildcard router is mounted exactly once', async () => {
+    const mounts = apiV1Mounts(await readAppSource())
+    for (const router of WILDCARD_ROUTERS) {
+      const count = mounts.filter((m) => m.router === router).length
+      expect(count, `${router} must be mounted exactly once`).toBe(1)
+    }
+  })
+
+  test('no other router is mounted at the bare /api/v1 prefix (except openapiRouter)', async () => {
+    // openapiRouter is a public, middleware-free router (GET /openapi.json,
+    // GET /docs) intentionally mounted before the dashboard rate limiter.
+    // It registers no `use('*')`, so it cannot shadow anything. Any OTHER
+    // bare `/api/v1` mount is a new wildcard hazard and must instead get a
+    // specific prefix or be added to WILDCARD_ROUTERS above (mounted last).
+    const mounts = apiV1Mounts(await readAppSource())
+    const bare = mounts.filter((m) => m.path === '/api/v1').map((m) => m.router)
+    expect(bare.sort()).toEqual(['evalsRouter', 'humanEvalsRouter', 'openapiRouter'])
+  })
+})

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -213,31 +213,23 @@ app.route('/api/v1/security',       securityRouter)
 app.route('/api/v1/prompts/playground', promptsPlaygroundRouter)
 app.route('/api/v1/prompts',        promptsRouter)
 app.route('/api/v1/prompt-experiments', promptExperimentsRouter)
-app.route('/api/v1/invitations', invitationsRouter)           // public GET /accept — must be before evalsRouter/humanEvalsRouter
-// Must be mounted BEFORE evalsRouter/humanEvalsRouter for the same reason
-// meRouter is: those two mount at the broad `/api/v1` prefix with
-// `.use('*', authJwt)`, so any route registered after them and matching
-// their wildcard gets the misleading "Invalid or expired token" 401
-// instead of running its own (here: dual JWT / sl_live_*) auth.
+app.route('/api/v1/invitations', invitationsRouter)           // public GET /accept — safe because wildcard routers mount last (see below)
+// recommendations uses dual auth (JWT or sl_live_*). It broke in production
+// on 2026-06-04 when it was mounted AFTER the `/api/v1` wildcard routers:
+// their `.use('*', authJwt)` caught the request first and 401'd every
+// API-key caller. The wildcard routers now mount LAST (see bottom of the
+// /api/v1 section) so this whole class of bug is structurally impossible.
 app.route('/api/v1/recommendations', recommendationsRouter)
-// pendingDeletions must be mounted BEFORE evalsRouter/humanEvalsRouter for
-// the same wildcard-collision reason as recommendations (gotcha #3).
 app.route('/api/v1/pending-deletions', pendingDeletionsRouter)
-// scoreConfigs has the same wildcard-collision concern as the routes above.
 app.route('/api/v1/score-configs',  scoreConfigsRouter)
-// feedback must be mounted BEFORE evalsRouter/humanEvalsRouter for the same
-// reason as recommendations / pending-deletions / score-configs above.
-// `feedbackRouter`'s GET / is intentionally PUBLIC (anonymous roadmap list);
-// mounting after the `/api/v1` wildcard routers lets their `.use('*', authJwt)`
-// catch the request first and 401 every anonymous visitor with "Missing or
-// invalid Authorization header" — exactly what production dogfood after
-// PR #304 surfaced. Per-route authJwt inside feedbackRouter only fires for
-// requests that actually reach this router.
+// `feedbackRouter`'s GET / is intentionally PUBLIC (anonymous roadmap list).
+// This was the second wildcard-shadowing incident (PR #304 dogfood): mounted
+// after the `/api/v1` wildcard routers, their `.use('*', authJwt)` 401'd
+// every anonymous visitor. Per-route authJwt inside feedbackRouter only
+// fires for requests that actually reach this router.
 app.route('/api/v1/feedback',       feedbackRouter)
-app.route('/api/v1',                evalsRouter)
 app.route('/api/v1/datasets',       datasetsRouter)
 app.route('/api/v1/experiments',    experimentsRouter)
-app.route('/api/v1',                humanEvalsRouter)
 app.route('/api/v1/audit-logs',     auditLogsRouter)
 app.route('/api/v1/organizations/:orgId/members', membersRouter)
 app.route('/api/v1/organizations/:orgId/invitations', orgInvitationsRouter)
@@ -259,6 +251,23 @@ app.route('/api/v1/admin/model-recommendations', adminModelRecommendationsRouter
 app.route('/api/v1/admin/background-migrations', adminBackgroundMigrationsRouter)
 app.route('/api/v1/admin/alerts', adminAlertsRouter)
 app.route('/api/v1/admin/feedback', adminFeedbackRouter)
+
+// ── Wildcard /api/v1 routers — MUST STAY LAST ─────────────────
+// evalsRouter and humanEvalsRouter mount at the broad `/api/v1` prefix and
+// register `.use('*', ...)` auth middleware (authJwtOrApiKey / authJwt).
+// Hono matches in registration order, so ANY /api/v1 route registered after
+// these wildcards first passes through their auth middleware — which either
+// wastes a duplicate Supabase auth round-trip (routes with their own auth)
+// or breaks the route outright (dual-auth and public routes get a misleading
+// 401 before their own middleware ever runs). This exact incident shipped
+// twice: recommendations (2026-06-04) and public feedback (PR #304).
+// Keeping the wildcards last makes the failure mode structurally impossible.
+//
+// INVARIANT (guarded by src/__tests__/api-v1-mount-order.test.ts):
+//   Add new specific /api/v1 routers ABOVE this comment block.
+//   Never mount anything at `/api/v1` after these two lines.
+app.route('/api/v1',                evalsRouter)
+app.route('/api/v1',                humanEvalsRouter)
 
 // Sprint 7 R-15 + R-20: global error handler. Every router can now
 // `throw new ApiError('CODE', 'message?')` and rely on this handler to


### PR DESCRIPTION
## Problem

`evalsRouter` and `humanEvalsRouter` mount at the broad `/api/v1` prefix and register `use('*')` auth middleware (`authJwtOrApiKey` / `authJwt`). They were mounted in the middle of the `/api/v1` section, with ~15 specific routers registered after them (datasets, experiments, audit-logs, members, invitations sub-routes, dismissals, me/*, models, webhooks, exports, system, shares, admin/*).

Because Hono matches in registration order, every request to those later routers first ran through the wildcards' auth middleware:

- **Today's cost**: 2-3 redundant Supabase auth round-trips per request on every later-mounted route (each router also mounts its own auth).
- **Tomorrow's incident**: any dual-auth or public route added after the wildcards silently breaks — the wildcard's `authJwt` 401s the request with a misleading "Invalid or expired token" before the route's own middleware ever runs. This exact incident shipped **twice**: `recommendations` (2026-06-04, API-key callers 401'd) and public `feedback` GET (PR #304, anonymous visitors 401'd). Each time the fix was to move that one router earlier, leaving the trap armed for the next one.

## Fix

Mount the two wildcard routers **last** among all `/api/v1` routes, after every specific mount. This kills the failure mode structurally: no specific route can ever be shadowed, and no new router added in the natural place (above the clearly-marked wildcard block) can regress.

**Safety verification done before moving:**

- Wildcard route paths are only `/evaluators`, `/evaluator-templates`, `/eval-runs*` (evals) and `/annotation/queue`, `/human-evals*` (human-evals) — no collision with any specific mount, so matching for those paths is unchanged.
- Every router previously mounted after the wildcards carries its own `use('*', authJwt...)` (or `authJwt + requireSystemAdmin` for admin/*) — audited all 20 files. Removing the wildcard pass-through only removes *duplicate* auth, never the only auth.
- `invitations` public `GET /accept` stays ahead of the wildcards (invariant preserved and now trivially true).
- `meRouter` `/api/v1/me/key-info` (authApiKey CLI introspection) stays ahead — unchanged.

## Guard rails

- New comment block in `app.ts` states the invariant: wildcard `/api/v1` routers mount LAST; add new specific routers ABOVE the block.
- New source-guard test `apps/server/src/__tests__/api-v1-mount-order.test.ts` (same pattern as `require-edit-dual-auth.test.ts`) pins: (1) the two wildcard mounts are the last `/api/v1` mounts, (2) each is mounted exactly once, (3) no new bare-`/api/v1` mounts appear besides the middleware-free `openapiRouter`. A router added below the wildcards now fails CI instead of failing in production.
- CLAUDE.md "새 기능 추가 시 흐름" item 3 updated to state the new invariant.

## Test plan

- [x] `pnpm --filter server typecheck` — clean
- [x] `pnpm --filter server lint` — clean
- [x] `pnpm --filter server test` — 127 files / 1519 tests passed, including the new mount-order guard
- [x] Dual-auth stays green: `eval-runs-dual-auth.test.ts`, `require-edit-dual-auth.test.ts` pass unchanged