### PR TITLE
fix(server): replay provider coverage, traces 404/search handling, judge-provider dedup

### DIFF
--- a/apps/server/src/__tests__/judge-providers.test.ts
+++ b/apps/server/src/__tests__/judge-providers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { VALID_JUDGE_PROVIDERS, isValidJudgeProvider } from '../lib/judge-providers.js'
+
+// 2026-07-13 audit: this list was hardcoded in three places inside
+// api/evals.ts and could drift. It is now a single module-level const —
+// this test pins the exact membership so an accidental expansion (a product
+// decision, not a refactor) fails loudly.
+
+describe('VALID_JUDGE_PROVIDERS', () => {
+  it('contains exactly the six judge providers', () => {
+    expect([...VALID_JUDGE_PROVIDERS]).toEqual([
+      'openai',
+      'anthropic',
+      'gemini',
+      'azure',
+      'mistral',
+      'openrouter',
+    ])
+  })
+
+  it('isValidJudgeProvider accepts members and rejects everything else', () => {
+    expect(isValidJudgeProvider('openai')).toBe(true)
+    expect(isValidJudgeProvider('openrouter')).toBe(true)
+    // Proxied providers that are deliberately NOT judges.
+    expect(isValidJudgeProvider('groq')).toBe(false)
+    expect(isValidJudgeProvider('deepseek')).toBe(false)
+    expect(isValidJudgeProvider('xai')).toBe(false)
+    expect(isValidJudgeProvider('cohere')).toBe(false)
+    expect(isValidJudgeProvider('')).toBe(false)
+  })
+})

--- a/apps/server/src/__tests__/postgrest-search.test.ts
+++ b/apps/server/src/__tests__/postgrest-search.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { ilikeOrPattern } from '../lib/postgrest-search.js'
+
+// 2026-07-13 audit: the traces search escaped only `%` and `,` — a search
+// term containing `(` / `)` broke PostgREST's or() parser (500), and `_`
+// acted as a LIKE single-char wildcard (wrong matches). ilikeOrPattern
+// double-quotes the value (PostgREST quoting rules: `"` and `\` escaped with
+// a backslash inside quotes) and LIKE-escapes `%`, `_`, `\`.
+
+describe('ilikeOrPattern', () => {
+  it('wraps a plain term in a quoted %...% pattern', () => {
+    expect(ilikeOrPattern('checkout')).toBe('"%checkout%"')
+  })
+
+  it('leaves parentheses and commas literal inside the quoted value', () => {
+    // Quoting is what makes these safe — PostgREST treats the whole quoted
+    // string as one value, so ( ) , no longer terminate the or() clause.
+    expect(ilikeOrPattern('fn(call)')).toBe('"%fn(call)%"')
+    expect(ilikeOrPattern('a,b')).toBe('"%a,b%"')
+  })
+
+  it('escapes underscore so it matches literally instead of any-single-char', () => {
+    // Value seen by PostgREST: %trace\\_a% → after quote-unescaping the SQL
+    // pattern is %trace\_a%, i.e. a literal underscore.
+    expect(ilikeOrPattern('trace_a')).toBe('"%trace\\\\_a%"')
+  })
+
+  it('escapes percent so it matches literally instead of any-substring', () => {
+    expect(ilikeOrPattern('100%')).toBe('"%100\\\\%%"')
+  })
+
+  it('escapes double quotes per PostgREST quoted-value rules', () => {
+    expect(ilikeOrPattern('say "hi"')).toBe('"%say \\"hi\\"%"')
+  })
+
+  it('escapes backslashes at both the LIKE and the quoting layer', () => {
+    // Input a\b → LIKE-escaped a\\b → quote-escaped a\\\\b. PostgREST
+    // unescapes to a\\b, and SQL LIKE unescapes to a literal a\b.
+    expect(ilikeOrPattern('a\\b')).toBe('"%a\\\\\\\\b%"')
+  })
+
+  it('handles the full delimiter soup in one term', () => {
+    expect(ilikeOrPattern('run(2), step_1')).toBe('"%run(2), step\\\\_1%"')
+  })
+})

