### PR TITLE
feat(sdk): Mistral + OpenRouter integrations, header helpers on every proxy subpath

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -36,9 +36,9 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
-    "@types/node": "^22.10.0",
+    "@types/node": "^25.8.0",
     "tsx": "^4.22.4",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.6"
   },
   "repository": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @spanlens/sdk changelog
 
+## 0.17.0
+
+Mistral and OpenRouter integrations, plus header-helper parity across every proxy subpath.
+
+### Added
+
+- `@spanlens/sdk/mistral` and `@spanlens/sdk/openrouter` subpaths. Both providers are OpenAI-compatible, so `createMistral(options?)` and `createOpenRouter(options?)` return an OpenAI client already pointed at the matching hosted Spanlens proxy route (`/proxy/mistral/v1`, `/proxy/openrouter/v1`). `DEFAULT_SPANLENS_MISTRAL_PROXY` and `DEFAULT_SPANLENS_OPENROUTER_PROXY` are exported for self-hosted overrides.
+- `observeMistral` and `observeOpenRouter` tracers, exported from the package root and from their subpaths. Both parse the standard OpenAI `usage` shape and tag the span with the right provider.
+- The X-Spanlens-* header helpers, `withUser`, `withSession`, `withLogBody`, `withCache`, and `withPromptVersion` (plus `cacheHeaderValue` and the header-name constants), are now exported from every proxy integration subpath: `gemini`, `groq`, `deepseek`, `xai`, `cohere`, `ollama`, `mistral`, and `openrouter`. Previously they were only available from `@spanlens/sdk/openai` and `@spanlens/sdk/anthropic`, which forced a second import to tag, for example, a Groq request with a user ID.
+
+### Changed
+
+- The header helpers now live in one shared internal module and are re-exported by each integration, so behavior is guaranteed identical across subpaths. No public API changes: existing imports from `@spanlens/sdk/openai` and `@spanlens/sdk/anthropic` keep working unchanged.
+
 ## 0.16.0
 
 Default API host moved to the official `api.spanlens.io` domain.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -31,7 +31,7 @@ import { createOpenAI } from '@spanlens/sdk/openai'
 const openai = createOpenAI()  // reads SPANLENS_API_KEY + baseURL automatically
 ```
 
-All three providers supported:
+All providers supported:
 
 ```ts
 import { createOpenAI } from '@spanlens/sdk/openai'
@@ -42,6 +42,22 @@ const openai    = createOpenAI()
 const anthropic = createAnthropic()
 const gemini    = createGemini()
 // gemini.getGenerativeModel() auto-routes through Spanlens proxy
+```
+
+Every OpenAI-compatible provider that Spanlens proxies has its own subpath with the same factory shape (v0.15.0+; Mistral and OpenRouter in v0.17.0+):
+
+```ts
+import { createGroq } from '@spanlens/sdk/groq'
+import { createDeepSeek } from '@spanlens/sdk/deepseek'
+import { createXai } from '@spanlens/sdk/xai'
+import { createCohere } from '@spanlens/sdk/cohere'
+import { createMistral } from '@spanlens/sdk/mistral'
+import { createOpenRouter } from '@spanlens/sdk/openrouter'
+
+const mistral    = createMistral()     // -> /proxy/mistral/v1
+const openrouter = createOpenRouter()  // -> /proxy/openrouter/v1
+// Each returns a regular OpenAI client pointed at the matching proxy route.
+// Register the provider key in Spanlens; SPANLENS_API_KEY is the only key in your app.
 ```
 
 The returned clients are **identical** to `new OpenAI(...)` etc, so all options (timeout, headers, organization, etc.) forward through. Peer dependencies (`openai`, `@anthropic-ai/sdk`, `@google/generative-ai`) are optional. Install only the ones you use.
@@ -60,11 +76,11 @@ const res = await openai.chat.completions.create(
 )
 ```
 
-Same helper on `@spanlens/sdk/anthropic`. For `observeOpenAI/Anthropic/Gemini`, pass `promptVersion` in options.
+The same helper is exported from every provider subpath (`anthropic`, `gemini`, `groq`, `deepseek`, `xai`, `cohere`, `ollama`, `mistral`, `openrouter`). For `observeOpenAI/Anthropic/Gemini/...`, pass `promptVersion` in options.
 
 ### Per-user, per-session, and body-redaction tagging
 
