### PR TITLE
feat(web): sitewide WebSite node + BreadcrumbList on marketing pages

### DIFF
--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 const ABOUT_DESCRIPTION =
   'Spanlens is an open-source LLM observability platform built by developers who shipped LLM apps to production and got tired of debugging cost spikes from a spreadsheet. MIT licensed, self-hostable.'
@@ -45,6 +46,7 @@ export default function AboutPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(aboutJsonLd) }}
       />
       <MarketingNav />
+      <BreadcrumbJsonLd trail={[{ name: 'About', path: '/about' }]} />
 
       <section className="max-w-3xl mx-auto px-6 py-20">
         <h1 className="text-[40px] sm:text-[48px] font-semibold tracking-[-0.8px] text-text mb-3 leading-[1.05]">

--- a/apps/web/app/accessibility/page.tsx
+++ b/apps/web/app/accessibility/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/accessibility' },
@@ -15,6 +16,7 @@ export default function AccessibilityPage() {
   return (
     <div className="min-h-screen bg-bg flex flex-col">
       <MarketingNav />
+      <BreadcrumbJsonLd trail={[{ name: 'Accessibility', path: '/accessibility' }]} />
 
       <main className="flex-1 max-w-3xl mx-auto px-6 py-12 prose prose-stone
         prose-headings:scroll-mt-20

--- a/apps/web/app/agent-tracing/page.tsx
+++ b/apps/web/app/agent-tracing/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 const DESCRIPTION =
   'AI agent tracing captures multi-step LLM workflows as waterfall span trees with critical path highlighting. Learn how to instrument LangChain, LangGraph, CrewAI, and the Vercel AI SDK with one line of code.'
@@ -92,6 +93,7 @@ export default function AgentTracingHub() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
       />
       <MarketingNav />
+      <BreadcrumbJsonLd trail={[{ name: 'Agent Tracing', path: '/agent-tracing' }]} />
 
       <article className="max-w-3xl mx-auto px-6 py-20">
         <h1 className="text-[40px] sm:text-[48px] font-semibold tracking-[-0.8px] text-text mb-3 leading-[1.05]">

--- a/apps/web/app/benchmarks/page.tsx
+++ b/apps/web/app/benchmarks/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/benchmarks' },
@@ -24,6 +25,7 @@ export default function BenchmarksPage() {
   return (
     <div className="min-h-screen bg-bg flex flex-col">
       <MarketingNav />
+      <BreadcrumbJsonLd trail={[{ name: 'Benchmarks', path: '/benchmarks' }]} />
 
       <main className="flex-1 max-w-3xl mx-auto px-6 py-12 prose prose-stone
         prose-headings:scroll-mt-20

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Rss } from 'lucide-react'
 import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 import { Footer } from '@/components/layout/footer'
 import { CHANGELOG_ENTRIES, type ChangelogEntry, type ChangelogTag } from '@/lib/changelog/entries'
 
@@ -71,6 +72,7 @@ export default function ChangelogPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(buildChangelogJsonLd(entries)) }}
       />
       <MarketingNav subtitle="Changelog" />
+      <BreadcrumbJsonLd trail={[{ name: 'Changelog', path: '/changelog' }]} />
 
       <main className="max-w-3xl mx-auto px-6 py-12">
         <header className="mb-12">

--- a/apps/web/app/compare/page.tsx
+++ b/apps/web/app/compare/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/compare' },
@@ -58,6 +59,7 @@ export default function ComparePage() {
   return (
     <div className="min-h-screen bg-bg">
       <MarketingNav />
+      <BreadcrumbJsonLd trail={[{ name: 'Compare', path: '/compare' }]} />
 
       <section className="max-w-[1000px] mx-auto px-6 pt-20 pb-12">
         <h1 className="text-[40px] sm:text-[48px] font-semibold tracking-[-0.8px] text-text leading-[1.05]">

--- a/apps/web/app/dpa/page.tsx
+++ b/apps/web/app/dpa/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/dpa' },
@@ -15,6 +16,7 @@ export default function DPAPage() {
   return (
     <div className="min-h-screen bg-bg flex flex-col">
       <MarketingNav />
+      <BreadcrumbJsonLd trail={[{ name: 'Data Processing Agreement', path: '/dpa' }]} />
 
       <main className="flex-1 max-w-3xl mx-auto px-6 py-12 prose prose-stone
         prose-headings:scroll-mt-20

--- a/apps/web/app/faq/page.tsx
+++ b/apps/web/app/faq/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 const FAQ_DESCRIPTION =
   'Frequently asked questions about Spanlens — open-source LLM observability for OpenAI, Anthropic, and Gemini. Pricing, self-hosting, integration, comparisons, and security.'
@@ -144,6 +145,7 @@ export default function FaqPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
       />
       <MarketingNav />
+      <BreadcrumbJsonLd trail={[{ name: 'FAQ', path: '/faq' }]} />
 
       <section className="max-w-3xl mx-auto px-6 py-20">
         <h1 className="text-[40px] sm:text-[48px] font-semibold tracking-[-0.8px] text-text mb-3 leading-[1.05]">

--- a/apps/web/app/feedback/page.tsx
+++ b/apps/web/app/feedback/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 import { Footer } from '@/components/layout/footer'
 import { FeedbackRoadmapClient } from './feedback-roadmap-client'
 
@@ -33,6 +34,7 @@ export default function FeedbackPage() {
   return (
     <div className="min-h-screen bg-bg">
       <MarketingNav subtitle="Feedback" />
+      <BreadcrumbJsonLd trail={[{ name: 'Feedback', path: '/feedback' }]} />
       <main className="max-w-3xl mx-auto px-6 py-12">
         <header className="mb-10">
           <h1 className="text-4xl font-bold tracking-tight mb-3">Feedback</h1>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -109,6 +109,23 @@ const organizationJsonLd = {
   ],
 }
 
+// Canonical WebSite entity for the whole site. Sitewide top-level node so
+// crawlers and LLMs have a single WebSite to reconcile every page against —
+// other blocks only ever nest WebSite via `isPartOf`, which does not
+// establish a site-level entity on its own (2026-07-15 schema follow-up).
+// No `potentialAction`/SearchAction: the site has no /search route, and a
+// SearchAction pointing at a 404 target is worse than none.
+const websiteJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  '@id': `${SITE_URL}/#website`,
+  name: 'Spanlens',
+  url: SITE_URL,
+  description: SITE_DESCRIPTION,
+  publisher: { '@id': `${SITE_URL}/#organization` },
+  inLanguage: 'en',
+}
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   // suppressHydrationWarning on the <html> tag silences hydration mismatch
   // warnings that come from third-party browser extensions injecting their
@@ -125,6 +142,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
         />
         {/* Pre-paint theme application — prevents a flash of the wrong theme.
             Emitted from the server <head> (real HTML), NOT from a client

--- a/apps/web/app/llm-cost-tracking/page.tsx
+++ b/apps/web/app/llm-cost-tracking/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 const DESCRIPTION =
   'LLM cost tracking captures per-request USD spend by model, prompt version, and customer. Learn how to monitor OpenAI, Anthropic, and Gemini bills, set budget alerts, and reduce spend with model swaps.'
@@ -92,6 +93,7 @@ export default function LlmCostTrackingHub() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
       />
       <MarketingNav />
+      <BreadcrumbJsonLd trail={[{ name: 'LLM Cost Tracking', path: '/llm-cost-tracking' }]} />
 
       <article className="max-w-3xl mx-auto px-6 py-20">
         <h1 className="text-[40px] sm:text-[48px] font-semibold tracking-[-0.8px] text-text mb-3 leading-[1.05]">

--- a/apps/web/app/llm-observability/page.tsx
+++ b/apps/web/app/llm-observability/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 const DESCRIPTION =
   'LLM observability is the practice of logging, tracing, and analyzing every call your application makes to a large language model. This guide covers what to monitor, how to instrument, and how Spanlens compares to Langfuse, Helicone, and LangSmith.'
@@ -92,6 +93,7 @@ export default function LlmObservabilityHub() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
       />
       <MarketingNav />
+      <BreadcrumbJsonLd trail={[{ name: 'LLM Observability', path: '/llm-observability' }]} />
 
       <article className="max-w-3xl mx-auto px-6 py-20">
         <h1 className="text-[40px] sm:text-[48px] font-semibold tracking-[-0.8px] text-text mb-3 leading-[1.05]">

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { Check } from 'lucide-react'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 import { cn } from '@/lib/utils'
 
 const PRICING_DESCRIPTION =
@@ -252,6 +253,7 @@ export default function PricingPage() {
       />
       {/* Nav */}
       <MarketingNav />
+      <BreadcrumbJsonLd trail={[{ name: 'Pricing', path: '/pricing' }]} />
 
       <section className="max-w-7xl mx-auto px-6 py-24">
         <div className="text-center mb-10">

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/privacy' },
@@ -15,6 +16,7 @@ export default function PrivacyPage() {
   return (
     <div className="min-h-screen bg-bg flex flex-col">
       <MarketingNav />
+      <BreadcrumbJsonLd trail={[{ name: 'Privacy Policy', path: '/privacy' }]} />
 
       <main className="flex-1 max-w-3xl mx-auto px-6 py-12 prose prose-stone
         prose-headings:scroll-mt-20

--- a/apps/web/app/refund/page.tsx
+++ b/apps/web/app/refund/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/refund' },
@@ -15,6 +16,7 @@ export default function RefundPage() {
   return (
     <div className="min-h-screen bg-bg flex flex-col">
       <MarketingNav />
+      <BreadcrumbJsonLd trail={[{ name: 'Refund Policy', path: '/refund' }]} />
 
       <main className="flex-1 max-w-3xl mx-auto px-6 py-12 prose prose-stone
         prose-headings:scroll-mt-20

--- a/apps/web/app/subprocessors/page.tsx
+++ b/apps/web/app/subprocessors/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/subprocessors' },
@@ -15,6 +16,7 @@ export default function SubprocessorsPage() {
   return (
     <div className="min-h-screen bg-bg flex flex-col">
       <MarketingNav />
+      <BreadcrumbJsonLd trail={[{ name: 'Subprocessors', path: '/subprocessors' }]} />
 
       <main className="flex-1 max-w-4xl mx-auto px-6 py-12 prose prose-stone
         prose-headings:scroll-mt-20

--- a/apps/web/app/terms/page.tsx
+++ b/apps/web/app/terms/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/terms' },
@@ -15,6 +16,7 @@ export default function TermsPage() {
   return (
     <div className="min-h-screen bg-bg flex flex-col">
       <MarketingNav />
+      <BreadcrumbJsonLd trail={[{ name: 'Terms of Service', path: '/terms' }]} />
 
       <main className="flex-1 max-w-3xl mx-auto px-6 py-12 prose prose-stone
         prose-headings:scroll-mt-20

--- a/apps/web/components/marketing/breadcrumb-jsonld.tsx
+++ b/apps/web/components/marketing/breadcrumb-jsonld.tsx
@@ -1,0 +1,40 @@
+const SITE_URL = 'https://www.spanlens.io'
+
+interface Crumb {
+  /** Human-readable label shown in the SERP breadcrumb trail. */
+  name: string
+  /** Path appended to SITE_URL, e.g. '/pricing'. */
+  path: string
+}
+
+/**
+ * BreadcrumbList JSON-LD for top-level marketing / content / legal pages.
+ * Docs pages get their breadcrumb from DocsJsonLd instead; this covers the
+ * flat one-level marketing routes (Home → <page>) that previously carried
+ * only the inherited Organization + WebSite nodes (2026-07-15 schema
+ * follow-up). Home is prepended automatically, so callers pass only the
+ * page's own crumb(s):
+ *
+ *   <BreadcrumbJsonLd trail={[{ name: 'Pricing', path: '/pricing' }]} />
+ */
+export function BreadcrumbJsonLd({ trail }: { trail: Crumb[] }) {
+  const items: Crumb[] = [{ name: 'Home', path: '' }, ...trail]
+
+  const payload = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((crumb, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: crumb.name,
+      item: `${SITE_URL}${crumb.path}`,
+    })),
+  }
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(payload) }}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
Closes the two structured-data gaps a schema audit flagged (the third, Product, is intentionally skipped in favor of SoftwareApplication for a SaaS).

- **WebSite node**: added a canonical top-level `WebSite` JSON-LD in the root layout (`@id: /#website`, `publisher` → Organization `@id`). Previously `WebSite` only ever appeared nested via `isPartOf`, which does not establish a site-level entity. No `SearchAction` — there is no `/search` route and a 404 target is worse than none.
- **BreadcrumbList**: added a shared `BreadcrumbJsonLd` component and applied it to the 16 indexable marketing/legal pages that carried only the inherited Organization node. Docs pages already emit breadcrumbs via `DocsJsonLd`; `alternatives`/`self-hosting` already had their own.

## Pages touched
Content: agent-tracing, llm-observability, llm-cost-tracking, pricing, faq, about, benchmarks, accessibility, compare, changelog
Legal: privacy, terms, dpa, subprocessors, refund, feedback

## Test plan
- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint`
- [x] Browser: verified `WebSite` node renders in `<head>` and `publisher.@id` reconciles to the Organization node
- [x] Browser: verified `BreadcrumbList` renders on `/pricing`