### PR TITLE
feat(server): immediate API key deletion, drop 72h grace queue

### DIFF
--- a/apps/server/src/api/apiKeys.ts
+++ b/apps/server/src/api/apiKeys.ts
@@ -3,9 +3,9 @@ import { authJwt, type JwtContext } from '../middleware/authJwt.js'
 import { requireRole } from '../middleware/requireRole.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { randomHex, sha256Hex } from '../lib/crypto.js'
-import { enqueueDeletion } from '../lib/pending-deletions.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
 import { invalidateApiKeyCache } from '../middleware/authApiKey.js'
+import { resetProviderKeyNamesCache } from '../lib/requests-query.js'
 import { ApiError } from '../lib/errors.js'
 
 /**
@@ -277,55 +277,47 @@ apiKeysRouter.patch('/:id', requireEdit, async (c) => {
   return c.json({ success: true })
 })
 
-// DELETE /api/v1/api-keys/:id — soft delete via pending_deletions queue.
+// DELETE /api/v1/api-keys/:id — immediate hard delete.
 //
-// The key is immediately deactivated (is_active=false) so proxy traffic
-// stops within the next authApiKey check, but the row stays around for
-// ~72 hours so an accidental deletion can be undone from
-// /settings/pending-deletions. Cron in apps/server/api/cron.ts walks the
-// queue and hard-deletes due rows.
+// Key deletion is instant and permanent, matching how every major provider
+// (OpenAI, Anthropic, Stripe, GitHub) treats API keys: a deleted key is
+// cheap to reissue, so a grace window buys little and costs a lot in UI
+// ambiguity (a queued-for-deletion key could be silently resurrected via
+// the is_active toggle while cron still hard-deleted it later). Nested
+// provider keys go with it via provider_keys.api_key_id ON DELETE CASCADE.
 apiKeysRouter.delete('/:id', requireEdit, async (c) => {
   const keyId = c.req.param('id')
   const orgId = c.get('orgId')
-  const userId = c.get('userId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const ownership = await loadKeyOwnership(keyId)
   if (!ownership) throw new ApiError('NOT_FOUND', 'API key not found')
   if (ownership.orgId !== orgId) throw new ApiError('FORBIDDEN', 'Access denied')
 
-  // Snapshot the row before deactivation so the audit log and any restore
-  // attempt have the full original state to work with.
+  // Snapshot before the delete: the audit log wants the original state and
+  // the auth cache is indexed by key_hash, which is gone after the delete.
   const { data: snapshot } = await supabaseAdmin
     .from('api_keys')
-    .select('*')
+    .select('id, name, scope, key_prefix, key_hash, project_id, organization_id')
     .eq('id', keyId)
     .maybeSingle()
   if (!snapshot) throw new ApiError('NOT_FOUND', 'API key not found')
 
-  const enqueued = await enqueueDeletion({
-    organizationId: orgId,
-    resourceType: 'api_key',
-    resourceId: keyId,
-    resourceSnapshot: snapshot as Record<string, unknown>,
-    requestedBy: userId ?? null,
-  })
+  const { error } = await supabaseAdmin
+    .from('api_keys')
+    .delete()
+    .eq('id', keyId)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to delete API key')
 
-  if (!enqueued.ok) {
-    if (enqueued.code === 'ALREADY_PENDING') {
-      throw new ApiError('CONFLICT', 'Already queued for deletion')
-    }
-    throw new ApiError('INTERNAL_ERROR', enqueued.error ?? 'Failed to queue deletion')
-  }
-
-  // R-4/R-5: drop the auth cache entry for this key the instant the
-  // soft-delete is queued. Without this, the cached lookup could keep
-  // authenticating proxy traffic for up to 30s after the operator
-  // pressed delete — the exact incident the cache TTL choice tried to
-  // bound. The snapshot row carries `key_hash` (sha256 of the raw key),
-  // which is what the cache is indexed by.
+  // R-4/R-5: drop the auth cache entry immediately. Without this, the
+  // cached lookup could keep authenticating proxy traffic for up to 30s
+  // after the operator pressed delete.
   const snapshotKeyHash = (snapshot as { key_hash?: string }).key_hash
   if (snapshotKeyHash) invalidateApiKeyCache(snapshotKeyHash)
+
+  // The cascade removed this key's provider keys — reset the name cache so
+  // /requests renders "(deleted)" instead of stale names.
+  resetProviderKeyNamesCache()
 
   void recordAuditEvent(c, {
     action: 'api_key.delete',
@@ -334,14 +326,9 @@ apiKeysRouter.delete('/:id', requireEdit, async (c) => {
     metadata: {
       name: (snapshot as { name?: string }).name,
       scope: (snapshot as { scope?: string }).scope,
-      pending_deletion_id: enqueued.pendingId,
-      scheduled_for: enqueued.scheduledFor,
+      key_prefix: (snapshot as { key_prefix?: string }).key_prefix,
     },
   })
 
-  return c.json({
-    success: true,
-    pendingDeletionId: enqueued.pendingId,
-    scheduledFor: enqueued.scheduledFor,
-  })
+  return c.json({ success: true })
 })

--- a/apps/server/src/api/providerKeys.ts
+++ b/apps/server/src/api/providerKeys.ts
@@ -4,7 +4,6 @@ import { requireRole } from '../middleware/requireRole.js'
 import { supabaseAdmin } from '../lib/db.js'
 import { getOrgClickhouse } from '../lib/clickhouse.js'
 import { aes256Encrypt } from '../lib/crypto.js'
-import { enqueueDeletion } from '../lib/pending-deletions.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
 import { resetProviderKeyNamesCache } from '../lib/requests-query.js'
 import { validateOptionalUuid } from '../lib/params.js'
@@ -275,13 +274,13 @@ providerKeysRouter.post('/', requireEdit, async (c) => {
   return c.json({ success: true, data }, 201)
 })
 
-// DELETE /api/v1/provider-keys/:id — soft delete via pending_deletions queue.
+// DELETE /api/v1/provider-keys/:id — immediate hard delete.
 //
-// Provider keys cost real money when leaked, and accidental deletion is the
-// #1 inbound support ticket pattern. We trade the previous "delete means
-// delete" simplicity for a 72-hour grace window: the row is flipped
-// is_active=false right away so proxy calls fail immediately, and a cron
-// performs the hard delete unless the user restores it first.
+// Matches the api_keys DELETE contract: deletion is instant and permanent
+// (the 72-hour pending_deletions grace window was dropped — see apiKeys.ts
+// for the rationale). The encrypted provider key is unrecoverable after
+// this; if the delete was a mistake the user re-adds the key from the
+// provider's dashboard.
 //
 // The "(deleted)" rendering for orphaned ClickHouse rows still works after
 // hard delete — the fetchProviderKeyNames helper in lib/requests-query.ts
@@ -289,31 +288,22 @@ providerKeysRouter.post('/', requireEdit, async (c) => {
 providerKeysRouter.delete('/:id', requireEdit, async (c) => {
   const keyId = c.req.param('id')
   const orgId = c.get('orgId')
-  const userId = c.get('userId')
   if (!orgId) throw new ApiError('NOT_FOUND', 'Organization not found')
 
   const { data: snapshot } = await supabaseAdmin
     .from('provider_keys')
-    .select('*')
+    .select('id, provider, name')
     .eq('id', keyId)
     .eq('organization_id', orgId)
     .maybeSingle()
   if (!snapshot) throw new ApiError('NOT_FOUND', 'Provider key not found')
 
-  const enqueued = await enqueueDeletion({
-    organizationId: orgId,
-    resourceType: 'provider_key',
-    resourceId: keyId,
-    resourceSnapshot: snapshot as Record<string, unknown>,
-    requestedBy: userId ?? null,
-  })
-
-  if (!enqueued.ok) {
-    if (enqueued.code === 'ALREADY_PENDING') {
-      throw new ApiError('CONFLICT', 'Already queued for deletion')
-    }
-    throw new ApiError('INTERNAL_ERROR', enqueued.error ?? 'Failed to queue deletion')
-  }
+  const { error } = await supabaseAdmin
+    .from('provider_keys')
+    .delete()
+    .eq('id', keyId)
+    .eq('organization_id', orgId)
+  if (error) throw new ApiError('INTERNAL_ERROR', 'Failed to delete provider key')
 
   resetProviderKeyNamesCache()
 
@@ -324,16 +314,10 @@ providerKeysRouter.delete('/:id', requireEdit, async (c) => {
     metadata: {
       provider: (snapshot as { provider?: string }).provider,
       name: (snapshot as { name?: string }).name,
-      pending_deletion_id: enqueued.pendingId,
-      scheduled_for: enqueued.scheduledFor,
     },
   })
 
-  return c.json({
-    success: true,
-    pendingDeletionId: enqueued.pendingId,
-    scheduledFor: enqueued.scheduledFor,
-  })
+  return c.json({ success: true })
 })
 
 // PATCH /api/v1/provider-keys/:id — rotate (replace encrypted_key) and/or rename.

--- a/apps/server/src/lib/pending-deletions.ts
+++ b/apps/server/src/lib/pending-deletions.ts
@@ -12,6 +12,12 @@ import { invalidatePromptName } from './prompt-cache.js'
  *      `hardDeleteByType()` for each due row, then stamps `executed_at`.
  *
  * The restore path lives in apps/server/src/api/pendingDeletions.ts.
+ *
+ * NOTE (2026-07-21): api_key and provider_key deletes are now immediate hard
+ * deletes (see apiKeys.ts / providerKeys.ts) — new enqueues only come from
+ * prompt_version. The api_key / provider_key branches below stay so the cron
+ * can drain rows queued before the switch and the restore path keeps working
+ * for them during their remaining grace window.
  */
 
 export type PendingResourceType = 'api_key' | 'provider_key' | 'prompt_version'