--- a/apps/server/src/__tests__/replay-providers.test.ts
+++ b/apps/server/src/__tests__/replay-providers.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  REPLAY_RUN_SUPPORTED_PROVIDERS,
+  buildReplayProxyPath,
+  buildReplayUpstream,
+  isOpenAiCompatReplayProvider,
+  parseReplayUsage,
+} from '../lib/replay-providers.js'
+
+// 2026-07-13 audit: POST /:id/replay/run rejected everything but
+// openai/anthropic/gemini even though the server proxies 10 providers, and
+// the curl-snippet builder emitted a bogus `/proxy/<p>` path for the
+// OpenAI-compatible ones. These tests pin the provider→path/upstream mapping.
+
+describe('buildReplayProxyPath', () => {
+  it('maps every proxied provider to its documented proxy base path', () => {
+    expect(buildReplayProxyPath('openai', 'gpt-4o')).toBe('/proxy/openai/v1/chat/completions')
+    expect(buildReplayProxyPath('anthropic', 'claude-3-5-sonnet')).toBe('/proxy/anthropic/v1/messages')
+    expect(buildReplayProxyPath('mistral', 'mistral-large-latest')).toBe('/proxy/mistral/v1/chat/completions')
+    expect(buildReplayProxyPath('openrouter', 'meta-llama/llama-3-8b')).toBe('/proxy/openrouter/v1/chat/completions')
+    expect(buildReplayProxyPath('groq', 'llama-3.3-70b')).toBe('/proxy/groq/v1/chat/completions')
+    expect(buildReplayProxyPath('deepseek', 'deepseek-chat')).toBe('/proxy/deepseek/v1/chat/completions')
+    expect(buildReplayProxyPath('xai', 'grok-3')).toBe('/proxy/xai/v1/chat/completions')
+    expect(buildReplayProxyPath('cohere', 'command-a-03-2025')).toBe('/proxy/cohere/v1/chat/completions')
+  })
+
+  it('azure mounts at /proxy/azure (docs base_url has no /v1 — the SDK appends /chat/completions)', () => {
+    expect(buildReplayProxyPath('azure', 'gpt-4o')).toBe('/proxy/azure/chat/completions')
+  })
+
+  it('gemini encodes the model into the URL, tolerating a models/ prefix', () => {
+    expect(buildReplayProxyPath('gemini', 'gemini-2.0-flash')).toBe(
+      '/proxy/gemini/v1beta/models/gemini-2.0-flash:generateContent',
+    )
+    expect(buildReplayProxyPath('gemini', 'models/gemini-2.0-flash')).toBe(
+      '/proxy/gemini/v1beta/models/gemini-2.0-flash:generateContent',
+    )
+  })
+
+  it('falls back to the bare proxy mount for unknown providers', () => {
+    expect(buildReplayProxyPath('someday-provider', 'x')).toBe('/proxy/someday-provider')
+  })
+})
+
+describe('buildReplayUpstream', () => {
+  const savedMistralBase = process.env['MISTRAL_API_BASE']
+
+  afterEach(() => {
+    if (savedMistralBase === undefined) delete process.env['MISTRAL_API_BASE']
+    else process.env['MISTRAL_API_BASE'] = savedMistralBase
+  })
+
+  it('routes OpenAI-compatible providers to their chat-completions endpoint with Bearer auth', () => {
+    const cases: Record<string, string> = {
+      openai: 'https://api.openai.com/v1/chat/completions',
+      mistral: 'https://api.mistral.ai/v1/chat/completions',
+      openrouter: 'https://openrouter.ai/api/v1/chat/completions',
+      groq: 'https://api.groq.com/openai/v1/chat/completions',
+      deepseek: 'https://api.deepseek.com/v1/chat/completions',
+      xai: 'https://api.x.ai/v1/chat/completions',
+      cohere: 'https://api.cohere.ai/compatibility/v1/chat/completions',
+    }
+    for (const [provider, url] of Object.entries(cases)) {
+      const upstream = buildReplayUpstream(provider, 'some-model', 'sk-test')
+      expect(upstream, provider).not.toBeNull()
+      expect(upstream?.url, provider).toBe(url)
+      expect(upstream?.headers['Authorization'], provider).toBe('Bearer sk-test')
+      expect(upstream?.headers['Content-Type'], provider).toBe('application/json')
+    }
+  })
+
+  it('honours the same env base override as the proxy modules (trailing /v1 stripped)', () => {
+    process.env['MISTRAL_API_BASE'] = 'https://mistral.example.com/v1/'
+    const upstream = buildReplayUpstream('mistral', 'mistral-small', 'sk-x')
+    expect(upstream?.url).toBe('https://mistral.example.com/v1/chat/completions')
+  })
+
+  it('anthropic uses x-api-key + anthropic-version headers', () => {
+    const upstream = buildReplayUpstream('anthropic', 'claude-3-5-sonnet', 'sk-ant-test')
+    expect(upstream?.url).toBe('https://api.anthropic.com/v1/messages')
+    expect(upstream?.headers['x-api-key']).toBe('sk-ant-test')
+    expect(upstream?.headers['anthropic-version']).toBe('2023-06-01')
+    expect(upstream?.headers['Authorization']).toBeUndefined()
+  })
+
+  it('gemini authenticates via the key query param and encodes the model in the URL', () => {
+    const upstream = buildReplayUpstream('gemini', 'gemini-2.0-flash', 'AIza-test')
+    expect(upstream?.url).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=AIza-test',
+    )
+  })
+
+  it('returns null for azure (per-key resource URL) and unknown providers', () => {
+    expect(buildReplayUpstream('azure', 'gpt-4o', 'azure-key')).toBeNull()
+    expect(buildReplayUpstream('someday-provider', 'x', 'k')).toBeNull()
+  })
+
+  it('the supported list matches what buildReplayUpstream actually supports', () => {
+    for (const provider of REPLAY_RUN_SUPPORTED_PROVIDERS) {
+      expect(buildReplayUpstream(provider, 'm', 'k'), provider).not.toBeNull()
+    }
+    expect(REPLAY_RUN_SUPPORTED_PROVIDERS).not.toContain('azure')
+    expect(isOpenAiCompatReplayProvider('azure')).toBe(false)
+  })
+})
+
+describe('parseReplayUsage', () => {
+  it('parses the OpenAI usage shape for openai and every compat provider', () => {
+    const body = { usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } }
+    for (const provider of ['openai', 'mistral', 'openrouter', 'groq', 'deepseek', 'xai', 'cohere']) {
+      expect(parseReplayUsage(provider, body), provider).toEqual({
+        promptTokens: 10,
+        completionTokens: 5,
+        totalTokens: 15,
+      })
+    }
+  })
+
+  it('parses anthropic input/output tokens and derives the total', () => {
+    expect(parseReplayUsage('anthropic', { usage: { input_tokens: 7, output_tokens: 3 } })).toEqual({
+      promptTokens: 7,
+      completionTokens: 3,
+      totalTokens: 10,
+    })
+  })
+
+  it('folds gemini thoughtsTokenCount into completion tokens (billed at output rate)', () => {
+    const body = {
+      usageMetadata: {
+        promptTokenCount: 20,
+        candidatesTokenCount: 8,
+        thoughtsTokenCount: 12,
+        totalTokenCount: 40,
+      },
+    }
+    expect(parseReplayUsage('gemini', body)).toEqual({
+      promptTokens: 20,
+      completionTokens: 20,
+      totalTokens: 40,
+    })
+  })
+
+  it('returns zeros when usage is absent or the provider is unknown', () => {
+    expect(parseReplayUsage('openai', {})).toEqual({ promptTokens: 0, completionTokens: 0, totalTokens: 0 })
+    expect(parseReplayUsage('someday-provider', { usage: { prompt_tokens: 9 } })).toEqual({
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+    })
+  })
+})

