### PR TITLE
ci: gate server coverage by running vitest with --coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,11 @@ jobs:
         run: pnpm --filter server lint
 
       - name: Test (server)
-        run: pnpm --filter server test
+        # --coverage activates the lines:35 floor in vitest.config.ts so a
+        # PR that drops server coverage below the ratchet fails CI. Bump the
+        # floor in vitest.config.ts as coverage rises (P2.3 target: 80% on
+        # Tier 1 modules).
+        run: pnpm --filter server test -- --coverage
         env:
           ENCRYPTION_KEY: ${{ secrets.CI_ENCRYPTION_KEY || 'YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=' }}
 


### PR DESCRIPTION
## Summary
`apps/server/vitest.config.ts` already defines `coverage.thresholds: { lines: 35 }` (a ratchet floor), but its own comment notes the gate was inert in CI: the `Test (server)` step ran `pnpm --filter server test` **without** `--coverage`, so the floor only applied to opt-in local runs. This PR flips the CI step to `--coverage`, activating the existing threshold so any PR that drops server line coverage below the ratchet fails CI.

## Change
- `.github/workflows/ci.yml`: `Test (server)` step → `pnpm --filter server test -- --coverage`
- No threshold change; uses the existing `lines: 35` floor already committed in `vitest.config.ts`

## Test plan
- [x] Local `pnpm --filter server test -- --coverage` passes the 35% floor on `main` (1585 tests, exit 0, no threshold error) so enabling the gate does not break CI today
- [x] `@vitest/coverage-v8` is already a devDependency
- [ ] CI green on this PR confirms the gate runs

## Follow-up
Bump the floor in `vitest.config.ts` as coverage rises (master plan P2.3 target: 80% on Tier 1 modules).
