### PR TITLE
feat(web): rewrite compare page SERP snippets from GSC query data

### DIFF
--- a/apps/web/app/compare/arize-phoenix/page.tsx
+++ b/apps/web/app/compare/arize-phoenix/page.tsx
@@ -2,9 +2,9 @@ import { CompareTemplate, type CompareGroup, type ComparePoint } from '@/compone
 
 export const metadata = {
   alternates: { canonical: '/compare/arize-phoenix' },
-  title: 'Spanlens vs Arize Phoenix · 2026 Comparison',
+  title: 'Arize Phoenix Is ELv2, Not OSI Open Source',
   description:
-    'Arize Phoenix has deep ML-engineer DNA. Spanlens is built for app developers shipping LLM features, with proxy-first install and first-class JS/TS.',
+    'Phoenix ships under Elastic License 2.0, which restricts hosted resale. Spanlens is MIT with no EE folder and self-hosts with one Docker command.',
 }
 
 const whySpanlens: ComparePoint[] = [

--- a/apps/web/app/compare/helicone/page.tsx
+++ b/apps/web/app/compare/helicone/page.tsx
@@ -2,9 +2,9 @@ import { CompareTemplate, type CompareGroup, type ComparePoint } from '@/compone
 
 export const metadata = {
   alternates: { canonical: '/compare/helicone' },
-  title: 'Spanlens vs Helicone · 2026 Comparison',
+  title: 'Helicone Alternative After the Mintlify Acquisition',
   description:
-    'Spanlens and Helicone are both proxy-based LLM observability tools. Spanlens adds Critical Path agent tracing, Prompt A/B testing, and durable logging.',
+    'Helicone entered maintenance mode after Mintlify acquired it in March 2026. Spanlens is MIT, still shipping, and swaps in with the same one-line baseURL.',
 }
 
 const whySpanlens: ComparePoint[] = [


### PR DESCRIPTION
## What

Rewrites `title` and `description` on two compare pages. Metadata only, page bodies untouched.

## Why

GSC (90 days) shows both pages rank but never get clicked:

| Page | Impressions | Clicks | Avg position |
|---|---|---|---|
| `/compare/helicone` | 142 | 0 | 10.8 |
| `/compare/arize-phoenix` | 138 | 0 | 13.4 |

For comparison, pages at position 5–6 convert normally on this domain (homepage 3.3% CTR, `/demo/dashboard` 6.7%). Zero clicks at position 10–13 is below what position alone predicts.

Per-page query data explains the gap:

```
/compare/helicone        helicone vs portkey (5)
                         helicone mintlify acquisition maintenance mode 2026 (1)
                         helicone proxy (1)

/compare/arize-phoenix   arize phoenix open source (3)
                         arize phoenix license elastic license 2.0 (1)
                         arize phoenix pricing (2)
```

Searchers arrive asking about **the acquisition** and about **licensing**. The old descriptions opened with what the tools have in common ("both proxy-based LLM observability tools"), which gives someone shopping for an alternative no reason to click.

## Changes

**`/compare/helicone`**
```diff
- Spanlens vs Helicone · 2026 Comparison
+ Helicone Alternative After the Mintlify Acquisition

- Spanlens and Helicone are both proxy-based LLM observability tools. Spanlens adds Critical Path agent tracing, Prompt A/B testing, and durable logging.
+ Helicone entered maintenance mode after Mintlify acquired it in March 2026. Spanlens is MIT, still shipping, and swaps in with the same one-line baseURL.
```

**`/compare/arize-phoenix`**
```diff
- Spanlens vs Arize Phoenix · 2026 Comparison
+ Arize Phoenix Is ELv2, Not OSI Open Source

- Arize Phoenix has deep ML-engineer DNA. Spanlens is built for app developers shipping LLM features, with proxy-first install and first-class JS/TS.
+ Phoenix ships under Elastic License 2.0, which restricts hosted resale. Spanlens is MIT with no EE folder and self-hosts with one Docker command.
```

Character budget: titles 51 and 42 (limit 60), descriptions 153 and 145 (limit 155).

## Claim sourcing

Every factual claim is quotable from a primary source, and no evaluative language is used about either competitor — only license names and dates.

- Maintenance mode: helicone.ai/blog/joining-mintlify (vendor's own wording)
- Acquisition date March 2026: mintlify.com/blog/mintlify-acquires-helicone
- ELv2 restricting hosted resale: Elastic License 2.0 text
- MIT: repository LICENSE

## Scope note

Two more pages were considered and dropped after checking their queries:

- `/docs/self-host` (442 impressions) ranks for debugging queries like `curl http://localhost:3001/health` and `gotrue_mailer_external_hosts`. Those visitors are troubleshooting Supabase, not shopping for observability. Zero CTR there is correct behavior, not a snippet problem.
- `/changelog` (168 impressions) returns no query data at all — every impression falls below the GSC privacy threshold, so there is no intent to write toward.

## Measurement

Combined baseline is 0 clicks on 280 impressions. Recheck 2026-08-26 (4 weeks). Three or more combined clicks counts as success; zero or one indicates position, not copy, is the binding constraint.

One caveat when reading the result: Google often ignores `description` and generates its own snippet from page text. The rendered SERP result should be checked by eye alongside the numbers, otherwise "the copy did not work" is indistinguishable from "Google did not use the copy."