### PR TITLE
fix(server): CSV formula-injection guard + ingest boundary validation and idempotent replay

### DIFF
--- a/apps/server/src/__tests__/exports-stream.test.ts
+++ b/apps/server/src/__tests__/exports-stream.test.ts
@@ -98,6 +98,62 @@ describe('buildCsvStream', () => {
   })
 })
 
+// ── CSV formula-injection guard (OWASP CSV injection) ────────────────────────
+//
+// Exported cells like error_message carry end-user-controlled LLM text. A cell
+// starting with = + - @ (or the tab / CR variants) executes as a formula when
+// the export is opened in Excel / Google Sheets. escapeCsv must prefix such
+// string cells with a single quote, while numeric cells (formatted by our own
+// code, e.g. negative deltas) must pass through untouched.
+
+describe('buildCsvStream formula-injection guard', () => {
+  test.each([
+    ['=SUM(A1:A9)', "'=SUM(A1:A9)"],
+    ['+1+2', "'+1+2"],
+    ['-2+3+cmd', "'-2+3+cmd"],
+    ['@HYPERLINK("x")', '"\'@HYPERLINK(""x"")"'],
+  ])('prefixes string cell %s with a single quote', async (input, expected) => {
+    const rows = fromArray<Record<string, unknown>>([{ v: input }])
+    const out = await readToString(buildCsvStream(['v'], rows))
+    expect(out).toBe(`v\n${expected}\n`)
+  })
+
+  test('guards tab / CR leading variants too', async () => {
+    const rows = fromArray<Record<string, unknown>>([
+      { v: '\t=1+1' },
+      { v: '\r=2+2' },
+    ])
+    const out = await readToString(buildCsvStream(['v'], rows))
+    // Tab variant has no chars needing RFC 4180 quoting; CR variant does.
+    expect(out).toBe('v\n' + "'\t=1+1\n" + '"\'\r=2+2"\n')
+  })
+
+  test('formula trigger combined with quotes/commas is quote-escaped after prefixing', async () => {
+    const rows = fromArray<Record<string, unknown>>([
+      { v: '=HYPERLINK("http://evil.example","click")' },
+    ])
+    const out = await readToString(buildCsvStream(['v'], rows))
+    expect(out).toBe('v\n' + '"\'=HYPERLINK(""http://evil.example"",""click"")"\n')
+  })
+
+  test('does not mangle legitimate negative numbers (typeof number)', async () => {
+    const rows = fromArray<Record<string, unknown>>([
+      { cost: -0.0042, latency: -5, note: 'ok' },
+    ])
+    const out = await readToString(buildCsvStream(['cost', 'latency', 'note'], rows))
+    expect(out).toBe('cost,latency,note\n-0.0042,-5,ok\n')
+  })
+
+  test('leaves benign strings untouched', async () => {
+    const rows = fromArray<Record<string, unknown>>([
+      { v: 'hello world' },
+      { v: 'a=b inside is fine' },
+    ])
+    const out = await readToString(buildCsvStream(['v'], rows))
+    expect(out).toBe('v\nhello world\na=b inside is fine\n')
+  })
+})
+
 // ── JSONL encoder ────────────────────────────────────────────────────────────
 
 describe('buildJsonlStream', () => {

--- a/apps/server/src/__tests__/ingest-validation.test.ts
+++ b/apps/server/src/__tests__/ingest-validation.test.ts
@@ -1,0 +1,358 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Hono } from 'hono'
+import { installOnError } from './helpers/install-on-error.js'
+
+/**
+ * 2026-07-13 audit fixes for the SDK ingest router:
+ *
+ *   1. Client-supplied `id` / `parent_span_id` / `request_id` (UUIDs) and
+ *      `started_at` / `ended_at` (dates) are validated at the boundary.
+ *      Malformed values used to reach Postgres, fail there, and surface as a
+ *      500 INTERNAL_ERROR carrying the raw PG error message. They are body
+ *      fields (not path params), so the contract is 400 VALIDATION_FAILED.
+ *
+ *   2. The file header promises idempotency via client-generated UUIDs, but
+ *      re-POSTing the same id hit a PG unique violation (23505) → 500. The
+ *      handlers now detect 23505 and return 200 with the existing row.
+ *
+ *   3. Raw PG error messages are never leaked in responses — they are logged
+ *      server-side only.
+ */
+
+const PG_DUPLICATE_MESSAGE = 'duplicate key value violates unique constraint "traces_pkey"'
+const PG_GENERIC_MESSAGE = 'insert or update on table violates something internal'
+
+const TRACE_UUID = '11111111-2222-4333-8444-555555555555'
+const SPAN_UUID = '99999999-8888-4777-8666-555555555555'
+
+const state = vi.hoisted(() => ({
+  /** Queue of results returned by `.insert(...).select(...).single()`. */
+  insertResults: [] as Array<{
+    data: Record<string, unknown> | null
+    error: { message: string; code?: string } | null
+  }>,
+  /** Queue of results returned by `.select(...).eq(...)....single()`. */
+  selectResults: [] as Array<{
+    data: Record<string, unknown> | null
+    error: { message: string } | null
+  }>,
+  /** Captured INSERT payloads, in call order. */
+  insertCalls: [] as Array<{ table: string; payload: unknown }>,
+}))
+
+vi.mock('../middleware/authApiKey.js', () => ({
+  authApiKey: async (
+    c: { set: (k: string, v: unknown) => void },
+    next: () => Promise<void>,
+  ) => {
+    c.set('organizationId', 'org-1')
+    c.set('projectId', 'project-1')
+    c.set('apiKeyId', 'apikey-1')
+    await next()
+  },
+}))
+
+vi.mock('../middleware/requireFullScope.js', () => ({
+  requireFullScope: async (_c: unknown, next: () => Promise<void>) => {
+    await next()
+  },
+}))
+
+vi.mock('../lib/events-writer.js', () => ({
+  writeTraceAsEvent: vi.fn(async () => undefined),
+  writeSpanAsEvent: vi.fn(async () => undefined),
+}))
+
+vi.mock('../lib/wait-until.js', () => ({
+  fireAndForget: vi.fn(),
+}))
+
+vi.mock('../lib/webhook-emit.js', () => ({
+  emitWebhookEvent: vi.fn(async () => undefined),
+}))
+
+vi.mock('../lib/db.js', () => {
+  const makeSelectChain = () => {
+    const chain: {
+      eq: () => unknown
+      single: () => Promise<unknown>
+    } = {
+      eq: () => chain,
+      single: async () => state.selectResults.shift() ?? { data: null, error: null },
+    }
+    return chain
+  }
+  const supabaseAdmin = {
+    from: (table: string) => ({
+      insert: (payload: unknown) => {
+        state.insertCalls.push({ table, payload })
+        return {
+          select: () => ({
+            single: async () =>
+              state.insertResults.shift() ?? {
+                data: null,
+                error: { message: 'unexpected insert (no queued result)' },
+              },
+          }),
+        }
+      },
+      select: () => makeSelectChain(),
+      update: () => ({
+        eq: () => ({
+          eq: () => ({
+            select: () => ({
+              single: async () => state.selectResults.shift() ?? { data: null, error: null },
+            }),
+          }),
+        }),
+      }),
+    }),
+  }
+  return { supabaseAdmin, supabaseClient: {} }
+})
+
+import { ingestRouter } from '../api/ingest.js'
+
+function buildApp() {
+  const app = new Hono()
+  app.route('/ingest', ingestRouter)
+  installOnError(app)
+  return app
+}
+
+function postJson(app: Hono, path: string, body: unknown, method = 'POST') {
+  return app.request(path, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  state.insertResults.length = 0
+  state.selectResults.length = 0
+  state.insertCalls.length = 0
+})
+
+// ── POST /ingest/traces ───────────────────────────────────────────────────────
+
+describe('POST /ingest/traces — boundary validation', () => {
+  it('rejects a malformed client-supplied id with 400 VALIDATION_FAILED before touching the DB', async () => {
+    const app = buildApp()
+    const res = await postJson(app, '/ingest/traces', { name: 't', id: 'not-a-uuid' })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: { code: string; message: string } }
+    expect(body.error.code).toBe('VALIDATION_FAILED')
+    expect(body.error.message).toContain('id')
+    expect(state.insertCalls).toHaveLength(0)
+  })
+
+  it('rejects an unparseable started_at with 400 VALIDATION_FAILED', async () => {
+    const app = buildApp()
+    const res = await postJson(app, '/ingest/traces', { name: 't', started_at: 'yesterday-ish' })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('VALIDATION_FAILED')
+    expect(state.insertCalls).toHaveLength(0)
+  })
+
+  it('accepts a valid client UUID + ISO date (201)', async () => {
+    state.insertResults.push({
+      data: { id: TRACE_UUID, started_at: '2026-07-13T00:00:00.000Z' },
+      error: null,
+    })
+    const app = buildApp()
+    const res = await postJson(app, '/ingest/traces', {
+      name: 't',
+      id: TRACE_UUID,
+      started_at: '2026-07-13T00:00:00.000Z',
+    })
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as { success: boolean; data: { id: string } }
+    expect(body.success).toBe(true)
+    expect(body.data.id).toBe(TRACE_UUID)
+  })
+})
+
+describe('POST /ingest/traces — idempotent replay on duplicate id', () => {
+  it('returns 200 with the existing row when the INSERT hits PG 23505', async () => {
+    state.insertResults.push({
+      data: null,
+      error: { message: PG_DUPLICATE_MESSAGE, code: '23505' },
+    })
+    // Idempotency lookup finds the previously created trace.
+    state.selectResults.push({
+      data: { id: TRACE_UUID, started_at: '2026-07-13T00:00:00.000Z' },
+      error: null,
+    })
+    const app = buildApp()
+    const res = await postJson(app, '/ingest/traces', { name: 't', id: TRACE_UUID })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { success: boolean; data: { id: string } }
+    expect(body.success).toBe(true)
+    expect(body.data.id).toBe(TRACE_UUID)
+  })
+
+  it('still 500s (generic, no PG message) when 23505 fires but the row is not visible to this org', async () => {
+    state.insertResults.push({
+      data: null,
+      error: { message: PG_DUPLICATE_MESSAGE, code: '23505' },
+    })
+    state.selectResults.push({ data: null, error: { message: 'not found' } })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const app = buildApp()
+    const res = await postJson(app, '/ingest/traces', { name: 't', id: TRACE_UUID })
+    expect(res.status).toBe(500)
+    const text = await res.text()
+    expect(text).not.toContain('duplicate key')
+    expect(text).not.toContain('traces_pkey')
+    consoleError.mockRestore()
+  })
+})
+
+describe('POST /ingest/traces — no PG error message leak', () => {
+  it('returns a generic 500 body and logs the PG message server-side instead', async () => {
+    state.insertResults.push({
+      data: null,
+      error: { message: PG_GENERIC_MESSAGE, code: '23502' },
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const app = buildApp()
+    const res = await postJson(app, '/ingest/traces', { name: 't' })
+    expect(res.status).toBe(500)
+    const body = (await res.json()) as { error: { code: string; message: string; details?: unknown } }
+    expect(body.error.code).toBe('INTERNAL_ERROR')
+    expect(body.error.message).toBe('Failed to create trace')
+    expect(JSON.stringify(body)).not.toContain(PG_GENERIC_MESSAGE)
+    // The message must still be observable server-side for debugging.
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('[ingest]'),
+      expect.stringContaining(PG_GENERIC_MESSAGE),
+    )
+    consoleError.mockRestore()
+  })
+})
+
+// ── PATCH /ingest/traces/:id ──────────────────────────────────────────────────
+
+describe('PATCH /ingest/traces/:id — boundary validation', () => {
+  it('rejects an unparseable ended_at with 400 VALIDATION_FAILED', async () => {
+    const app = buildApp()
+    const res = await postJson(
+      app,
+      `/ingest/traces/${TRACE_UUID}`,
+      { status: 'completed', ended_at: 'garbage-date' },
+      'PATCH',
+    )
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: { code: string; message: string } }
+    expect(body.error.code).toBe('VALIDATION_FAILED')
+    expect(body.error.message).toContain('ended_at')
+  })
+})
+
+// ── POST /ingest/traces/:id/spans ─────────────────────────────────────────────
+
+describe('POST /ingest/traces/:id/spans — boundary validation', () => {
+  function queueTraceOwnership() {
+    state.selectResults.push({
+      data: { id: TRACE_UUID, project_id: 'project-1' },
+      error: null,
+    })
+  }
+
+  it('rejects a malformed parent_span_id with 400 VALIDATION_FAILED before the INSERT', async () => {
+    queueTraceOwnership()
+    const app = buildApp()
+    const res = await postJson(app, `/ingest/traces/${TRACE_UUID}/spans`, {
+      name: 's',
+      parent_span_id: 'nope',
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: { code: string; message: string } }
+    expect(body.error.code).toBe('VALIDATION_FAILED')
+    expect(body.error.message).toContain('parent_span_id')
+    expect(state.insertCalls).toHaveLength(0)
+  })
+
+  it('rejects a malformed request_id with 400 VALIDATION_FAILED', async () => {
+    queueTraceOwnership()
+    const app = buildApp()
+    const res = await postJson(app, `/ingest/traces/${TRACE_UUID}/spans`, {
+      name: 's',
+      request_id: '12345',
+    })
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('VALIDATION_FAILED')
+    expect(state.insertCalls).toHaveLength(0)
+  })
+
+  it('returns 200 with the existing row when a duplicate span id hits PG 23505', async () => {
+    queueTraceOwnership()
+    state.insertResults.push({
+      data: null,
+      error: { message: PG_DUPLICATE_MESSAGE, code: '23505' },
+    })
+    state.selectResults.push({
+      data: { id: SPAN_UUID, started_at: '2026-07-13T00:00:01.000Z' },
+      error: null,
+    })
+    const app = buildApp()
+    const res = await postJson(app, `/ingest/traces/${TRACE_UUID}/spans`, {
+      name: 's',
+      id: SPAN_UUID,
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { success: boolean; data: { id: string } }
+    expect(body.success).toBe(true)
+    expect(body.data.id).toBe(SPAN_UUID)
+  })
+
+  it('span INSERT failure returns a generic 500 without the PG message', async () => {
+    queueTraceOwnership()
+    state.insertResults.push({
+      data: null,
+      error: { message: PG_GENERIC_MESSAGE, code: '23502' },
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const app = buildApp()
+    const res = await postJson(app, `/ingest/traces/${TRACE_UUID}/spans`, { name: 's' })
+    expect(res.status).toBe(500)
+    const text = await res.text()
+    expect(text).toContain('Failed to create span')
+    expect(text).not.toContain(PG_GENERIC_MESSAGE)
+    consoleError.mockRestore()
+  })
+})
+
+// ── PATCH /ingest/spans/:id ───────────────────────────────────────────────────
+
+describe('PATCH /ingest/spans/:id — boundary validation', () => {
+  it('rejects an unparseable ended_at with 400 VALIDATION_FAILED', async () => {
+    const app = buildApp()
+    const res = await postJson(
+      app,
+      `/ingest/spans/${SPAN_UUID}`,
+      { status: 'completed', ended_at: 'not a date at all zzz' },
+      'PATCH',
+    )
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('VALIDATION_FAILED')
+  })
+
+  it('rejects a malformed request_id with 400 VALIDATION_FAILED', async () => {
+    const app = buildApp()
+    const res = await postJson(
+      app,
+      `/ingest/spans/${SPAN_UUID}`,
+      { request_id: 'req_abc' },
+      'PATCH',
+    )
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error: { code: string; message: string } }
+    expect(body.error.code).toBe('VALIDATION_FAILED')
+    expect(body.error.message).toContain('request_id')
+  })
+})

--- a/apps/server/src/api/exports.ts
+++ b/apps/server/src/api/exports.ts
@@ -65,9 +65,26 @@ function coerceNumericColumns<Row extends Record<string, unknown>>(row: Row): Ro
   return out as Row
 }
 
+/**
+ * Leading characters Excel / Google Sheets interpret as a formula trigger
+ * (`=SUM(...)`, `+cmd|...`, `@HYPERLINK(...)`), including the tab / CR
+ * variants some spreadsheet importers also honour. Exported cells such as
+ * `error_message` carry end-user-controlled LLM text, so an attacker can plant
+ * `=HYPERLINK(...)` in a prompt and have it execute when the victim opens the
+ * export. OWASP mitigation: prefix the cell with a single quote so the
+ * spreadsheet renders it as literal text.
+ */
+const CSV_FORMULA_TRIGGER = /^[=+\-@\t\r]/
+
 function escapeCsv(val: unknown): string {
   if (val === null || val === undefined) return ''
-  const s = String(val)
+  let s = String(val)
+  // Formula-injection guard — string cells only. Numeric columns are coerced
+  // to real numbers before reaching this encoder (coerceNumericColumns), so
+  // legitimate negative numbers are `typeof 'number'` and stay untouched.
+  if (typeof val === 'string' && CSV_FORMULA_TRIGGER.test(s)) {
+    s = "'" + s
+  }
   if (s.includes(',') || s.includes('"') || s.includes('\n') || s.includes('\r')) {
     return '"' + s.replace(/"/g, '""') + '"'
   }
@@ -458,7 +475,10 @@ exportsRouter.get('/security', async (c) => {
   // /exports/requests JSON path — so pandas/BigQuery get numeric columns.
   const rows: Record<string, unknown>[] = data.map((row) => {
     const isoCreated = fromClickhouseTimestamp(row.created_at) ?? row.created_at
-    if (format === 'csv') return { ...row, created_at: isoCreated }
+    // CSV also coerces ClickHouse string-encoded numerics so the formula-
+    // injection guard in escapeCsv (string cells only) can never prefix a
+    // legitimate negative number rendered as a numeric string.
+    if (format === 'csv') return { ...coerceNumericColumns(row), created_at: isoCreated }
     let parsedFlags: unknown = []
     try { parsedFlags = JSON.parse(row.flags) } catch { parsedFlags = row.flags }
     return { ...coerceNumericColumns(row), flags: parsedFlags, created_at: isoCreated }

--- a/apps/server/src/api/ingest.ts
+++ b/apps/server/src/api/ingest.ts
@@ -5,6 +5,7 @@ import { supabaseAdmin } from '../lib/db.js'
 import { fireAndForget } from '../lib/wait-until.js'
 import { emitWebhookEvent } from '../lib/webhook-emit.js'
 import { ApiError } from '../lib/errors.js'
+import { validateOptionalDate, validateOptionalUuid } from '../lib/params.js'
 
 /**
  * SDK용 ingestion 라우터 — authApiKey 미들웨어로 SHA-256 해시 API 키 검증.
@@ -81,8 +82,18 @@ ingestRouter.post('/traces', async (c) => {
     api_key_id: apiKeyId,
     name: body.name.trim(),
   }
-  if (typeof body.id === 'string') insert.id = body.id
-  if (typeof body.started_at === 'string') insert.started_at = body.started_at
+  // Client-supplied fields are validated before they reach Postgres — a
+  // malformed UUID / date otherwise fails inside PG and used to surface as a
+  // raw 500 with the PG error message leaked. Body fields → 400 (these are
+  // not path params, so VALIDATION_FAILED rather than 404).
+  if (typeof body.id === 'string') {
+    const id = validateOptionalUuid(body.id, 'id')
+    if (id) insert.id = id
+  }
+  if (typeof body.started_at === 'string') {
+    const startedAt = validateOptionalDate(body.started_at, 'started_at')
+    if (startedAt) insert.started_at = startedAt
+  }
   if (body.metadata && typeof body.metadata === 'object') {
     insert.metadata = body.metadata as Record<string, unknown>
   }
@@ -94,7 +105,21 @@ ingestRouter.post('/traces', async (c) => {
     .single()
 
   if (error || !data) {
-    throw new ApiError('INTERNAL_ERROR', 'Failed to create trace', { detail: error?.message })
+    // Idempotent replay — the file header promises client-generated UUIDs make
+    // re-POSTs safe, so a unique violation (PG 23505) on a client-supplied id
+    // returns the existing row instead of a 500.
+    if (error?.code === '23505' && insert.id) {
+      const { data: existing } = await supabaseAdmin
+        .from('traces')
+        .select('id, started_at')
+        .eq('id', insert.id)
+        .eq('organization_id', organizationId)
+        .single()
+      if (existing) return c.json({ success: true, data: existing }, 200)
+    }
+    // Never leak the raw PG error message to the client — log it server-side.
+    console.error('[ingest] trace INSERT failed:', error?.message ?? 'no row returned')
+    throw new ApiError('INTERNAL_ERROR', 'Failed to create trace')
   }
 
   // Phase 5.1 dual-write to events. Best-effort — events is the shadow
@@ -156,7 +181,8 @@ ingestRouter.patch('/traces/:id', async (c) => {
     updates['status'] = body.status
   }
   if (typeof body.ended_at === 'string') {
-    updates['ended_at'] = body.ended_at
+    const endedAt = validateOptionalDate(body.ended_at, 'ended_at')
+    if (endedAt) updates['ended_at'] = endedAt
   }
   if (typeof body.error_message === 'string') {
     updates['error_message'] = body.error_message
@@ -298,17 +324,31 @@ ingestRouter.post('/traces/:id/spans', async (c) => {
     organization_id: organizationId,
     name: body.name.trim(),
   }
-  if (typeof body.id === 'string') insert.id = body.id
-  if (typeof body.parent_span_id === 'string') insert.parent_span_id = body.parent_span_id
+  // Same boundary validation as the trace POST — malformed client UUIDs /
+  // dates become a clean 400 instead of a PG error surfaced as a 500.
+  if (typeof body.id === 'string') {
+    const id = validateOptionalUuid(body.id, 'id')
+    if (id) insert.id = id
+  }
+  if (typeof body.parent_span_id === 'string') {
+    const parentSpanId = validateOptionalUuid(body.parent_span_id, 'parent_span_id')
+    if (parentSpanId) insert.parent_span_id = parentSpanId
+  }
   if (typeof body.span_type === 'string' && VALID_SPAN_TYPE.has(body.span_type as SpanType)) {
     insert.span_type = body.span_type
   }
-  if (typeof body.started_at === 'string') insert.started_at = body.started_at
+  if (typeof body.started_at === 'string') {
+    const startedAt = validateOptionalDate(body.started_at, 'started_at')
+    if (startedAt) insert.started_at = startedAt
+  }
   if (body.input !== undefined) insert.input = body.input
   if (body.metadata && typeof body.metadata === 'object') {
     insert.metadata = body.metadata as Record<string, unknown>
   }
-  if (typeof body.request_id === 'string') insert.request_id = body.request_id
+  if (typeof body.request_id === 'string') {
+    const requestId = validateOptionalUuid(body.request_id, 'request_id')
+    if (requestId) insert.request_id = requestId
+  }
 
   const { data, error } = await supabaseAdmin
     .from('spans')
@@ -317,7 +357,20 @@ ingestRouter.post('/traces/:id/spans', async (c) => {
     .single()
 
   if (error || !data) {
-    throw new ApiError('INTERNAL_ERROR', 'Failed to create span', { detail: error?.message })
+    // Idempotent replay on client-supplied UUID re-POSTs — same contract as
+    // the trace POST above (PG unique violation 23505 → 200 with existing id).
+    if (error?.code === '23505' && insert.id) {
+      const { data: existing } = await supabaseAdmin
+        .from('spans')
+        .select('id, started_at')
+        .eq('id', insert.id)
+        .eq('organization_id', organizationId)
+        .single()
+      if (existing) return c.json({ success: true, data: existing }, 200)
+    }
+    // Never leak the raw PG error message to the client — log it server-side.
+    console.error('[ingest] span INSERT failed:', error?.message ?? 'no row returned')
+    throw new ApiError('INTERNAL_ERROR', 'Failed to create span')
   }
 
   // Phase 5.1 dual-write to events — awaited for the same reason as the
@@ -390,7 +443,8 @@ ingestRouter.patch('/spans/:id', async (c) => {
     updates['status'] = body.status
   }
   if (typeof body.ended_at === 'string') {
-    updates['ended_at'] = body.ended_at
+    const endedAt = validateOptionalDate(body.ended_at, 'ended_at')
+    if (endedAt) updates['ended_at'] = endedAt
   }
   if (body.output !== undefined) {
     updates['output'] = body.output
@@ -405,7 +459,10 @@ ingestRouter.patch('/spans/:id', async (c) => {
   if (typeof body.completion_tokens === 'number') updates['completion_tokens'] = body.completion_tokens
   if (typeof body.total_tokens === 'number') updates['total_tokens'] = body.total_tokens
   if (typeof body.cost_usd === 'number') updates['cost_usd'] = body.cost_usd
-  if (typeof body.request_id === 'string') updates['request_id'] = body.request_id
+  if (typeof body.request_id === 'string') {
+    const requestId = validateOptionalUuid(body.request_id, 'request_id')
+    if (requestId) updates['request_id'] = requestId
+  }
 
   if (Object.keys(updates).length === 0) {
     throw new ApiError('BAD_REQUEST', 'No valid fields to update')


### PR DESCRIPTION
## Summary

Two security/correctness fixes in `apps/server` from the 2026-07-13 audit.

### 1. CSV formula injection in exports (`apps/server/src/api/exports.ts`)

`escapeCsv()` handled RFC 4180 quoting (commas, quotes, newlines) but not formula injection. Exported cells such as `error_message` carry end-user-controlled LLM text, so a cell starting with `=`, `+`, `-`, `@` (or the tab/CR variants) executes as a formula when the export is opened in Excel or Google Sheets.

- String cells that start with a formula trigger are now prefixed with a single quote (standard OWASP CSV-injection mitigation), then RFC 4180 quoting applies as before.
- The guard applies to **string cells only**. Numeric columns are coerced to real numbers before reaching the encoder (`coerceNumericColumns`, already applied on the streaming path via `withIsoCreatedAt`), so legitimate negative numbers are untouched. The `/exports/security` CSV path now coerces numerics too, closing the one path where ClickHouse string-encoded numerics reached the encoder as strings.

### 2. Ingest boundary validation + idempotency (`apps/server/src/api/ingest.ts`)

Client-supplied `id`, `parent_span_id`, `request_id` (UUIDs) and `started_at` / `ended_at` (dates) were inserted into Postgres without format validation.

- Malformed UUID/date body fields now return **400 `VALIDATION_FAILED`** (body fields, not path params) via the existing `lib/params.ts` helpers (`validateOptionalUuid` / `validateOptionalDate`), before any DB round trip.
- The router header promises idempotency via client-generated UUIDs, but re-POSTing the same `id` hit a PG unique violation and returned 500. Trace and span POST handlers now detect PG error code **23505** and return **200 with the existing row** (org-scoped lookup), matching the documented contract.
- Raw PG error messages are no longer leaked in responses (previously surfaced via `details.detail` on the 500 envelope). They are logged server-side; clients get the generic `INTERNAL_ERROR` envelope.

## Failure scenarios addressed

| Before | After |
| --- | --- |
| Attacker plants `=HYPERLINK(...)` in a prompt → executes when victim opens CSV export | Cell rendered as literal text (`'=HYPERLINK(...)`) |
| `POST /ingest/traces` with `id: "not-a-uuid"` → PG error → 500 with raw PG message | 400 `VALIDATION_FAILED`, no DB call |
| `POST /ingest/traces` with `started_at: "garbage"` → PG error → 500 | 400 `VALIDATION_FAILED` |
| SDK retry re-POSTs same trace/span UUID → 23505 → 500 | 200 with existing row (idempotent) |
| Any ingest INSERT failure → raw `error.message` in response `details` | Generic 500; PG message logged server-side only |

## Test plan

- [x] New `src/__tests__/ingest-validation.test.ts` (13 tests): malformed UUID/date → 400 with `VALIDATION_FAILED` and no INSERT attempted; duplicate id → 200 idempotent replay for traces and spans; cross-org 23505 → generic 500; PG messages absent from response bodies and present in server-side logs.
- [x] Extended `src/__tests__/exports-stream.test.ts` (+8 tests): `=`, `+`, `-`, `@`, tab, CR triggers get the quote prefix; interaction with RFC 4180 quote escaping; negative numbers and benign strings untouched.
- [x] `pnpm --filter server typecheck` — clean
- [x] `pnpm --filter server lint` — clean
- [x] `pnpm --filter server test` — 127 files / 1537 tests, all passing
