### PR TITLE
ci: reclaim 4 externally-scheduled crons into IaC, note retry-webhooks

### DIFF
--- a/.github/workflows/cron-server.yml
+++ b/.github/workflows/cron-server.yml
@@ -47,6 +47,25 @@ name: Cron — server sub-daily
 # the same endpoint is fine — every handler holds an advisory lock or
 # is naturally idempotent.
 #
+# Usage / billing crons reclaimed into IaC (2026-07-22): these four were
+# firing in production via an external Better Stack monitor but were
+# declared in NEITHER vercel.json NOR this file, so their schedule lived
+# only in Better Stack's dashboard. If that monitor is ever deleted they
+# stop silently. Adding them here makes the schedule version-controlled
+# and gives defense-in-depth; Better Stack stays as the primary/backup.
+# Cadences match the observed production runs in cron_job_runs.
+#
+#   /cron/aggregate-usage           hourly at :00
+#     Rolls raw usage into usage_daily. Silent = usage rollups stall.
+#   /cron/check-quota-warnings      hourly at :15
+#     80/100% quota warning emails + dashboard banner. Silent = users
+#     hit their cap with no warning.
+#   /cron/prune-logs                daily 03:00
+#     Retention pruning + rate-limit bucket cleanup. Silent = tables grow.
+#   /cron/report-usage-overage      daily 03:30
+#     Paddle usage-based overage reporting. Silent = overage revenue is
+#     never billed. Highest-stakes of the four.
+#
 # Required secret: CRON_SECRET in Settings → Secrets, matching the
 # Vercel env var of the same name (the handler compares against it).
 #
@@ -72,6 +91,8 @@ on:
     - cron: '15 3 * * *'       # daily 03:15 — purge-proxy-cache
     - cron: '0 9 * * 1'        # weekly Monday 09:00 — stale-key-reminders + weekly-digest
     - cron: '30 */6 * * *'     # every 6h at :30 — detect-data-silence
+    - cron: '15 * * * *'       # hourly :15 — check-quota-warnings
+    - cron: '30 3 * * *'       # daily 03:30 — report-usage-overage
   workflow_dispatch:
 
 concurrency:
@@ -328,6 +349,79 @@ jobs:
           STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
             -H "Authorization: Bearer $CRON_SECRET" \
             "$BASE_URL/cron/weekly-digest")
+          echo "Status: $STATUS"
+          cat /tmp/body
+          if [ "$STATUS" -ge 400 ]; then exit 1; fi
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+
+  # ── Usage / billing crons reclaimed into IaC (see header note) ───────
+  hourly-00-aggregate-usage:
+    name: Hourly at :00 (aggregate-usage)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '0 * * * *' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: POST /cron/aggregate-usage
+        run: |
+          BASE_URL='https://spanlens-server.vercel.app'
+          STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            "$BASE_URL/cron/aggregate-usage")
+          echo "Status: $STATUS"
+          cat /tmp/body
+          if [ "$STATUS" -ge 400 ]; then exit 1; fi
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+
+  hourly-15-check-quota-warnings:
+    name: Hourly at :15 (check-quota-warnings)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '15 * * * *' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: POST /cron/check-quota-warnings
+        run: |
+          BASE_URL='https://spanlens-server.vercel.app'
+          STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            "$BASE_URL/cron/check-quota-warnings")
+          echo "Status: $STATUS"
+          cat /tmp/body
+          if [ "$STATUS" -ge 400 ]; then exit 1; fi
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+
+  daily-03-prune-logs:
+    name: Daily 03:00 UTC (prune-logs)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '0 3 * * *' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: POST /cron/prune-logs
+        run: |
+          BASE_URL='https://spanlens-server.vercel.app'
+          STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            "$BASE_URL/cron/prune-logs")
+          echo "Status: $STATUS"
+          cat /tmp/body
+          if [ "$STATUS" -ge 400 ]; then exit 1; fi
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+
+  daily-03-30-report-usage-overage:
+    name: Daily 03:30 UTC (report-usage-overage)
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '30 3 * * *' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: POST /cron/report-usage-overage
+        run: |
+          BASE_URL='https://spanlens-server.vercel.app'
+          STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            "$BASE_URL/cron/report-usage-overage")
           echo "Status: $STATUS"
           cat /tmp/body
           if [ "$STATUS" -ge 400 ]; then exit 1; fi

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -242,7 +242,14 @@ cronRouter.get('/recommend-savings-alerts', async (c) => {
   }
 })
 
-// ── Webhook retry (every 5 minutes) ────────────────────────────
+// ── Webhook retry (every 5 minutes when scheduled) ─────────────
+// INTENTIONALLY UNSCHEDULED as of 2026-07-22: no scheduler (vercel.json,
+// cron-server.yml, or Better Stack) fires this, and cron_job_runs shows
+// zero executions. Safe because the outbound-webhooks feature has zero
+// production usage (0 configured, 0 deliveries). When webhooks ship to
+// customers, add a `*/5 * * * *` job for /cron/retry-webhooks to
+// .github/workflows/cron-server.yml (and/or Better Stack) so failed
+// deliveries actually retry — otherwise a failed delivery never retries.
 cronRouter.get('/retry-webhooks', async (c) => {
   assertCronAuth(c.req.header('Authorization'))
 


### PR DESCRIPTION
## Summary
A cron audit found 5 endpoints defined in `apps/server/src/api/cron.ts` (23 total) that were absent from both schedulers in version control: `vercel.json` (18) and `.github/workflows/cron-server.yml` (15). I checked production `cron_job_runs` to see whether they actually run.

**4 run in production on fixed cadences (last run today), via an external Better Stack monitor** that is the only place their schedule was declared:

| cron | prod runs | cadence | stakes if it stops |
|---|---|---|---|
| `aggregate-usage` | 1338 | hourly :00 | usage rollups stall |
| `check-quota-warnings` | 1380 | hourly :15 | users hit cap with no warning |
| `prune-logs` | 61 | daily 03:00 | retention/rate-limit tables grow |
| `report-usage-overage` | 51 | daily 03:30 | **Paddle overage never billed (revenue)** |

This is IaC drift, not dead code: they work, but the schedule lives only in Better Stack's dashboard. Delete that monitor and they stop silently.

**1 is genuinely unscheduled — `retry-webhooks`:** zero runs ever, and the outbound-webhooks feature has zero production usage (0 configured, 0 deliveries), so nothing to retry. Harmless today.

## Changes
- `.github/workflows/cron-server.yml`: add the 4 live crons as code-visible jobs at their observed cadences (reusing the existing `0 * * * *` and `0 3 * * *` schedules, adding `15 * * * *` and `30 3 * * *`). Better Stack stays primary; both firing is safe since handlers are idempotent (same convention as every existing job here). Header note explains the reclaim.
- `apps/server/src/api/cron.ts`: document `retry-webhooks` as an intentional deferral, with instructions to add a `*/5` job when webhooks ship to customers.

## Test plan
- [x] `pnpm --filter server typecheck` passes (cron.ts change is comment-only)
- [x] `cron-server.yml` parses as valid YAML: 16 jobs (+4), 14 schedule entries (+2)
- [x] New jobs gate on their schedule via `if:` predicates, matching the existing pattern
- [ ] After merge: confirm the 4 new jobs appear in the Actions run history at their next cadence

## Follow-up (separate PR)
A source-guard test that fails CI when a `cron.ts` route is in neither scheduler nor an explicit UNSCHEDULED allowlist, to prevent this drift class from recurring.
