### PR TITLE
fix(server): await cron run logging so rows are not dropped on Vercel

### DIFF
--- a/apps/server/src/__tests__/cron-logger.test.ts
+++ b/apps/server/src/__tests__/cron-logger.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+/**
+ * cron-logger contract tests (2026-07-13 audit — cron run logging drain).
+ *
+ * Two guarantees callers rely on:
+ *
+ *   1. `logCronRun` never throws. Handlers `await` it directly (so the
+ *      `cron_job_runs` row is drained before the response returns —
+ *      CLAUDE.md gotcha #8); if a Supabase blip could reject, awaiting
+ *      would flip a successful cron run into a 500.
+ *
+ *   2. `withCronLog` awaits the log write before resolving. The old
+ *      implementation fired `logCronRun(...).catch(...)` without awaiting,
+ *      which Vercel drops after the handler returns → row lost → the
+ *      cron-health monitoring (gotcha #32) misreads "cron never fired".
+ */
+
+const insertMock = vi.fn()
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: (table: string) => ({
+      insert: (payload: unknown) => insertMock(table, payload),
+    }),
+  },
+}))
+
+import { logCronRun, withCronLog } from '../lib/cron-logger.js'
+
+beforeEach(() => {
+  insertMock.mockReset()
+  vi.spyOn(console, 'error').mockImplementation(() => undefined)
+})
+
+describe('logCronRun', () => {
+  test('inserts one row into cron_job_runs with rounded duration', async () => {
+    insertMock.mockResolvedValue({ error: null })
+
+    await logCronRun('test-job', 'ok', 123.6)
+
+    expect(insertMock).toHaveBeenCalledTimes(1)
+    expect(insertMock).toHaveBeenCalledWith('cron_job_runs', {
+      job_name: 'test-job',
+      status: 'ok',
+      duration_ms: 124,
+      error_message: null,
+    })
+  })
+
+  test('passes errorMessage through for error runs', async () => {
+    insertMock.mockResolvedValue({ error: null })
+
+    await logCronRun('test-job', 'error', 10, 'boom')
+
+    expect(insertMock).toHaveBeenCalledWith(
+      'cron_job_runs',
+      expect.objectContaining({ status: 'error', error_message: 'boom' }),
+    )
+  })
+
+  test('never throws when the insert rejects (network failure)', async () => {
+    insertMock.mockRejectedValue(new Error('network down'))
+
+    await expect(logCronRun('test-job', 'ok', 10)).resolves.toBeUndefined()
+    expect(console.error).toHaveBeenCalled()
+  })
+
+  test('never throws when supabase returns an error envelope', async () => {
+    insertMock.mockResolvedValue({ error: { message: 'permission denied' } })
+
+    await expect(logCronRun('test-job', 'ok', 10)).resolves.toBeUndefined()
+    expect(console.error).toHaveBeenCalled()
+  })
+})
+
+describe('withCronLog', () => {
+  test('log write completes before withCronLog resolves (Vercel drain guarantee)', async () => {
+    let logWritten = false
+    insertMock.mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      logWritten = true
+      return { error: null }
+    })
+
+    const result = await withCronLog('test-job', async () => 'done')
+
+    expect(result).toBe('done')
+    expect(logWritten).toBe(true)
+  })
+
+  test('logs error status and returns null when fn throws', async () => {
+    insertMock.mockResolvedValue({ error: null })
+
+    const result = await withCronLog('test-job', async () => {
+      throw new Error('job failed')
+    })
+
+    expect(result).toBeNull()
+    expect(insertMock).toHaveBeenCalledWith(
+      'cron_job_runs',
+      expect.objectContaining({
+        job_name: 'test-job',
+        status: 'error',
+        error_message: 'job failed',
+      }),
+    )
+  })
+})

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -38,6 +38,15 @@ import { runKeepWarmJob } from '../lib/cron-jobs/keep-warm.js'
  * `CRON_SECRET` env var so external callers cannot trigger these endpoints.
  *
  * If `CRON_SECRET` is unset, the endpoints refuse to run (fail-closed).
