### PR TITLE
fix(server): scope model price lookup by provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,8 +101,8 @@ DB 읽기(조회) → supabaseClient (anon key, RLS 적용)
 - **⚠️ ClickHouse 마이그레이션은 deploy 파이프라인에 없음 — production 수동 적용**: `deploy-server.yml`은 Supabase만 `db push`. CH 마이그레이션(`clickhouse/migrations/NNN`)은 **ClickHouse Cloud SQL 콘솔에서 수동 실행** (009_dedup_events_as_requests_view가 그렇게 적용됨). gotcha #21 순서(migration 먼저 → INSERT 코드) 지키려면 PR 머지 **전에** 손으로 적용. Postgres(gotcha #25)와 달리 자동화 안 됨.
 ## 핵심 모듈 — 중복 구현 금지
 lib/crypto.ts — AES-256-GCM 암/복호화 (Provider Key 전용)
-lib/cost.ts — 비용 계산 calculateCost(provider, model, usage). 동기 함수 — DB 가격은 lib/model-prices-cache.ts가 백그라운드로 stale-while-revalidate 갱신 (5분 TTL)
-lib/model-prices-cache.ts — getCachedPrices() 동기 lookup + refreshPricesNow() 강제 갱신. FALLBACK_PRICES 콜드스타트 안전망. 핫 패스에서 await 금지
+lib/cost.ts — 비용 계산 calculateCost(provider, model, usage). 동기 함수 — DB 가격은 lib/model-prices-cache.ts가 백그라운드로 stale-while-revalidate 갱신 (5분 TTL). **provider 인자는 실제로 조회에 쓰임** — 모델명은 프로바이더 간 유일하지 않음(`qwen/qwen3-32b`가 groq $0.29 / openrouter $0.08). `azure`는 rows가 없어 `PRICE_TABLE_PROVIDER`가 `openai`로 리라이트. 조회 순서: exact `provider:model` → exact FALLBACK → provider-scoped 최장 prefix → FALLBACK 최장 prefix (exact가 언제나 prefix보다 우선)
+lib/model-prices-cache.ts — getCachedPrices() 동기 lookup + refreshPricesNow() 강제 갱신. **캐시 키는 `"<provider>:<model>"`** (priceKey 헬퍼). FALLBACK_PRICES는 model-only 유지 — direct provider 모델만 담아 중복 이름이 없어야 함(openrouter id 넣지 말 것, 테스트가 가드). 핫 패스에서 await 금지
 lib/logger.ts — 비동기 로깅 logRequestAsync(data) + parseLogBodyMode(header). CH INSERT 실패 시 Supabase `requests_fallback` 큐에 자동 보관 (P2.6)
 lib/fallback-replay.ts — `replayFallbackQueue()` / `fallbackQueueSize()`. CH 복구 후 `requests_fallback` → ClickHouse 이관. cron `/replay-fallback` 5분 간격
 lib/db.ts — supabaseAdmin / supabaseClient 인스턴스