--- a/apps/server/src/__tests__/traces-events-notfound.test.ts
+++ b/apps/server/src/__tests__/traces-events-notfound.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import { installOnError } from './helpers/install-on-error.js'
+
+/**
+ * 2026-07-13 audit: on the events read path, GET /api/v1/traces/:id threw
+ * ApiError NOT_FOUND *inside* the try block when the trace didn't exist, and
+ * the surrounding catch logged "[traces:detail] events path failed" and fell
+ * back to Postgres. Every lookup of a nonexistent trace therefore emitted a
+ * fake failure log (polluting incident triage) and issued two pointless
+ * Postgres queries. The fix rethrows NOT_FOUND from the catch; only
+ * unexpected errors trigger the Postgres fallback.
+ */
+
+const state = vi.hoisted(() => ({
+  fromCalls: [] as string[],
+}))
+
+const eventsMocks = vi.hoisted(() => ({
+  listTracesFromEvents: vi.fn(),
+  getTraceWithSpansFromEvents: vi.fn(),
+}))
+
+vi.mock('../middleware/authJwtOrApiKey.js', () => ({
+  // Pass-through auth that just scopes the request to a fixed org.
+  authJwtOrApiKey: async (
+    c: { set: (k: string, v: unknown) => void },
+    next: () => Promise<void>,
+  ) => {
+    c.set('orgId', 'org-1')
+    await next()
+  },
+}))
+
+vi.mock('../lib/events-read-flag.js', () => ({
+  useEventsForTraces: async () => true,
+}))
+
+vi.mock('../lib/traces-events-queries.js', () => eventsMocks)
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: (table: string) => {
+      state.fromCalls.push(table)
+      if (table === 'traces') {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                single: async () => ({
+                  data: { id: 'trace-pg', name: 'pg trace', organization_id: 'org-1' },
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        }
+      }
+      // spans
+      return {
+        select: () => ({
+          eq: () => ({
+            order: async () => ({ data: [], error: null }),
+          }),
+        }),
+      }
+    },
+  },
+  supabaseClient: {},
+}))
+
+async function buildApp() {
+  const { tracesRouter } = await import('../api/traces.js')
+  const app = new Hono()
+  app.route('/api/v1/traces', tracesRouter)
+  installOnError(app)
+  return app
+}
+
+describe('GET /api/v1/traces/:id — events-path NOT_FOUND handling', () => {
+  beforeEach(() => {
+    state.fromCalls.length = 0
+    eventsMocks.getTraceWithSpansFromEvents.mockReset()
+  })
+
+  test('nonexistent trace → clean 404, no fake failure log, no Postgres fallback', async () => {
+    eventsMocks.getTraceWithSpansFromEvents.mockResolvedValue({ trace: null, spans: [] })
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const app = await buildApp()
+      const res = await app.request('/api/v1/traces/no-such-trace')
+      expect(res.status).toBe(404)
+      const body = (await res.json()) as { error: { code: string } }
+      expect(body.error.code).toBe('NOT_FOUND')
+      // The legit 404 must not be reported as an events-path failure...
+      expect(errSpy).not.toHaveBeenCalled()
+      // ...and must not re-query Postgres for a row we know is absent.
+      expect(state.fromCalls).toEqual([])
+    } finally {
+      errSpy.mockRestore()
+    }
+  })
+
+  test('unexpected events error → logs once and falls back to Postgres', async () => {
+    eventsMocks.getTraceWithSpansFromEvents.mockRejectedValue(new Error('CH timeout'))
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const app = await buildApp()
+      const res = await app.request('/api/v1/traces/trace-pg')
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { data: { id: string } }
+      expect(body.data.id).toBe('trace-pg')
+      expect(errSpy).toHaveBeenCalledTimes(1)
+      expect(state.fromCalls).toContain('traces')
+    } finally {
+      errSpy.mockRestore()
+    }
+  })
+})

--- a/apps/server/src/api/evals.ts
+++ b/apps/server/src/api/evals.ts
@@ -8,6 +8,11 @@ import { EMBEDDING_PROVIDERS } from '../lib/eval-runners/embedding.js'
 import { fireAndForget } from '../lib/wait-until.js'
 import { ApiError } from '../lib/errors.js'
 import { parsePageLimit } from '../lib/params.js'
+import {
+  VALID_JUDGE_PROVIDERS,
+  isValidJudgeProvider,
+  type JudgeProvider,
+} from '../lib/judge-providers.js'
 
 // P2-8: evals are dual-auth so CI / SDK can run them with an sl_live_* key,
 // not just a dashboard JWT — this is the "prompt CI" enabler. Reads accept