--- a/apps/web/app/(dashboard)/projects/projects-client.tsx
+++ b/apps/web/app/(dashboard)/projects/projects-client.tsx
@@ -244,7 +244,9 @@ export function ProjectsClient() {
 
   // Delete confirms
   const [deleteApiKeyId, setDeleteApiKeyId] = useState<string | null>(null)
+  const [deleteApiKeyError, setDeleteApiKeyError] = useState<string | null>(null)
   const [deleteProvKeyId, setDeleteProvKeyId] = useState<string | null>(null)
+  const [deleteProvKeyError, setDeleteProvKeyError] = useState<string | null>(null)
   // Public-key revoke confirm — mirrors the Spanlens-key delete flow so a
   // single misclick can't revoke a workspace credential. Separate state from
   // deleteApiKeyId because the two dialogs describe different consequences.
@@ -385,8 +387,13 @@ export function ProjectsClient() {
 
   async function handleDeleteApiKey() {
     if (!deleteApiKeyId) return
-    await deleteApiKey.mutateAsync(deleteApiKeyId)
-    setDeleteApiKeyId(null)
+    setDeleteApiKeyError(null)
+    try {
+      await deleteApiKey.mutateAsync(deleteApiKeyId)
+      setDeleteApiKeyId(null)
+    } catch (err) {
+      setDeleteApiKeyError(err instanceof Error ? err.message : 'Failed to delete key')
+    }
   }
 
   async function handleRevokePublicKey() {
@@ -402,8 +409,13 @@ export function ProjectsClient() {
 
   async function handleDeleteProviderKey() {
     if (!deleteProvKeyId) return
-    await deleteProviderKey.mutateAsync(deleteProvKeyId)
-    setDeleteProvKeyId(null)
+    setDeleteProvKeyError(null)
+    try {
+      await deleteProviderKey.mutateAsync(deleteProvKeyId)
+      setDeleteProvKeyId(null)
+    } catch (err) {
+      setDeleteProvKeyError(err instanceof Error ? err.message : 'Failed to delete key')
+    }
   }
 
   function openDeleteProjectDialog(id: string, name: string) {
@@ -1437,20 +1449,26 @@ export function ProjectsClient() {
       {/* Delete Spanlens key confirm */}
       <Dialog
         open={deleteApiKeyId !== null}
-        onOpenChange={(open) => { if (!open) setDeleteApiKeyId(null) }}
+        onOpenChange={(open) => { if (!open) { setDeleteApiKeyId(null); setDeleteApiKeyError(null) } }}
       >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Delete Spanlens key</DialogTitle>
           </DialogHeader>
           <DialogDescription className="text-[12.5px] text-text-muted mt-1">
-            All provider keys under this Spanlens key will also be deleted (CASCADE). Apps using
-            this key will stop working immediately.
+            This permanently deletes the key right away and cannot be undone. All
+            provider keys under this Spanlens key are deleted with it, and apps
+            using this key stop working immediately.
           </DialogDescription>
 
           <div className="space-y-4 mt-2">
+            {deleteApiKeyError && (
+              <div className="rounded-md border border-bad/30 bg-bad/10 px-3 py-2 text-[12px] text-bad">
+                {deleteApiKeyError}
+              </div>
+            )}
             <div className="flex gap-3">
-              <GhostBtn className="flex-1" onClick={() => setDeleteApiKeyId(null)}>
+              <GhostBtn className="flex-1" onClick={() => { setDeleteApiKeyId(null); setDeleteApiKeyError(null) }}>
                 Cancel
               </GhostBtn>
               <button
@@ -1506,21 +1524,26 @@ export function ProjectsClient() {
       {/* Delete provider key confirm */}
       <Dialog
         open={deleteProvKeyId !== null}
-        onOpenChange={(open) => { if (!open) setDeleteProvKeyId(null) }}
+        onOpenChange={(open) => { if (!open) { setDeleteProvKeyId(null); setDeleteProvKeyError(null) } }}
       >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Delete provider key</DialogTitle>
           </DialogHeader>
           <DialogDescription className="text-[12.5px] text-text-muted mt-1">
-            This provider key will be permanently removed. The parent Spanlens
-            key will fail when calling this provider until you add a new one.
-            Existing request logs stay intact.
+            This provider key is permanently removed right away and cannot be
+            undone. The parent Spanlens key will fail when calling this provider
+            until you add a new one. Existing request logs stay intact.
           </DialogDescription>
 
           <div className="space-y-4 mt-2">
+            {deleteProvKeyError && (
+              <div className="rounded-md border border-bad/30 bg-bad/10 px-3 py-2 text-[12px] text-bad">
+                {deleteProvKeyError}
+              </div>
+            )}
             <div className="flex gap-3">
-              <GhostBtn className="flex-1" onClick={() => setDeleteProvKeyId(null)}>
+              <GhostBtn className="flex-1" onClick={() => { setDeleteProvKeyId(null); setDeleteProvKeyError(null) }}>
                 Cancel
               </GhostBtn>
               <button

--- a/apps/web/app/(dashboard)/settings/pending-deletions/pending-deletions-client.tsx
+++ b/apps/web/app/(dashboard)/settings/pending-deletions/pending-deletions-client.tsx
@@ -89,7 +89,9 @@ export function PendingDeletionsClient() {
           <div className="px-5 py-8 text-sm text-red-600">Failed to load.</div>
         ) : !active.data || active.data.length === 0 ? (
           <div className="px-5 py-8 text-sm text-[var(--text-muted)]">
-            Nothing pending. Deletions appear here for 72 hours before becoming permanent.
+            Nothing pending. Prompt version deletions appear here for 72 hours before
+            becoming permanent. API keys and provider keys are deleted immediately and
+            never appear in this queue.
           </div>
         ) : (
           <ul className="divide-y divide-[var(--border-strong)]">

--- a/apps/web/app/docs/features/projects/page.tsx
+++ b/apps/web/app/docs/features/projects/page.tsx
@@ -168,28 +168,21 @@ export default function ProjectsDocs() {
           changes.
         </li>
         <li>
-          <strong>Deleted with a 72-hour grace period.</strong> The trash icon on a
-          Spanlens key or a provider key flips <code>is_active = false</code> right away
-          so the proxy stops accepting it, then queues a hard delete that runs every six
-          hours. While the row is in the queue you can restore it from{' '}
-          <a href="/settings">Settings</a> → <strong>Pending deletions</strong>. After the
-          grace window the hard delete runs and the row is gone for good.
+          <strong>Deleted immediately and permanently.</strong> The trash icon on a
+          Spanlens key or a provider key hard-deletes the row right away, the same way
+          key deletion works at OpenAI, Anthropic, or Stripe. The proxy stops accepting
+          the key within seconds (the auth cache is evicted on delete), and deleting a
+          Spanlens key also deletes every provider key nested under it. Deletion cannot
+          be undone; if it was a mistake, issue a fresh key and re-add the provider
+          credential from the provider&apos;s dashboard.
         </li>
       </ul>
 
-      <h3>Restoring an accidental deletion</h3>
       <p>
-        Misclicked the trash icon? Open <a href="/settings">Settings</a> →{' '}
-        <strong>Pending deletions</strong>. Every soft-deleted key, provider key, and
-        prompt version shows up there with a timer; click <em>Restore</em> to reactivate
-        the row. After the timer expires the row is hard-deleted and restore is no longer
-        possible — you&apos;d have to issue a fresh key (the SHA-256 hash is irreversible).
-      </p>
-      <p>
-        Audit events are recorded both for the original delete request
-        (<code>api_key.delete</code> / <code>provider_key.delete</code>) and for the
-        restore (<code>pending_deletion.restore</code>), so the trail stays intact even
-        when the action is reversed.
+        Every delete is recorded as an audit event (<code>api_key.delete</code> /{' '}
+        <code>provider_key.delete</code>) with the key&apos;s name and prefix, so the
+        trail of who deleted what stays intact. Existing request logs also stay intact —
+        rows from a deleted key render its name as <em>(deleted)</em>.
       </p>
 
       <p>
@@ -212,7 +205,7 @@ POST   /api/v1/api-keys/issue                { "name": "prod-backend",
                                                "projectId": "<uuid>" }
 # → { "id": "...", "key": "sl_live_..." }   ← shown ONCE
 PATCH  /api/v1/api-keys/:id                  { "is_active": false }    # toggle
-DELETE /api/v1/api-keys/:id                  # is_active=false + 72h delete queue
+DELETE /api/v1/api-keys/:id                  # immediate, permanent (cascades to provider keys)
 
 # ── Provider keys (under a specific Spanlens key) ─────────────
 GET    /api/v1/provider-keys?apiKeyId=<spanlens-key-uuid>
@@ -222,12 +215,7 @@ POST   /api/v1/provider-keys                 { "api_key_id": "<uuid>",
                                                "name": "prod-openai" }
 PATCH  /api/v1/provider-keys/:id             { "key": "sk-rotated..." }   # rotate
 PATCH  /api/v1/provider-keys/:id             { "name": "renamed" }        # rename
-DELETE /api/v1/provider-keys/:id             # is_active=false + 72h delete queue
-
-# ── Pending deletions queue (restore within 72h) ──────────────
-GET    /api/v1/pending-deletions             # active queue
-GET    /api/v1/pending-deletions/history     # terminal rows (executed or cancelled)
-POST   /api/v1/pending-deletions/:id/restore # cancel + flip is_active back to true`}</CodeBlock>
+DELETE /api/v1/provider-keys/:id             # immediate, permanent`}</CodeBlock>
 
       <h3>How requests get their project</h3>
       <p>

--- a/apps/web/app/docs/features/settings/page.tsx
+++ b/apps/web/app/docs/features/settings/page.tsx
@@ -199,22 +199,21 @@ export default function SettingsDocs() {
         silently swaps the underlying credential on the next request.
       </p>
 
-      <h3>Deactivating a provider key</h3>
+      <h3>Deleting a provider key</h3>
       <p>
-        The trash icon next to a provider key flips <code>is_active = false</code> right
-        away and queues a hard delete for 72 hours later. Subsequent requests for that
-        provider on that Spanlens key return <code>400 No active provider key</code>{' '}
-        until you add a new one. Restore the row from <strong>Pending deletions</strong>{' '}
-        if you mis-clicked — see <a href="/docs/features/projects#restoring-an-accidental-deletion">Restoring an accidental deletion</a>.
+        The trash icon next to a provider key deletes it immediately and permanently.
+        Subsequent requests for that provider on that Spanlens key return{' '}
+        <code>400 No active provider key</code> until you add a new one. If the delete
+        was a mistake, re-add the credential from the provider&apos;s dashboard — the
+        encrypted key is not recoverable.
       </p>
 
       <h3>Deleting a Spanlens key</h3>
       <p>
-        The trash icon next to a Spanlens key flips <code>is_active = false</code>{' '}
-        immediately (so apps using that key start failing with 401 right away) and queues
-        the hard delete for 72 hours later. Provider keys attached to the key stay around
-        for that window too. Cron runs every six hours and finalises any expired rows;
-        restore is possible until then.
+        The trash icon next to a Spanlens key deletes it immediately and permanently
+        (apps using that key start failing with 401 within seconds). Provider keys
+        attached to the key are deleted with it. Deletion cannot be undone; issue a
+        fresh key if you need to replace it.
       </p>
 
       <h3>API</h3>
@@ -223,7 +222,7 @@ GET    /api/v1/api-keys?projectId=<uuid>
 POST   /api/v1/api-keys/issue           { "name": "prod-backend", "projectId": "<uuid>" }
 # → { "id": ..., "key": "sl_live_..." }   ← shown ONCE
 PATCH  /api/v1/api-keys/:id             { "is_active": false }    # toggle
-DELETE /api/v1/api-keys/:id             # is_active=false + 72h delete queue
+DELETE /api/v1/api-keys/:id             # immediate, permanent (cascades to provider keys)
 
 # ── Provider keys (under a specific Spanlens key) ──────────────
 GET    /api/v1/provider-keys?apiKeyId=<spanlens-key-uuid>
@@ -231,12 +230,7 @@ POST   /api/v1/provider-keys            { "api_key_id": "<uuid>", "provider": "o
                                           "key": "sk-...", "name": "prod-openai" }
 PATCH  /api/v1/provider-keys/:id        { "key": "sk-rotated..." }   # rotate
 PATCH  /api/v1/provider-keys/:id        { "name": "renamed" }        # rename
-DELETE /api/v1/provider-keys/:id        # is_active=false + 72h delete queue
-
-# ── Pending deletions queue (restore within 72h) ───────────────
-GET    /api/v1/pending-deletions             # active queue
-GET    /api/v1/pending-deletions/history     # terminal rows
-POST   /api/v1/pending-deletions/:id/restore # cancel + reactivate`}</CodeBlock>
+DELETE /api/v1/provider-keys/:id        # immediate, permanent`}</CodeBlock>
 
       <h2>Security guarantees</h2>
       <ul>


### PR DESCRIPTION
## Summary

API key / provider key deletion is now **immediate and permanent**, replacing the 72-hour `pending_deletions` grace queue for those two resource types. This matches how every major provider (OpenAI, Anthropic, Stripe, GitHub) treats key revocation, and removes a class of bugs the queued state created.

### Bugs fixed by removing the queue

- **Resurrection bug**: a queued-for-deletion key still showed the active/inactive toggle. Flipping it set `is_active=true` while the `pending_deletions` row survived, so cron still hard-deleted the key up to 72h later while it looked active.
- **Silent 409**: re-deleting a queued key returned 409 `ALREADY_PENDING`, but the delete dialog had no error handling or display, so it appeared frozen.
- **Ambiguous strikethrough**: manually-disabled and queued-for-deletion keys rendered identically.

### Server

- `DELETE /api/v1/api-keys/:id`: hard delete immediately. Auth cache evicted on delete (proxy traffic stops within seconds), nested provider keys removed via existing `ON DELETE CASCADE`, provider-key name cache reset so `/requests` renders `(deleted)`. Response simplified to `{ success: true }`.
- `DELETE /api/v1/provider-keys/:id`: same contract.
- `lib/pending-deletions.ts` unchanged in behavior: `prompt_version` still uses the 72h queue (real data, restore is valuable), and rows queued before this switch drain normally through the existing cron/restore paths. Header comment documents the split.

### Web

- Delete dialogs (Spanlens key + provider key) get try/catch + inline error display; copy states immediate/permanent + cascade.
- Strikethrough now only ever means "manually toggled off".
- Pending-deletions settings page empty state clarifies keys no longer pass through the queue.
- Docs (`/docs/features/projects`, `/docs/features/settings`) rewritten to the new contract; removed the "Restoring an accidental deletion" section and 72h references for keys.

### Notes

- No DB migration. Cascade FK already exists (`20260505080000`).
- Audit events (`api_key.delete` / `provider_key.delete`) still record name/scope/prefix.
- Existing queued key rows at deploy time are drained by the unchanged cron; no cleanup needed.

## Test plan

- [x] `pnpm --filter server typecheck && lint && test` (1585 tests green, incl. openapi-drift + pending-deletions lib tests)
- [x] `pnpm --filter web typecheck && lint`
- [x] `pnpm build` (full monorepo)
- [ ] Post-deploy smoke: delete a throwaway key on production, confirm it disappears from `/projects` immediately and proxy returns 401 within seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
