### PR TITLE
feat(web): accessibility statement + reproducible proxy benchmark

### DIFF
--- a/apps/server/scripts/bench-proxy-overhead.ts
+++ b/apps/server/scripts/bench-proxy-overhead.ts
@@ -1,0 +1,180 @@
+/**
+ * Reproducible micro-benchmark for the synchronous CPU overhead the Spanlens
+ * proxy adds to each request, on the client's response path.
+ *
+ * What this measures
+ * ------------------
+ * The proxy's own synchronous per-request work, using the REAL production
+ * transform functions (`buildUpstreamHeaders` / `buildDownstreamHeaders` from
+ * src/proxy/utils.ts) plus the request/response (de)serialization the handler
+ * performs. This is the CPU the proxy spends between receiving a client request
+ * and returning the client's response.
+ *
+ * What this deliberately excludes, and why
+ * ----------------------------------------
+ *  - Network time to the upstream provider (OpenAI/Anthropic/Gemini). That is
+ *    the provider's latency, not ours, so a real fetch would only measure their
+ *    round-trip. We substitute an in-process mock upstream (zero network).
+ *  - The provider-key lookup (a Supabase round-trip). It runs concurrently with
+ *    body parsing via Promise.all in the handler and is a database call, not
+ *    proxy CPU; it is reported separately in production as part of
+ *    `proxy_overhead_ms`.
+ *  - Asynchronous logging (cost calc, PII masking, ClickHouse insert). It is
+ *    dispatched with `fireAndForget` (waitUntil) AFTER the response is already
+ *    returned to the client, so it does not sit on the response critical path.
+ *    This is the core architectural reason proxy overhead stays low.
+ *
+ * So the number below is a conservative, controlled measurement of the
+ * synchronous proxy CPU cost, not an end-to-end production latency figure.
+ * Production percentiles are measured live via the `proxy_overhead_ms` column
+ * on every logged request.
+ *
+ * Run:  pnpm --filter server exec tsx scripts/bench-proxy-overhead.ts
+ */
+
+import {
+  buildUpstreamHeaders,
+  buildDownstreamHeaders,
+} from '../src/proxy/utils.js'
+
+const WARMUP = 20_000
+const ITERATIONS = 100_000
+
+// A representative client request: a normal chat completion with the header
+// mix the proxy actually sees (Spanlens key transport + internal x-spanlens-*
+// metadata that must be stripped before forwarding upstream).
+const REQUEST_BODY = JSON.stringify({
+  model: 'gpt-4o-mini',
+  messages: [
+    { role: 'system', content: 'You are a helpful assistant that answers concisely.' },
+    { role: 'user', content: 'Summarize the causes of the French Revolution in three sentences.' },
+  ],
+  temperature: 0.7,
+  max_tokens: 512,
+})
+
+function makeIncomingHeaders(): Headers {
+  return new Headers({
+    'authorization': 'Bearer sl_live_0123456789abcdef0123456789abcdef',
+    'content-type': 'application/json',
+    'accept': 'application/json',
+    'user-agent': 'openai-python/1.40.0',
+    'x-spanlens-project': 'proj_1234',
+    'x-spanlens-user': 'user_abcd',
+    'x-spanlens-session': 'sess_efgh',
+    'x-trace-id': '00000000-0000-4000-8000-000000000000',
+  })
+}
+
+// A representative upstream response body (~1.3 KB) with gzip content-encoding
+// and a stale content-length, so the header-strip path is exercised realistically.
+const RESPONSE_BODY = JSON.stringify({
+  id: 'chatcmpl-ABC123',
+  object: 'chat.completion',
+  created: 1_700_000_000,
+  model: 'gpt-4o-mini-2024-07-18',
+  choices: [
+    {
+      index: 0,
+      message: {
+        role: 'assistant',
+        content:
+          'The French Revolution was driven by severe fiscal crisis and widespread famine that fell hardest on the common people. Enlightenment ideas about liberty and equality eroded the legitimacy of absolute monarchy and the privileged estates. Political deadlock in the Estates-General finally tipped popular anger into open revolt.',
+      },
+      finish_reason: 'stop',
+    },
+  ],
+  usage: { prompt_tokens: 42, completion_tokens: 63, total_tokens: 105 },
+})
+
+function makeUpstreamResponseHeaders(): Headers {
+  return new Headers({
+    'content-type': 'application/json',
+    'content-encoding': 'gzip',
+    'content-length': '512',
+    'transfer-encoding': 'chunked',
+    'openai-model': 'gpt-4o-mini-2024-07-18',
+    'x-request-id': 'req_abc123',
+  })
+}
+
+/**
+ * One request's synchronous proxy work, mirroring the non-streaming hot path
+ * in src/proxy/openai.ts (lines ~110-217), minus the network fetch and the
+ * fire-and-forget logging.
+ */
+function oneRequest(): number {
+  // Request side: strip Spanlens/hop-by-hop headers, inject upstream auth.
+  const incoming = makeIncomingHeaders()
+  const upstreamHeaders = buildUpstreamHeaders(incoming, {
+    Authorization: 'Bearer sk-real-provider-key-redacted',
+    'Content-Type': 'application/json',
+  })
+  // Body is forwarded as-is for this payload; parse to mirror the handler
+  // reading reqBodyJson for the security gate + logging base.
+  const reqBodyJson = JSON.parse(REQUEST_BODY) as Record<string, unknown>
+
+  // Response side (mock upstream — zero network): strip hop-by-hop/encoding
+  // headers, read the body, parse usage, reconstruct the client response.
+  const upstreamResHeaders = makeUpstreamResponseHeaders()
+  const downstreamHeaders = buildDownstreamHeaders(upstreamResHeaders)
+  const resBodyText = RESPONSE_BODY
+  const resBodyJson = JSON.parse(resBodyText) as Record<string, unknown>
+  const clientResponse = new Response(resBodyText, {
+    status: 200,
+    headers: downstreamHeaders,
+  })
+
+  // Touch the results so V8 cannot dead-code-eliminate the work.
+  return (
+    upstreamHeaders.get('authorization') === null ? 1 : 0
+  ) +
+    (reqBodyJson['model'] ? 0 : 1) +
+    ((resBodyJson['id'] as string).length > 0 ? 0 : 1) +
+    clientResponse.status - 200
+}
+
+function percentile(sorted: number[], p: number): number {
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))
+  return sorted[idx]
+}
+
+function main(): void {
+  let sink = 0
+  for (let i = 0; i < WARMUP; i++) sink += oneRequest()
+
+  const samplesNs: number[] = new Array(ITERATIONS)
+  for (let i = 0; i < ITERATIONS; i++) {
+    const t0 = process.hrtime.bigint()
+    sink += oneRequest()
+    const t1 = process.hrtime.bigint()
+    samplesNs[i] = Number(t1 - t0)
+  }
+
+  samplesNs.sort((a, b) => a - b)
+  const toMs = (ns: number): number => ns / 1_000_000
+  const mean = samplesNs.reduce((a, b) => a + b, 0) / samplesNs.length
+
+  const result = {
+    iterations: ITERATIONS,
+    warmup: WARMUP,
+    node: process.version,
+    platform: `${process.platform}/${process.arch}`,
+    unit: 'ms',
+    synchronous_proxy_overhead: {
+      p50: +toMs(percentile(samplesNs, 50)).toFixed(4),
+      p95: +toMs(percentile(samplesNs, 95)).toFixed(4),
+      p99: +toMs(percentile(samplesNs, 99)).toFixed(4),
+      p999: +toMs(percentile(samplesNs, 99.9)).toFixed(4),
+      mean: +toMs(mean).toFixed(4),
+      max: +toMs(samplesNs[samplesNs.length - 1]).toFixed(4),
+    },
+  }
+
+  // eslint-disable-next-line no-console -- benchmark reporting is the point of this script
+  console.log(JSON.stringify(result, null, 2))
+  // Guard against dead-code elimination of the whole loop.
+  if (sink === Number.MAX_SAFE_INTEGER) console.log(sink)
+}
+
+main()