@@ -97,8 +102,7 @@ evalsRouter.post('/evaluators', requireFullScope, requireEdit, async (c) => {
     const scaleMax = typeof config.scale_max === 'number' ? config.scale_max : 1
 
     if (!criterion) throw new ApiError('VALIDATION_FAILED', 'config.criterion is required')
-    const VALID_JUDGE_PROVIDERS = ['openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter']
-    if (!VALID_JUDGE_PROVIDERS.includes(judgeProvider)) {
+    if (!isValidJudgeProvider(judgeProvider)) {
       throw new ApiError('VALIDATION_FAILED', `config.judge_provider must be one of: ${VALID_JUDGE_PROVIDERS.join(', ')}`)
     }
     if (!judgeModel) throw new ApiError('VALIDATION_FAILED', 'config.judge_model is required')
@@ -221,8 +225,7 @@ evalsRouter.post('/evaluators', requireFullScope, requireEdit, async (c) => {
     const scaleMax = typeof config.scale_max === 'number' ? config.scale_max : 1
     const rubric = typeof config.rubric === 'string' ? config.rubric.trim() : ''
     if (!criterion) throw new ApiError('VALIDATION_FAILED', 'config.criterion is required')
-    const VALID_JUDGE_PROVIDERS = ['openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter']
-    if (!VALID_JUDGE_PROVIDERS.includes(judgeProvider)) {
+    if (!isValidJudgeProvider(judgeProvider)) {
       throw new ApiError('VALIDATION_FAILED', `config.judge_provider must be one of: ${VALID_JUDGE_PROVIDERS.join(', ')}`)
     }
     if (!judgeModel) throw new ApiError('VALIDATION_FAILED', 'config.judge_model is required')
@@ -673,11 +676,9 @@ evalsRouter.post('/eval-runs/estimate', async (c) => {
   const judgeModel = typeof body.judgeModel === 'string' ? body.judgeModel : 'gpt-4o-mini'
   // P3-13: take the real provider from the caller instead of sniffing prefixes.
   // Default to 'openai' for back-compat with old callers that only sent judgeModel.
-  const VALID_JUDGE_PROVIDERS = ['openai', 'anthropic', 'gemini', 'azure', 'mistral', 'openrouter'] as const
-  type JudgeProvider = typeof VALID_JUDGE_PROVIDERS[number]
   const judgeProvider: JudgeProvider =
-    typeof body.judgeProvider === 'string' && (VALID_JUDGE_PROVIDERS as readonly string[]).includes(body.judgeProvider)
-      ? (body.judgeProvider as JudgeProvider)
+    typeof body.judgeProvider === 'string' && isValidJudgeProvider(body.judgeProvider)
+      ? body.judgeProvider
       : 'openai'
   const criterionChars = typeof body.criterionChars === 'number' && body.criterionChars >= 0 ? body.criterionChars : undefined
   const avgResponseChars = typeof body.avgResponseChars === 'number' && body.avgResponseChars >= 0 ? body.avgResponseChars : undefined

--- a/apps/server/src/api/requests.ts
+++ b/apps/server/src/api/requests.ts
@@ -3,7 +3,13 @@ import type { JwtContext } from '../middleware/authJwt.js'
 import { authJwtOrApiKey } from '../middleware/authJwtOrApiKey.js'
 import { requireRole } from '../middleware/requireRole.js'
 import { getDecryptedProviderKeyById, getDecryptedProviderKey } from '../proxy/utils.js'
-import { calculateCost } from '../lib/cost.js'
+import { calculateCost, type Provider } from '../lib/cost.js'
+import {
+  REPLAY_RUN_SUPPORTED_PROVIDERS,
+  buildReplayProxyPath,
+  buildReplayUpstream,
+  parseReplayUsage,
+} from '../lib/replay-providers.js'
 import { logRequestAsync } from '../lib/logger.js'
 import { fireAndForget } from '../lib/wait-until.js'
 import { parsePageLimit, validateOptionalUuid, validateOptionalDate, isUuid } from '../lib/params.js'
@@ -352,20 +358,12 @@ requestsRouter.post('/:id/replay', requireRole('admin', 'editor'), async (c) => 
     )
   }
 
-  // Build provider-specific proxy path for the curl snippet.
-  // Gemini encodes the model in the URL: /v1beta/models/{model}:generateContent
+  // Build provider-specific proxy path for the curl snippet. The mapping
+  // covers all 10 proxied providers (OpenAI-compatible ones mount at
+  // /proxy/<p>/v1, azure at /proxy/azure, gemini encodes the model in the
+  // URL) — see lib/replay-providers.ts.
   const model = (overrideModel ?? data.model ?? '') as string
-  let proxyPath: string
-  if (data.provider === 'openai') {
-    proxyPath = '/proxy/openai/v1/chat/completions'
-  } else if (data.provider === 'anthropic') {
-    proxyPath = '/proxy/anthropic/v1/messages'
-  } else if (data.provider === 'gemini') {
-    const geminiModel = model.startsWith('models/') ? model : `models/${model}`
-    proxyPath = `/proxy/gemini/v1beta/${geminiModel}:generateContent`
-  } else {
-    proxyPath = `/proxy/${data.provider as string}`
-  }
+  const proxyPath = buildReplayProxyPath(data.provider, model)
 
   return c.json({
     success: true,
@@ -452,27 +450,21 @@ requestsRouter.post('/:id/replay/run', requireRole('admin', 'editor'), async (c)
   const model = (replayBody.model ?? data.model ?? '') as string
 
   // ── Resolve upstream endpoint + headers ───────────────────────────────────
+  // OpenAI-compatible providers (mistral, openrouter, groq, deepseek, xai,
+  // cohere) reuse the OpenAI chat-completions replay shape against their own
+  // upstream base. Azure stays unsupported: its base URL is per-key
+  // (provider_metadata.resource_url), so the error names what IS supported.
   const provider = data.provider
-  let upstreamUrl: string
-  let upstreamHeaders: Record<string, string>
-
-  if (provider === 'openai') {
-    upstreamUrl = 'https://api.openai.com/v1/chat/completions'
-    upstreamHeaders = { Authorization: `Bearer ${providerKey.plaintext}`, 'Content-Type': 'application/json' }
-  } else if (provider === 'anthropic') {
-    upstreamUrl = 'https://api.anthropic.com/v1/messages'
-    upstreamHeaders = {
-      'x-api-key': providerKey.plaintext,
-      'anthropic-version': '2023-06-01',
-      'Content-Type': 'application/json',
-    }
-  } else if (provider === 'gemini') {
-    const geminiModel = model.startsWith('models/') ? model : `models/${model}`
-    upstreamUrl = `https://generativelanguage.googleapis.com/v1beta/${geminiModel}:generateContent?key=${providerKey.plaintext}`
-    upstreamHeaders = { 'Content-Type': 'application/json' }
-  } else {
-    throw new ApiError('VALIDATION_FAILED', `Unsupported provider for run: ${provider}`)
+  const upstream = buildReplayUpstream(provider, model, providerKey.plaintext)
+  if (!upstream) {
+    throw new ApiError(
+      'VALIDATION_FAILED',
+      `Replay run is not supported for provider "${provider}". ` +
+        `Supported providers: ${REPLAY_RUN_SUPPORTED_PROVIDERS.join(', ')}. ` +
+        'Use POST /:id/replay to get a curl snippet instead.',
+    )
   }
+  const { url: upstreamUrl, headers: upstreamHeaders } = upstream
 
   // ── Call upstream ─────────────────────────────────────────────────────────
   const startMs = Date.now()
@@ -504,31 +496,11 @@ requestsRouter.post('/:id/replay/run', requireRole('admin', 'editor'), async (c)
   }
 
   // ── Parse token usage ─────────────────────────────────────────────────────
-  let promptTokens = 0, completionTokens = 0, totalTokens = 0
+  // Per-provider usage shapes live in lib/replay-providers.ts (OpenAI-compat
+  // `usage`, Anthropic input/output, Gemini usageMetadata incl. thoughts).
+  const { promptTokens, completionTokens, totalTokens } = parseReplayUsage(provider, resBody)
 
-  if (provider === 'openai') {
-    const u = resBody.usage as Record<string, number> | undefined
-    promptTokens    = u?.prompt_tokens    ?? 0
-    completionTokens = u?.completion_tokens ?? 0
-    totalTokens     = u?.total_tokens     ?? 0
-  } else if (provider === 'anthropic') {
-    const u = resBody.usage as Record<string, number> | undefined
-    promptTokens    = u?.input_tokens  ?? 0
-    completionTokens = u?.output_tokens ?? 0
-    totalTokens     = promptTokens + completionTokens
-  } else if (provider === 'gemini') {
-    const u = resBody.usageMetadata as Record<string, number> | undefined
-    promptTokens    = u?.promptTokenCount     ?? 0
-    // Gemini 2.5+/3 thinking models report reasoning tokens in
-    // thoughtsTokenCount, which Google bills at the OUTPUT rate and which
-    // candidatesTokenCount excludes — fold them into completion tokens so cost
-    // isn't under-reported (see parsers/gemini.ts). totalTokenCount already
-    // includes thoughts, so prompt + completion stays consistent with total.
-    completionTokens = (u?.candidatesTokenCount ?? 0) + (u?.thoughtsTokenCount ?? 0)
-    totalTokens     = u?.totalTokenCount      ?? promptTokens + completionTokens
-  }
-
-  const costResult = calculateCost(provider as 'openai', model, { promptTokens, completionTokens })
+  const costResult = calculateCost(provider as Provider, model, { promptTokens, completionTokens })
   const costUsd = costResult?.totalCost ?? null
 
   // ── Log async (fire-and-forget) ───────────────────────────────────────────

--- a/apps/server/src/api/traces.ts
+++ b/apps/server/src/api/traces.ts
@@ -9,7 +9,8 @@ import {
   listTracesFromEvents,
   getTraceWithSpansFromEvents,
 } from '../lib/traces-events-queries.js'
-import { ApiError } from '../lib/errors.js'
+import { ApiError, isApiError } from '../lib/errors.js'
+import { ilikeOrPattern } from '../lib/postgrest-search.js'
 import { traceToOtlp, type SpanlensTrace, type SpanlensSpan } from '../lib/otel-export.js'
 
 export const tracesRouter = new Hono<JwtContext>()
@@ -93,11 +94,14 @@ tracesRouter.get('/', async (c) => {
     // and only fall back to `id.eq` when the query looks like a full UUID.
     // Short UUID-prefix searches aren't supported here; the user can paste
     // a full ID or jump in via /traces/<id> directly.
-    const escaped = q.replace(/[%,]/g, '\\$&')
+    // ilikeOrPattern quotes the term for PostgREST's or() parser (bare `(`,
+    // `)` or `,` in a search made the whole filter unparseable → 500) and
+    // escapes the LIKE wildcards `%`/`_` so they match literally.
+    const pattern = ilikeOrPattern(q)
     const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(q)
     const clauses = [
-      `name.ilike.%${escaped}%`,
-      `external_trace_id.ilike.%${escaped}%`,
+      `name.ilike.${pattern}`,
+      `external_trace_id.ilike.${pattern}`,
       ...(isUuid ? [`id.eq.${q}`] : []),
     ]
     query = query.or(clauses.join(','))
@@ -192,6 +196,11 @@ tracesRouter.get('/:id', async (c) => {
         data: { ...trace, spans, critical_span_ids: criticalSpanIds },
       })
     } catch (eventsErr) {
+      // A NOT_FOUND thrown above is a legitimate answer ("this trace does not
+      // exist"), not an events-path failure — rethrow it instead of logging a
+      // fake "events path failed" line and re-querying Postgres for a row we
+      // already know is absent. Only unexpected errors trigger the fallback.
+      if (isApiError(eventsErr) && eventsErr.code === 'NOT_FOUND') throw eventsErr
       console.error('[traces:detail] events path failed, falling back to Postgres:', {
         message: eventsErr instanceof Error ? eventsErr.message : String(eventsErr),
         traceId,

--- a/apps/server/src/lib/judge-providers.ts
+++ b/apps/server/src/lib/judge-providers.ts
@@ -1,0 +1,23 @@
+/**
+ * Providers accepted as LLM judges for evaluators and eval-run cost
+ * estimation. Deliberately narrower than the 10 providers the proxy
+ * supports — expanding this list is a product decision, not a refactor.
+ *
+ * Single source of truth for the three validation sites in `api/evals.ts`
+ * (evaluator create, evaluator update, estimate), which previously each
+ * carried their own copy of this array and could drift apart.
+ */
+export const VALID_JUDGE_PROVIDERS = [
+  'openai',
+  'anthropic',
+  'gemini',
+  'azure',
+  'mistral',
+  'openrouter',
+] as const
+
+export type JudgeProvider = (typeof VALID_JUDGE_PROVIDERS)[number]
+
+export function isValidJudgeProvider(value: string): value is JudgeProvider {
+  return (VALID_JUDGE_PROVIDERS as readonly string[]).includes(value)
+}

--- a/apps/server/src/lib/postgrest-search.ts
+++ b/apps/server/src/lib/postgrest-search.ts
@@ -1,0 +1,25 @@
+/**
+ * Escaping helpers for user-supplied search terms that end up inside a
+ * PostgREST `.or()` filter string (supabase-js `query.or('name.ilike.…')`).
+ *
+ * Two escaping layers stack:
+ *
+ *  1. SQL LIKE level — `%` and `_` are pattern metacharacters (and `\` is
+ *     the escape character), so each is backslash-escaped to match literally.
+ *     Without this, searching "trace_a" also matches "traceXa".
+ *
+ *  2. PostgREST or-filter level — `(`, `)` and `,` delimit the or() logic
+ *     tree. An unquoted value containing them makes PostgREST fail to parse
+ *     the whole filter (surfaces as a 500 on the traces list). PostgREST's
+ *     documented fix is to double-quote the value; inside a quoted value,
+ *     `"` and `\` are themselves escaped with a backslash.
+ *
+ * Order matters: LIKE-escape first, then quote-escape, so the backslashes
+ * injected for LIKE survive PostgREST's quoted-string unescaping and reach
+ * the SQL layer intact.
+ */
+export function ilikeOrPattern(term: string): string {
+  const likeEscaped = term.replace(/[\\%_]/g, '\\$&')
+  const quoteEscaped = `%${likeEscaped}%`.replace(/[\\"]/g, '\\$&')
+  return `"${quoteEscaped}"`
+}

--- a/apps/server/src/lib/replay-providers.ts
+++ b/apps/server/src/lib/replay-providers.ts
@@ -1,0 +1,167 @@
+/**
+ * Provider routing for the request-replay endpoints in `api/requests.ts`:
+ *
+ *   POST /api/v1/requests/:id/replay      — builds a curl-ready proxy path
+ *   POST /api/v1/requests/:id/replay/run  — calls the provider API directly
+ *
+ * The server proxies 10 providers (see `proxy/`). Seven of them speak the
+ * OpenAI chat-completions dialect end to end (request body, response body,
+ * `usage` object): openai itself plus mistral, openrouter, groq, deepseek,
+ * xai, and cohere (via its `/compatibility` layer — that is the surface our
+ * proxy logs, so stored request bodies are already OpenAI-shaped). Those all
+ * reuse the OpenAI replay path with their own upstream base URL.
+ *
+ * anthropic and gemini have their own request/usage shapes and are handled
+ * explicitly. azure is the one provider replay-run does NOT support: its
+ * upstream base URL is per-key (`provider_keys.provider_metadata.resource_url`)
+ * and uses `api-key` auth — callers get a clear error naming the supported
+ * providers instead of a generic validation failure.
+ *
+ * Upstream bases mirror the env overrides honoured by the proxy modules
+ * (`MISTRAL_API_BASE`, ...) so a self-hosted deployment that points its proxy
+ * at a mirror replays against the same host. Resolved at call time (not
+ * module load) so tests and runtime env changes behave predictably.
+ */
+
+/** Providers whose chat-completions surface is OpenAI-compatible. */
+const OPENAI_COMPAT_UPSTREAMS: Record<string, { envVar: string; defaultBase: string }> = {
+  openai: { envVar: 'OPENAI_API_BASE', defaultBase: 'https://api.openai.com' },
+  mistral: { envVar: 'MISTRAL_API_BASE', defaultBase: 'https://api.mistral.ai' },
+  openrouter: { envVar: 'OPENROUTER_API_BASE', defaultBase: 'https://openrouter.ai/api' },
+  groq: { envVar: 'GROQ_API_BASE', defaultBase: 'https://api.groq.com/openai' },
+  deepseek: { envVar: 'DEEPSEEK_API_BASE', defaultBase: 'https://api.deepseek.com' },
+  xai: { envVar: 'XAI_API_BASE', defaultBase: 'https://api.x.ai' },
+  cohere: { envVar: 'COHERE_API_BASE', defaultBase: 'https://api.cohere.ai/compatibility' },
+} as const
+
+export const REPLAY_RUN_SUPPORTED_PROVIDERS = [
+  'openai',
+  'anthropic',
+  'gemini',
+  'mistral',
+  'openrouter',
+  'groq',
+  'deepseek',
+  'xai',
+  'cohere',
+] as const
+
+export function isOpenAiCompatReplayProvider(provider: string): boolean {
+  return provider in OPENAI_COMPAT_UPSTREAMS
+}
+
+function resolveCompatBase(provider: string): string {
+  const entry = OPENAI_COMPAT_UPSTREAMS[provider]
+  if (!entry) throw new Error(`Not an OpenAI-compatible replay provider: ${provider}`)
+  // Same trailing-/v1 strip as the proxy modules — guards against an operator
+  // setting FOO_API_BASE with a redundant /v1.
+  return (process.env[entry.envVar] ?? entry.defaultBase).replace(/\/v1\/?$/, '')
+}
+
+function geminiModelPath(model: string): string {
+  return model.startsWith('models/') ? model : `models/${model}`
+}
+
+/**
+ * Spanlens proxy path for the curl snippet returned by POST /:id/replay.
+ * Per-provider base paths match the public docs (`apps/web/app/docs/proxy/page.tsx`):
+ * OpenAI-compatible providers mount at `/proxy/<p>/v1`, azure mounts at
+ * `/proxy/azure` (the OpenAI SDK appends `/chat/completions` itself), gemini
+ * encodes the model in the URL. Unknown providers fall back to the bare
+ * proxy mount so the snippet at least points at the right router.
+ */
+export function buildReplayProxyPath(provider: string, model: string): string {
+  if (provider === 'anthropic') return '/proxy/anthropic/v1/messages'
+  if (provider === 'gemini') return `/proxy/gemini/v1beta/${geminiModelPath(model)}:generateContent`
+  if (provider === 'azure') return '/proxy/azure/chat/completions'
+  if (isOpenAiCompatReplayProvider(provider)) return `/proxy/${provider}/v1/chat/completions`
+  return `/proxy/${provider}`
+}
+
+export interface ReplayUpstream {
+  url: string
+  headers: Record<string, string>
+}
+
+/**
+ * Upstream endpoint + auth headers for POST /:id/replay/run.
+ * Returns null for providers replay-run cannot support (azure — per-key
+ * resource URL — and anything unknown); the caller surfaces a clear error
+ * listing REPLAY_RUN_SUPPORTED_PROVIDERS.
+ *
+ * SECURITY: the plaintext provider key goes straight into the returned
+ * headers (or the gemini query param, which is how Google authenticates) and
+ * must never be logged.
+ */
+export function buildReplayUpstream(
+  provider: string,
+  model: string,
+  providerKeyPlaintext: string,
+): ReplayUpstream | null {
+  if (provider === 'anthropic') {
+    return {
+      url: 'https://api.anthropic.com/v1/messages',
+      headers: {
+        'x-api-key': providerKeyPlaintext,
+        'anthropic-version': '2023-06-01',
+        'Content-Type': 'application/json',
+      },
+    }
+  }
+  if (provider === 'gemini') {
+    return {
+      url: `https://generativelanguage.googleapis.com/v1beta/${geminiModelPath(model)}:generateContent?key=${providerKeyPlaintext}`,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  }
+  if (isOpenAiCompatReplayProvider(provider)) {
+    return {
+      url: `${resolveCompatBase(provider)}/v1/chat/completions`,
+      headers: {
+        Authorization: `Bearer ${providerKeyPlaintext}`,
+        'Content-Type': 'application/json',
+      },
+    }
+  }
+  return null
+}
+
+export interface ReplayUsage {
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+}
+
+/**
+ * Extract token usage from a non-streaming replay response.
+ * OpenAI-compatible providers all report the OpenAI `usage` object.
+ */
+export function parseReplayUsage(provider: string, resBody: Record<string, unknown>): ReplayUsage {
+  if (provider === 'anthropic') {
+    const u = resBody['usage'] as Record<string, number> | undefined
+    const promptTokens = u?.['input_tokens'] ?? 0
+    const completionTokens = u?.['output_tokens'] ?? 0
+    return { promptTokens, completionTokens, totalTokens: promptTokens + completionTokens }
+  }
+  if (provider === 'gemini') {
+    const u = resBody['usageMetadata'] as Record<string, number> | undefined
+    const promptTokens = u?.['promptTokenCount'] ?? 0
+    // Gemini 2.5+/3 thinking models report reasoning tokens in
+    // thoughtsTokenCount, which Google bills at the OUTPUT rate and which
+    // candidatesTokenCount excludes — fold them into completion tokens so cost
+    // isn't under-reported (see parsers/gemini.ts). totalTokenCount already
+    // includes thoughts, so prompt + completion stays consistent with total.
+    const completionTokens = (u?.['candidatesTokenCount'] ?? 0) + (u?.['thoughtsTokenCount'] ?? 0)
+    const totalTokens = u?.['totalTokenCount'] ?? promptTokens + completionTokens
+    return { promptTokens, completionTokens, totalTokens }
+  }
+  if (isOpenAiCompatReplayProvider(provider)) {
+    const u = resBody['usage'] as Record<string, number> | undefined
+    return {
+      promptTokens: u?.['prompt_tokens'] ?? 0,
+      completionTokens: u?.['completion_tokens'] ?? 0,
+      totalTokens: u?.['total_tokens'] ?? 0,
+    }
+  }
+  return { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
+}


### PR DESCRIPTION
2026-07-13 audit follow-ups: three related server fixes bundled into one PR. Validated with `pnpm --filter server typecheck && lint && test` (130 files / 1541 tests green, 4 new test files).

## 1. Replay supports the OpenAI-compatible providers (`api/requests.ts`)

`POST /api/v1/requests/:id/replay/run` rejected everything except openai/anthropic/gemini with a generic `VALIDATION_FAILED`, even though the server proxies 10 providers.

- New `lib/replay-providers.ts` is the single source of truth for provider -> proxy path / upstream endpoint / usage parsing, shared by both replay endpoints so they cannot drift.
- **Now supported for direct run (9 total):** openai, anthropic, gemini + mistral, openrouter, groq, deepseek, xai, **cohere**. The compat providers reuse the OpenAI chat-completions replay shape against their own upstream base (same env overrides as the proxy modules: `MISTRAL_API_BASE`, `GROQ_API_BASE`, ..., trailing `/v1` stripped). Cohere is included because our proxy logs its OpenAI `/compatibility` surface, so stored request bodies are already OpenAI-shaped.
- **Azure stays unsupported** for direct run: its upstream base is per-key (`provider_keys.provider_metadata.resource_url`) with `api-key` auth. The error now names the supported providers and points at the curl flow instead of a generic message.
- **Curl-snippet builder (`POST /:id/replay`) fixed:** the generic `/proxy/${provider}` fallback produced broken paths. It now emits the documented per-provider base paths (`/proxy/mistral/v1/chat/completions`, `/proxy/groq/v1/chat/completions`, ..., `/proxy/azure/chat/completions` — azure mounts without `/v1`, matching `docs/proxy`).
- Token-usage parsing for the compat providers reuses the OpenAI `usage` shape; gemini keeps the `thoughtsTokenCount` fold-in (gotcha #1).

Tests: `__tests__/replay-providers.test.ts` pins the full provider -> path/upstream/usage matrix, env-override behaviour, and that `REPLAY_RUN_SUPPORTED_PROVIDERS` matches what `buildReplayUpstream` actually supports.

## 2. traces.ts no longer logs fake failures for legit 404s

On the events read path, `GET /api/v1/traces/:id` threw `ApiError NOT_FOUND` *inside* the try block, so the surrounding catch logged `[traces:detail] events path failed, falling back to Postgres` and issued two pointless Postgres queries for every lookup of a nonexistent trace — polluting real incident triage.

Fix: the catch rethrows `NOT_FOUND` (via the `isApiError` guard, which survives dual module loading) and only treats unexpected errors as fallback triggers.

Tests: `__tests__/traces-events-notfound.test.ts` — nonexistent trace returns a clean 404 with no `console.error` and no Postgres query; an unexpected events error still logs once and falls back to Postgres.

## 3. traces search escaping covers PostgREST delimiters and LIKE wildcards

`q.replace(/[%,]/g, '\$&')` missed `(` / `)` (PostgREST `.or()` syntax delimiters — a parenthesized search term made the whole filter unparseable, surfacing as a 500) and `_` (LIKE single-char wildcard — wrong matches).

Fix: new `lib/postgrest-search.ts` `ilikeOrPattern()` double-quotes the value per PostgREST quoted-value rules (which makes `(`, `)` and `,` literal; `"` and `\` are backslash-escaped inside quotes) and LIKE-escapes `%`, `_`, `\`. Escaping order is LIKE-level first, then quote-level, so the injected backslashes survive PostgREST unescaping and reach SQL intact.

Tests: `__tests__/postgrest-search.test.ts` covers parentheses, underscore, percent, comma, quotes, backslash, and a combined term.

## 4. evals.ts judge-provider list deduplicated

`VALID_JUDGE_PROVIDERS` was hardcoded in three places inside `api/evals.ts` (evaluator create, evaluator update, estimate) and could drift. Hoisted to `lib/judge-providers.ts` with an `isValidJudgeProvider` type guard. Same six providers — deliberately NOT expanded (that is a product decision, and the module comment says so).

Tests: `__tests__/judge-providers.test.ts` pins the exact six-member list and rejects groq/deepseek/xai/cohere.

## Test plan
- [x] `pnpm --filter server typecheck`
- [x] `pnpm --filter server lint`
- [x] `pnpm --filter server test` (1541 tests, all green)
- [ ] Post-deploy: replay-run a mistral/groq request from the dashboard and confirm the logged row + cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)