### PR TITLE
fix(db): refresh model prices across all providers (2026-07)

### DIFF
--- a/apps/server/src/__tests__/proxy-mistral.test.ts
+++ b/apps/server/src/__tests__/proxy-mistral.test.ts
@@ -218,9 +218,9 @@ describe('mistral proxy — logging + cost', () => {
     expect(row['model']).toBe('mistral-large-latest')
     expect(row['promptTokens']).toBe(1_000_000)
     expect(row['completionTokens']).toBe(500_000)
-    // mistral-large-latest: $2.00 / 1M prompt + $6.00 / 1M completion
-    // 1M * 2.00 + 0.5M * 6.00 = 2 + 3 = 5
-    expect(row['costUsd']).toBeCloseTo(5.0, 4)
+    // mistral-large-latest (Mistral Large 3): $0.50 / 1M prompt + $1.50 / 1M completion
+    // 1M * 0.50 + 0.5M * 1.50 = 0.5 + 0.75 = 1.25
+    expect(row['costUsd']).toBeCloseTo(1.25, 4)
   })
 
   test('upstream non-2xx is passed through and recorded with errorMessage', async () => {

--- a/apps/server/src/__tests__/proxy-openai-compat-providers.test.ts
+++ b/apps/server/src/__tests__/proxy-openai-compat-providers.test.ts
@@ -122,8 +122,11 @@ const CASES: ProviderCase[] = [
   { slug: 'groq', expectedUrl: 'https://api.groq.com/openai/v1/chat/completions', model: 'llama-3.3-70b-versatile', expectedCost: 0.985 },
   // deepseek-chat: $0.14/1M in + $0.28/1M out → 1*0.14 + 0.5*0.28
   { slug: 'deepseek', expectedUrl: 'https://api.deepseek.com/v1/chat/completions', model: 'deepseek-chat', expectedCost: 0.28 },
-  // grok-4.3: $1.25/1M in + $2.50/1M out → 1*1.25 + 0.5*2.50
-  { slug: 'xai', expectedUrl: 'https://api.x.ai/v1/chat/completions', model: 'grok-4.3', expectedCost: 2.5 },
+  // grok-4.3 at the LONG tier: the 1M-token prompt below crosses xAI's 200k
+  // threshold, which re-rates the whole request at 2x ($2.50/1M in +
+  // $5.00/1M out) → 1*2.50 + 0.5*5.00. Short-tier pricing is covered by the
+  // dedicated test after this block.
+  { slug: 'xai', expectedUrl: 'https://api.x.ai/v1/chat/completions', model: 'grok-4.3', expectedCost: 5.0 },
   // command-a-03-2025: $2.50/1M in + $10.00/1M out → 1*2.50 + 0.5*10.00
   { slug: 'cohere', expectedUrl: 'https://api.cohere.ai/compatibility/v1/chat/completions', model: 'command-a-03-2025', expectedCost: 7.5 },
 ]
@@ -225,3 +228,47 @@ for (const c of CASES) {
     })
   })
 }
+
+// xAI is the only provider whose long-context tier re-rates the ENTIRE request
+// (docs.x.ai: "requests whose prompt reaches the listed token threshold are
+// billed at the higher rate for all tokens"). Guard both sides of the 200k
+// boundary so a future price refresh can't silently drop the tier.
+describe('xai long-context tier boundary', () => {
+  test('prompt under 200k uses the short tier', async () => {
+    mockUpstream(openAIChatResponse({
+      model: 'grok-4.3',
+      promptTokens: 100_000,
+      completionTokens: 50_000,
+    }))
+    const app = await buildApp()
+
+    await app.request('/proxy/xai/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'grok-4.3', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    // 0.1M * $1.25 + 0.05M * $2.50 = 0.125 + 0.125
+    expect(proxyState.loggerCalls[0]!['costUsd']).toBeCloseTo(0.25, 6)
+  })
+
+  test('prompt over 200k re-rates the whole request at 2x', async () => {
+    mockUpstream(openAIChatResponse({
+      model: 'grok-4.3',
+      promptTokens: 250_000,
+      completionTokens: 50_000,
+    }))
+    const app = await buildApp()
+
+    await app.request('/proxy/xai/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'grok-4.3', messages: [] }),
+    })
+    await drainPendingTasks()
+
+    // 0.25M * $2.50 + 0.05M * $5.00 = 0.625 + 0.25
+    expect(proxyState.loggerCalls[0]!['costUsd']).toBeCloseTo(0.875, 6)
+  })
+})

--- a/apps/server/src/lib/model-prices-cache.ts
+++ b/apps/server/src/lib/model-prices-cache.ts
@@ -55,7 +55,7 @@ export interface ModelPrice {
   longCacheWrite?: number | undefined
 }
 
-// Prices in USD per 1M tokens (verified against provider pricing pages 2026-05-22).
+// Prices in USD per 1M tokens (verified against provider pricing pages 2026-07-29).
 // This map is the COLD-START FALLBACK — used when the DB cache is empty
 // (first request after deploy / DB unreachable). The DB is the source of truth
 // once loaded; this constant exists to guarantee `calculateCost()` always has