-The same `headers`-style helpers cover the other `X-Spanlens-*` headers. Available on both `@spanlens/sdk/openai` and `@spanlens/sdk/anthropic`.
+The same `headers`-style helpers cover the other `X-Spanlens-*` headers. Available on every provider subpath (`@spanlens/sdk/openai`, `/anthropic`, `/gemini`, `/groq`, `/deepseek`, `/xai`, `/cohere`, `/ollama`, `/mistral`, `/openrouter`).
 
 ```ts
 import { createOpenAI, withUser, withSession, withLogBody } from '@spanlens/sdk/openai'
@@ -512,6 +528,7 @@ The table below is the honest, file-level comparison of what each package ships 
 | Proxy client factory (Anthropic) | ✓ `createAnthropic` | ✓ `create_anthropic` |
 | Proxy client factory (Gemini) | ✓ `createGemini` | ✓ `create_gemini` |
 | Proxy client factory (Ollama) | ✓ `createOllama` (`@spanlens/sdk/ollama`) | ✗ (use a raw OpenAI client at `localhost:11434`) |
+| Proxy client factories (OpenAI-compatible: Groq, DeepSeek, xAI, Cohere, Mistral, OpenRouter) | ✓ (`@spanlens/sdk/<provider>` subpaths) | ✗ (point `base_url` at the proxy route manually) |
 | LangChain integration | ✓ | ✓ |
 | LangGraph integration | ✓ (via the LangChain handler) | ✓ (via the LangChain handler) |
 | LlamaIndex integration | ✓ | ✓ |

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spanlens/sdk",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Spanlens SDK — agent tracing, LLM usage capture, and cost observability for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",
@@ -42,6 +42,14 @@
     "./cohere": {
       "import": "./dist/integrations/cohere.js",
       "types": "./dist/integrations/cohere.d.ts"
+    },
+    "./mistral": {
+      "types": "./dist/integrations/mistral.d.ts",
+      "import": "./dist/integrations/mistral.js"
+    },
+    "./openrouter": {
+      "types": "./dist/integrations/openrouter.d.ts",
+      "import": "./dist/integrations/openrouter.js"
     },
     "./langchain": {
       "import": "./dist/integrations/langchain.js",
@@ -115,6 +123,8 @@
     "grok",
     "xai",
     "cohere",
+    "mistral",
+    "openrouter",
     "next.js",
     "nextjs",
     "typescript",

--- a/packages/sdk/src/__tests__/header-helpers-parity.test.ts
+++ b/packages/sdk/src/__tests__/header-helpers-parity.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import * as headers from '../integrations/_headers.js'
+import * as openai from '../integrations/openai.js'
+import * as anthropic from '../integrations/anthropic.js'
+import * as gemini from '../integrations/gemini.js'
+import * as groq from '../integrations/groq.js'
+import * as deepseek from '../integrations/deepseek.js'
+import * as xai from '../integrations/xai.js'
+import * as cohere from '../integrations/cohere.js'
+import * as ollama from '../integrations/ollama.js'
+import * as mistral from '../integrations/mistral.js'
+import * as openrouter from '../integrations/openrouter.js'
+
+/**
+ * Every proxy integration subpath must re-export the X-Spanlens-* header
+ * helpers from the canonical ./_headers.ts module, so users get single-import
+ * ergonomics regardless of provider:
+ *
+ *   import { createGroq, withUser } from '@spanlens/sdk/groq'
+ *
+ * These tests pin (a) presence on every subpath and (b) reference identity
+ * with the canonical implementation — a re-export, not a copy.
+ */
+
+const HELPER_NAMES = [
+  'withPromptVersion',
+  'withUser',
+  'withSession',
+  'withLogBody',
+  'withCache',
+  'cacheHeaderValue',
+] as const
+
+const HEADER_CONSTANTS = [
+  'PROMPT_VERSION_HEADER',
+  'USER_HEADER',
+  'SESSION_HEADER',
+  'LOG_BODY_HEADER',
+  'CACHE_HEADER',
+  'CACHE_DEFAULT_TTL_SECONDS',
+  'CACHE_MAX_TTL_SECONDS',
+] as const
+
+const MODULES = [
+  { name: 'openai', mod: openai },
+  { name: 'anthropic', mod: anthropic },
+  { name: 'gemini', mod: gemini },
+  { name: 'groq', mod: groq },
+  { name: 'deepseek', mod: deepseek },
+  { name: 'xai', mod: xai },
+  { name: 'cohere', mod: cohere },
+  { name: 'ollama', mod: ollama },
+  { name: 'mistral', mod: mistral },
+  { name: 'openrouter', mod: openrouter },
+] as const
+
+describe('X-Spanlens-* header helper parity across integrations', () => {
+  for (const { name, mod } of MODULES) {
+    describe(`@spanlens/sdk/${name}`, () => {
+      it('re-exports the canonical helper functions (same reference, no copies)', () => {
+        for (const helper of HELPER_NAMES) {
+          const exported = (mod as Record<string, unknown>)[helper]
+          expect(exported, `${name} is missing ${helper}`).toBeTypeOf('function')
+          expect(exported, `${name}.${helper} is a copy, not a re-export`).toBe(
+            headers[helper],
+          )
+        }
+      })
+
+      it('re-exports the header-name constants', () => {
+        for (const constant of HEADER_CONSTANTS) {
+          expect(
+            (mod as Record<string, unknown>)[constant],
+            `${name} is missing ${constant}`,
+          ).toBe(headers[constant])
+        }
+      })
+    })
+  }
+
+  it('helpers emit the documented x-spanlens-* headers', () => {
+    expect(headers.withPromptVersion('greeter@latest')).toEqual({
+      headers: { 'x-spanlens-prompt-version': 'greeter@latest' },
+    })
+    expect(headers.withUser('u1')).toEqual({
+      headers: { 'x-spanlens-user': 'u1' },
+    })
+    expect(headers.withSession('s1')).toEqual({
+      headers: { 'x-spanlens-session': 's1' },
+    })
+    expect(headers.withLogBody('meta')).toEqual({
+      headers: { 'x-spanlens-log-body': 'meta' },
+    })
+    expect(headers.withCache(600)).toEqual({
+      headers: { 'x-spanlens-cache': '600' },
+    })
+  })
+})

--- a/packages/sdk/src/__tests__/proxy-providers.test.ts
+++ b/packages/sdk/src/__tests__/proxy-providers.test.ts
@@ -3,9 +3,11 @@ import { createGroq, DEFAULT_SPANLENS_GROQ_PROXY, observeGroq } from '../integra
 import { createDeepSeek, DEFAULT_SPANLENS_DEEPSEEK_PROXY, observeDeepSeek } from '../integrations/deepseek.js'
 import { createXai, DEFAULT_SPANLENS_XAI_PROXY, observeXai } from '../integrations/xai.js'
 import { createCohere, DEFAULT_SPANLENS_COHERE_PROXY, observeCohere } from '../integrations/cohere.js'
+import { createMistral, DEFAULT_SPANLENS_MISTRAL_PROXY, observeMistral } from '../integrations/mistral.js'
+import { createOpenRouter, DEFAULT_SPANLENS_OPENROUTER_PROXY, observeOpenRouter } from '../integrations/openrouter.js'
 
 /**
- * The four OpenAI-compatible provider factories all route through the hosted
+ * The OpenAI-compatible provider factories all route through the hosted
  * Spanlens proxy (unlike createOllama, which is local). They share the
  * makeSpanlensProxyClient helper, so these tests pin the per-provider default
  * URL, the SPANLENS_API_KEY requirement, and the observe re-export.
@@ -16,6 +18,8 @@ const CASES = [
   { name: 'DeepSeek', create: createDeepSeek, url: DEFAULT_SPANLENS_DEEPSEEK_PROXY, observe: observeDeepSeek, slug: 'deepseek' },
   { name: 'xAI', create: createXai, url: DEFAULT_SPANLENS_XAI_PROXY, observe: observeXai, slug: 'xai' },
   { name: 'Cohere', create: createCohere, url: DEFAULT_SPANLENS_COHERE_PROXY, observe: observeCohere, slug: 'cohere' },
+  { name: 'Mistral', create: createMistral, url: DEFAULT_SPANLENS_MISTRAL_PROXY, observe: observeMistral, slug: 'mistral' },
+  { name: 'OpenRouter', create: createOpenRouter, url: DEFAULT_SPANLENS_OPENROUTER_PROXY, observe: observeOpenRouter, slug: 'openrouter' },
 ] as const
 
 describe('OpenAI-compatible proxy client factories', () => {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -11,6 +11,8 @@ export {
   observeDeepSeek,
   observeXai,
   observeCohere,
+  observeMistral,
+  observeOpenRouter,
 } from './observe.js'
 export type { ProviderObserveOptions } from './observe.js'
 export { parseOpenAIUsage, parseAnthropicUsage, parseGeminiUsage } from './parsers.js'

--- a/packages/sdk/src/integrations/_headers.ts
+++ b/packages/sdk/src/integrations/_headers.ts
@@ -1,0 +1,176 @@
+/**
+ * Canonical X-Spanlens-* request-header helpers, shared by every proxy
+ * integration subpath (`@spanlens/sdk/openai`, `/anthropic`, `/gemini`,
+ * `/groq`, `/deepseek`, `/xai`, `/cohere`, `/ollama`, `/mistral`,
+ * `/openrouter`).
+ *
+ * Each helper returns `{ headers: { ... } }`, which is exactly the shape the
+ * OpenAI / Anthropic SDKs accept as per-request options, so you can pass the
+ * result directly as the second argument of `chat.completions.create()` /
+ * `messages.create()`. Combine helpers by merging their `headers`:
+ *
+ *   { headers: { ...withUser(u).headers, ...withSession(s).headers } }
+ *
+ * This module has no external dependencies on purpose — integrations that do
+ * not require the `openai` peer dependency (e.g. `@spanlens/sdk/gemini`)
+ * re-export from here without pulling one in.
+ */
+
+import type { LogBodyMode } from '../types.js'
+
+export const PROMPT_VERSION_HEADER = 'x-spanlens-prompt-version'
+export const USER_HEADER = 'x-spanlens-user'
+export const SESSION_HEADER = 'x-spanlens-session'
+export const LOG_BODY_HEADER = 'x-spanlens-log-body'
+export const CACHE_HEADER = 'x-spanlens-cache'
+
+/** Default TTL applied server-side when the cache header is `true`. */
+export const CACHE_DEFAULT_TTL_SECONDS = 3600
+/** Server caps any requested TTL at this many seconds (24h). */
+export const CACHE_MAX_TTL_SECONDS = 86400
+
+/**
+ * Tag a single request with a Spanlens prompt version — links the request
+ * row to a `prompt_versions` entry so it shows up in the A/B comparison
+ * on /prompts.
+ *
+ * @param id Either a raw `prompt_versions.id` UUID, `"<name>@<version>"`
+ *           (e.g. `"chatbot-system@3"`), or `"<name>@latest"` to always
+ *           resolve to the latest version server-side.
+ *
+ * @example
+ *   import { createOpenAI, withPromptVersion } from '@spanlens/sdk/openai'
+ *   const openai = createOpenAI()
+ *
+ *   const res = await openai.chat.completions.create(
+ *     { model: 'gpt-4o-mini', messages: [...] },
+ *     withPromptVersion('chatbot-system@3'),
+ *   )
+ */
+export function withPromptVersion(id: string): { headers: Record<string, string> } {
+  return { headers: { [PROMPT_VERSION_HEADER]: id } }
+}
+
+/**
+ * Tag a request with an end-user ID — populates `requests.user_id` so the
+ * dashboard can filter and aggregate by user.
+ *
+ * @example
+ *   import { createOpenAI, withUser } from '@spanlens/sdk/openai'
+ *   const openai = createOpenAI()
+ *
+ *   const res = await openai.chat.completions.create(
+ *     { model: 'gpt-4o-mini', messages: [...] },
+ *     withUser(currentUser.id),
+ *   )
+ */
+export function withUser(userId: string): { headers: Record<string, string> } {
+  return { headers: { [USER_HEADER]: userId } }
+}
+
+/**
+ * Tag a request with a session ID — groups requests that belong to the same
+ * conversation or workflow for end-user attribution.
+ *
+ * @example
+ *   import { createOpenAI, withSession } from '@spanlens/sdk/openai'
+ *   const openai = createOpenAI()
+ *
+ *   const res = await openai.chat.completions.create(
+ *     { model: 'gpt-4o-mini', messages: [...] },
+ *     withSession(currentSession.id),
+ *   )
+ *
+ * Combine with `withUser` and `withPromptVersion` by merging headers:
+ *   { headers: { ...withUser(u).headers, ...withSession(s).headers } }
+ */
+export function withSession(sessionId: string): { headers: Record<string, string> } {
+  return { headers: { [SESSION_HEADER]: sessionId } }
+}
+
+/**
+ * Opt out of body logging for a single request. The proxy still records
+ * tokens, latency, cost, model — just not the prompt/response bodies.
+ *
+ * - `'full'` (server default): stores request_body + response_body with
+ *   API-key pattern masking. Setting this explicitly is a no-op.
+ * - `'meta'`: prompts and responses are NOT stored, but token/cost/latency
+ *   metadata is. Use when prompts contain customer PII you don't want on
+ *   the Spanlens side.
+ * - `'none'`: same as `'meta'` plus drops `user_id` and `session_id` from
+ *   the log row. For the strictest data-minimization deployments.
+ *
+ * @example
+ *   import { createOpenAI, withLogBody } from '@spanlens/sdk/openai'
+ *   const openai = createOpenAI()
+ *
+ *   const res = await openai.chat.completions.create(
+ *     { model: 'gpt-4o-mini', messages: patientPrompt },
+ *     withLogBody('meta'),
+ *   )
+ *
+ * Combine with other helpers by merging headers:
+ *   { headers: { ...withLogBody('meta').headers, ...withUser(u).headers } }
+ */
+export function withLogBody(mode: LogBodyMode): { headers: Record<string, string> } {
+  return { headers: { [LOG_BODY_HEADER]: mode } }
+}
+
+/**
+ * Serialize a `withCache` argument into the `x-spanlens-cache` header value,
+ * or `null` when the input is not a valid cache directive.
+ *
+ * Semantics mirror the server (`apps/server/src/lib/proxy-cache.ts`):
+ *   - `true` (or omitted) → `'true'` (server applies the default 3600s TTL).
+ *   - a positive integer  → the integer as a string, clamped to
+ *     CACHE_MAX_TTL_SECONDS (86400) so the emitted value is never rejected.
+ *   - anything else (non-integer, zero, negative, NaN) → `null`. The helper
+ *     emits no header, matching how the server treats a malformed value as
+ *     "no caching" rather than throwing.
+ */
+export function cacheHeaderValue(ttl?: number | true): string | null {
+  if (ttl === undefined || ttl === true) return 'true'
+  if (typeof ttl !== 'number' || !Number.isInteger(ttl) || ttl <= 0) return null
+  return String(Math.min(ttl, CACHE_MAX_TTL_SECONDS))
+}
+
+/**
+ * Opt a single request into the Spanlens proxy response cache — repeated,
+ * byte-identical requests are served from the cache instead of calling the
+ * provider again, so they cost nothing and return in milliseconds.
+ *
+ * Caching is off by default and only applies to non-streaming requests whose
+ * upstream response is a 200 JSON body under 256 KB. Entries are scoped to your
+ * Spanlens API key, so they are never shared across keys, projects, or orgs.
+ * See the {@link https://spanlens.io/docs/proxy#response-caching proxy caching docs}
+ * for the full rules.
+ *
+ * @param ttl `true` (or omitted) caches with the default TTL
+ *   ({@link CACHE_DEFAULT_TTL_SECONDS}, 1 hour). A positive integer sets the TTL
+ *   in seconds; the server caps it at {@link CACHE_MAX_TTL_SECONDS} (24h) and
+ *   this helper clamps to the same ceiling. Invalid values (non-integer, zero,
+ *   negative) emit no header, matching the server's fail-safe.
+ *
+ * @example
+ *   import { createOpenAI, withCache } from '@spanlens/sdk/openai'
+ *   const openai = createOpenAI()
+ *
+ *   // Default TTL (1 hour)
+ *   const res = await openai.chat.completions.create(
+ *     { model: 'gpt-4o-mini', messages: [...] },
+ *     withCache(),
+ *   )
+ *
+ *   // Custom TTL (10 minutes)
+ *   const res2 = await openai.chat.completions.create(
+ *     { model: 'gpt-4o-mini', messages: [...] },
+ *     withCache(600),
+ *   )
+ *
+ * Combine with other helpers by merging headers:
+ *   { headers: { ...withCache(600).headers, ...withUser(u).headers } }
+ */
+export function withCache(ttl?: number | true): { headers: Record<string, string> } {
+  const value = cacheHeaderValue(ttl)
+  return { headers: value == null ? {} : { [CACHE_HEADER]: value } }
+}

--- a/packages/sdk/src/integrations/anthropic.ts
+++ b/packages/sdk/src/integrations/anthropic.ts
@@ -9,18 +9,25 @@
 
 import Anthropic from '@anthropic-ai/sdk'
 import type { ClientOptions } from '@anthropic-ai/sdk'
-import type { LogBodyMode } from '../types.js'
 
-export const PROMPT_VERSION_HEADER = 'x-spanlens-prompt-version'
-export const USER_HEADER = 'x-spanlens-user'
-export const SESSION_HEADER = 'x-spanlens-session'
-export const LOG_BODY_HEADER = 'x-spanlens-log-body'
-export const CACHE_HEADER = 'x-spanlens-cache'
-
-/** Default TTL applied server-side when the cache header is `true`. */
-export const CACHE_DEFAULT_TTL_SECONDS = 3600
-/** Server caps any requested TTL at this many seconds (24h). */
-export const CACHE_MAX_TTL_SECONDS = 86400
+// X-Spanlens-* request-header helpers. Canonical implementations live in
+// ./_headers.ts — re-exported here so `@spanlens/sdk/anthropic` keeps its
+// single-import ergonomics (`import { createAnthropic, withUser } from ...`).
+export {
+  PROMPT_VERSION_HEADER,
+  USER_HEADER,
+  SESSION_HEADER,
+  LOG_BODY_HEADER,
+  CACHE_HEADER,
+  CACHE_DEFAULT_TTL_SECONDS,
+  CACHE_MAX_TTL_SECONDS,
+  withPromptVersion,
+  withUser,
+  withSession,
+  withLogBody,
+  withCache,
+  cacheHeaderValue,
+} from './_headers.js'
 
 export const DEFAULT_SPANLENS_ANTHROPIC_PROXY =
   'https://api.spanlens.io/proxy/anthropic'
@@ -47,83 +54,4 @@ function readEnv(name: string): string | undefined {
     return process.env[name]
   }
   return undefined
-}
-
-/**
- * Tag a single Anthropic request with a Spanlens prompt version.
- *
- * @param id Either a raw `prompt_versions.id` UUID, `"<name>@<version>"`, or
- *           `"<name>@latest"`.
- *
- * @example
- *   import { createAnthropic, withPromptVersion } from '@spanlens/sdk/anthropic'
- *   const anthropic = createAnthropic()
- *
- *   const msg = await anthropic.messages.create(
- *     { model: 'claude-3-5-sonnet-20241022', max_tokens: 1024, messages: [...] },
- *     withPromptVersion('greeter@latest'),
- *   )
- */
-export function withPromptVersion(id: string): { headers: Record<string, string> } {
-  return { headers: { [PROMPT_VERSION_HEADER]: id } }
-}
-
-/** Tag a request with an end-user ID. Same semantics as the OpenAI helper. */
-export function withUser(userId: string): { headers: Record<string, string> } {
-  return { headers: { [USER_HEADER]: userId } }
-}
-
-/** Tag a request with a session ID. Same semantics as the OpenAI helper. */
-export function withSession(sessionId: string): { headers: Record<string, string> } {
-  return { headers: { [SESSION_HEADER]: sessionId } }
-}
-
-/**
- * Opt out of body logging for a single request. See the OpenAI helper for
- * full semantics — modes are identical (`'full'` | `'meta'` | `'none'`).
- *
- * @example
- *   import { createAnthropic, withLogBody } from '@spanlens/sdk/anthropic'
- *   const anthropic = createAnthropic()
- *
- *   const msg = await anthropic.messages.create(
- *     { model: 'claude-3-5-sonnet-20241022', max_tokens: 1024, messages },
- *     withLogBody('meta'),
- *   )
- */
-export function withLogBody(mode: LogBodyMode): { headers: Record<string, string> } {
-  return { headers: { [LOG_BODY_HEADER]: mode } }
-}
-
-/**
- * Serialize a `withCache` argument into the `x-spanlens-cache` header value,
- * or `null` when the input is not a valid cache directive. Same semantics as
- * the OpenAI helper.
- */
-export function cacheHeaderValue(ttl?: number | true): string | null {
-  if (ttl === undefined || ttl === true) return 'true'
-  if (typeof ttl !== 'number' || !Number.isInteger(ttl) || ttl <= 0) return null
-  return String(Math.min(ttl, CACHE_MAX_TTL_SECONDS))
-}
-
-/**
- * Opt a single Anthropic request into the Spanlens proxy response cache. See
- * the OpenAI helper for full semantics — behavior is identical.
- *
- * @param ttl `true` (or omitted) uses the default TTL
- *   ({@link CACHE_DEFAULT_TTL_SECONDS}, 1 hour); a positive integer sets seconds,
- *   clamped to {@link CACHE_MAX_TTL_SECONDS} (24h). Invalid values emit no header.
- *
- * @example
- *   import { createAnthropic, withCache } from '@spanlens/sdk/anthropic'
- *   const anthropic = createAnthropic()
- *
- *   const msg = await anthropic.messages.create(
- *     { model: 'claude-3-5-sonnet-20241022', max_tokens: 1024, messages },
- *     withCache(600),
- *   )
- */
-export function withCache(ttl?: number | true): { headers: Record<string, string> } {
-  const value = cacheHeaderValue(ttl)
-  return { headers: value == null ? {} : { [CACHE_HEADER]: value } }
 }

--- a/packages/sdk/src/integrations/cohere.ts
+++ b/packages/sdk/src/integrations/cohere.ts
@@ -43,3 +43,23 @@ export function createCohere(options: ClientOptions = {}): OpenAI {
 }
 
 export { observeCohere } from '../observe.js'
+
+// X-Spanlens-* request-header helpers (withUser / withSession / withLogBody /
+// withCache / withPromptVersion) — canonical implementations live in
+// ./_headers.ts. Re-exported so every proxy subpath has the same single-import
+// ergonomics as `@spanlens/sdk/openai`.
+export {
+  PROMPT_VERSION_HEADER,
+  USER_HEADER,
+  SESSION_HEADER,
+  LOG_BODY_HEADER,
+  CACHE_HEADER,
+  CACHE_DEFAULT_TTL_SECONDS,
+  CACHE_MAX_TTL_SECONDS,
+  withPromptVersion,
+  withUser,
+  withSession,
+  withLogBody,
+  withCache,
+  cacheHeaderValue,
+} from './_headers.js'

--- a/packages/sdk/src/integrations/deepseek.ts
+++ b/packages/sdk/src/integrations/deepseek.ts
@@ -42,3 +42,23 @@ export function createDeepSeek(options: ClientOptions = {}): OpenAI {
 }
 
 export { observeDeepSeek } from '../observe.js'
+
+// X-Spanlens-* request-header helpers (withUser / withSession / withLogBody /
+// withCache / withPromptVersion) — canonical implementations live in
+// ./_headers.ts. Re-exported so every proxy subpath has the same single-import
+// ergonomics as `@spanlens/sdk/openai`.
+export {
+  PROMPT_VERSION_HEADER,
+  USER_HEADER,
+  SESSION_HEADER,
+  LOG_BODY_HEADER,
+  CACHE_HEADER,
+  CACHE_DEFAULT_TTL_SECONDS,
+  CACHE_MAX_TTL_SECONDS,
+  withPromptVersion,
+  withUser,
+  withSession,
+  withLogBody,
+  withCache,
+  cacheHeaderValue,
+} from './_headers.js'

--- a/packages/sdk/src/integrations/gemini.ts
+++ b/packages/sdk/src/integrations/gemini.ts
@@ -73,3 +73,23 @@ function readEnv(name: string): string | undefined {
   }
   return undefined
 }
+
+// X-Spanlens-* request-header helpers (withUser / withSession / withLogBody /
+// withCache / withPromptVersion) — canonical implementations live in
+// ./_headers.ts. Re-exported so every proxy subpath has the same single-import
+// ergonomics as `@spanlens/sdk/openai`.
+export {
+  PROMPT_VERSION_HEADER,
+  USER_HEADER,
+  SESSION_HEADER,
+  LOG_BODY_HEADER,
+  CACHE_HEADER,
+  CACHE_DEFAULT_TTL_SECONDS,
+  CACHE_MAX_TTL_SECONDS,
+  withPromptVersion,
+  withUser,
+  withSession,
+  withLogBody,
+  withCache,
+  cacheHeaderValue,
+} from './_headers.js'

--- a/packages/sdk/src/integrations/groq.ts
+++ b/packages/sdk/src/integrations/groq.ts
@@ -44,3 +44,23 @@ export function createGroq(options: ClientOptions = {}): OpenAI {
 // Re-export the tracer so a single `@spanlens/sdk/groq` import gives both the
 // client factory and the matching `observe` helper.
 export { observeGroq } from '../observe.js'
+
+// X-Spanlens-* request-header helpers (withUser / withSession / withLogBody /
+// withCache / withPromptVersion) — canonical implementations live in
+// ./_headers.ts. Re-exported so every proxy subpath has the same single-import
+// ergonomics as `@spanlens/sdk/openai`.
+export {
+  PROMPT_VERSION_HEADER,
+  USER_HEADER,
+  SESSION_HEADER,
+  LOG_BODY_HEADER,
+  CACHE_HEADER,
+  CACHE_DEFAULT_TTL_SECONDS,
+  CACHE_MAX_TTL_SECONDS,
+  withPromptVersion,
+  withUser,
+  withSession,
+  withLogBody,
+  withCache,
+  cacheHeaderValue,
+} from './_headers.js'

--- a/packages/sdk/src/integrations/mistral.ts
+++ b/packages/sdk/src/integrations/mistral.ts
@@ -1,0 +1,66 @@
+/**
+ * Mistral client helper — pre-configured for the Spanlens proxy.
+ *
+ * Mistral exposes an OpenAI-compatible API, so the OpenAI SDK works unchanged
+ * with `baseURL` pointed at the Spanlens Mistral proxy route. Your requests
+ * are recorded in /requests (tokens, latency, cost) and forwarded to Mistral
+ * using the Mistral key you registered in Spanlens.
+ *
+ *   import { createMistral, observeMistral } from '@spanlens/sdk/mistral'
+ *   const mistral = createMistral()
+ *
+ * `openai` is a peer dependency — install it alongside this SDK.
+ *
+ * @example  Full traced call.
+ *   import { SpanlensClient } from '@spanlens/sdk'
+ *   import { createMistral, observeMistral } from '@spanlens/sdk/mistral'
+ *
+ *   const spanlens = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+ *   const mistral = createMistral()
+ *
+ *   const trace = spanlens.startTrace({ name: 'chat' })
+ *   const res = await observeMistral(trace, 'chat', (headers) =>
+ *     mistral.chat.completions.create(
+ *       { model: 'mistral-small-latest', messages: [{ role: 'user', content: 'Hi' }] },
+ *       { headers },
+ *     ),
+ *   )
+ *   await trace.end({ status: 'completed' })
+ */
+
+import type OpenAI from 'openai'
+import type { ClientOptions } from 'openai'
+import { makeSpanlensProxyClient } from './_proxy-client.js'
+
+/** Default Spanlens Mistral proxy URL. Override for self-hosted deployments. */
+export const DEFAULT_SPANLENS_MISTRAL_PROXY =
+  'https://api.spanlens.io/proxy/mistral/v1'
+
+/** Build an OpenAI-compatible client whose requests flow through the Spanlens Mistral proxy. */
+export function createMistral(options: ClientOptions = {}): OpenAI {
+  return makeSpanlensProxyClient('Mistral', DEFAULT_SPANLENS_MISTRAL_PROXY, options)
+}
+
+// Re-export the tracer so a single `@spanlens/sdk/mistral` import gives both
+// the client factory and the matching `observe` helper.
+export { observeMistral } from '../observe.js'
+
+// X-Spanlens-* request-header helpers (withUser / withSession / withLogBody /
+// withCache / withPromptVersion) — canonical implementations live in
+// ./_headers.ts. Re-exported so every proxy subpath has the same single-import
+// ergonomics as `@spanlens/sdk/openai`.
+export {
+  PROMPT_VERSION_HEADER,
+  USER_HEADER,
+  SESSION_HEADER,
+  LOG_BODY_HEADER,
+  CACHE_HEADER,
+  CACHE_DEFAULT_TTL_SECONDS,
+  CACHE_MAX_TTL_SECONDS,
+  withPromptVersion,
+  withUser,
+  withSession,
+  withLogBody,
+  withCache,
+  cacheHeaderValue,
+} from './_headers.js'

--- a/packages/sdk/src/integrations/ollama.ts
+++ b/packages/sdk/src/integrations/ollama.ts
@@ -70,3 +70,23 @@ export function createOllama(options: ClientOptions = {}): OpenAI {
 // both the client factory and the matching `observe` helper — mirrors how
 // `@spanlens/sdk/openai` co-locates `createOpenAI` with its header helpers.
 export { observeOllama } from '../observe.js'
+
+// X-Spanlens-* request-header helpers (withUser / withSession / withLogBody /
+// withCache / withPromptVersion) — canonical implementations live in
+// ./_headers.ts. Re-exported so every proxy subpath has the same single-import
+// ergonomics as `@spanlens/sdk/openai`.
+export {
+  PROMPT_VERSION_HEADER,
+  USER_HEADER,
+  SESSION_HEADER,
+  LOG_BODY_HEADER,
+  CACHE_HEADER,
+  CACHE_DEFAULT_TTL_SECONDS,
+  CACHE_MAX_TTL_SECONDS,
+  withPromptVersion,
+  withUser,
+  withSession,
+  withLogBody,
+  withCache,
+  cacheHeaderValue,
+} from './_headers.js'

--- a/packages/sdk/src/integrations/openai.ts
+++ b/packages/sdk/src/integrations/openai.ts
@@ -21,22 +21,29 @@
 
 import OpenAI from 'openai'
 import type { ClientOptions } from 'openai'
-import type { LogBodyMode } from '../types.js'
 
 /** Default Spanlens proxy URL. Override for self-hosted deployments. */
 export const DEFAULT_SPANLENS_OPENAI_PROXY =
   'https://api.spanlens.io/proxy/openai/v1'
 
-export const PROMPT_VERSION_HEADER = 'x-spanlens-prompt-version'
-export const USER_HEADER = 'x-spanlens-user'
-export const SESSION_HEADER = 'x-spanlens-session'
-export const LOG_BODY_HEADER = 'x-spanlens-log-body'
-export const CACHE_HEADER = 'x-spanlens-cache'
-
-/** Default TTL applied server-side when the cache header is `true`. */
-export const CACHE_DEFAULT_TTL_SECONDS = 3600
-/** Server caps any requested TTL at this many seconds (24h). */
-export const CACHE_MAX_TTL_SECONDS = 86400
+// X-Spanlens-* request-header helpers. Canonical implementations live in
+// ./_headers.ts — re-exported here so `@spanlens/sdk/openai` keeps its
+// single-import ergonomics (`import { createOpenAI, withUser } from ...`).
+export {
+  PROMPT_VERSION_HEADER,
+  USER_HEADER,
+  SESSION_HEADER,
+  LOG_BODY_HEADER,
+  CACHE_HEADER,
+  CACHE_DEFAULT_TTL_SECONDS,
+  CACHE_MAX_TTL_SECONDS,
+  withPromptVersion,
+  withUser,
+  withSession,
+  withLogBody,
+  withCache,
+  cacheHeaderValue,
+} from './_headers.js'
 
 /**
  * Build an OpenAI client whose requests flow through the Spanlens proxy.
@@ -70,150 +77,4 @@ function readEnv(name: string): string | undefined {
     return process.env[name]
   }
   return undefined
-}
-
-/**
- * Tag a single OpenAI request with a Spanlens prompt version — links the
- * request row to a `prompt_versions` entry so it shows up in the A/B
- * comparison on /prompts.
- *
- * @param id Either a raw `prompt_versions.id` UUID, `"<name>@<version>"`
- *           (e.g. `"chatbot-system@3"`), or `"<name>@latest"` to always
- *           resolve to the latest version server-side.
- *
- * @example
- *   import { createOpenAI, withPromptVersion } from '@spanlens/sdk/openai'
- *   const openai = createOpenAI()
- *
- *   const res = await openai.chat.completions.create(
- *     { model: 'gpt-4o-mini', messages: [...] },
- *     withPromptVersion('chatbot-system@3'),
- *   )
- */
-export function withPromptVersion(id: string): { headers: Record<string, string> } {
-  return { headers: { [PROMPT_VERSION_HEADER]: id } }
-}
-
-/**
- * Tag a request with an end-user ID — populates `requests.user_id` so the
- * dashboard can filter and aggregate by user.
- *
- * @example
- *   import { createOpenAI, withUser } from '@spanlens/sdk/openai'
- *   const openai = createOpenAI()
- *
- *   const res = await openai.chat.completions.create(
- *     { model: 'gpt-4o-mini', messages: [...] },
- *     withUser(currentUser.id),
- *   )
- */
-export function withUser(userId: string): { headers: Record<string, string> } {
-  return { headers: { [USER_HEADER]: userId } }
-}
-
-/**
- * Tag a request with a session ID — groups requests that belong to the same
- * conversation or workflow for end-user attribution.
- *
- * @example
- *   import { createOpenAI, withSession } from '@spanlens/sdk/openai'
- *   const openai = createOpenAI()
- *
- *   const res = await openai.chat.completions.create(
- *     { model: 'gpt-4o-mini', messages: [...] },
- *     withSession(currentSession.id),
- *   )
- *
- * Combine with `withUser` and `withPromptVersion` by merging headers:
- *   { headers: { ...withUser(u).headers, ...withSession(s).headers } }
- */
-export function withSession(sessionId: string): { headers: Record<string, string> } {
-  return { headers: { [SESSION_HEADER]: sessionId } }
-}
-
-/**
- * Opt out of body logging for a single request. The proxy still records
- * tokens, latency, cost, model — just not the prompt/response bodies.
- *
- * - `'full'` (server default): stores request_body + response_body with
- *   API-key pattern masking. Setting this explicitly is a no-op.
- * - `'meta'`: prompts and responses are NOT stored, but token/cost/latency
- *   metadata is. Use when prompts contain customer PII you don't want on
- *   the Spanlens side.
- * - `'none'`: same as `'meta'` plus drops `user_id` and `session_id` from
- *   the log row. For the strictest data-minimization deployments.
- *
- * @example
- *   import { createOpenAI, withLogBody } from '@spanlens/sdk/openai'
- *   const openai = createOpenAI()
- *
- *   const res = await openai.chat.completions.create(
- *     { model: 'gpt-4o-mini', messages: patientPrompt },
- *     withLogBody('meta'),
- *   )
- *
- * Combine with other helpers by merging headers:
- *   { headers: { ...withLogBody('meta').headers, ...withUser(u).headers } }
- */
-export function withLogBody(mode: LogBodyMode): { headers: Record<string, string> } {
-  return { headers: { [LOG_BODY_HEADER]: mode } }
-}
-
-/**
- * Serialize a `withCache` argument into the `x-spanlens-cache` header value,
- * or `null` when the input is not a valid cache directive.
- *
- * Semantics mirror the server (`apps/server/src/lib/proxy-cache.ts`):
- *   - `true` (or omitted) → `'true'` (server applies the default 3600s TTL).
- *   - a positive integer  → the integer as a string, clamped to
- *     CACHE_MAX_TTL_SECONDS (86400) so the emitted value is never rejected.
- *   - anything else (non-integer, zero, negative, NaN) → `null`. The helper
- *     emits no header, matching how the server treats a malformed value as
- *     "no caching" rather than throwing.
- */
-export function cacheHeaderValue(ttl?: number | true): string | null {
-  if (ttl === undefined || ttl === true) return 'true'
-  if (typeof ttl !== 'number' || !Number.isInteger(ttl) || ttl <= 0) return null
-  return String(Math.min(ttl, CACHE_MAX_TTL_SECONDS))
-}
-
-/**
- * Opt a single request into the Spanlens proxy response cache — repeated,
- * byte-identical requests are served from the cache instead of calling the
- * provider again, so they cost nothing and return in milliseconds.
- *
- * Caching is off by default and only applies to non-streaming requests whose
- * upstream response is a 200 JSON body under 256 KB. Entries are scoped to your
- * Spanlens API key, so they are never shared across keys, projects, or orgs.
- * See the {@link https://spanlens.io/docs/proxy#response-caching proxy caching docs}
- * for the full rules.
- *
- * @param ttl `true` (or omitted) caches with the default TTL
- *   ({@link CACHE_DEFAULT_TTL_SECONDS}, 1 hour). A positive integer sets the TTL
- *   in seconds; the server caps it at {@link CACHE_MAX_TTL_SECONDS} (24h) and
- *   this helper clamps to the same ceiling. Invalid values (non-integer, zero,
- *   negative) emit no header, matching the server's fail-safe.
- *
- * @example
- *   import { createOpenAI, withCache } from '@spanlens/sdk/openai'
- *   const openai = createOpenAI()
- *
- *   // Default TTL (1 hour)
- *   const res = await openai.chat.completions.create(
- *     { model: 'gpt-4o-mini', messages: [...] },
- *     withCache(),
- *   )
- *
- *   // Custom TTL (10 minutes)
- *   const res2 = await openai.chat.completions.create(
- *     { model: 'gpt-4o-mini', messages: [...] },
- *     withCache(600),
- *   )
- *
- * Combine with other helpers by merging headers:
- *   { headers: { ...withCache(600).headers, ...withUser(u).headers } }
- */
-export function withCache(ttl?: number | true): { headers: Record<string, string> } {
-  const value = cacheHeaderValue(ttl)
-  return { headers: value == null ? {} : { [CACHE_HEADER]: value } }
 }

--- a/packages/sdk/src/integrations/openrouter.ts
+++ b/packages/sdk/src/integrations/openrouter.ts
@@ -1,0 +1,68 @@
+/**
+ * OpenRouter client helper — pre-configured for the Spanlens proxy.
+ *
+ * OpenRouter is a meta-provider: one API key, one OpenAI-compatible base URL,
+ * 100+ models from 30+ providers (OpenAI, Anthropic, Mistral, Meta, DeepSeek,
+ * Qwen, ...). The OpenAI SDK works unchanged with `baseURL` pointed at the
+ * Spanlens OpenRouter proxy route. Your requests are recorded in /requests
+ * (tokens, latency, cost) and forwarded to OpenRouter using the OpenRouter
+ * key you registered in Spanlens.
+ *
+ *   import { createOpenRouter, observeOpenRouter } from '@spanlens/sdk/openrouter'
+ *   const openrouter = createOpenRouter()
+ *
+ * `openai` is a peer dependency — install it alongside this SDK.
+ *
+ * @example  Full traced call.
+ *   import { SpanlensClient } from '@spanlens/sdk'
+ *   import { createOpenRouter, observeOpenRouter } from '@spanlens/sdk/openrouter'
+ *
+ *   const spanlens = new SpanlensClient({ apiKey: process.env.SPANLENS_API_KEY! })
+ *   const openrouter = createOpenRouter()
+ *
+ *   const trace = spanlens.startTrace({ name: 'chat' })
+ *   const res = await observeOpenRouter(trace, 'chat', (headers) =>
+ *     openrouter.chat.completions.create(
+ *       { model: 'anthropic/claude-3.5-sonnet', messages: [{ role: 'user', content: 'Hi' }] },
+ *       { headers },
+ *     ),
+ *   )
+ *   await trace.end({ status: 'completed' })
+ */
+
+import type OpenAI from 'openai'
+import type { ClientOptions } from 'openai'
+import { makeSpanlensProxyClient } from './_proxy-client.js'
+
+/** Default Spanlens OpenRouter proxy URL. Override for self-hosted deployments. */
+export const DEFAULT_SPANLENS_OPENROUTER_PROXY =
+  'https://api.spanlens.io/proxy/openrouter/v1'
+
+/** Build an OpenAI-compatible client whose requests flow through the Spanlens OpenRouter proxy. */
+export function createOpenRouter(options: ClientOptions = {}): OpenAI {
+  return makeSpanlensProxyClient('OpenRouter', DEFAULT_SPANLENS_OPENROUTER_PROXY, options)
+}
+
+// Re-export the tracer so a single `@spanlens/sdk/openrouter` import gives
+// both the client factory and the matching `observe` helper.
+export { observeOpenRouter } from '../observe.js'
+
+// X-Spanlens-* request-header helpers (withUser / withSession / withLogBody /
+// withCache / withPromptVersion) — canonical implementations live in
+// ./_headers.ts. Re-exported so every proxy subpath has the same single-import
+// ergonomics as `@spanlens/sdk/openai`.
+export {
+  PROMPT_VERSION_HEADER,
+  USER_HEADER,
+  SESSION_HEADER,
+  LOG_BODY_HEADER,
+  CACHE_HEADER,
+  CACHE_DEFAULT_TTL_SECONDS,
+  CACHE_MAX_TTL_SECONDS,
+  withPromptVersion,
+  withUser,
+  withSession,
+  withLogBody,
+  withCache,
+  cacheHeaderValue,
+} from './_headers.js'

--- a/packages/sdk/src/integrations/xai.ts
+++ b/packages/sdk/src/integrations/xai.ts
@@ -42,3 +42,23 @@ export function createXai(options: ClientOptions = {}): OpenAI {
 }
 
 export { observeXai } from '../observe.js'
+
+// X-Spanlens-* request-header helpers (withUser / withSession / withLogBody /
+// withCache / withPromptVersion) — canonical implementations live in
+// ./_headers.ts. Re-exported so every proxy subpath has the same single-import
+// ergonomics as `@spanlens/sdk/openai`.
+export {
+  PROMPT_VERSION_HEADER,
+  USER_HEADER,
+  SESSION_HEADER,
+  LOG_BODY_HEADER,
+  CACHE_HEADER,
+  CACHE_DEFAULT_TTL_SECONDS,
+  CACHE_MAX_TTL_SECONDS,
+  withPromptVersion,
+  withUser,
+  withSession,
+  withLogBody,
+  withCache,
+  cacheHeaderValue,
+} from './_headers.js'

--- a/packages/sdk/src/observe.ts
+++ b/packages/sdk/src/observe.ts
@@ -87,11 +87,13 @@ type Usage =
   | 'deepseek'
   | 'xai'
   | 'cohere'
+  | 'mistral'
+  | 'openrouter'
 
 // OpenAI-compatible providers whose responses carry the standard OpenAI
 // `usage` shape (prompt_tokens / completion_tokens) — parsed by parseOpenAIUsage.
 const OPENAI_SHAPED = new Set<Usage>([
-  'openai', 'ollama', 'groq', 'deepseek', 'xai', 'cohere',
+  'openai', 'ollama', 'groq', 'deepseek', 'xai', 'cohere', 'mistral', 'openrouter',
 ])
 
 const PROMPT_VERSION_HEADER = 'x-spanlens-prompt-version'
@@ -339,4 +341,31 @@ export function observeCohere<T>(
   fn: (headers: Record<string, string>) => Promise<T>,
 ): Promise<T> {
   return observeProvider('cohere', parent, nameOrOptions, fn)
+}
+
+/**
+ * Mistral variant — Mistral's API is OpenAI-compatible, so `usage` is parsed
+ * with the OpenAI parser and the span is tagged `provider: 'mistral'`. Prefer
+ * the dedicated `createMistral()` client from `@spanlens/sdk/mistral`.
+ */
+export function observeMistral<T>(
+  parent: TraceHandle | SpanHandle,
+  nameOrOptions: string | ProviderObserveOptions,
+  fn: (headers: Record<string, string>) => Promise<T>,
+): Promise<T> {
+  return observeProvider('mistral', parent, nameOrOptions, fn)
+}
+
+/**
+ * OpenRouter variant — OpenRouter speaks the OpenAI wire protocol, so `usage`
+ * is parsed with the OpenAI parser and the span is tagged
+ * `provider: 'openrouter'`. Prefer the dedicated `createOpenRouter()` client
+ * from `@spanlens/sdk/openrouter`.
+ */
+export function observeOpenRouter<T>(
+  parent: TraceHandle | SpanHandle,
+  nameOrOptions: string | ProviderObserveOptions,
+  fn: (headers: Record<string, string>) => Promise<T>,
+): Promise<T> {
+  return observeProvider('openrouter', parent, nameOrOptions, fn)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,17 +302,17 @@ importers:
         version: 3.25.76
     devDependencies:
       '@types/node':
-        specifier: ^22.10.0
-        version: 22.19.19
+        specifier: ^25.8.0
+        version: 25.9.1
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@22.19.19)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
+        version: 3.2.6(@types/node@25.9.1)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
 
   packages/sdk:
     devDependencies:
@@ -7338,6 +7338,14 @@ snapshots:
     optionalDependencies:
       vite: 7.3.5(@types/node@25.8.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
 
+  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
+
   '@vitest/pretty-format@3.2.6':
     dependencies:
       tinyrainbow: 2.0.0
@@ -10332,6 +10340,27 @@ snapshots:
       - tsx
       - yaml
 
+  vite-node@3.2.4(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4):
     dependencies:
       esbuild: 0.27.7
@@ -10358,6 +10387,22 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.8.0
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      terser: 5.48.0
+      tsx: 4.22.4
+
+  vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.61.1
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.1
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
@@ -10433,6 +10478,48 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.8.0
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.6(@types/node@25.9.1)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
+      vite-node: 3.2.4(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.1
       jsdom: 25.0.1
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
## Summary

SDK integration parity fixes from the 2026-07-13 audit.

### 1. New provider integrations: Mistral and OpenRouter

The server has proxied Mistral and OpenRouter for a while (`/proxy/mistral/v1`, `/proxy/openrouter/v1`, both OpenAI-compatible), but the SDK had no matching subpaths. This PR adds `@spanlens/sdk/mistral` and `@spanlens/sdk/openrouter`, mirroring the groq pattern exactly:

- `createMistral(options?)` / `createOpenRouter(options?)` factories built on the shared `makeSpanlensProxyClient`, defaulting to the hosted `https://api.spanlens.io` proxy routes, with `DEFAULT_SPANLENS_MISTRAL_PROXY` / `DEFAULT_SPANLENS_OPENROUTER_PROXY` exported for self-hosted overrides.
- `observeMistral` / `observeOpenRouter` tracers (OpenAI-shaped `usage` parsing, provider-tagged spans), exported from the subpaths and the package root.
- `package.json` exports entries for `./mistral` and `./openrouter`. The new entries put `"types"` first (correct resolution order); existing entries are intentionally left untouched in this PR.