--- a/apps/server/src/__tests__/cache-savings.test.ts
+++ b/apps/server/src/__tests__/cache-savings.test.ts
@@ -35,6 +35,7 @@ function chReturn(rows: object[]) {
 
 function row(overrides: Partial<CacheSavingsRow> = {}): CacheSavingsRow {
   return {
+    provider: 'openai',
     model: 'gpt-4o-mini',
     cache_read_tokens_sum: '0',
     cache_hit_requests: '0',

--- a/apps/server/src/lib/cache-savings.ts
+++ b/apps/server/src/lib/cache-savings.ts
@@ -1,6 +1,6 @@
 import { unscopedClickhouse, toClickhouseTimestamp } from './clickhouse.js'
 import { requestsScope } from './requests-query.js'
-import { lookupPrice } from './cost.js'
+import { lookupPrice, type Provider } from './cost.js'
 
 /**
  * Prompt-cache savings estimator.
@@ -26,6 +26,11 @@ import { lookupPrice } from './cost.js'
 
 /** Shape returned by the ClickHouse aggregate (JSONEachRow → numerics as strings). */
 export interface CacheSavingsRow {
+  /**
+   * Required for pricing: model names are not unique across providers, so
+   * `lookupPrice` needs the owning provider to pick the right row.
+   */
+  provider: string
   model: string
   /**
    * Aliased `cache_read_tokens_sum`, NOT `cache_read_tokens`. Aliasing the
@@ -74,7 +79,7 @@ export function computeCacheSavings(rows: CacheSavingsRow[]): CacheSavingsTotals
     cacheReadTokens += tokens
     cacheHitRequests += Number.isFinite(hits) ? hits : 0
 
-    const price = lookupPrice(row.model)
+    const price = lookupPrice(row.provider as Provider, row.model)
     if (!price) continue // unknown model — no price data, no savings claim
 
     // No explicit cacheRead price means the provider bills cache reads at the
@@ -99,6 +104,7 @@ export async function getCacheSavings(organizationId: string): Promise<CacheSavi
   const res = await unscopedClickhouse().query({
     query: `
       SELECT
+        provider,
         model,
         sum(cache_read_tokens) AS cache_read_tokens_sum,
         count()                AS cache_hit_requests
@@ -107,7 +113,7 @@ export async function getCacheSavings(organizationId: string): Promise<CacheSavi
         AND created_at >= parseDateTime64BestEffort({monthStart:String})
         AND status_code IN (200, 201, 202, 204)
         AND cache_read_tokens > 0
-      GROUP BY model
+      GROUP BY provider, model
     `,
     query_params: {
       ...scope.scopeParams,

--- a/apps/server/src/lib/cost.test.ts
+++ b/apps/server/src/lib/cost.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { calculateCost } from './cost.js'
+import { _resetCacheForTests, _setCacheForTests } from './model-prices-cache.js'
 
 describe('calculateCost — basic (no cache)', () => {
   test('gpt-4o-mini: 1k prompt + 500 completion', () => {
@@ -324,5 +325,79 @@ describe('calculateCost — regression vs. old behavior', () => {
     expect(cost!.totalCost).toBeCloseTo(0.057, 6)
     const oldCostEstimate = 100_000 / 1_000_000 * 3
     expect(oldCostEstimate / cost!.totalCost).toBeGreaterThan(5)
+  })
+})
+
+describe('lookupPrice — provider scoping', () => {
+  // These exercise the DB-backed cache, which is empty under plain unit tests,
+  // so seed it directly. Prices are the real 2026-07 values.
+  const GROQ_QWEN = { prompt: 0.29, completion: 0.59 }
+  const OPENROUTER_QWEN = { prompt: 0.08, completion: 0.28 }
+
+  beforeEach(() => {
+    _setCacheForTests({
+      'groq:qwen/qwen3-32b': GROQ_QWEN,
+      'openrouter:qwen/qwen3-32b': OPENROUTER_QWEN,
+      'openai:gpt-4o': { prompt: 2.5, completion: 10, cacheRead: 1.25 },
+      'openrouter:anthropic/claude-opus-4.7': { prompt: 5, completion: 25 },
+    })
+  })
+
+  afterEach(() => {
+    _resetCacheForTests()
+  })
+
+  test('same model name resolves to the calling provider’s price', () => {
+    const groq = calculateCost('groq', 'qwen/qwen3-32b', {
+      promptTokens: 1_000_000, completionTokens: 0,
+    })
+    const openrouter = calculateCost('openrouter', 'qwen/qwen3-32b', {
+      promptTokens: 1_000_000, completionTokens: 0,
+    })
+
+    expect(groq!.totalCost).toBeCloseTo(0.29, 8)
+    expect(openrouter!.totalCost).toBeCloseTo(0.08, 8)
+  })
+
+  test('azure borrows the OpenAI table (it owns no rows of its own)', () => {
+    const azure = calculateCost('azure', 'gpt-4o', { promptTokens: 1_000_000, completionTokens: 0 })
+    const openai = calculateCost('openai', 'gpt-4o', { promptTokens: 1_000_000, completionTokens: 0 })
+
+    expect(azure).not.toBeNull()
+    expect(azure!.totalCost).toBe(openai!.totalCost)
+  })
+
+  test('a prefix match cannot cross provider boundaries', () => {
+    // 'qwen/qwen3-32b' is a boundary-aware prefix of this dated variant, but
+    // only the calling provider's row may supply it.
+    const dated = calculateCost('groq', 'qwen/qwen3-32b-2026-01-01', {
+      promptTokens: 1_000_000, completionTokens: 0,
+    })
+    expect(dated!.totalCost).toBeCloseTo(0.29, 8)
+
+    // cohere has no qwen rows at all and no fallback entry → null, rather than
+    // silently borrowing Groq's or OpenRouter's price.
+    expect(
+      calculateCost('cohere', 'qwen/qwen3-32b', { promptTokens: 1000, completionTokens: 0 }),
+    ).toBeNull()
+  })
+
+  test('OpenRouter ids keep their vendor prefix for lookup', () => {
+    // Our openrouter rows store the full id. Stripping it first (the old
+    // behaviour) matched nothing: the stripped name uses dots
+    // ('claude-opus-4.7') while our Anthropic rows use dashes.
+    const cost = calculateCost('openrouter', 'anthropic/claude-opus-4.7', {
+      promptTokens: 1_000_000, completionTokens: 0,
+    })
+    expect(cost!.totalCost).toBeCloseTo(5, 8)
+  })
+
+  test('falls back to FALLBACK_PRICES when the DB cache has no row', () => {
+    // gpt-4o-mini is absent from the seeded cache above but present in the
+    // cold-start map — this is the path that runs before the first refresh.
+    const cost = calculateCost('openai', 'gpt-4o-mini', {
+      promptTokens: 1_000_000, completionTokens: 0,
+    })
+    expect(cost!.totalCost).toBeCloseTo(0.15, 8)
   })
 })

--- a/apps/server/src/lib/cost.ts
+++ b/apps/server/src/lib/cost.ts
@@ -10,13 +10,12 @@
 // all DB I/O in the background.
 // ─────────────────────────────────────────────────────────────────────────────
 
-import { getCachedPrices, type ModelPrice } from './model-prices-cache.js'
+import { getCachedPrices, priceKey, FALLBACK_PRICES, type ModelPrice } from './model-prices-cache.js'
 import type { ServiceTier } from '../parsers/openai.js'
 
-// 'azure' shares the OpenAI price table (Azure OpenAI exposes OpenAI models
-// at OpenAI prices). The proxy in proxy/azure.ts calls calculateCost('openai', ...)
-// directly, but the type is included here so type-safe call sites that pass
-// `requests.provider` through don't have to special-case it.
+// 'azure' shares the OpenAI price table (Azure OpenAI exposes OpenAI models at
+// OpenAI prices) — there are no `provider = 'azure'` rows in model_prices, so
+// PRICE_TABLE_PROVIDER below rewrites it to 'openai' before every lookup.
 export type Provider =
   | 'openai'
   | 'anthropic'
@@ -89,37 +88,82 @@ export interface CostResult {
 }
 
 /**
+ * Providers that do not own rows in `model_prices` and borrow another
+ * provider's table. Azure OpenAI serves OpenAI models at OpenAI list prices,
+ * and the deployment name customers pick is usually the OpenAI model id.
+ */
+const PRICE_TABLE_PROVIDER: Partial<Record<Provider, Provider>> = {
+  azure: 'openai',
+}
+
+/**
  * OpenAI는 종종 dated suffix를 포함해 모델명을 반환합니다 (예: gpt-4o-mini-2024-07-18).
  * 정확 매칭이 실패하면 등록된 키들 중 가장 긴 prefix를 찾아 fallback 매칭합니다.
  * (boundary-aware: 다음 글자가 단어 경계가 되도록 — 'gpt-4'가 'gpt-4o' prefix로 잘못 잡히는 일 방지)
  *
+ * Resolution order — every exact match is tried before any prefix match,
+ * because a prefix hit on a sibling model is far more wrong than a slightly
+ * stale exact price (`gpt-4o-mini` prefix-matching `gpt-4o` would be 16x):
+ *   1. exact `provider:model` in the DB-backed cache
+ *   2. exact `model` in FALLBACK_PRICES
+ *   3. longest boundary-aware prefix WITHIN that provider's cache keys
+ *   4. longest boundary-aware prefix in FALLBACK_PRICES
+ *
+ * Steps 2/4 are the cold-start net: the DB cache is empty until the first
+ * refresh lands. Ignoring the provider there is safe because FALLBACK_PRICES
+ * carries direct-provider models exclusively and has no duplicated names
+ * (guarded by a test in model-prices-cache.test.ts). Steps 1/3 are what keep
+ * `qwen/qwen3-32b` on Groq from being priced with OpenRouter's cheaper row
+ * once the real table is loaded.
+ *
  * Exported so other cost math (e.g. lib/cache-savings.ts) reuses this exact
  * matching algorithm instead of re-implementing it. Do NOT copy this logic.
  */
-export function lookupPrice(model: string): ModelPrice | null {
+export function lookupPrice(provider: Provider, model: string): ModelPrice | null {
+  const table = PRICE_TABLE_PROVIDER[provider] ?? provider
   const prices = getCachedPrices()
-  const exact = prices[model]
-  if (exact) return exact
 
+  return prices[priceKey(table, model)]
+    ?? FALLBACK_PRICES[model]
+    ?? longestPrefixMatch(prices, model, `${table}:`)
+    ?? longestPrefixMatch(FALLBACK_PRICES, model, '')
+}
+
+/**
+ * Longest boundary-aware prefix match over `prices`, considering only keys
+ * that start with `keyPrefix` (use '' to search the whole map).
+ *
+ * Boundary-aware: a prefix only matches when the next char after it is a
+ * version boundary ('-'), so a shorter key (e.g. 'gpt-4') can't bleed into a
+ * longer variant (e.g. 'gpt-4.5-preview'). Dated variants like
+ * 'gpt-4o-mini-2024-07-18' still match 'gpt-4o-mini'.
+ */
+function longestPrefixMatch(
+  prices: Record<string, ModelPrice>,
+  model: string,
+  keyPrefix: string,
+): ModelPrice | null {
   let bestKey = ''
+  let bestName = ''
   for (const key of Object.keys(prices)) {
-    // Boundary-aware: only accept a prefix match when the next char after the
-    // key is a version boundary ('-'), so a shorter key (e.g. 'gpt-4') can't
-    // bleed across into a longer variant (e.g. 'gpt-4.5-preview'). Dated
-    // variants like 'gpt-4o-mini-2024-07-18' still match 'gpt-4o-mini'.
-    if (!(model === key || model.startsWith(key + '-'))) continue
+    if (keyPrefix && !key.startsWith(keyPrefix)) continue
+    const name = key.slice(keyPrefix.length)
+    if (!(model === name || model.startsWith(name + '-'))) continue
     // longest prefix wins
-    if (key.length > bestKey.length) bestKey = key
+    if (name.length > bestName.length) {
+      bestName = name
+      bestKey = key
+    }
   }
   return bestKey ? prices[bestKey] ?? null : null
 }
 
 export function calculateCost(
-  _provider: Provider,
+  provider: Provider,
   model: string,
   usage: Usage,
 ): CostResult | null {
-  const prices = lookupPrice(model)
+  const prices = lookupPrice(provider, model)
   if (!prices) return null
 
   const cacheRead = usage.cacheReadTokens ?? 0

--- a/apps/server/src/lib/model-prices-cache.test.ts
+++ b/apps/server/src/lib/model-prices-cache.test.ts
@@ -12,6 +12,23 @@ vi.mock('./db.js', () => ({
 // Dynamic import so the mock is in place first.
 let cache: typeof import('./model-prices-cache.js')
 
+/** DB row shape the refresh path reads. */
+function dbRow(over: Record<string, unknown> = {}) {
+  return {
+    provider: 'openai',
+    model: 'gpt-4o',
+    prompt_price_per_1m: '2.5',
+    completion_price_per_1m: '10',
+    cache_read_price_per_1m: null,
+    cache_write_price_per_1m: null,
+    ...over,
+  }
+}
+
+function mockSelect(data: unknown, error: unknown = null) {
+  fromMock.mockReturnValue({ select: vi.fn().mockResolvedValue({ data, error }) })
+}
+
 beforeEach(async () => {
   vi.resetModules()
   fromMock.mockReset()
@@ -24,91 +41,74 @@ afterEach(() => {
 })
 
 describe('model-prices-cache', () => {
-  test('cold start returns fallback prices synchronously', () => {
-    const prices = cache.getCachedPrices()
-    expect(prices['gpt-4o']).toBeDefined()
-    expect(prices['gpt-4o']?.prompt).toBe(2.5)
-    expect(prices['claude-sonnet-4-6']?.cacheRead).toBe(0.3)
+  test('cache is empty before the first refresh (callers fall back)', () => {
+    // The DB map can't be pre-seeded from FALLBACK_PRICES any more: those keys
+    // carry no provider. Cold-start resolution lives in lookupPrice() instead.
+    expect(cache.getCachedPrices()).toEqual({})
   })
 
-  test('refreshPricesNow loads from DB and overrides fallback', async () => {
-    fromMock.mockReturnValue({
-      select: vi.fn().mockResolvedValue({
-        data: [
-          {
-            model: 'gpt-4o',
-            prompt_price_per_1m: '99.99',
-            completion_price_per_1m: '100.00',
-            cache_read_price_per_1m: null,
-            cache_write_price_per_1m: null,
-          },
-        ],
-        error: null,
-      }),
-    })
+  test('rows are keyed "<provider>:<model>", not by model alone', async () => {
+    mockSelect([dbRow()])
 
     const ok = await cache.refreshPricesNow()
     expect(ok).toBe(true)
 
     const prices = cache.getCachedPrices()
-    expect(prices['gpt-4o']?.prompt).toBe(99.99)
-    expect(prices['gpt-4o']?.completion).toBe(100)
-    // Other models still come from fallback
-    expect(prices['gpt-4o-mini']?.prompt).toBe(0.15)
+    expect(prices['openai:gpt-4o']?.prompt).toBe(2.5)
+    expect(prices['gpt-4o']).toBeUndefined()
+  })
+
+  test('same model name under two providers keeps both prices', async () => {
+    // The bug this keying exists to prevent: qwen/qwen3-32b is $0.29/1M on
+    // Groq and $0.08/1M on OpenRouter. Under a model-only key whichever row
+    // the DB returned last silently won.
+    mockSelect([
+      dbRow({ provider: 'groq', model: 'qwen/qwen3-32b', prompt_price_per_1m: '0.29', completion_price_per_1m: '0.59' }),
+      dbRow({ provider: 'openrouter', model: 'qwen/qwen3-32b', prompt_price_per_1m: '0.08', completion_price_per_1m: '0.28' }),
+    ])
+
+    await cache.refreshPricesNow()
+    const prices = cache.getCachedPrices()
+
+    expect(prices['groq:qwen/qwen3-32b']?.prompt).toBe(0.29)
+    expect(prices['openrouter:qwen/qwen3-32b']?.prompt).toBe(0.08)
+  })
+
+  test('rows without a provider are skipped rather than keyed "undefined:"', async () => {
+    mockSelect([dbRow({ provider: null })])
+
+    await cache.refreshPricesNow()
+    expect(cache.getCachedPrices()).toEqual({})
   })
 
   test('numeric string columns are coerced to Number (ClickHouse-style strings)', async () => {
-    fromMock.mockReturnValue({
-      select: vi.fn().mockResolvedValue({
-        data: [
-          {
-            model: 'gpt-4o',
-            prompt_price_per_1m: '0.0001',
-            completion_price_per_1m: '0.0002',
-            cache_read_price_per_1m: '0.00005',
-            cache_write_price_per_1m: null,
-          },
-        ],
-        error: null,
-      }),
-    })
+    mockSelect([dbRow({
+      prompt_price_per_1m: '0.0001',
+      completion_price_per_1m: '0.0002',
+      cache_read_price_per_1m: '0.00005',
+    })])
 
     await cache.refreshPricesNow()
     const prices = cache.getCachedPrices()
-    expect(typeof prices['gpt-4o']?.prompt).toBe('number')
-    expect(prices['gpt-4o']?.prompt).toBe(0.0001)
-    expect(prices['gpt-4o']?.cacheRead).toBe(0.00005)
+    expect(typeof prices['openai:gpt-4o']?.prompt).toBe('number')
+    expect(prices['openai:gpt-4o']?.prompt).toBe(0.0001)
+    expect(prices['openai:gpt-4o']?.cacheRead).toBe(0.00005)
   })
 
   test('null cache columns are omitted from the result (not converted to 0)', async () => {
-    fromMock.mockReturnValue({
-      select: vi.fn().mockResolvedValue({
-        data: [
-          {
-            model: 'gemini-2.5-pro',
-            prompt_price_per_1m: '1.25',
-            completion_price_per_1m: '10',
-            cache_read_price_per_1m: null,
-            cache_write_price_per_1m: null,
-          },
-        ],
-        error: null,
-      }),
-    })
+    mockSelect([dbRow({ provider: 'gemini', model: 'gemini-2.5-pro' })])
 
     await cache.refreshPricesNow()
     const prices = cache.getCachedPrices()
-    expect(prices['gemini-2.5-pro']?.cacheRead).toBeUndefined()
-    expect(prices['gemini-2.5-pro']?.cacheWrite).toBeUndefined()
+    expect(prices['gemini:gemini-2.5-pro']?.cacheRead).toBeUndefined()
+    expect(prices['gemini:gemini-2.5-pro']?.cacheWrite).toBeUndefined()
   })
 
-  test('DB error → returns false, falls back to existing cache', async () => {
-    fromMock.mockReturnValue({
-      select: vi.fn().mockResolvedValue({
-        data: null,
-        error: { message: 'connection refused' },
-      }),
-    })
+  test('DB error → returns false, leaves the previous snapshot intact', async () => {
+    mockSelect([dbRow()])
+    await cache.refreshPricesNow()
+
+    mockSelect(null, { message: 'connection refused' })
 
     // Suppress the intentional console.warn from this error path so test
     // stderr stays clean. We still verify the warn was issued.
@@ -117,29 +117,41 @@ describe('model-prices-cache', () => {
     const ok = await cache.refreshPricesNow()
     expect(ok).toBe(false)
     expect(warnSpy).toHaveBeenCalledOnce()
-    // Fallback prices still available
-    expect(cache.getCachedPrices()['gpt-4o']?.prompt).toBe(2.5)
+    expect(cache.getCachedPrices()['openai:gpt-4o']?.prompt).toBe(2.5)
 
     warnSpy.mockRestore()
   })
 
-  test('empty table preserves fallback prices', async () => {
-    fromMock.mockReturnValue({
-      select: vi.fn().mockResolvedValue({ data: [], error: null }),
-    })
-
+  test('empty table leaves the previous snapshot intact', async () => {
+    mockSelect([dbRow()])
     await cache.refreshPricesNow()
-    expect(cache.getCachedPrices()['gpt-4o']?.prompt).toBe(2.5)
+
+    mockSelect([])
+    await cache.refreshPricesNow()
+
+    expect(cache.getCachedPrices()['openai:gpt-4o']?.prompt).toBe(2.5)
   })
 
   test('FALLBACK_PRICES contains all critical models', () => {
     const required = [
-      'gpt-4o', 'gpt-4o-mini', 'gpt-4.1', 'gpt-4-turbo',
-      'claude-sonnet-4-6', 'claude-opus-4-7', 'claude-haiku-4-5',
-      'gemini-2.5-pro', 'gemini-2.5-flash',
+      'gpt-4o', 'gpt-4o-mini', 'gpt-4.1', 'gpt-4-turbo', 'gpt-5.6-sol',
+      'claude-sonnet-4-6', 'claude-opus-4-7', 'claude-haiku-4-5', 'claude-opus-5',
+      'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-3.6-flash',
     ]
     for (const model of required) {
       expect(cache.FALLBACK_PRICES[model], `missing fallback for ${model}`).toBeDefined()
+    }
+  })
+
+  test('FALLBACK_PRICES stays provider-unambiguous', () => {
+    // lookupPrice() consults FALLBACK_PRICES without a provider, which is only
+    // safe while it holds direct-provider models exclusively. OpenRouter ids
+    // carry a vendor prefix and would collide with the direct rows.
+    for (const model of Object.keys(cache.FALLBACK_PRICES)) {
+      expect(model.startsWith('anthropic/'), `${model} looks like an OpenRouter id`).toBe(false)
+      expect(model.startsWith('google/'), `${model} looks like an OpenRouter id`).toBe(false)
+      expect(model.startsWith('mistralai/'), `${model} looks like an OpenRouter id`).toBe(false)
+      expect(model.startsWith('x-ai/'), `${model} looks like an OpenRouter id`).toBe(false)
     }
   })
 
@@ -148,6 +160,9 @@ describe('model-prices-cache', () => {
     // because VITEST env disables auto-refresh (to keep test stderr clean).
     // Instead, verify the explicit-refresh path: while refresh is in flight,
     // sync reads continue to return the existing cached snapshot.
+    mockSelect([dbRow()])
+    await cache.refreshPricesNow()
+
     let resolveSelect: (v: { data: unknown; error: unknown }) => void = () => {}
     const selectPromise = new Promise<{ data: unknown; error: unknown }>((resolve) => {
       resolveSelect = resolve
@@ -159,22 +174,16 @@ describe('model-prices-cache', () => {
 
     const refreshPromise = cache.refreshPricesNow()
 
-    // While the DB call is pending, sync reads return the existing (fallback) snapshot
-    expect(cache.getCachedPrices()['gpt-4o']?.prompt).toBe(2.5)
+    // While the DB call is pending, sync reads return the previous snapshot.
+    expect(cache.getCachedPrices()['openai:gpt-4o']?.prompt).toBe(2.5)
 
     resolveSelect({
-      data: [{
-        model: 'gpt-4o',
-        prompt_price_per_1m: '77',
-        completion_price_per_1m: '88',
-        cache_read_price_per_1m: null,
-        cache_write_price_per_1m: null,
-      }],
+      data: [dbRow({ prompt_price_per_1m: '77', completion_price_per_1m: '88' })],
       error: null,
     })
 
     const ok = await refreshPromise
     expect(ok).toBe(true)
-    expect(cache.getCachedPrices()['gpt-4o']?.prompt).toBe(77)
+    expect(cache.getCachedPrices()['openai:gpt-4o']?.prompt).toBe(77)
   })
 })

--- a/apps/server/src/lib/model-prices-cache.ts
+++ b/apps/server/src/lib/model-prices-cache.ts
@@ -24,6 +24,14 @@
 // fleet, expect ≤2× TTL worst-case (5–10 min) for full propagation. This is
 // acceptable for prices that change quarterly at most.
 //
+// KEYING: the DB-backed cache is keyed `"<provider>:<model>"`, because model
+// names are NOT unique across providers — `qwen/qwen3-32b` costs $0.29/1M on
+// Groq and $0.08/1M on OpenRouter. A model-only key let whichever row the DB
+// returned last silently win. FALLBACK_PRICES stays model-only on purpose: it
+// contains direct-provider models exclusively (no OpenRouter rows), so it has
+// no ambiguous names, and it is only consulted when the provider-scoped
+// lookup misses. See lookupPrice() in cost.ts for the full resolution order.
+//
 // IMPORTANT: never await on this module from the proxy hot path. The whole
 // point is that `getCachedPrices()` is synchronous and returns immediately.
 // ─────────────────────────────────────────────────────────────────────────────
@@ -258,14 +266,24 @@ export const FALLBACK_PRICES: Record<string, ModelPrice> = {
 const CACHE_TTL_MS = 5 * 60 * 1000  // 5 minutes
 const ERROR_LOG_THROTTLE_MS = 60 * 1000  // log refresh failures at most once / min
 
-let cache: Record<string, ModelPrice> = { ...FALLBACK_PRICES }
+/** Cache key for the provider-scoped map. Keep in sync with lookupPrice(). */
+export function priceKey(provider: string, model: string): string {
+  return `${provider}:${model}`
+}
+
+// Empty until the first refresh lands. Callers fall back to FALLBACK_PRICES —
+// see lookupPrice(). Seeding this from FALLBACK_PRICES is not possible any
+// more: those keys carry no provider, so they cannot be placed in a
+// provider-scoped map without inventing an owner for each one.
+let cache: Record<string, ModelPrice> = {}
 let lastRefreshedAt = 0
 let refreshInFlight: Promise<void> | null = null
 let lastErrorLoggedAt = 0
 
 /**
- * Synchronous price lookup map. Always returns a non-empty record (worst case:
- * the FALLBACK_PRICES). Triggers an async refresh if the cache is stale.
+ * Synchronous price map keyed `"<provider>:<model>"`. Empty until the first
+ * successful refresh — callers must fall back to FALLBACK_PRICES on a miss.
+ * Triggers an async refresh if the cache is stale.
  *
  * Safe to call on every request — never throws, never awaits.
  */
@@ -297,9 +315,15 @@ export async function refreshPricesNow(): Promise<boolean> {
  * never needs to reset because the cache self-refreshes.
  */
 export function _resetCacheForTests(): void {
-  cache = { ...FALLBACK_PRICES }
+  cache = {}
   lastRefreshedAt = 0
   refreshInFlight = null
+}
+
+/** Test helper: seed the provider-scoped cache without touching Supabase. */
+export function _setCacheForTests(next: Record<string, ModelPrice>): void {
+  cache = { ...next }
+  lastRefreshedAt = Date.now()
 }
 
 // ── Internals ─────────────────────────────────────────────────────────────────
@@ -328,7 +352,7 @@ async function doRefresh(): Promise<void> {
   const { data, error } = await supabaseAdmin
     .from('model_prices')
     .select(
-      'model, prompt_price_per_1m, completion_price_per_1m, cache_read_price_per_1m, cache_write_price_per_1m,' +
+      'provider, model, prompt_price_per_1m, completion_price_per_1m, cache_read_price_per_1m, cache_write_price_per_1m,' +
       ' long_context_threshold_tokens, long_prompt_price_per_1m, long_completion_price_per_1m,' +
       ' long_cache_read_price_per_1m, long_cache_write_price_per_1m',
     )
@@ -351,8 +375,9 @@ async function doRefresh(): Promise<void> {
     // the values defensively.
     const r = row as unknown as Record<string, unknown>
     const model = r['model'] as string
-    if (!model) continue
-    next[model] = {
+    const provider = r['provider'] as string
+    if (!model || !provider) continue
+    next[priceKey(provider, model)] = {
       prompt: Number(r['prompt_price_per_1m']),
       completion: Number(r['completion_price_per_1m']),
       ...(r['cache_read_price_per_1m'] != null && { cacheRead: Number(r['cache_read_price_per_1m']) }),
@@ -374,9 +399,11 @@ async function doRefresh(): Promise<void> {
       }),
     }
   }
-  // Merge with fallback so any model present in fallback but missing from DB
-  // still resolves (avoids regression if an admin accidentally deletes a row).
-  cache = { ...FALLBACK_PRICES, ...next }
+  // Straight replace, no merge with FALLBACK_PRICES: those keys have no
+  // provider and merging them in would resurrect the cross-provider collisions
+  // this map exists to prevent. A model deleted from the DB still resolves,
+  // because lookupPrice() consults FALLBACK_PRICES after this map misses.
+  cache = next
   lastRefreshedAt = Date.now()
 }
 

--- a/apps/server/src/proxy/azure.ts
+++ b/apps/server/src/proxy/azure.ts
@@ -134,9 +134,11 @@ azureProxy.all('/*', async (c) => {
     } catch { /* ignore */ }
   }
 
-  // Azure exposes OpenAI models at OpenAI prices — reuse the OpenAI price
-  // table rather than maintaining a parallel one.
-  const cost = calculateCost('openai', resolvedModel, {
+  // Azure exposes OpenAI models at OpenAI prices and has no rows of its own in
+  // model_prices. Pass the real provider tag — lookupPrice() rewrites 'azure'
+  // to 'openai' via PRICE_TABLE_PROVIDER, so the mapping lives in one place
+  // instead of being re-derived at each call site.
+  const cost = calculateCost('azure', resolvedModel, {
     promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
   })
 

--- a/apps/server/src/proxy/openrouter.ts
+++ b/apps/server/src/proxy/openrouter.ts
@@ -154,16 +154,23 @@ openrouterProxy.all('/*', async (c) => {
   // Cost preference order:
   //   1. OpenRouter's own usage.cost field — authoritative, includes any
   //      per-customer discount / margin we don't see.
-  //   2. Our local calculator against the model id with the vendor prefix
-  //      stripped (`anthropic/claude-3-5-sonnet` → `claude-3-5-sonnet`).
-  //   3. NULL — unknown model, cost not surfaced by upstream.
+  //   2. Our local calculator against the FULL model id. `model_prices` stores
+  //      OpenRouter rows with the vendor prefix intact (`anthropic/claude-...`),
+  //      so the id goes in as-is. It used to be stripped first, which could
+  //      never match those rows — and the stripped name didn't match our
+  //      Anthropic rows either, since those use the dashed form
+  //      (`claude-opus-4-7`, not `claude-opus-4.7`).
+  //   3. The vendor-stripped name, as a last resort for models missing from
+  //      our OpenRouter rows (resolves against FALLBACK_PRICES).
+  //   4. NULL — unknown model, cost not surfaced by upstream.
   let finalCostUsd: number | null = null
   if (openrouterReportedCost !== null) {
     finalCostUsd = openrouterReportedCost
   } else {
-    const lookup = calculateCost('openrouter', stripVendorPrefix(resolvedModel), {
-      promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
-    })
+    const usage = { promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier }
+    const lookup =
+      calculateCost('openrouter', resolvedModel, usage) ??
+      calculateCost('openrouter', stripVendorPrefix(resolvedModel), usage)
     finalCostUsd = lookup?.totalCost ?? null
   }
 

--- a/apps/server/src/proxy/stream-logger.ts
+++ b/apps/server/src/proxy/stream-logger.ts
@@ -195,8 +195,10 @@ export async function logOpenRouterStream(
 
   // Cost preference order matches the non-streaming path in proxy/openrouter.ts:
   //   1. usage.cost from the final SSE chunk (authoritative).
-  //   2. local calculator against the vendor-stripped model id.
-  //   3. NULL.
+  //   2. local calculator against the FULL model id (our OpenRouter price rows
+  //      keep the vendor prefix).
+  //   3. the vendor-stripped id, as a last resort.
+  //   4. NULL.
   const strippedModel = (() => {
     const idx = model.indexOf('/')
     return idx === -1 ? model : model.slice(idx + 1)
@@ -205,9 +207,10 @@ export async function logOpenRouterStream(
   if (openrouterReportedCost !== null) {
     finalCostUsd = openrouterReportedCost
   } else if (promptTokens > 0 || completionTokens > 0) {
-    const lookup = calculateCost('openrouter' as Provider, strippedModel, {
-      promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier,
-    })
+    const usage = { promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens, serviceTier }
+    const lookup =
+      calculateCost('openrouter' as Provider, model, usage) ??
+      calculateCost('openrouter' as Provider, strippedModel, usage)
     finalCostUsd = lookup?.totalCost ?? null
   }
   // else: no authoritative usage.cost AND no token usage captured (truncated

--- a/docs/CODEMAPS/backend.md
+++ b/docs/CODEMAPS/backend.md
@@ -67,8 +67,8 @@ Per-job code in `src/lib/cron-jobs/`:
 ## Core libs (do not reimplement)
 
 - `lib/crypto.ts` — AES-256-GCM, all async (gotcha #12 — never skip `await`)
-- `lib/cost.ts` — `calculateCost(provider, model, usage)` sync, exact + longest-prefix model match
-- `lib/model-prices-cache.ts` — SWR price cache (5m TTL, FALLBACK_PRICES cold-start safety)
+- `lib/cost.ts` — `calculateCost(provider, model, usage)` sync, provider-scoped exact + longest-prefix match (`azure` → `openai` via `PRICE_TABLE_PROVIDER`)
+- `lib/model-prices-cache.ts` — SWR price cache keyed `"<provider>:<model>"` (5m TTL, FALLBACK_PRICES cold-start safety)
 - `lib/logger.ts` — `logRequestAsync` + `parseLogBodyMode`
 - `lib/wait-until.ts` — `fireAndForget(c, promise)` — Vercel Edge/Node-safe (gotcha #8)
 - `lib/clickhouse.ts` — singleton + `toClickhouseTimestamp()` (gotcha #18)


### PR DESCRIPTION
Follow-up to #441, which surfaced this by adding a second colliding model name.

## The bug

`calculateCost()` accepted a provider argument and ignored it (`_provider`), so the price cache was keyed on model name alone. Model names are **not** unique across providers, and whichever DB row loaded last silently won:

| model | groq | openrouter |
|---|---|---|
| `qwen/qwen3-32b` | $0.29 / $0.59 | $0.08 / $0.28 |
| `qwen/qwen3.6-27b` | $0.60 / $3.00 | $0.2885 / $3.17 |

Groq traffic on either model could be priced with OpenRouter's cheaper row, or vice versa, depending on row order.

## The fix

The DB-backed cache is now keyed `"<provider>:<model>"` and `lookupPrice()` takes the provider. `FALLBACK_PRICES` stays model-only — it holds direct-provider models exclusively so it has no ambiguous names, and it is only consulted when the provider-scoped lookup misses. A test guards that property so nobody adds an OpenRouter-style id to it later.

Resolution order now puts **every exact match ahead of every prefix match**:

1. exact `provider:model` in the DB cache
2. exact `model` in `FALLBACK_PRICES`
3. longest boundary-aware prefix within that provider's cache keys
4. longest boundary-aware prefix in `FALLBACK_PRICES`

The old code ran the prefix pass before consulting the fallback at all, so a model missing from the DB could prefix-match a sibling — `gpt-4o-mini` resolving to `gpt-4o` is a **16x overcharge**. Found while writing the cold-start test for this change, not something I set out to fix.

## Two dependent fixes

**Azure** owns no rows in `model_prices` and only worked *because* the lookup ignored the provider. `proxy/azure.ts` now passes its real `'azure'` tag and `PRICE_TABLE_PROVIDER` rewrites it to `openai`, so the mapping lives in one place instead of being re-derived at the call site.

**OpenRouter fallback** stripped the vendor prefix before looking up, but our openrouter rows store the full id (`anthropic/claude-...`), so it could never match them — and the stripped name didn't match our Anthropic rows either, since those use the dashed form (`claude-opus-4-7`, not `claude-opus-4.7`). Both the streaming and non-streaming paths now try the full id first, keeping the stripped name as a last resort. Masked in practice because OpenRouter reports its own `usage.cost`, which still takes precedence.

`lib/cache-savings.ts` groups by provider as well as model so it can price each row with the right table.

## Behaviour change to be aware of

`getCachedPrices()` no longer merges `FALLBACK_PRICES` into the returned map, and is empty until the first refresh lands. Merging would have reintroduced the very collisions this keying prevents. Callers must go through `lookupPrice()` / `calculateCost()`, which handle the fallback — both in-tree callers already do.

## Test plan

- [x] `pnpm --filter server typecheck`
- [x] `pnpm --filter server lint`
- [x] `pnpm --filter server test` — 1598 passed
- [x] New: same model name under two providers resolves to the caller's price
- [x] New: prefix matches cannot cross provider boundaries
- [x] New: azure and openai produce identical cost for the same model
- [x] New: OpenRouter ids keep their vendor prefix for lookup
- [x] New: cold-start falls back to `FALLBACK_PRICES` when the DB cache has no row
- [x] New: `FALLBACK_PRICES` is provider-unambiguous (no vendor-prefixed ids)
- [x] Rewrote `model-prices-cache.test.ts` for the new keying contract