+ *
+ * Logging convention: every handler MUST `await logCronRun(...)` before
+ * returning. A naked fire-and-forget (`logCronRun(...).catch(...)`) is
+ * dropped by Vercel once the response returns (CLAUDE.md gotcha #8), which
+ * silently loses the `cron_job_runs` row and makes the cron-health
+ * monitoring (gotcha #32) misread "cron never fired". Cron endpoints are
+ * scheduler-invoked and not latency-sensitive, so awaiting the single
+ * INSERT is free; `logCronRun` never throws, so awaiting cannot flip a
+ * successful run into a 500.
  */
 
 export const cronRouter = new Hono()
@@ -72,7 +81,7 @@ cronRouter.get('/aggregate-usage', async (c) => {
   const start = Date.now()
   const result = await runAggregateUsageJob()
   const errorMsg = result.success ? undefined : result.results.find((r) => r.error)?.error
-  logCronRun('aggregate-usage', result.success ? 'ok' : 'error', Date.now() - start, errorMsg).catch(() => undefined)
+  await logCronRun('aggregate-usage', result.success ? 'ok' : 'error', Date.now() - start, errorMsg)
   return c.json(result)
 })
 
@@ -82,7 +91,7 @@ cronRouter.get('/evaluate-alerts', async (c) => {
 
   const start = Date.now()
   const result = await runEvaluateAlertsJob()
-  logCronRun('evaluate-alerts', 'ok', Date.now() - start).catch(() => undefined)
+  await logCronRun('evaluate-alerts', 'ok', Date.now() - start)
   return c.json(result)
 })
 
@@ -93,11 +102,11 @@ cronRouter.get('/report-usage-overage', async (c) => {
   const start = Date.now()
   try {
     const reports = await computeAndReportOverages()
-    logCronRun('report-usage-overage', 'ok', Date.now() - start).catch(console.error)
+    await logCronRun('report-usage-overage', 'ok', Date.now() - start)
     return c.json({ success: true, count: reports.length, reports })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
-    logCronRun('report-usage-overage', 'error', Date.now() - start, msg).catch(console.error)
+    await logCronRun('report-usage-overage', 'error', Date.now() - start, msg)
     throw new ApiError('INTERNAL_ERROR', msg)
   }
 })
@@ -109,11 +118,11 @@ cronRouter.get('/check-quota-warnings', async (c) => {
   const start = Date.now()
   try {
     const result = await runQuotaWarningsJob()
-    logCronRun('check-quota-warnings', 'ok', Date.now() - start).catch(console.error)
+    await logCronRun('check-quota-warnings', 'ok', Date.now() - start)
     return c.json({ success: true, ...result })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
-    logCronRun('check-quota-warnings', 'error', Date.now() - start, msg).catch(console.error)
+    await logCronRun('check-quota-warnings', 'error', Date.now() - start, msg)
     throw new ApiError('INTERNAL_ERROR', msg)
   }
 })
@@ -127,11 +136,11 @@ cronRouter.get('/snapshot-anomalies', async (c) => {
     const results = await snapshotAnomaliesForAllOrgs()
     const total = results.reduce((s, r) => s + r.detected, 0)
     const errored = results.filter((r) => r.errors.length > 0).length
-    logCronRun('snapshot-anomalies', 'ok', Date.now() - start).catch(console.error)
+    await logCronRun('snapshot-anomalies', 'ok', Date.now() - start)
     return c.json({ success: true, orgs: results.length, anomalies: total, errors: errored, results })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
-    logCronRun('snapshot-anomalies', 'error', Date.now() - start, msg).catch(console.error)
+    await logCronRun('snapshot-anomalies', 'error', Date.now() - start, msg)
     throw new ApiError('INTERNAL_ERROR', msg)
   }
 })
@@ -147,11 +156,11 @@ cronRouter.get('/prune-logs', async (c) => {
   ])
 
   if (logsResult.error) {
-    logCronRun('prune-logs', 'error', Date.now() - start, logsResult.error.message).catch(console.error)
+    await logCronRun('prune-logs', 'error', Date.now() - start, logsResult.error.message)
     throw new ApiError('INTERNAL_ERROR', logsResult.error.message)
   }
 
-  logCronRun('prune-logs', 'ok', Date.now() - start).catch(console.error)
+  await logCronRun('prune-logs', 'ok', Date.now() - start)
   return c.json({
     success: true,
     logs: logsResult.data,
@@ -166,11 +175,11 @@ cronRouter.get('/stale-key-reminders', async (c) => {
   const start = Date.now()
   try {
     const result = await runStaleKeyDigestJob()
-    logCronRun('stale-key-reminders', 'ok', Date.now() - start).catch(console.error)
+    await logCronRun('stale-key-reminders', 'ok', Date.now() - start)
     return c.json({ success: true, ...result })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
-    logCronRun('stale-key-reminders', 'error', Date.now() - start, msg).catch(console.error)
+    await logCronRun('stale-key-reminders', 'error', Date.now() - start, msg)
     throw new ApiError('INTERNAL_ERROR', msg)
   }
 })
@@ -184,11 +193,11 @@ cronRouter.get('/detect-data-silence', async (c) => {
     const result = await runDataSilenceJob()
     const status = result.errors.length > 0 ? 'error' : 'ok'
     const errSummary = result.errors.length > 0 ? result.errors.join('; ').slice(0, 500) : undefined
-    logCronRun('detect-data-silence', status, Date.now() - start, errSummary).catch(console.error)
+    await logCronRun('detect-data-silence', status, Date.now() - start, errSummary)
     return c.json({ success: result.errors.length === 0, ...result })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
-    logCronRun('detect-data-silence', 'error', Date.now() - start, msg).catch(console.error)
+    await logCronRun('detect-data-silence', 'error', Date.now() - start, msg)
     throw new ApiError('INTERNAL_ERROR', msg)
   }
 })
@@ -205,11 +214,11 @@ cronRouter.get('/weekly-digest', async (c) => {
     // retry would double-send to every org that already succeeded.
     const status = result.completed ? 'ok' : 'error'
     const errSummary = result.errors.length > 0 ? result.errors.join('; ').slice(0, 500) : undefined
-    logCronRun('weekly-digest', status, Date.now() - start, errSummary).catch(console.error)
+    await logCronRun('weekly-digest', status, Date.now() - start, errSummary)
     return c.json({ success: result.completed, ...result })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
-    logCronRun('weekly-digest', 'error', Date.now() - start, msg).catch(console.error)
+    await logCronRun('weekly-digest', 'error', Date.now() - start, msg)
     throw new ApiError('INTERNAL_ERROR', msg)
   }
 })
@@ -224,11 +233,11 @@ cronRouter.get('/recommend-savings-alerts', async (c) => {
     const totalSent    = results.reduce((s, r) => s + r.sent, 0)
     const totalSkipped = results.reduce((s, r) => s + r.skipped, 0)
     const totalErrors  = results.reduce((s, r) => s + r.errors.length, 0)
-    logCronRun('recommend-savings-alerts', 'ok', Date.now() - start).catch(console.error)
+    await logCronRun('recommend-savings-alerts', 'ok', Date.now() - start)
     return c.json({ success: true, orgs: results.length, sent: totalSent, skipped: totalSkipped, errors: totalErrors, results })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
-    logCronRun('recommend-savings-alerts', 'error', Date.now() - start, msg).catch(console.error)
+    await logCronRun('recommend-savings-alerts', 'error', Date.now() - start, msg)
     throw new ApiError('INTERNAL_ERROR', msg)
   }
 })
