### PR TITLE
chore: add model-price-refresh skill

### DIFF
--- a/.claude/skills/model-price-refresh/SKILL.md
+++ b/.claude/skills/model-price-refresh/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: model-price-refresh
+description: >-
+  Audit every LLM provider's official pricing page against the `model_prices`
+  table and ship the diff as a migration. Use this whenever the user asks
+  whether our providers' models are up to date, mentions a specific model
+  missing from cost tracking, reports `cost_usd` coming back null or looking
+  wrong, asks to "refresh prices" / "check the latest models" / "add <model>",
+  or when a scheduled price-refresh routine fires. Also use it proactively
+  before adding any single model by hand — the table has three mirrors and a
+  provider-scoped key, and editing one place silently desyncs the others.
+---
+
+# Model price refresh
+
+Spanlens prices every proxied request from the `model_prices` table. A model
+that isn't in the table logs `cost_usd = NULL`, which the dashboard renders as
+missing data — the customer sees a gap, not an error. A model that's in the
+table at a stale rate is worse: the number looks fine and is quietly wrong.
+
+Providers ship new flagship models faster than you'd expect (Gemini shipped
+3.5-flash → 3.6-flash inside a month in mid-2026), so this drifts continuously.
+
+## What you're keeping in sync
+
+Prices live in **three** places, and they serve different purposes. All three
+have to move together or you get correct-looking-but-wrong behavior:
+
+| Where | Purpose | Consequence if stale |
+|---|---|---|
+| `model_prices` table (via `supabase/migrations/`) | Runtime source of truth | Wrong or missing cost on every request |
+| `supabase/seeds/model_prices.sql` | Reference mirror + local `db reset` | Local/CI prices diverge from prod |
+| `FALLBACK_PRICES` in `apps/server/src/lib/model-prices-cache.ts` | Cold-start map, read before the first DB refresh lands | Wrong prices for the first seconds after every deploy |
+
+The seed file has drifted from the migrations before (2026-07: it still carried
+Mistral's pre-Large-3 prices and was missing three Anthropic models). Assume it's
+behind until you've diffed it.
+
+## Workflow
+
+### 1. Read the current state
+
+Query production rather than trusting the repo, because the repo mirrors lag:
+
+```sql
+select provider, model,
+       prompt_price_per_1m::float8, completion_price_per_1m::float8,
+       cache_read_price_per_1m::float8, cache_write_price_per_1m::float8,
+       long_context_threshold_tokens
+from model_prices
+order by provider, model;
+```
+
+Use the Supabase MCP (`execute_sql`) against the `spanlens` project. Skip
+`provider = 'openrouter'` for the detailed pass — it's a meta-provider with
+100+ churning rows, and its proxy prefers the cost OpenRouter reports itself.
+
+### 2. Pull each provider's official pricing
+
+Read `references/providers.md` for the URL, the extraction technique that
+actually works for each page, and the per-provider traps. Several pricing pages
+are JS-rendered tab groups where a plain fetch returns nothing useful — that
+file has the browser snippets that pair headings with their price tables.
+
+Providers currently in scope: `openai`, `anthropic`, `gemini`, `mistral`,
+`groq`, `deepseek`, `xai`, `cohere` (+ `azure`, which owns no rows and borrows
+OpenAI's, and `openrouter`).
+
+Check `apps/server/src/proxy/` for the authoritative list — a new proxy file
+means a new provider to audit.
+
+### 3. Diff, and classify what you find
+
+Sort findings by what they cost the customer, not by provider:
+
+- **Missing model** → requests log `cost_usd = NULL`. Highest priority.
+- **Wrong price** → silently mis-billed. Equally urgent, harder to notice.
+- **Missing `cache_read`** → `calculateCost()` falls back to the full input
+  rate (see `lib/cost.ts`), so every cache hit over-charges. Gemini and xAI both
+  publish cached-input rates; check whether the column is actually populated
+  rather than assuming.
+- **Missing long-context tier** → requests above the threshold under-charge.
+  OpenAI GPT-5.x is 272k; Gemini Pro and xAI are 200k. xAI is unusual: crossing
+  the threshold re-rates the *entire* request at 2x, not just the excess.
+- **Model gone from the pricing page** → keep the row so historical requests
+  still price, and note it. Don't delete.
+
+### 4. Check for name collisions before adding anything
+
+This is the step that's easy to skip and expensive to miss. The price cache is
+keyed `"<provider>:<model>"` precisely because model names are **not** unique
+across providers — `qwen/qwen3-32b` is $0.29/1M on Groq and $0.08/1M on
+OpenRouter. Adding a model that already exists under a different provider is
+fine now, but you should know you're doing it, and the fallback map has a
+stricter rule (below).
+
+```sql
+select model, count(*) n,
+       string_agg(provider||': '||prompt_price_per_1m::float8, ' | ' order by provider) v
+from model_prices group by model having count(*) > 1 order by model;
+```
+
+Run this **after** drafting the migration, mentally applying your additions.
+`FALLBACK_PRICES` is keyed by model alone, so it must stay unambiguous: never
+put a vendor-prefixed OpenRouter id in it. A test enforces this.
+
+### 5. Decide what NOT to add
+
+`model_prices` has a single `completion_price_per_1m`, but image/video/audio
+models bill output by modality — `gemini-3-pro-image` is $12/1M for text and
+$120/1M for images. Picking either number silently mis-bills the other case,
+which is worse than a visible NULL. Leave them out and say so in the migration
+header until there's a modality-aware column.
+
+Same for models with no published per-token price (Cohere's `command-a-plus`
+and the specialized `command-a-*` variants are sales-quoted).
+
+### 6. Write the migration
+
+New file, `supabase/migrations/YYYYMMDDHHMMSS_seed_models_YYYY_MM.sql`. Never
+edit an existing migration — a pre-commit hook blocks it.
+
+Make it idempotent so a re-run is harmless:
+
+```sql
+INSERT INTO model_prices (
+  provider, model,
+  prompt_price_per_1m, completion_price_per_1m,
+  cache_read_price_per_1m, cache_write_price_per_1m
+) VALUES
+  ('openai', 'gpt-5.6-sol', 5.00, 30.00, 0.50, 6.25)
+ON CONFLICT (provider, model) DO UPDATE
+  SET prompt_price_per_1m      = EXCLUDED.prompt_price_per_1m,
+      completion_price_per_1m  = EXCLUDED.completion_price_per_1m,
+      cache_read_price_per_1m  = EXCLUDED.cache_read_price_per_1m,
+      cache_write_price_per_1m = EXCLUDED.cache_write_price_per_1m,
+      updated_at               = now();
+```
+
+Long-context tiers go in follow-up `UPDATE` statements (see the
+20260729100000 migration for the shape).
+
+Write the header comment as a record of *why*, not a list of *what* — the diff
+already shows what. Verification date, the pages you checked, what you
+deliberately left out and on what reasoning, and any dated price change coming.
+
+### 7. Mirror into the seed and the fallback map
+
+Apply the same changes to `supabase/seeds/model_prices.sql` and
+`FALLBACK_PRICES`. While you're in there, diff the whole provider block against
+what you just read from the DB — that's how the 2026-07 Mistral drift surfaced.
+
+`FALLBACK_PRICES` doesn't need every model; it needs the ones that would hurt
+if they priced wrong for a few seconds after deploy. Current flagships,
+high-volume models, anything a customer is actively running.
+
+### 8. Verify
+
+```bash
+pnpm --filter server typecheck && pnpm --filter server lint && pnpm --filter server test
+```
+
+Price corrections **will** break tests that hardcode the old numbers — that's
+the test doing its job, not a problem to route around. Update the expected value
+*and* the comment that explains the arithmetic, so the next reader can check it.
+Known ones: `proxy-mistral.test.ts` and `proxy-openai-compat-providers.test.ts`
+both assert specific per-1M rates.
+
+When you change a tier boundary or add a new pricing dimension, add a test that
+pins both sides of it. A price table with no test is a price table that will
+quietly regress.
+
+### 9. Ship
+
+Conventional commit (`fix(db):` for corrections, `feat(db):` for pure
+additions). In the PR body, lead with customer impact — which models were
+logging NULL, which rate was wrong and by how much — then the follow-ups.
+
+After merge, `deploy-server.yml` runs `supabase db push` automatically. Confirm
+the rows actually landed by querying production; don't infer it from a green
+workflow.
+
+## Recurring obligations
+
+Some price changes are scheduled rather than discovered. When you find one,
+write it into the migration header **and** tell the user to calendar it —
+a comment alone won't fire.
+
+Currently pending:
+
+- **2026-09-01** — `claude-sonnet-5` introductory pricing ($2/$10, cache
+  0.20/2.50) expires. Standard is $3/$15, cache 0.30/3.75. Missing this
+  under-reports Sonnet 5 by 33%.
+
+## Reference
+
+- `references/providers.md` — per-provider pricing URLs, extraction techniques
+  for the JS-rendered pages, and known traps
+- `supabase/migrations/20260729100000_seed_models_2026_07.sql` — worked example
+  covering additions, a correction, cache backfill, and tier setup
+- `apps/server/src/lib/cost.ts` — resolution order (exact before prefix,
+  provider-scoped before fallback) and the `azure → openai` mapping

--- a/.claude/skills/model-price-refresh/references/providers.md
+++ b/.claude/skills/model-price-refresh/references/providers.md
@@ -1,0 +1,233 @@
+# Provider pricing sources
+
+Per-provider URLs, the extraction technique that actually works, and traps.
+Verified 2026-07-29 — if a snippet stops returning rows, the page was
+restructured; adapt it rather than guessing at prices.
+
+## Contents
+
+- [How to read a JS-rendered pricing page](#how-to-read-a-js-rendered-pricing-page)
+- [OpenAI](#openai) · [Anthropic](#anthropic) · [Gemini](#gemini)
+- [Mistral](#mistral) · [Groq](#groq) · [DeepSeek](#deepseek) · [xAI](#xai) · [Cohere](#cohere)
+- [Azure](#azure) · [OpenRouter](#openrouter)
+- [Cross-provider notes](#cross-provider-notes)
+
+## How to read a JS-rendered pricing page
+
+`WebFetch` works when the page has a text or markdown representation. It fails
+on the tabbed, JS-built tables that Gemini and Mistral use — it returns prose
+about the tiers and no numbers, or silently drops most models.
+
+For those, open the page in the browser pane (`preview_start` with the URL,
+then `navigate`) and extract with `javascript_tool`. Two techniques carry most
+of the work:
+
+**Pair every table with the heading above it.** Pricing pages nest tables deep
+inside tab containers, so `nextElementSibling` walks from a heading don't
+reach them. Walk all headings, `code` elements and tables in document order and
+carry the last-seen heading forward:
+
+```js
+(()=>{const els=document.querySelectorAll('h2,h3,code,table');
+let name='',code='';const out=[];
+els.forEach(e=>{
+  if(e.tagName==='H2'||e.tagName==='H3'){name=e.innerText.trim();code=''}
+  else if(e.tagName==='CODE'){if(!code)code=e.innerText.trim()}
+  else{const rows=Array.from(e.querySelectorAll('tr'))
+        .map(r=>r.innerText.replace(/\s+/g,' ').trim());
+       out.push(`${name} [${code}]\n  ${rows.join('\n  ')}`)}});
+return out.join('\n\n')})()
+```
+
+The `code` element usually holds the real API model id, which is what you need —
+the heading is marketing copy ("Nano Banana Pro" is `gemini-3-pro-image`).
+
+**Pull one field across all tables.** Once you know the layout, grab just the
+row you care about instead of dumping everything:
+
+```js
+(()=>{const t=document.querySelectorAll('table');
+return [0,9,23].map(i=>'#'+i+': '+
+  t[i].innerText.replace(/\s*\n\s*/g,' | ').slice(0,400)).join('\n\n')})()
+```
+
+Careful: tab groups repeat the same model across Standard / Batch / Flex /
+Priority tables. Only **Standard** goes in `model_prices` — `lib/cost.ts`
+derives the other tiers with `TIER_MULTIPLIERS`.
+
+A page served in the user's locale may be a stale translation. Append `?hl=en`
+on Google properties; the English page has been a full generation ahead.
+
+---
+
+## OpenAI
+
+- <https://developers.openai.com/api/docs/pricing>
+- Markdown works: append `.md` to the URL and `WebFetch` it. Easiest provider.
+
+The flagship table shows only the newest family; the "All models" table has the
+long tail. The `.md` version contains both, which is why it's preferred.
+
+Traps:
+- Response bodies return **dated** ids (`gpt-4o-mini-2024-07-18`) and that's
+  what lands in `requests.model`. Seed the base id and let the boundary-aware
+  prefix match in `lookupPrice()` handle the variants.
+- Long-context threshold is 272k, in a tooltip on the "Long context" header
+  rather than the table.
+- GPT-5.6 introduced OpenAI's first published **cache write** rate (1.25x
+  input). Earlier families have cached-input only.
+- Image/realtime/transcription models are priced per modality — out of scope.
+
+## Anthropic
+
+- <https://platform.claude.com/en/docs/about-claude/pricing> — the rate table
+- <https://platform.claude.com/en/docs/about-claude/models/overview> — API ids
+- Both work with `WebFetch` or the browser.
+
+You need both pages: pricing lists models by display name ("Claude Opus 5"),
+and the overview maps them to API ids (`claude-opus-5`). Guessing the id from
+the display name breaks on the dashed-vs-dotted convention.
+
+Traps:
+- From the 4.6 generation on, ids are dateless but still pinned snapshots. Both
+  the alias and any dated form need rows.
+- Cache columns are derivable: `cache_read = 0.1x input`,
+  `cache_write (5min) = 1.25x input`. The 1-hour cache write is a different
+  multiplier we don't model.
+- Introductory pricing is a real, dated thing — Sonnet 5 launched at $2/$10
+  through 2026-08-31. Record the expiry, it won't announce itself.
+- Invitation-only models (Mythos) still get rows; a customer with access will
+  otherwise log NULL.
+
+## Gemini
+
+- <https://ai.google.dev/gemini-api/docs/pricing?hl=en>
+- Browser + the heading-pairing snippet. `WebFetch` returns the tier prose only.
+
+`?hl=en` is not optional. The localized page has been served from a stale cache
+missing an entire model generation.
+
+Traps:
+- Every current model publishes a **context caching** rate that is easy to miss
+  because it sits in a third table row. Leaving it NULL over-charges every
+  cache hit. Take the text/image/video number; audio caches higher and isn't
+  modelled.
+- The `$1.00 / 1M tokens per hour` storage fee on the same row is a separate
+  charge Google bills directly — not `cache_read`.
+- Pro-family and Computer Use split at 200k tokens; the >200k rate goes in the
+  `long_*` columns.
+- The models page lists retired models under a "legacy" heading — worth reading
+  to catch things that quietly went away.
+- Image models (`*-image`, "Nano Banana") price output per image. Out of scope.
+
+## Mistral
+
+- <https://mistral.ai/pricing/api>
+- Browser. The plain `/pricing` page has no table; `WebFetch` on `/pricing/api`
+  returns a partial list.
+
+Model cards render as a grid; this pulls id + prices:
+
+```js
+(()=>{const t=document.body.innerText;const i=t.indexOf('results');
+const seg=t.slice(i,i+14000);const out=[];
+const re=/\$([\d.]+)\s*\n+\s*Output \(\/M tokens\)\s*\n+\s*\$([\d.]+)\s*\n+\s*([a-z0-9\-.]+)/g;
+let m;while((m=re.exec(seg)))out.push(m[3]+' = '+m[1]+'/'+m[2]);
+return out.join('\n')})()
+```
+
+Traps:
+- `*-latest` ids are **moving pointers**. `mistral-large-latest` went from
+  $2/$6 to $0.50/$1.50 when Large 3 shipped, and `mistral-small-latest` rose
+  from $0.10/$0.30 to $0.15/$0.60 with Small 4. Re-verify these every run even
+  when no new model appeared — this is the provider most likely to have moved
+  under you.
+- Open-weight ids carry an `open-` prefix (`open-mixtral-8x22b`). We shipped a
+  bare `mixtral-8x22b` row once that never matched a single request.
+
+## Groq
+
+- <https://groq.com/pricing>
+- `WebFetch` works.
+
+Traps:
+- Catalogue turns over fast; models disappear without deprecation notices.
+- Ids are namespaced (`openai/gpt-oss-120b`, `qwen/qwen3.6-27b`), which is
+  exactly where collisions with OpenRouter come from. Run the collision query.
+- Cached-input rates are published for some models only.
+
+## DeepSeek
+
+- <https://api-docs.deepseek.com/quick_start/pricing>
+- `WebFetch` works.
+
+Traps:
+- `deepseek-chat` / `deepseek-reasoner` are compatibility aliases that resolve
+  to the current v4 model. Keep rows for all of them.
+- `cache_read` here is the published cache-**hit** input rate and is dramatically
+  lower than input (~2% of it), so leaving it NULL is a large over-charge.
+
+## xAI
+
+- <https://docs.x.ai/docs/models>
+- `WebFetch` works.
+
+Traps:
+- Every Grok model has a cached-input rate **and** a 200k tier. The tier
+  semantics are unusual: reaching the threshold re-rates *all* tokens in the
+  request at 2x, not just the overage. That happens to match how
+  `long_context_threshold_tokens` is applied, so it maps cleanly — but it means
+  a 250k-token request costs double throughout.
+- Ids are versioned oddly (`grok-4.20-0309-reasoning`). Copy them exactly.
+
+## Cohere
+
+- <https://cohere.com/pricing> — partial, JS-heavy
+- <https://docs.cohere.com/docs/models> — the reliable id list
+
+Traps:
+- The flagship `command-a-plus-*` and specialized `command-a-{reasoning,
+  vision,translate}-*` models have **no public per-token price**. Deliberately
+  unseeded; they log NULL. If sales-quoted pricing becomes available, that's
+  the moment to add them.
+- The public page mixes in legacy models that are no longer served.
+
+## Azure
+
+No pricing page to check and **no rows in `model_prices`**. Azure OpenAI serves
+OpenAI models at OpenAI list prices, so `lib/cost.ts` rewrites `azure → openai`
+via `PRICE_TABLE_PROVIDER`. Nothing to do here during a refresh — just don't
+"fix" the missing rows by adding them.
+
+## OpenRouter
+
+- <https://openrouter.ai/models> (API: `https://openrouter.ai/api/v1/models`)
+
+A meta-provider with 100+ rows that churn weekly. Deliberately **not** mirrored
+into the seed file or `FALLBACK_PRICES`.
+
+Traps:
+- Rows are stored **with** the vendor prefix (`anthropic/claude-opus-4.7`), and
+  the proxy looks up the full id. Don't strip it.
+- OpenRouter uses dotted versions where our Anthropic rows use dashes
+  (`claude-opus-4.7` vs `claude-opus-4-7`). They are not interchangeable.
+- The proxy prefers the `usage.cost` OpenRouter reports, so our table is only a
+  fallback. Bulk-refreshing it is low value; fix specific misses instead.
+
+---
+
+## Cross-provider notes
+
+**Tiers.** Only Standard rates belong in the table. Batch/Flex/Priority are
+derived in `lib/cost.ts` via `TIER_MULTIPLIERS` (0.5x / 0.5x / 1.8x).
+
+**Embeddings** are input-only: set `completion_price_per_1m = 0`, not NULL.
+
+**Multimodal input** (image/audio/video tokens priced above text) isn't
+modelled — one `prompt_price_per_1m` per row. Seed the text rate and note it.
+
+**Deprecated models** keep their rows so historical requests still price
+correctly. Deleting a row silently re-prices the past.
+
+**New provider?** Adding one is more than a price row — see the provider
+addition checklist in the project docs for the full layer list.


### PR DESCRIPTION
Captures the provider price audit run in #441 / #442 as a repeatable procedure, and wires it to a twice-monthly cloud routine.

## Why a skill and not just a doc

The prices themselves were the cheap part of that audit. What took the time was everything around them:

- Prices live in **three** places — the migration/DB, `supabase/seeds/model_prices.sql`, and `FALLBACK_PRICES`. The seed had silently drifted a full Mistral generation behind, so anyone auditing against it would have "confirmed" wrong numbers.
- Several pricing pages are JS-rendered tab groups where a plain fetch returns tier prose and no numbers. `references/providers.md` carries the browser snippets that pair headings with their tables.
- Google's localized pricing page was serving a cached copy missing an entire model generation. `?hl=en` is load-bearing.
- Model names are not unique across providers, so additions need a collision check before they land — that is exactly how #441 introduced the `qwen/qwen3.6-27b` collision that #442 then had to fix.
- Image/video/audio models bill output per modality and must stay unpriced until there's a modality-aware column. A plausible-looking wrong number is worse than a visible NULL, and that reasoning is easy to lose.
- Mistral's `*-latest` ids are moving pointers that re-price without a new model appearing, so they need re-verifying every run even when the catalogue looks unchanged.

## Contents

| File | What it holds |
|---|---|
| `SKILL.md` | The workflow: read state → pull official pages → classify by customer impact → collision check → migration → mirror → verify → ship |
| `references/providers.md` | Per-provider URLs, the extraction technique that actually works for each, and the traps |

Also records dated obligations that won't announce themselves — currently `claude-sonnet-5` leaving introductory pricing on 2026-09-01, which would otherwise under-report by 33%.

## Routine

A cloud routine (`trig_011D8Dh13u6UvTevGXPywtCG`) runs this on the 1st and 15th at 09:07 KST, opens a PR when it finds drift, and stays quiet when it doesn't. It reads the skill from `main`, so this needs to merge before its first run on 2026-08-01.

The routine has no MCP connectors, so it audits against the repo mirrors rather than querying production. That only stays valid while migrations keep the seed and `FALLBACK_PRICES` in sync — which is precisely what the skill's workflow enforces.

## Test plan

- [x] Docs only — no code paths touched
- [ ] First real exercise is the routine's 2026-08-01 run