@@ -63,10 +63,22 @@ export interface ModelPrice {
 //
 // Cache rates:
 //   • Anthropic — cache_read = 0.1 × input, cache_write (5min) = 1.25 × input
-//   • OpenAI    — cached input ≈ 0.5 × input (gpt-4o / gpt-4.1 families; explicit per-model in GPT-5.x)
-//   • Gemini    — caching priced but our integration doesn't surface it yet
+//   • OpenAI    — cached input ≈ 0.5 × input (gpt-4o / gpt-4.1 families; explicit per-model in GPT-5.x).
+//                 GPT-5.6 is the first OpenAI family with a published cache_write rate (1.25 × input)
+//   • Gemini    — cacheRead is the published text/image/video context-caching rate (audio caches higher)
+//   • xAI       — every Grok model has a cached-input rate and a ≥200k tier that re-rates the whole request
 //   • Tiered Gemini models use the ≤200k token band
 export const FALLBACK_PRICES: Record<string, ModelPrice> = {
+  // ── OpenAI: GPT-5.6 flagship (long-context tier at ≥272k tokens) ─────────
+  'gpt-5.6-sol':       { prompt: 5.0,  completion: 30,  cacheRead: 0.5,  cacheWrite: 6.25,
+                         longThreshold: 272000, longPrompt: 10, longCompletion: 45,
+                         longCacheRead: 1.0, longCacheWrite: 12.5 },
+  'gpt-5.6-terra':     { prompt: 2.5,  completion: 15,  cacheRead: 0.25, cacheWrite: 3.125,
+                         longThreshold: 272000, longPrompt: 5, longCompletion: 22.5,
+                         longCacheRead: 0.5, longCacheWrite: 6.25 },
+  'gpt-5.6-luna':      { prompt: 1.0,  completion: 6,   cacheRead: 0.1,  cacheWrite: 1.25,
+                         longThreshold: 272000, longPrompt: 2, longCompletion: 9,
+                         longCacheRead: 0.2, longCacheWrite: 2.5 },
   // ── OpenAI: GPT-5.x flagship ─────────────────────────────────────────────
   // gpt-5.5 / 5.5-pro / 5.4 / 5.4-pro have a long-context tier at ≥272k tokens.
   'gpt-5.5':           { prompt: 5.0,  completion: 30,  cacheRead: 0.5,
@@ -133,17 +145,25 @@ export const FALLBACK_PRICES: Record<string, ModelPrice> = {
   // ── Mistral: chat completion + embeddings (OpenAI-compatible API) ────────
   // Same rows live in supabase/seeds/model_prices.sql + the 20260612150000
   // migration. cache pricing not published by Mistral.
-  'mistral-large-latest':         { prompt: 2.00, completion: 6.00 },
-  'mistral-medium-latest':        { prompt: 0.40, completion: 2.00 },
-  'mistral-small-latest':         { prompt: 0.20, completion: 0.60 },
+  'mistral-large-latest':         { prompt: 0.50, completion: 1.50 },
+  'mistral-medium-latest':        { prompt: 1.50, completion: 7.50 },
+  'mistral-small-latest':         { prompt: 0.15, completion: 0.60 },
+  'magistral-medium-latest':      { prompt: 2.00, completion: 5.00 },
+  'magistral-small-latest':       { prompt: 0.50, completion: 1.50 },
+  'devstral-medium-latest':       { prompt: 0.40, completion: 2.00 },
+  'devstral-small-latest':        { prompt: 0.10, completion: 0.30 },
   'pixtral-large-latest':         { prompt: 2.00, completion: 6.00 },
   'pixtral-12b':                  { prompt: 0.15, completion: 0.15 },
-  'codestral-latest':             { prompt: 0.20, completion: 0.60 },
-  'ministral-3b-latest':          { prompt: 0.04, completion: 0.04 },
-  'ministral-8b-latest':          { prompt: 0.10, completion: 0.10 },
+  'codestral-latest':             { prompt: 0.30, completion: 0.90 },
+  'ministral-3b-latest':          { prompt: 0.10, completion: 0.10 },
+  'ministral-8b-latest':          { prompt: 0.15, completion: 0.15 },
+  'ministral-14b-latest':         { prompt: 0.20, completion: 0.20 },
   'open-mistral-nemo':            { prompt: 0.15, completion: 0.15 },
-  'mixtral-8x22b':                { prompt: 2.00, completion: 6.00 },
+  'open-mixtral-8x7b':            { prompt: 0.70, completion: 0.70 },
+  'open-mixtral-8x22b':           { prompt: 2.00, completion: 6.00 },
+  'mixtral-8x22b':                { prompt: 2.00, completion: 6.00 }, // legacy alias
   'mistral-embed':                { prompt: 0.10, completion: 0 },
+  'codestral-embed':              { prompt: 0.15, completion: 0 },
   // ── Groq / DeepSeek / xAI / Cohere (OpenAI-compatible) ───────────────────
   // Representative production models; full set lives in the seed +
   // 20260701120100 migration. Cold-start fallback so cost lands non-NULL.
@@ -155,13 +175,28 @@ export const FALLBACK_PRICES: Record<string, ModelPrice> = {
   'deepseek-reasoner':            { prompt: 0.14,  completion: 0.28, cacheRead: 0.0028 },
   'deepseek-v4-flash':            { prompt: 0.14,  completion: 0.28, cacheRead: 0.0028 },
   'deepseek-v4-pro':              { prompt: 0.435, completion: 0.87, cacheRead: 0.003625 },
-  'grok-4.3':                     { prompt: 1.25,  completion: 2.50 },
-  'grok-build-0.1':               { prompt: 1.00,  completion: 2.00 },
+  'qwen/qwen3.6-27b':             { prompt: 0.60,  completion: 3.00 },
+  // Grok re-rates the WHOLE request at 2x once the prompt reaches 200k.
+  'grok-4.5':                     { prompt: 2.00,  completion: 6.00, cacheRead: 0.30,
+                                    longThreshold: 200000, longPrompt: 4, longCompletion: 12, longCacheRead: 0.6 },
+  'grok-4.3':                     { prompt: 1.25,  completion: 2.50, cacheRead: 0.20,
+                                    longThreshold: 200000, longPrompt: 2.5, longCompletion: 5, longCacheRead: 0.4 },
+  'grok-build-0.1':               { prompt: 1.00,  completion: 2.00, cacheRead: 0.20,
+                                    longThreshold: 200000, longPrompt: 2, longCompletion: 4, longCacheRead: 0.4 },
   'command-a-03-2025':            { prompt: 2.50,  completion: 10.00 },
   'command-r-plus-08-2024':       { prompt: 2.50,  completion: 10.00 },
   'command-r-08-2024':            { prompt: 0.15,  completion: 0.60 },
   'command-r7b-12-2024':          { prompt: 0.0375, completion: 0.15 },
+  // ── Anthropic: Claude 5 ──────────────────────────────────────────────────
+  'claude-fable-5':               { prompt: 10,   completion: 50, cacheRead: 1.0,  cacheWrite: 12.5 },
+  'claude-mythos-5':              { prompt: 10,   completion: 50, cacheRead: 1.0,  cacheWrite: 12.5 }, // invite-only
+  'claude-mythos-preview':        { prompt: 10,   completion: 50, cacheRead: 1.0,  cacheWrite: 12.5 }, // invite-only
+  'claude-opus-5':                { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 },
+  // ⚠ INTRODUCTORY pricing through 2026-08-31. From 2026-09-01 Sonnet 5 is
+  // 3 / 15 / 0.30 / 3.75 — update here AND in a follow-up migration.
+  'claude-sonnet-5':              { prompt: 2,    completion: 10, cacheRead: 0.2,  cacheWrite: 2.5 },
   // ── Anthropic: Claude 4.x (aliases + dated variants) ─────────────────────
+  'claude-opus-4-8':              { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 },
   'claude-opus-4-7':              { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 },
   'claude-opus-4-6':              { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 }, // alias only; no dated form per docs
   'claude-opus-4-5':              { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 },
@@ -186,27 +221,36 @@ export const FALLBACK_PRICES: Record<string, ModelPrice> = {
   'claude-3-opus-20240229':       { prompt: 15,   completion: 75, cacheRead: 1.5,  cacheWrite: 18.75 },
   'claude-3-haiku-20240307':      { prompt: 0.25, completion: 1.25 }, // retired 2026-04-19, no cache
   // ── Gemini 3.x (Pro family has >200k tier) ───────────────────────────────
-  'gemini-3.5-flash':                       { prompt: 1.5,  completion: 9 },
-  'gemini-3.1-pro-preview':                 { prompt: 2.0,  completion: 12,
-                                              longThreshold: 200000, longPrompt: 4, longCompletion: 18 },
-  'gemini-3.1-pro-preview-customtools':     { prompt: 2.0,  completion: 12,
-                                              longThreshold: 200000, longPrompt: 4, longCompletion: 18 },
-  'gemini-3.1-flash-lite':                  { prompt: 0.25, completion: 1.5 },
-  'gemini-3.1-flash-lite-preview':          { prompt: 0.25, completion: 1.5 },
-  'gemini-3-flash-preview':                 { prompt: 0.5,  completion: 3 },
+  'gemini-3.6-flash':                       { prompt: 1.5,  completion: 7.5, cacheRead: 0.15 },
+  'gemini-3.5-flash':                       { prompt: 1.5,  completion: 9,   cacheRead: 0.15 },
+  'gemini-3.5-flash-lite':                  { prompt: 0.3,  completion: 2.5, cacheRead: 0.03 },
+  'gemini-3.1-pro-preview':                 { prompt: 2.0,  completion: 12,  cacheRead: 0.2,
+                                              longThreshold: 200000, longPrompt: 4, longCompletion: 18,
+                                              longCacheRead: 0.4 },
+  'gemini-3.1-pro-preview-customtools':     { prompt: 2.0,  completion: 12,  cacheRead: 0.2,
+                                              longThreshold: 200000, longPrompt: 4, longCompletion: 18,
+                                              longCacheRead: 0.4 },
+  'gemini-3.1-flash-lite':                  { prompt: 0.25, completion: 1.5, cacheRead: 0.025 },
+  'gemini-3.1-flash-lite-preview':          { prompt: 0.25, completion: 1.5, cacheRead: 0.025 },
+  'gemini-3-flash-preview':                 { prompt: 0.5,  completion: 3,   cacheRead: 0.05 },
   // ── Gemini 2.5 (Pro + Computer Use have >200k tier) ──────────────────────
-  'gemini-2.5-pro':                         { prompt: 1.25, completion: 10,
-                                              longThreshold: 200000, longPrompt: 2.5, longCompletion: 15 },
-  'gemini-2.5-flash':                       { prompt: 0.3,  completion: 2.5 },
-  'gemini-2.5-flash-lite':                  { prompt: 0.1,  completion: 0.4 },
-  'gemini-2.5-flash-lite-preview-09-2025':  { prompt: 0.1,  completion: 0.4 },
+  'gemini-2.5-pro':                         { prompt: 1.25, completion: 10,  cacheRead: 0.125,
+                                              longThreshold: 200000, longPrompt: 2.5, longCompletion: 15,
+                                              longCacheRead: 0.25 },
+  'gemini-2.5-flash':                       { prompt: 0.3,  completion: 2.5, cacheRead: 0.03 },
+  'gemini-2.5-flash-lite':                  { prompt: 0.1,  completion: 0.4, cacheRead: 0.01 },
+  'gemini-2.5-flash-lite-preview-09-2025':  { prompt: 0.1,  completion: 0.4, cacheRead: 0.01 },
   'gemini-2.5-computer-use-preview-10-2025': { prompt: 1.25, completion: 10,
                                               longThreshold: 200000, longPrompt: 2.5, longCompletion: 15 },
   // ── Gemini 2.0 / 1.5 ─────────────────────────────────────────────────────
-  'gemini-2.0-flash':      { prompt: 0.1,   completion: 0.4 },
+  'gemini-2.0-flash':      { prompt: 0.1,   completion: 0.4, cacheRead: 0.025 },
   'gemini-2.0-flash-lite': { prompt: 0.075, completion: 0.3 },
   'gemini-1.5-pro':        { prompt: 1.25,  completion: 5 },
   'gemini-1.5-flash':      { prompt: 0.075, completion: 0.3 },
+  // ── Gemini: specialized (embeddings are input-only) ──────────────────────
+  'gemini-robotics-er-1.6-preview': { prompt: 1.0,  completion: 5 },
+  'gemini-embedding-2':             { prompt: 0.2,  completion: 0 },
+  'gemini-embedding-001':           { prompt: 0.15, completion: 0 },
 }
 
 // ── Cache state ───────────────────────────────────────────────────────────────

--- a/supabase/migrations/20260729100000_seed_models_2026_07.sql
+++ b/supabase/migrations/20260729100000_seed_models_2026_07.sql
@@ -1,0 +1,190 @@
+-- Model price refresh — 2026-07-29.
+--
+-- Verified against the official pricing pages on 2026-07-29:
+--   OpenAI    developers.openai.com/api/docs/pricing
+--   Anthropic platform.claude.com  (Pricing + Models overview)
+--   Gemini    ai.google.dev/gemini-api/docs/pricing
+--   xAI       docs.x.ai/docs/models
+--   Groq      groq.com/pricing
+--   Mistral   mistral.ai/pricing/api
+--
+-- What this migration does:
+--   1. Adds current flagship models that were missing entirely (their requests
+--      were logging cost_usd = NULL — gotcha #2).
+--   2. Fixes one wrong price (mistral-small-latest) and one wrong model id
+--      (open-mixtral-8x22b).
+--   3. Backfills cache_read for Gemini and xAI, which publish cached-input
+--      rates that we were not modelling. Without them calculateCost() falls
+--      back to the full input rate (lib/cost.ts:144) and over-charges cache
+--      hits — up to 6x on Grok.
+--   4. Adds the long-context (>threshold) tier for xAI. Grok bills EVERY token
+--      of the request at the higher rate once the prompt reaches 200k, which is
+--      exactly the semantics of long_context_threshold_tokens.
+--
+-- Deliberately NOT seeded here:
+--   • Image / video / audio / TTS models (gpt-image-*, sora-*, gpt-realtime-*,
+--     gemini-*-image, gemini-*-tts, veo-*, lyria-*). Their output token rate
+--     differs by modality (e.g. gemini-3-pro-image is $12/1M text but $120/1M
+--     image), and model_prices has a single completion_price_per_1m. Seeding
+--     one of the two would silently mis-bill the other, which is worse than a
+--     visible NULL. Needs a modality-aware column first.
+--   • Cohere command-a-plus-05-2026 and the command-a-{reasoning,vision,
+--     translate} variants — still sales-quoted, no public per-token price
+--     (same reasoning as the 20260701120100 migration).
+--
+-- Idempotent: ON CONFLICT DO UPDATE on the (provider, model) unique index.
+
+INSERT INTO model_prices (
+  provider, model,
+  prompt_price_per_1m, completion_price_per_1m,
+  cache_read_price_per_1m, cache_write_price_per_1m
+) VALUES
+  -- ── OpenAI: GPT-5.6 flagship family ──────────────────────────────────────
+  -- First OpenAI family with a published cache-WRITE rate (1.25x input, the
+  -- same multiplier Anthropic uses). Long-context tier applied below.
+  ('openai', 'gpt-5.6-sol',                       5.00,  30.00,  0.50,   6.250),
+  ('openai', 'gpt-5.6-terra',                     2.50,  15.00,  0.25,   3.125),
+  ('openai', 'gpt-5.6-luna',                      1.00,   6.00,  0.10,   1.250),
+  -- ── Anthropic: Claude 5 ──────────────────────────────────────────────────
+  ('anthropic', 'claude-opus-5',                  5.00,  25.00,  0.50,   6.25),
+  -- NOTE: claude-sonnet-5 is at INTRODUCTORY pricing ($2/$10) through
+  -- 2026-08-31. Standard pricing ($3/$15, cache 0.30/3.75) takes effect
+  -- 2026-09-01 — a follow-up migration must flip these four numbers on that
+  -- date or we under-report Sonnet 5 cost by 33%.
+  ('anthropic', 'claude-sonnet-5',                2.00,  10.00,  0.20,   2.50),
+  -- Invitation-only (Project Glasswing); same specs/pricing as claude-fable-5.
+  ('anthropic', 'claude-mythos-preview',         10.00,  50.00,  1.00,  12.50),
+  -- ── Gemini: current text models ──────────────────────────────────────────
+  ('gemini', 'gemini-3.6-flash',                  1.50,   7.50,  0.15,   NULL),
+  ('gemini', 'gemini-3.5-flash-lite',             0.30,   2.50,  0.03,   NULL),
+  ('gemini', 'gemini-robotics-er-1.6-preview',    1.00,   5.00,  NULL,   NULL),
+  -- Embeddings are input-only (completion stays 0). gemini-embedding-2 is
+  -- multimodal and the seeded rate is the TEXT input rate; image ($0.45),
+  -- audio ($6.50) and video ($12.00) input are billed higher and are not
+  -- modelled (single prompt_price_per_1m column).
+  ('gemini', 'gemini-embedding-2',                0.20,   0.00,  NULL,   NULL),
+  ('gemini', 'gemini-embedding-001',              0.15,   0.00,  NULL,   NULL),
+  -- ── xAI: Grok 4.5 ────────────────────────────────────────────────────────
+  ('xai', 'grok-4.5',                             2.00,   6.00,  0.30,   NULL),
+  -- ── Groq: current catalogue additions ────────────────────────────────────
+  ('groq', 'qwen/qwen3.6-27b',                    0.60,   3.00,  NULL,   NULL),
+  ('groq', 'openai/gpt-oss-safeguard-20b',        0.075,  0.30,  NULL,   NULL),
+  -- ── Mistral: correct open-mixtral ids ────────────────────────────────────
+  -- The existing 'mixtral-8x22b' row never matched real traffic: the API id is
+  -- 'open-mixtral-8x22b'. Left in place as a harmless legacy alias.
+  ('mistral', 'open-mixtral-8x22b',               2.00,   6.00,  NULL,   NULL),
+  ('mistral', 'open-mixtral-8x7b',                0.70,   0.70,  NULL,   NULL)
+ON CONFLICT (provider, model) DO UPDATE
+  SET prompt_price_per_1m      = EXCLUDED.prompt_price_per_1m,
+      completion_price_per_1m  = EXCLUDED.completion_price_per_1m,
+      cache_read_price_per_1m  = EXCLUDED.cache_read_price_per_1m,
+      cache_write_price_per_1m = EXCLUDED.cache_write_price_per_1m,
+      updated_at               = now();
+
+-- ── Price correction ────────────────────────────────────────────────────────
+-- mistral-small-latest now resolves to Mistral Small 4 at $0.15/$0.60. We were
+-- seeded at the Small 3.x rate ($0.10/$0.30) and under-reporting by 40%.
+UPDATE model_prices
+   SET prompt_price_per_1m     = 0.15,
+       completion_price_per_1m = 0.60,
+       updated_at              = now()
+ WHERE provider = 'mistral' AND model = 'mistral-small-latest';
+
+-- ── Gemini: cached-input rates ──────────────────────────────────────────────
+-- Google publishes a context-caching rate for every current Gemini model; we
+-- had them all NULL. Values are the text/image/video rate (audio caching is
+-- billed higher and is not modelled). The $1.00 / 1M-tokens-per-hour storage
+-- fee is a separate line item Google bills directly and is out of scope.
+UPDATE model_prices SET cache_read_price_per_1m = 0.15,  updated_at = now()
+ WHERE provider = 'gemini' AND model = 'gemini-3.5-flash';
+UPDATE model_prices SET cache_read_price_per_1m = 0.025, updated_at = now()
+ WHERE provider = 'gemini' AND model IN ('gemini-3.1-flash-lite', 'gemini-3.1-flash-lite-preview');
+UPDATE model_prices SET cache_read_price_per_1m = 0.05,  updated_at = now()
+ WHERE provider = 'gemini' AND model = 'gemini-3-flash-preview';
+UPDATE model_prices SET cache_read_price_per_1m = 0.03,  updated_at = now()
+ WHERE provider = 'gemini' AND model = 'gemini-2.5-flash';
+UPDATE model_prices SET cache_read_price_per_1m = 0.01,  updated_at = now()
+ WHERE provider = 'gemini' AND model IN ('gemini-2.5-flash-lite', 'gemini-2.5-flash-lite-preview-09-2025');
+UPDATE model_prices SET cache_read_price_per_1m = 0.025, updated_at = now()
+ WHERE provider = 'gemini' AND model = 'gemini-2.0-flash';
+
+-- Pro family caches at 0.10x input on both context tiers.
+UPDATE model_prices
+   SET cache_read_price_per_1m      = 0.20,
+       long_cache_read_price_per_1m = 0.40,
+       updated_at                   = now()
+ WHERE provider = 'gemini' AND model IN ('gemini-3.1-pro-preview', 'gemini-3.1-pro-preview-customtools');
+
+UPDATE model_prices
+   SET cache_read_price_per_1m      = 0.125,
+       long_cache_read_price_per_1m = 0.25,
+       updated_at                   = now()
+ WHERE provider = 'gemini' AND model = 'gemini-2.5-pro';
+
+-- ── OpenAI GPT-5.6: long-context tier ───────────────────────────────────────
+-- Threshold is 272,000 tokens, same as the rest of the GPT-5.x family
+-- (see the 20260522020000 migration).
+UPDATE model_prices
+   SET long_context_threshold_tokens = 272000,
+       long_prompt_price_per_1m      = 10.00,
+       long_completion_price_per_1m  = 45.00,
+       long_cache_read_price_per_1m  =  1.00,
+       long_cache_write_price_per_1m = 12.50,
+       updated_at                    = now()
+ WHERE provider = 'openai' AND model = 'gpt-5.6-sol';
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 272000,
+       long_prompt_price_per_1m      =  5.00,
+       long_completion_price_per_1m  = 22.50,
+       long_cache_read_price_per_1m  =  0.50,
+       long_cache_write_price_per_1m =  6.25,
+       updated_at                    = now()
+ WHERE provider = 'openai' AND model = 'gpt-5.6-terra';
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 272000,
+       long_prompt_price_per_1m      =  2.00,
+       long_completion_price_per_1m  =  9.00,
+       long_cache_read_price_per_1m  =  0.20,
+       long_cache_write_price_per_1m =  2.50,
+       updated_at                    = now()
+ WHERE provider = 'openai' AND model = 'gpt-5.6-luna';
+
+-- ── xAI: cached input + long-context tier ───────────────────────────────────
+-- docs.x.ai publishes a cached-input rate and a >=200k tier for every Grok
+-- model: "requests whose prompt reaches the listed token threshold are billed
+-- at the higher rate for all tokens in the request" — i.e. the whole request
+-- flips to 2x, which is what long_* models.
+UPDATE model_prices
+   SET cache_read_price_per_1m       = 0.20,
+       long_context_threshold_tokens = 200000,
+       long_prompt_price_per_1m      = 2.50,
+       long_completion_price_per_1m  = 5.00,
+       long_cache_read_price_per_1m  = 0.40,
+       updated_at                    = now()
+ WHERE provider = 'xai'
+   AND model IN (
+     'grok-4.3',
+     'grok-4.20-0309-reasoning',
+     'grok-4.20-0309-non-reasoning',
+     'grok-4.20-multi-agent-0309'
+   );
+
+UPDATE model_prices
+   SET cache_read_price_per_1m       = 0.30,
+       long_context_threshold_tokens = 200000,
+       long_prompt_price_per_1m      = 4.00,
+       long_completion_price_per_1m  = 12.00,
+       long_cache_read_price_per_1m  = 0.60,
+       updated_at                    = now()
+ WHERE provider = 'xai' AND model = 'grok-4.5';
+
+UPDATE model_prices
+   SET cache_read_price_per_1m       = 0.20,
+       long_context_threshold_tokens = 200000,
+       long_prompt_price_per_1m      = 2.00,
+       long_completion_price_per_1m  = 4.00,
+       long_cache_read_price_per_1m  = 0.40,
+       updated_at                    = now()
+ WHERE provider = 'xai' AND model = 'grok-build-0.1';

--- a/supabase/seeds/model_prices.sql
+++ b/supabase/seeds/model_prices.sql
@@ -1,16 +1,32 @@
--- Seed: Model pricing table (USD per 1M tokens, verified against provider pricing 2026-05-22)
+-- Seed: Model pricing table (USD per 1M tokens, verified against provider pricing 2026-07-29)
+--
+-- SCOPE: direct providers only. The 170 `openrouter` rows live exclusively in
+-- migration 20260613060000 — OpenRouter is a meta-provider whose catalogue
+-- churns weekly and mirroring it here would go stale immediately.
 --
 -- Cache pricing notes:
 --   • Anthropic prompt caching — cache_read = 0.1 × input price · cache_write (5min ephemeral) = 1.25 × input price
---   • OpenAI prompt caching    — cached input ≈ 0.5 × input price (gpt-4o / gpt-4.1 families; varies by model in GPT-5.x; no cache_write concept)
---   • Gemini context caching   — priced by Google but our integration doesn't surface it yet, so leave NULL
+--   • OpenAI prompt caching    — cached input ≈ 0.5 × input price (gpt-4o / gpt-4.1 families; explicit per-model in GPT-5.x).
+--                                GPT-5.6 is the first OpenAI family with a published cache_write rate (1.25 × input)
+--   • Gemini context caching   — cache_read is the published text/image/video rate; audio caches higher (not modelled).
+--                                The $1.00 / 1M-tokens-per-hour storage fee is billed by Google separately, out of scope
+--   • xAI                      — every Grok model has a published cached-input rate and a ≥200k tier that re-rates the
+--                                WHOLE request at 2× (modelled with long_context_threshold_tokens below)
 --   • Tiered prices (Gemini Pro / 2.5 Computer Use) use the ≤200k token band — most production traffic fits
+--
+-- NOT seeded on purpose: image / video / audio / TTS models. Their output rate
+-- differs by modality (gemini-3-pro-image is $12/1M text but $120/1M image) and
+-- this table has a single completion_price_per_1m — a wrong number is worse
+-- than a visible NULL. Same for Cohere command-a-plus / command-a-* (sales-quoted).
 INSERT INTO model_prices (
   provider, model,
   prompt_price_per_1m, completion_price_per_1m,
   cache_read_price_per_1m, cache_write_price_per_1m
 ) VALUES
   -- ── OpenAI: GPT-5.x flagship family ───────────────────────────────────────
+  ('openai', 'gpt-5.6-sol',                      5.00,  30.00,   0.50,   6.250),
+  ('openai', 'gpt-5.6-terra',                    2.50,  15.00,   0.25,   3.125),
+  ('openai', 'gpt-5.6-luna',                     1.00,   6.00,   0.10,   1.250),
   ('openai', 'gpt-5.5',                          5.00,  30.00,   0.50,   NULL),
   ('openai', 'gpt-5.5-pro',                     30.00, 180.00,   NULL,   NULL),
   ('openai', 'gpt-5.4',                          2.50,  15.00,   0.25,   NULL),
@@ -68,44 +84,71 @@ INSERT INTO model_prices (
   ('openai', 'text-embedding-3-large',           0.130,  0.000,  NULL,   NULL),
   ('openai', 'text-embedding-ada-002',           0.100,  0.000,  NULL,   NULL),
   -- ── Mistral: chat completion + multimodal + embeddings ───────────────────
-  -- Source: mistral.ai/technology pricing page, 2026-06. Cache pricing not
-  -- published (Mistral doesn't surface cache tokens in usage today).
-  ('mistral', 'mistral-large-latest',            2.00,   6.00,   NULL,   NULL),
-  ('mistral', 'mistral-medium-latest',           0.40,   2.00,   NULL,   NULL),
-  ('mistral', 'mistral-small-latest',            0.20,   0.60,   NULL,   NULL),
-  ('mistral', 'pixtral-large-latest',            2.00,   6.00,   NULL,   NULL),
-  ('mistral', 'pixtral-12b',                     0.15,   0.15,   NULL,   NULL),
-  ('mistral', 'codestral-latest',                0.20,   0.60,   NULL,   NULL),
-  ('mistral', 'ministral-3b-latest',             0.04,   0.04,   NULL,   NULL),
-  ('mistral', 'ministral-8b-latest',             0.10,   0.10,   NULL,   NULL),
+  -- Source: mistral.ai/pricing/api, 2026-07-29. Cache pricing not published
+  -- (Mistral doesn't surface cache tokens in usage today).
+  ('mistral', 'mistral-large-latest',            0.50,   1.50,   NULL,   NULL), -- Mistral Large 3
+  ('mistral', 'mistral-medium-latest',           1.50,   7.50,   NULL,   NULL), -- Mistral Medium 3.5
+  ('mistral', 'mistral-small-latest',            0.15,   0.60,   NULL,   NULL), -- Mistral Small 4
+  ('mistral', 'magistral-medium-latest',         2.00,   5.00,   NULL,   NULL),
+  ('mistral', 'magistral-small-latest',          0.50,   1.50,   NULL,   NULL),
+  ('mistral', 'devstral-medium-latest',          0.40,   2.00,   NULL,   NULL),
+  ('mistral', 'devstral-small-latest',           0.10,   0.30,   NULL,   NULL),
+  ('mistral', 'codestral-latest',                0.30,   0.90,   NULL,   NULL),
+  ('mistral', 'ministral-3b-latest',             0.10,   0.10,   NULL,   NULL),
+  ('mistral', 'ministral-8b-latest',             0.15,   0.15,   NULL,   NULL),
+  ('mistral', 'ministral-14b-latest',            0.20,   0.20,   NULL,   NULL),
   ('mistral', 'open-mistral-nemo',               0.15,   0.15,   NULL,   NULL),
-  ('mistral', 'mixtral-8x22b',                   2.00,   6.00,   NULL,   NULL),
+  ('mistral', 'open-mixtral-8x7b',               0.70,   0.70,   NULL,   NULL),
+  ('mistral', 'open-mixtral-8x22b',              2.00,   6.00,   NULL,   NULL),
+  ('mistral', 'mixtral-8x22b',                   2.00,   6.00,   NULL,   NULL), -- legacy alias; real API id is open-mixtral-8x22b
+  ('mistral', 'pixtral-large-latest',            2.00,   6.00,   NULL,   NULL), -- off the current pricing page
+  ('mistral', 'pixtral-12b',                     0.15,   0.15,   NULL,   NULL), -- off the current pricing page
+  ('mistral', 'voxtral-small-latest',            0.10,   0.40,   NULL,   NULL),
+  ('mistral', 'mistral-moderation-2603',         0.10,   0.000,  NULL,   NULL),
   ('mistral', 'mistral-embed',                   0.10,   0.000,  NULL,   NULL),
+  ('mistral', 'codestral-embed',                 0.15,   0.000,  NULL,   NULL),
   -- ── Groq (OpenAI-compatible, api.groq.com/openai/v1) ─────────────────────
   ('groq', 'llama-3.3-70b-versatile',                    0.59,  0.79,    NULL,     NULL),
   ('groq', 'llama-3.1-8b-instant',                       0.05,  0.08,    NULL,     NULL),
   ('groq', 'openai/gpt-oss-120b',                        0.15,  0.60,    0.075,    NULL),
   ('groq', 'openai/gpt-oss-20b',                         0.075, 0.30,    0.0375,   NULL),
+  ('groq', 'openai/gpt-oss-safeguard-20b',               0.075, 0.30,    NULL,     NULL),
+  ('groq', 'qwen/qwen3.6-27b',                           0.60,  3.00,    NULL,     NULL),
+  ('groq', 'moonshotai/kimi-k2-instruct-0905',           1.00,  3.00,    0.50,     NULL),
+  -- Off the current Groq pricing page (2026-07-29) — kept so historical rows
+  -- still price correctly, but Groq appears to have stopped serving them.
   ('groq', 'meta-llama/llama-4-scout-17b-16e-instruct',  0.11,  0.34,    NULL,     NULL),
   ('groq', 'qwen/qwen3-32b',                             0.29,  0.59,    NULL,     NULL),
-  ('groq', 'moonshotai/kimi-k2-instruct-0905',           1.00,  3.00,    0.50,     NULL),
   -- ── DeepSeek (OpenAI-compatible, api.deepseek.com/v1) ────────────────────
   ('deepseek', 'deepseek-chat',                          0.14,  0.28,    0.0028,   NULL),
   ('deepseek', 'deepseek-reasoner',                      0.14,  0.28,    0.0028,   NULL),
   ('deepseek', 'deepseek-v4-flash',                      0.14,  0.28,    0.0028,   NULL),
   ('deepseek', 'deepseek-v4-pro',                        0.435, 0.87,    0.003625, NULL),
   -- ── xAI / Grok (OpenAI-compatible, api.x.ai/v1) ──────────────────────────
-  ('xai', 'grok-4.3',                                    1.25,  2.50,    NULL,     NULL),
-  ('xai', 'grok-4.20-0309-reasoning',                    1.25,  2.50,    NULL,     NULL),
-  ('xai', 'grok-4.20-0309-non-reasoning',                1.25,  2.50,    NULL,     NULL),
-  ('xai', 'grok-4.20-multi-agent-0309',                  1.25,  2.50,    NULL,     NULL),
-  ('xai', 'grok-build-0.1',                              1.00,  2.00,    NULL,     NULL),
+  -- Every Grok model doubles ALL token rates once the prompt reaches 200k —
+  -- modelled with the long_* columns at the bottom of this file.
+  ('xai', 'grok-4.5',                                    2.00,  6.00,    0.30,     NULL),
+  ('xai', 'grok-4.3',                                    1.25,  2.50,    0.20,     NULL),
+  ('xai', 'grok-4.20-0309-reasoning',                    1.25,  2.50,    0.20,     NULL),
+  ('xai', 'grok-4.20-0309-non-reasoning',                1.25,  2.50,    0.20,     NULL),
+  ('xai', 'grok-4.20-multi-agent-0309',                  1.25,  2.50,    0.20,     NULL),
+  ('xai', 'grok-build-0.1',                              1.00,  2.00,    0.20,     NULL),
   -- ── Cohere (OpenAI-compatible, api.cohere.ai/compatibility/v1) ───────────
   ('cohere', 'command-a-03-2025',                        2.50,  10.00,   NULL,     NULL),
   ('cohere', 'command-r-plus-08-2024',                   2.50,  10.00,   NULL,     NULL),
   ('cohere', 'command-r-08-2024',                        0.15,  0.60,    NULL,     NULL),
   ('cohere', 'command-r7b-12-2024',                      0.0375, 0.15,   NULL,     NULL),
+  -- ── Anthropic: Claude 5 ──────────────────────────────────────────────────
+  ('anthropic', 'claude-fable-5',               10.00,  50.00,   1.00,  12.50),
+  -- Invitation-only (Project Glasswing); same specs + pricing as Fable 5.
+  ('anthropic', 'claude-mythos-5',              10.00,  50.00,   1.00,  12.50),
+  ('anthropic', 'claude-mythos-preview',        10.00,  50.00,   1.00,  12.50),
+  ('anthropic', 'claude-opus-5',                 5.00,  25.00,   0.50,   6.25),
+  -- ⚠ INTRODUCTORY pricing through 2026-08-31. From 2026-09-01 this becomes
+  -- 3.00 / 15.00 / 0.30 / 3.75 — flip it or we under-report Sonnet 5 by 33%.
+  ('anthropic', 'claude-sonnet-5',               2.00,  10.00,   0.20,   2.50),
   -- ── Anthropic: Claude 4.x (aliases + dated variants) ────────────────────
+  ('anthropic', 'claude-opus-4-8',               5.00,  25.00,   0.50,   6.25),
   ('anthropic', 'claude-opus-4-7',               5.00,  25.00,   0.50,   6.25),
   ('anthropic', 'claude-opus-4-6',               5.00,  25.00,   0.50,   6.25), -- alias only; no dated form per docs
   ('anthropic', 'claude-opus-4-5',               5.00,  25.00,   0.50,   6.25),
@@ -129,23 +172,32 @@ INSERT INTO model_prices (
   ('anthropic', 'claude-3-opus-20240229',       15.00,  75.00,   1.50,  18.75),
   ('anthropic', 'claude-3-haiku-20240307',       0.25,   1.25,   NULL,   NULL), -- retired 2026-04-19
   -- ── Gemini 3.x ───────────────────────────────────────────────────────────
-  ('gemini', 'gemini-3.5-flash',                       1.50,   9.00,   NULL, NULL),
-  ('gemini', 'gemini-3.1-pro-preview',                 2.00,  12.00,   NULL, NULL), -- ≤200k tier; >200k is 4.00/18.00
-  ('gemini', 'gemini-3.1-pro-preview-customtools',     2.00,  12.00,   NULL, NULL),
-  ('gemini', 'gemini-3.1-flash-lite',                  0.25,   1.50,   NULL, NULL),
-  ('gemini', 'gemini-3.1-flash-lite-preview',          0.25,   1.50,   NULL, NULL),
-  ('gemini', 'gemini-3-flash-preview',                 0.50,   3.00,   NULL, NULL),
+  ('gemini', 'gemini-3.6-flash',                       1.50,   7.50,   0.15,  NULL),
+  ('gemini', 'gemini-3.5-flash',                       1.50,   9.00,   0.15,  NULL),
+  ('gemini', 'gemini-3.5-flash-lite',                  0.30,   2.50,   0.03,  NULL),
+  ('gemini', 'gemini-3.1-pro-preview',                 2.00,  12.00,   0.20,  NULL), -- ≤200k tier; >200k is 4.00/18.00/0.40
+  ('gemini', 'gemini-3.1-pro-preview-customtools',     2.00,  12.00,   0.20,  NULL),
+  ('gemini', 'gemini-3.1-flash-lite',                  0.25,   1.50,   0.025, NULL),
+  ('gemini', 'gemini-3.1-flash-lite-preview',          0.25,   1.50,   0.025, NULL), -- retired
+  ('gemini', 'gemini-3-flash-preview',                 0.50,   3.00,   0.05,  NULL),
   -- ── Gemini 2.5 ───────────────────────────────────────────────────────────
-  ('gemini', 'gemini-2.5-pro',                         1.25,  10.00,   NULL, NULL), -- ≤200k tier; >200k is 2.50/15.00
-  ('gemini', 'gemini-2.5-flash',                       0.30,   2.50,   NULL, NULL),
-  ('gemini', 'gemini-2.5-flash-lite',                  0.10,   0.40,   NULL, NULL),
-  ('gemini', 'gemini-2.5-flash-lite-preview-09-2025',  0.10,   0.40,   NULL, NULL),
-  ('gemini', 'gemini-2.5-computer-use-preview-10-2025', 1.25, 10.00,   NULL, NULL), -- ≤200k tier; >200k is 2.50/15.00
+  ('gemini', 'gemini-2.5-pro',                         1.25,  10.00,   0.125, NULL), -- ≤200k tier; >200k is 2.50/15.00/0.25
+  ('gemini', 'gemini-2.5-flash',                       0.30,   2.50,   0.03,  NULL),
+  ('gemini', 'gemini-2.5-flash-lite',                  0.10,   0.40,   0.01,  NULL),
+  ('gemini', 'gemini-2.5-flash-lite-preview-09-2025',  0.10,   0.40,   0.01,  NULL),
+  ('gemini', 'gemini-2.5-computer-use-preview-10-2025', 1.25, 10.00,   NULL,  NULL), -- ≤200k tier; >200k is 2.50/15.00. No published cache rate
   -- ── Gemini 2.0 / 1.5 ─────────────────────────────────────────────────────
-  ('gemini', 'gemini-2.0-flash',                       0.10,   0.40,   NULL, NULL), -- deprecated 2026-06-01
-  ('gemini', 'gemini-2.0-flash-lite',                  0.075,  0.30,   NULL, NULL), -- deprecated 2026-06-01
-  ('gemini', 'gemini-1.5-pro',                         1.25,   5.00,   NULL, NULL),
-  ('gemini', 'gemini-1.5-flash',                       0.075,  0.30,   NULL, NULL)
+  ('gemini', 'gemini-2.0-flash',                       0.10,   0.40,   0.025, NULL), -- deprecated 2026-06-01
+  ('gemini', 'gemini-2.0-flash-lite',                  0.075,  0.30,   NULL,  NULL), -- deprecated 2026-06-01. Caching not offered
+  ('gemini', 'gemini-1.5-pro',                         1.25,   5.00,   NULL,  NULL), -- retired, off the pricing page
+  ('gemini', 'gemini-1.5-flash',                       0.075,  0.30,   NULL,  NULL), -- retired, off the pricing page
+  -- ── Gemini: specialized ──────────────────────────────────────────────────
+  ('gemini', 'gemini-robotics-er-1.6-preview',         1.00,   5.00,   NULL,  NULL),
+  -- Embeddings are input-only (completion stays 0). gemini-embedding-2 is
+  -- multimodal; the seeded rate is TEXT input — image (0.45) / audio (6.50) /
+  -- video (12.00) input bill higher and are not modelled.
+  ('gemini', 'gemini-embedding-2',                     0.20,   0.00,   NULL,  NULL),
+  ('gemini', 'gemini-embedding-001',                   0.15,   0.00,   NULL,  NULL)
 ON CONFLICT (provider, model) DO UPDATE
   SET prompt_price_per_1m      = EXCLUDED.prompt_price_per_1m,
       completion_price_per_1m  = EXCLUDED.completion_price_per_1m,
@@ -192,6 +244,31 @@ UPDATE model_prices
 --
 --   OpenAI threshold = 272,000 tokens (per the pricing-page tooltip on the Long context header)
 --   Gemini threshold = 200,000 tokens (Pro family explicit ≤/> split)
+--   xAI    threshold = 200,000 tokens (docs.x.ai: reaching it re-rates the whole request)
+UPDATE model_prices
+   SET long_context_threshold_tokens = 272000,
+       long_prompt_price_per_1m      = 10.00,
+       long_completion_price_per_1m  = 45.00,
+       long_cache_read_price_per_1m  =  1.00,
+       long_cache_write_price_per_1m = 12.50
+ WHERE provider = 'openai' AND model = 'gpt-5.6-sol';
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 272000,
+       long_prompt_price_per_1m      =  5.00,
+       long_completion_price_per_1m  = 22.50,
+       long_cache_read_price_per_1m  =  0.50,
+       long_cache_write_price_per_1m =  6.25
+ WHERE provider = 'openai' AND model = 'gpt-5.6-terra';
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 272000,
+       long_prompt_price_per_1m      =  2.00,
+       long_completion_price_per_1m  =  9.00,
+       long_cache_read_price_per_1m  =  0.20,
+       long_cache_write_price_per_1m =  2.50
+ WHERE provider = 'openai' AND model = 'gpt-5.6-luna';
+
 UPDATE model_prices
    SET long_context_threshold_tokens = 272000,
        long_prompt_price_per_1m      = 10.00,
@@ -221,13 +298,15 @@ UPDATE model_prices
 UPDATE model_prices
    SET long_context_threshold_tokens = 200000,
        long_prompt_price_per_1m      =  2.50,
-       long_completion_price_per_1m  = 15.00
+       long_completion_price_per_1m  = 15.00,
+       long_cache_read_price_per_1m  =  0.25
  WHERE provider = 'gemini' AND model = 'gemini-2.5-pro';
 
 UPDATE model_prices
    SET long_context_threshold_tokens = 200000,
        long_prompt_price_per_1m      =  4.00,
-       long_completion_price_per_1m  = 18.00
+       long_completion_price_per_1m  = 18.00,
+       long_cache_read_price_per_1m  =  0.40
  WHERE provider = 'gemini' AND model IN ('gemini-3.1-pro-preview', 'gemini-3.1-pro-preview-customtools');
 
 UPDATE model_prices
@@ -235,3 +314,31 @@ UPDATE model_prices
        long_prompt_price_per_1m      =  2.50,
        long_completion_price_per_1m  = 15.00
  WHERE provider = 'gemini' AND model = 'gemini-2.5-computer-use-preview-10-2025';
+
+-- xAI: reaching the threshold re-rates the entire request at 2×.
+UPDATE model_prices
+   SET long_context_threshold_tokens = 200000,
+       long_prompt_price_per_1m      = 2.50,
+       long_completion_price_per_1m  = 5.00,
+       long_cache_read_price_per_1m  = 0.40
+ WHERE provider = 'xai'
+   AND model IN (
+     'grok-4.3',
+     'grok-4.20-0309-reasoning',
+     'grok-4.20-0309-non-reasoning',
+     'grok-4.20-multi-agent-0309'
+   );
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 200000,
+       long_prompt_price_per_1m      =  4.00,
+       long_completion_price_per_1m  = 12.00,
+       long_cache_read_price_per_1m  =  0.60
+ WHERE provider = 'xai' AND model = 'grok-4.5';
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 200000,
+       long_prompt_price_per_1m      = 2.00,
+       long_completion_price_per_1m  = 4.00,
+       long_cache_read_price_per_1m  = 0.40
+ WHERE provider = 'xai' AND model = 'grok-build-0.1';


### PR DESCRIPTION
## Why

Audited all nine registered providers against their official pricing pages on 2026-07-29. Current flagship models were missing outright, so their requests were logging `cost_usd = NULL`, and several rates we do model had drifted.

## Added (were logging NULL)

| Provider | Models |
|---|---|
| openai | `gpt-5.6-sol` / `-terra` / `-luna` — incl. the 272k long-context tier and OpenAI's first published cache-write rate |
| anthropic | `claude-opus-5`, `claude-sonnet-5`, `claude-mythos-preview` |
| gemini | `gemini-3.6-flash`, `gemini-3.5-flash-lite`, `gemini-embedding-2` / `-001`, `gemini-robotics-er-1.6-preview` |
| xai | `grok-4.5` |
| groq | `qwen/qwen3.6-27b`, `openai/gpt-oss-safeguard-20b` |
| mistral | `open-mixtral-8x7b`, `open-mixtral-8x22b` |

## Corrected

- `mistral-small-latest` now resolves to Mistral Small 4 at $0.15/$0.60. We were seeded at the Small 3.x rate ($0.10/$0.30) and under-reporting by 40%.
- `mixtral-8x22b` never matched real traffic: the API id is `open-mixtral-8x22b`. Old row kept as a harmless legacy alias.

## Backfilled cached-input rates

Both Gemini and xAI publish cached-input rates that we left NULL. `calculateCost()` falls back to the full input rate when `cacheRead` is absent, so every cache hit was over-charged — up to 6x on Grok.

Also added xAI's 200k tier, which re-rates the **whole** request at 2x once the prompt reaches the threshold (exactly the semantics of `long_context_threshold_tokens`).

## Seed / fallback drift

`supabase/seeds/model_prices.sql` and `FALLBACK_PRICES` had fallen behind the migrations — missing Fable 5 / Mythos 5 / Opus 4.8, and carrying stale Mistral prices. The cold-start path reads `FALLBACK_PRICES`, so that drift meant wrong prices for the first seconds after every deploy. Both are now in sync.

## Deliberately not included

- **Image / video / audio / TTS models.** Their output rate differs by modality (`gemini-3-pro-image` is $12/1M text but $120/1M image) and `model_prices` has a single `completion_price_per_1m`. Seeding one silently mis-bills the other, which is worse than a visible NULL. Needs a modality-aware column first.
- **Cohere `command-a-plus-05-2026` and the `command-a-{reasoning,vision,translate}` variants** — still sales-quoted, no public per-token price (same call as the 20260701120100 migration).

## Follow-ups

- ⏰ **`claude-sonnet-5` is at introductory pricing ($2/$10) through 2026-08-31.** Standard pricing ($3/$15, cache 0.30/3.75) starts 2026-09-01 — needs a migration on that date or we under-report by 33%.
- `calculateCost()` ignores its `provider` argument, so the price cache is keyed on model name globally. One real collision today: `qwen/qwen3-32b` (groq $0.29/$0.59 vs openrouter $0.08/$0.28), resolved by DB row order. Azure currently depends on this behaviour to borrow the OpenAI table, so a provider-scoped lookup has to map `azure → openai` explicitly. Separate PR.
- The OpenRouter fallback in `proxy/openrouter.ts:164` strips the vendor prefix before lookup, but the openrouter rows are stored *with* the prefix, and the stripped name (`claude-opus-4.7`) doesn't match our Anthropic dash form (`claude-opus-4-7`). Masked in practice because OpenRouter reports its own cost. Same follow-up PR.
- Groq appears to have stopped serving `qwen/qwen3-32b` and `meta-llama/llama-4-scout-17b-16e-instruct` (off the pricing page). Rows kept so historical requests still price correctly.

## Test plan

- [x] `pnpm --filter server typecheck`
- [x] `pnpm --filter server lint`
- [x] `pnpm --filter server test` — 1590 passed
- [x] `pnpm --filter server build`
- [x] Two proxy tests asserted the old Mistral / Grok numbers and were updated to the corrected rates
- [x] Added coverage for both sides of the xAI 200k tier boundary
- [ ] CI "Validate migrations apply cleanly"