@@ -240,11 +249,11 @@ cronRouter.get('/retry-webhooks', async (c) => {
   const start = Date.now()
   try {
     const result = await retryFailedWebhooks()
-    logCronRun('retry-webhooks', 'ok', Date.now() - start).catch(console.error)
+    await logCronRun('retry-webhooks', 'ok', Date.now() - start)
     return c.json({ success: true, ...result })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
-    logCronRun('retry-webhooks', 'error', Date.now() - start, msg).catch(console.error)
+    await logCronRun('retry-webhooks', 'error', Date.now() - start, msg)
     throw new ApiError('INTERNAL_ERROR', msg)
   }
 })
@@ -256,11 +265,11 @@ cronRouter.get('/leak-detect-keys', async (c) => {
   const start = Date.now()
   try {
     const result = await runLeakDetectionJob()
-    logCronRun('leak-detect-keys', 'ok', Date.now() - start).catch(console.error)
+    await logCronRun('leak-detect-keys', 'ok', Date.now() - start)
     return c.json({ success: true, ...result })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
-    logCronRun('leak-detect-keys', 'error', Date.now() - start, msg).catch(console.error)
+    await logCronRun('leak-detect-keys', 'error', Date.now() - start, msg)
     throw new ApiError('INTERNAL_ERROR', msg)
   }
 })
@@ -281,7 +290,7 @@ cronRouter.get('/replay-fallback', async (c) => {
     const backlog = await alertOnFallbackBacklog()
     const topErr = requestsResult.error ?? eventsResult.error
     const status = topErr ? 'error' : 'ok'
-    logCronRun('replay-fallback', status, Date.now() - start, topErr).catch(console.error)
+    await logCronRun('replay-fallback', status, Date.now() - start, topErr)
     return c.json({
       success: !topErr,
       requests: requestsResult,
@@ -290,7 +299,7 @@ cronRouter.get('/replay-fallback', async (c) => {
     })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
-    logCronRun('replay-fallback', 'error', Date.now() - start, msg).catch(console.error)
+    await logCronRun('replay-fallback', 'error', Date.now() - start, msg)
     throw new ApiError('INTERNAL_ERROR', msg)
   }
 })
@@ -304,11 +313,11 @@ cronRouter.get('/check-past-due-downgrades', async (c) => {
     const result = await runDowngradeCheck()
     const status = result.errors.length > 0 ? 'error' : 'ok'
     const errSummary = result.errors.length > 0 ? result.errors.join('; ').slice(0, 500) : undefined
-    logCronRun('check-past-due-downgrades', status, Date.now() - start, errSummary).catch(console.error)
+    await logCronRun('check-past-due-downgrades', status, Date.now() - start, errSummary)
     return c.json({ success: result.errors.length === 0, ...result })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
-    logCronRun('check-past-due-downgrades', 'error', Date.now() - start, msg).catch(console.error)
+    await logCronRun('check-past-due-downgrades', 'error', Date.now() - start, msg)
     throw new ApiError('INTERNAL_ERROR', msg)
   }
 })