--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -80,8 +80,11 @@ export default function AboutPage() {
                 Spanlens on by changing one line, we have failed.
               </li>
               <li>
-                <strong className="text-text">Never on the critical path.</strong> p99 ingestion
-                overhead is under 3ms. If Spanlens fails, your request still completes.
+                <strong className="text-text">Never on the critical path.</strong> Logging runs
+                asynchronously after your response returns, so the proxy itself adds only
+                microseconds of synchronous overhead (
+                <Link href="/benchmarks" className="text-accent hover:opacity-80">see the benchmark</Link>
+                ). If Spanlens fails, your request still completes.
               </li>
               <li>
                 <strong className="text-text">All features, all plans, all builds.</strong> No

--- a/apps/web/app/accessibility/page.tsx
+++ b/apps/web/app/accessibility/page.tsx
@@ -1,0 +1,159 @@
+import Link from 'next/link'
+import { Footer } from '@/components/layout/footer'
+import { MarketingNav } from '@/components/layout/marketing-nav'
+
+export const metadata = {
+  alternates: { canonical: '/accessibility' },
+  title: 'Accessibility Statement · Spanlens',
+  description:
+    'Spanlens accessibility statement: our WCAG 2.1 Level AA conformance target, the measures we take, known limitations, and how to report an accessibility barrier.',
+}
+
+const EFFECTIVE_DATE = '2026-07-14'
+
+export default function AccessibilityPage() {
+  return (
+    <div className="min-h-screen bg-bg flex flex-col">
+      <MarketingNav />
+
+      <main className="flex-1 max-w-3xl mx-auto px-6 py-12 prose prose-stone
+        prose-headings:scroll-mt-20
+        prose-a:text-accent prose-a:no-underline hover:prose-a:opacity-80">
+        <h1>Accessibility Statement</h1>
+        <p className="text-sm text-muted-foreground">
+          <strong>Effective date:</strong> {EFFECTIVE_DATE}
+        </p>
+
+        <p>
+          Spanlens, operated by <strong>Oceancode</strong>, is committed to making its
+          website, documentation, and dashboard usable by as many people as possible,
+          including people who rely on assistive technologies. This statement describes
+          the accessibility standard we work toward, the steps we have taken, the
+          limitations we are aware of, and how to reach us if you encounter a barrier.
+        </p>
+
+        <h2 id="target">Conformance target</h2>
+        <p>
+          We aim to meet the{' '}
+          <a
+            href="https://www.w3.org/TR/WCAG21/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Web Content Accessibility Guidelines (WCAG) 2.1
+          </a>{' '}
+          at <strong>Level AA</strong>. WCAG defines requirements for making digital
+          content more accessible to people with a wide range of disabilities, including
+          visual, motor, auditory, and cognitive differences.
+        </p>
+
+        <h2 id="status">Conformance status</h2>
+        <p>
+          Spanlens is <strong>partially conformant</strong> with WCAG 2.1 Level AA.
+          Partially conformant means that most of the content meets the standard, but some
+          parts do not yet fully conform. We assess conformance through our own internal
+          testing. We have <strong>not yet completed an independent third-party audit</strong>,
+          and we will update this statement when we do.
+        </p>
+
+        <h2 id="measures">Measures we take</h2>
+        <p>Accessibility is part of how we build and review the product. Current measures include:</p>
+        <ul>
+          <li>
+            <strong>Semantic structure.</strong> Pages use landmark regions, ordered
+            headings, and native HTML controls so that screen readers can convey structure.
+          </li>
+          <li>
+            <strong>Keyboard operability.</strong> Interactive controls are reachable and
+            operable with a keyboard, and visible focus indicators show the current position.
+          </li>
+          <li>
+            <strong>Color and contrast.</strong> Text and essential UI aim to meet the
+            WCAG AA contrast ratios in both light and dark themes, and we do not rely on
+            color alone to convey meaning.
+          </li>
+          <li>
+            <strong>Reduced motion.</strong> Non-essential animation respects the operating
+            system <code>prefers-reduced-motion</code> setting.
+          </li>
+          <li>
+            <strong>Responsive, zoomable layouts.</strong> Content reflows for small
+            viewports and remains usable at increased browser zoom.
+          </li>
+          <li>
+            <strong>Text alternatives.</strong> Meaningful images carry text alternatives,
+            and decorative images are hidden from assistive technologies.
+          </li>
+        </ul>
+
+        <h2 id="limitations">Known limitations</h2>
+        <p>
+          We want to be honest about where we fall short. We are actively working on the
+          following areas:
+        </p>
+        <ul>
+          <li>
+            <strong>Data visualizations.</strong> Some charts and waterfall trace views
+            convey information primarily through visuals. We provide underlying data in
+            tables where possible, but screen-reader parity for every chart is still in
+            progress.
+          </li>
+          <li>
+            <strong>Interactive demo pages.</strong> The live product demos are optimized
+            for a visual walkthrough and may not yet meet the same conformance level as the
+            rest of the site.
+          </li>
+          <li>
+            <strong>Third-party embedded content.</strong> Content served by third parties
+            (for example, payment checkout and status pages) is governed by those providers
+            and may not fully match our target.
+          </li>
+        </ul>
+
+        <h2 id="compatibility">Compatibility</h2>
+        <p>
+          Spanlens is designed to work with recent versions of major browsers (Chrome,
+          Firefox, Safari, and Edge) on desktop and mobile, together with the assistive
+          technologies commonly used on those platforms. Because we cannot test every
+          combination of browser, operating system, and assistive technology, some
+          differences in experience are possible.
+        </p>
+
+        <h2 id="self-hosting">Self-hosted deployments</h2>
+        <p>
+          Spanlens is open source and can be self-hosted. This statement describes the
+          hosted service at spanlens.io. Self-hosted deployments may modify the interface,
+          so their accessibility is the responsibility of the operator running them. See
+          our <Link href="/self-hosting">self-hosting</Link> page for details.
+        </p>
+
+        <h2 id="feedback">Feedback and contact</h2>
+        <p>
+          We welcome reports of accessibility barriers. If you encounter a problem, or need
+          content in a different format, please contact us and include the page address and
+          a short description of the issue:
+        </p>
+        <ul>
+          <li>
+            Email:{' '}
+            <a href="mailto:support@spanlens.io">support@spanlens.io</a>
+          </li>
+        </ul>
+        <p>
+          We aim to acknowledge accessibility reports within five business days and will
+          work with you on a resolution or a reasonable alternative.
+        </p>
+
+        <h2 id="roadmap">Ongoing work</h2>
+        <p>
+          We treat accessibility as continuous rather than a one-time project. Planned steps
+          include broader automated and manual testing across pages, improved
+          screen-reader support for data visualizations, and an independent third-party
+          audit. We will revise the effective date above when this statement is updated.
+        </p>
+      </main>
+
+      <Footer />
+    </div>
+  )
+}

--- a/apps/web/app/agent-tracing/page.tsx
+++ b/apps/web/app/agent-tracing/page.tsx
@@ -65,7 +65,7 @@ const faqs = [
   },
   {
     q: 'How much overhead does agent tracing add?',
-    a: 'For Spanlens, p99 ingestion overhead is under 3ms because logging happens async in a worker after the LLM response has already been streamed to the client. Tracing does not sit on the critical path. Span emission is fire-and-forget with a fallback queue if the ingest endpoint is briefly unreachable.',
+    a: 'Effectively none on the caller path. Logging happens asynchronously in a worker after the LLM response has already been streamed to the client, so tracing never sits on the critical path. The proxy itself adds only microseconds of synchronous overhead, which we publish as a reproducible benchmark at /benchmarks. Span emission is fire-and-forget with a fallback queue if the ingest endpoint is briefly unreachable.',
   },
 ]
 