### 2. Header helpers exported from every proxy subpath

`withUser` / `withSession` / `withLogBody` / `withCache` / `withPromptVersion` were only exported from `@spanlens/sdk/openai` and `@spanlens/sdk/anthropic` — as two duplicated copies. Tagging a Groq or Gemini request with a user ID forced an unrelated second import.

- Canonical implementations extracted to `packages/sdk/src/integrations/_headers.ts` (dependency-free on purpose, so `gemini` can re-export without pulling in the `openai` peer dependency).
- `openai.ts` and `anthropic.ts` now re-export from it (public API unchanged), and all other proxy subpaths (`gemini`, `groq`, `deepseek`, `xai`, `cohere`, `ollama`, `mistral`, `openrouter`) re-export the same set: the 5 helpers plus `cacheHeaderValue` and the header-name constants.

### 3. mcp-server toolchain alignment (devDeps only)

`packages/mcp-server` pinned `typescript ^5.7.0` / `@types/node ^22.10.0` while the sdk uses `^6.0.3` / `^25.8.0`. Aligned to the sdk versions. `tsconfig.json` already has `"types": ["node"]` (CI/CD gotcha #28), so build/typecheck/tests pass unchanged. No mcp-server version bump — deps-only, no publish needed.

### 4. Version + docs

- `@spanlens/sdk` 0.16.0 → 0.17.0 with a CHANGELOG entry covering 1 + 2. **No tag pushed** — publish stays a manual decision.
- README: OpenAI-compatible provider list now includes all subpaths (Groq/DeepSeek/xAI/Cohere were previously missing too), helper-availability notes updated, parity table row added for the OpenAI-compatible factories.

## Test plan

- [x] `pnpm --filter @spanlens/sdk typecheck` — clean
- [x] `pnpm --filter @spanlens/sdk build` — clean
- [x] `pnpm --filter @spanlens/sdk test` — 211 tests / 17 files pass, including:
  - Mistral + OpenRouter added to the OpenAI-compatible factory matrix (default URL, env key pickup, missing-key error, overrides, observe re-export)
  - new `header-helpers-parity.test.ts` pinning that every subpath re-exports the exact same helper references (re-export, not a copy) and that the emitted `x-spanlens-*` headers match the documented contract
- [x] `pnpm --filter @spanlens/mcp-server typecheck && test && build` — clean on TS 6 / @types/node 25
- [ ] After merge + npm publish 0.17.0: smoke-test `createMistral()` / `createOpenRouter()` against production proxy routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)