@@ -386,10 +395,9 @@ cronRouter.get('/detect-missing-model-prices', async (c) => {
   // Match the legacy call shape: only pass `errorMessage` when there IS one
   // (test spies use `toHaveBeenCalledWith` which rejects an undefined 4th arg).
   const dur = Date.now() - start
-  const p = result.ok
+  await (result.ok
     ? logCronRun('detect-missing-model-prices', 'ok', dur)
-    : logCronRun('detect-missing-model-prices', 'error', dur, result.error)
-  await p.catch(() => undefined)
+    : logCronRun('detect-missing-model-prices', 'error', dur, result.error))
   return c.json(result, result.ok ? 200 : 500)
 })
 
@@ -400,10 +408,9 @@ cronRouter.get('/self-monitor', async (c) => {
   const start = Date.now()
   const result = await runSelfMonitorJob()
   const dur = Date.now() - start
-  const p = result.ok
+  await (result.ok
     ? logCronRun('self-monitor', 'ok', dur)
-    : logCronRun('self-monitor', 'error', dur, result.error)
-  p.catch(() => undefined)
+    : logCronRun('self-monitor', 'error', dur, result.error))
   return c.json(result, result.ok ? 200 : 500)
 })
 
@@ -414,10 +421,9 @@ cronRouter.get('/detect-orphan-spans', async (c) => {
   const start = Date.now()
   const result = await runDetectOrphanSpansJob()
   const dur = Date.now() - start
-  const p = result.ok
+  await (result.ok
     ? logCronRun('detect-orphan-spans', 'ok', dur)
-    : logCronRun('detect-orphan-spans', 'error', dur, result.error)
-  p.catch(() => undefined)
+    : logCronRun('detect-orphan-spans', 'error', dur, result.error))
   return c.json(result, result.ok ? 200 : 500)
 })
 
@@ -428,10 +434,9 @@ cronRouter.get('/prune-judge-cache', async (c) => {
   const start = Date.now()
   const result = await runPruneJudgeCacheJob()
   const dur = Date.now() - start
-  const p = result.ok
+  await (result.ok
     ? logCronRun('prune-judge-cache', 'ok', dur)
-    : logCronRun('prune-judge-cache', 'error', dur, result.error)
-  p.catch(() => undefined)
+    : logCronRun('prune-judge-cache', 'error', dur, result.error))
   return c.json(result, result.ok ? 200 : 500)
 })
 
@@ -454,6 +459,6 @@ cronRouter.get('/purge-proxy-cache', async (c) => {
   // purgeExpiredProxyCache is fail-open: it never throws and returns the
   // count deleted so far, so this handler always logs 'ok'.
   const deleted = await purgeExpiredProxyCache()
-  logCronRun('purge-proxy-cache', 'ok', Date.now() - start).catch(console.error)
+  await logCronRun('purge-proxy-cache', 'ok', Date.now() - start)
   return c.json({ deleted })
 })