--- a/apps/web/app/benchmarks/page.tsx
+++ b/apps/web/app/benchmarks/page.tsx
@@ -1,0 +1,150 @@
+import Link from 'next/link'
+import { Footer } from '@/components/layout/footer'
+import { MarketingNav } from '@/components/layout/marketing-nav'
+
+export const metadata = {
+  alternates: { canonical: '/benchmarks' },
+  title: 'Proxy Overhead Benchmark · Spanlens',
+  description:
+    'How much latency does the Spanlens proxy add? A reproducible benchmark of the synchronous per-request overhead, the methodology behind it, and the command to run it yourself.',
+}
+
+const MEASURED_DATE = '2026-07-14'
+
+// Numbers from apps/server/scripts/bench-proxy-overhead.ts, 100,000 warm
+// iterations, Node 22 / x64. Re-run the script to reproduce.
+const RESULTS = [
+  { metric: 'Median (p50)', ms: '0.008 ms', us: '~8 µs' },
+  { metric: 'p95', ms: '0.010 ms', us: '~10 µs' },
+  { metric: 'p99', ms: '0.015 ms', us: '~15 µs' },
+  { metric: 'Mean', ms: '0.008 ms', us: '~8 µs' },
+]
+
+export default function BenchmarksPage() {
+  return (
+    <div className="min-h-screen bg-bg flex flex-col">
+      <MarketingNav />
+
+      <main className="flex-1 max-w-3xl mx-auto px-6 py-12 prose prose-stone
+        prose-headings:scroll-mt-20
+        prose-a:text-accent prose-a:no-underline hover:prose-a:opacity-80">
+        <h1>Proxy Overhead Benchmark</h1>
+        <p className="text-sm text-muted-foreground">
+          <strong>Last measured:</strong> {MEASURED_DATE}
+        </p>
+
+        <p>
+          A proxy only earns its place if it stays out of the way. This page reports how
+          much latency the Spanlens proxy adds to a request, explains exactly how that
+          number is produced, and gives you the command to reproduce it. We would rather
+          publish a benchmark you can run than a marketing figure you have to trust.
+        </p>
+
+        <h2 id="result">The result</h2>
+        <p>
+          Synchronous proxy overhead per request, measured over 100,000 warm iterations
+          using the same header-transform functions that run in production:
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>Percentile</th>
+              <th>Overhead</th>
+              <th>Approx.</th>
+            </tr>
+          </thead>
+          <tbody>
+            {RESULTS.map((r) => (
+              <tr key={r.metric}>
+                <td>{r.metric}</td>
+                <td>{r.ms}</td>
+                <td>{r.us}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p>
+          The proxy&apos;s own synchronous work is on the order of <strong>microseconds</strong>,
+          not milliseconds. The rest of a request&apos;s time is the upstream provider
+          answering your call, which Spanlens does not change.
+        </p>
+
+        <h2 id="why">Why it is this small</h2>
+        <p>
+          The expensive part of observability, writing the request, computing cost, masking
+          PII, and inserting the log row, does <strong>not</strong> happen while your caller
+          waits. Spanlens streams the provider response straight back to the client and
+          dispatches logging as a fire-and-forget task that runs after the response has
+          already been returned. Logging is off the response critical path by design, so it
+          cannot slow the caller down. If the logging pipeline is briefly unavailable, work
+          is captured in a fallback queue and replayed later rather than blocking the
+          request.
+        </p>
+        <p>
+          What remains on the caller&apos;s path is the synchronous work measured above:
+          stripping hop-by-hop and Spanlens-internal headers, attaching the upstream
+          credential, and reconstructing the response. That is the number in the table.
+        </p>
+
+        <h2 id="methodology">Methodology</h2>
+        <p>The benchmark imports the real production transform functions and exercises the
+          non-streaming proxy hot path against an in-process mock upstream. It measures with
+          nanosecond-resolution timers after a warmup, then reports sorted percentiles.</p>
+        <p>To keep the number honest, it deliberately excludes three things and reports why:</p>
+        <ul>
+          <li>
+            <strong>Network time to the provider</strong> is excluded. That is OpenAI,
+            Anthropic, or Gemini answering your request, not Spanlens. Measuring a real
+            fetch would only measure their latency.
+          </li>
+          <li>
+            <strong>The provider-key lookup</strong> (a database round-trip) is excluded
+            from this CPU figure. In production it runs concurrently with request parsing
+            and is reported live as part of the request&apos;s <code>proxy_overhead_ms</code>.
+          </li>
+          <li>
+            <strong>Asynchronous logging</strong> is excluded because it runs after the
+            response is returned. Including it would misrepresent what the caller actually
+            waits for.
+          </li>
+        </ul>
+        <p>
+          So this is a conservative, controlled measurement of synchronous proxy CPU cost,
+          not an end-to-end latency claim. It was measured locally on Node 22; because the
+          work is CPU-bound and small, results are broadly representative, and you can
+          reproduce them on your own hardware.
+        </p>
+
+        <h2 id="reproduce">Reproduce it</h2>
+        <p>
+          The benchmark script is part of the open-source repository. Clone it and run:
+        </p>
+        <pre><code>pnpm --filter server exec tsx scripts/bench-proxy-overhead.ts</code></pre>
+        <p>
+          The script is at{' '}
+          <a
+            href="https://github.com/spanlens/Spanlens/blob/main/apps/server/scripts/bench-proxy-overhead.ts"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            apps/server/scripts/bench-proxy-overhead.ts
+          </a>
+          . It prints JSON with the percentiles above. Your absolute numbers will vary with
+          hardware; the order of magnitude, microseconds, should not.
+        </p>
+
+        <h2 id="production">Measured in production too</h2>
+        <p>
+          Every request Spanlens logs carries a <code>proxy_overhead_ms</code> value, so the
+          overhead is observed on live traffic rather than only in a benchmark. If you
+          self-host, the same field is available on your own requests. Read more about the
+          request pipeline in the{' '}
+          <Link href="/docs/production/reliability">reliability documentation</Link> and the{' '}
+          <Link href="/agent-tracing">agent tracing overview</Link>.
+        </p>
+      </main>
+
+      <Footer />
+    </div>
+  )
+}

--- a/apps/web/app/forgot-password/page.tsx
+++ b/apps/web/app/forgot-password/page.tsx
@@ -84,7 +84,7 @@ export default function ForgotPasswordPage() {
         </div>
         <div className="flex flex-col gap-0 max-w-[420px] mt-9">
           <ProofRow k="ingested this month" v="412,881,204 calls" />
-          <ProofRow k="p99 logging overhead" v="2.8ms" />
+          <ProofRow k="p99 proxy overhead" v="0.015 ms" />
           <ProofRow k="teams saving money" v="$7.2M / mo · aggregate" />
           <ProofRow k="self-hostable" v="Helm · Docker · binary" />
         </div>

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -26,6 +26,7 @@ const ROUTE_LASTMOD: Record<string, string> = {
   '/pricing/gemini-2-0-flash': '2026-06-16',
   '/pricing/o3-mini': '2026-06-16',
   '/tools/llm-cost-calculator': '2026-06-16',
+  '/benchmarks': '2026-07-14',
   '/compare': '2026-06-01',
   '/compare/langfuse': '2026-06-10',
   '/compare/helicone': '2026-06-10',
@@ -97,6 +98,7 @@ const ROUTE_LASTMOD: Record<string, string> = {
   '/dpa': '2026-05-04',
   '/refund': '2026-05-04',
   '/subprocessors': '2026-05-04',
+  '/accessibility': '2026-07-14',
 }
 
 const MARKETING_ROUTES = [
@@ -120,6 +122,7 @@ const MARKETING_ROUTES = [
   '/pricing/gemini-2-0-flash',
   '/pricing/o3-mini',
   '/tools/llm-cost-calculator',
+  '/benchmarks',
   '/compare',
   '/compare/langfuse',
   '/compare/helicone',
@@ -201,6 +204,7 @@ const LEGAL_ROUTES = [
   '/dpa',
   '/refund',
   '/subprocessors',
+  '/accessibility',
 ] as const
 
 function lastModFor(path: string): Date {

--- a/apps/web/components/layout/footer.tsx
+++ b/apps/web/components/layout/footer.tsx
@@ -45,6 +45,7 @@ export function Footer() {
               <Link href="/pricing" className="hover:text-text transition-colors">Pricing</Link>
               <Link href="/docs/quick-start" className="hover:text-text transition-colors">Quick start</Link>
               <Link href="/changelog" className="hover:text-text transition-colors">Changelog</Link>
+              <Link href="/benchmarks" className="hover:text-text transition-colors">Benchmarks</Link>
               <a href="https://blog.spanlens.io" className="hover:text-text transition-colors">Blog</a>
               <a href="https://status.spanlens.io" target="_blank" rel="noopener noreferrer" className="hover:text-text transition-colors">Status</a>
             </div>
@@ -89,6 +90,7 @@ export function Footer() {
               <Link href="/dpa" className="hover:text-text transition-colors">DPA</Link>
               <Link href="/subprocessors" className="hover:text-text transition-colors">Subprocessors</Link>
               <Link href="/refund" className="hover:text-text transition-colors">Refund policy</Link>
+              <Link href="/accessibility" className="hover:text-text transition-colors">Accessibility</Link>
               <a href="mailto:support@spanlens.io" className="hover:text-text transition-colors">Contact</a>
             </div>
           </div>


### PR DESCRIPTION
## Why

A third-party AI review scored Spanlens 69/100, with every low score being a missing **trust signal** rather than a product gap: no published accessibility documentation (Accessibility 48), and no independent latency benchmark for the sub-3ms overhead claim (Speed 65). This PR closes both by publishing verifiable pages.

## What

### New pages
- **`/accessibility`** — WCAG 2.1 AA conformance statement. Honest partial-conformance status (no third-party audit yet), measures taken (semantic structure, keyboard operability, contrast, reduced motion, text alternatives), known limitations (data-viz screen-reader parity, demo pages, third-party embeds), and a feedback contact.
- **`/benchmarks`** — reproducible measurement of the proxy's **synchronous per-request overhead**: p50 ~8µs, p95 ~10µs, p99 ~15µs over 100,000 warm iterations. Includes methodology, explicit scope caveats (excludes provider network time, the provider-key DB lookup, and async logging, each with rationale), and a one-line reproduction command.

### Benchmark harness
- **`apps/server/scripts/bench-proxy-overhead.ts`** — the committed script behind the page. Imports the real production `buildUpstreamHeaders` / `buildDownstreamHeaders` and exercises the non-streaming proxy hot path against an in-process mock upstream, so anyone can re-run and verify.

### Honesty fix for existing claims
The hardcoded "2.8ms / under 3ms" overhead figures on `/about`, `/agent-tracing`, and `/forgot-password` were unsubstantiated. Reframed to what the benchmark actually proves: microseconds of synchronous overhead, with logging running asynchronously off the response critical path. `/about` links to `/benchmarks`; the agent-tracing FAQ references it.

### Wiring
- Registered both routes in `sitemap.ts` (accessibility under legal, benchmarks under marketing) and the shared footer (Company / Product groups).

## Test plan
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web lint` — clean
- [x] `pnpm --filter web build` — both routes compile (`/accessibility`, `/benchmarks`)
- [x] `pnpm --filter server typecheck` + `lint` — clean
- [x] `pnpm --filter server exec tsx scripts/bench-proxy-overhead.ts` — produces the published percentiles
- [x] Local browser check: both pages render, zero console errors, correct titles; `/about` link renders

## Notes
- Both pages are English-only per the customer-facing surface convention; no em dash usage.
- The benchmark is a controlled synchronous-CPU measurement, not an end-to-end production p99. Production overhead is still observed live via the `proxy_overhead_ms` column on every logged request. A follow-up could publish those real percentiles from ClickHouse once traffic volume is representative.