--- a/apps/server/src/lib/cron-logger.ts
+++ b/apps/server/src/lib/cron-logger.ts
@@ -1,8 +1,16 @@
 import { supabaseAdmin } from './db.js'
 
 /**
- * Record one cron job execution. Fire-and-forget — never throws.
- * Caller measures elapsed time and passes it in.
+ * Record one cron job execution. Never throws — a failed log write must not
+ * fail the cron run itself, so callers can safely `await` this directly.
+ *
+ * Callers MUST `await` the returned promise (or route it through
+ * `fireAndForget(c, ...)` from lib/wait-until.ts). A naked fire-and-forget
+ * call (`logCronRun(...).catch(...)`) is dropped by Vercel the moment the
+ * response returns (CLAUDE.md gotcha #8), which silently loses the
+ * `cron_job_runs` row and makes the cron-health monitoring (gotcha #32)
+ * misread "cron never fired". Cron endpoints are not latency-sensitive,
+ * so awaiting the single INSERT is the standard pattern.
  */
 export async function logCronRun(
   jobName: string,
@@ -10,17 +18,27 @@ export async function logCronRun(
   durationMs: number,
   errorMessage?: string,
 ): Promise<void> {
-  await supabaseAdmin.from('cron_job_runs').insert({
-    job_name: jobName,
-    status,
-    duration_ms: Math.round(durationMs),
-    error_message: errorMessage ?? null,
-  })
+  try {
+    const { error } = await supabaseAdmin.from('cron_job_runs').insert({
+      job_name: jobName,
+      status,
+      duration_ms: Math.round(durationMs),
+      error_message: errorMessage ?? null,
+    })
+    if (error) {
+      console.error(`[cron-logger] failed to record run for ${jobName}: ${error.message}`)
+    }
+  } catch (err) {
+    console.error(`[cron-logger] failed to record run for ${jobName}:`, err)
+  }
 }
 
 /**
  * Wrap an async function so the result is logged to cron_job_runs.
  * Returns the wrapped function's return value; never re-throws.
+ * The log write is awaited so it is drained before the caller's
+ * response returns (gotcha #8) — `logCronRun` never throws, so this
+ * cannot change the wrapped function's outcome.
  */
 export async function withCronLog<T>(
   jobName: string,
@@ -29,11 +47,11 @@ export async function withCronLog<T>(
   const start = Date.now()
   try {
     const result = await fn()
-    logCronRun(jobName, 'ok', Date.now() - start).catch(console.error)
+    await logCronRun(jobName, 'ok', Date.now() - start)
     return result
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
-    logCronRun(jobName, 'error', Date.now() - start, msg).catch(console.error)
+    await logCronRun(jobName, 'error', Date.now() - start, msg)
     return null
   }
 }


### PR DESCRIPTION
## Problem

2026-07-13 audit finding: `apps/server/src/api/cron.ts` had ~20 call sites using naked fire-and-forget for run logging (`logCronRun(...).catch(console.error)` or `.catch(() => undefined)`), and `withCronLog` in `apps/server/src/lib/cron-logger.ts` did the same internally.

On Vercel, a pending promise is dropped the moment the handler returns (CLAUDE.md gotcha #8). The cron endpoint responds 200, but the `cron_job_runs` INSERT silently vanishes. Since the cron-health monitoring reads `cron_job_runs` to detect scheduler gaps (gotcha #32), lost rows make it misread "cron never fired" — false alarms on exactly the signal we use to detect real scheduler failures. A handful of handlers (`execute-pending-deletions`, `run-background-migrations`, `events-reconciliation`) already awaited, so behavior was inconsistent.

## Fix — one consistent approach: `await` the log write

Chose `await logCronRun(...)` at every call site (rather than `fireAndForget(c, ...)`), because:

- Cron endpoints are scheduler-invoked, not user-facing — blocking a few ms on one INSERT is free.
- It is strictly stronger than `waitUntil`: the row is committed **before** the 200 returns, so a monitor querying right after the response always sees it.
- It matches the call sites that already awaited, minimizing churn and leaving a single pattern in the file.

To make awaiting safe, `logCronRun` now **never throws**: the insert is wrapped in try/catch and a returned Supabase error envelope is logged via `console.error`. A log-write failure can no longer flip a successful cron run into a 500 (same fail-open behavior the old `.catch(console.error)` sites had, now guaranteed centrally). `withCronLog` awaits its internal log write for the same drain guarantee.

Response shapes, statuses, and the `logCronRun` call signatures at every site are unchanged (the ternary shape for `detect-missing-model-prices` etc. is preserved for the existing test spies).

## Changes

- `apps/server/src/api/cron.ts` — all ~20 fire-and-forget sites now `await logCronRun(...)`; router header documents the convention.
- `apps/server/src/lib/cron-logger.ts` — `logCronRun` never throws (try/catch + error-envelope logging); `withCronLog` awaits the log write.
- `apps/server/src/__tests__/cron-logger.test.ts` — new contract tests: never-throws on insert rejection and on Supabase error envelope, drain guarantee (log write completes before `withCronLog` resolves), error-status logging.

## Test plan

- [x] `pnpm --filter server typecheck` — clean
- [x] `pnpm --filter server lint` — clean
- [x] `pnpm --filter server test` — 127 files / 1522 tests pass (includes new cron-logger tests; existing cron handler tests unchanged)
- [ ] Post-deploy: confirm `cron_job_runs` row counts per job match scheduler cadence (gotcha #32 query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)