### PR TITLE
fix(web): stop settings crash from colliding current-user query key

### DIFF
--- a/apps/web/lib/queries/query-key-uniqueness.test.ts
+++ b/apps/web/lib/queries/query-key-uniqueness.test.ts
@@ -18,8 +18,15 @@ import { describe, expect, it } from 'vitest'
 
 const QUERIES_DIR = join(__dirname)
 
-/** Matches `queryKey: ['a', 'b']`, allowing a trailing `as const`. */
-const STATIC_KEY = /queryKey:\s*\[((?:\s*'[^']*'\s*,?)+)\]/
+/**
+ * Captures the contents of a single-line `queryKey: [...]`. Deliberately one
+ * flat character class rather than a repeated group of segments: a nested
+ * quantifier here is an ReDoS shape (CodeQL js/redos) even though this only
+ * ever reads our own source.
+ */
+const KEY_ARRAY = /queryKey:\s*\[([^\]\n]*)\]/
+/** A key segment that is a plain string literal, e.g. `'current-user'`. */
+const STRING_SEGMENT = /^'[^']*'$/
 
 /**
  * Cache-management calls (`invalidateQueries`, `cancelQueries`,
@@ -35,13 +42,14 @@ function collectStaticKeys(): Map<string, string[]> {
     const lines = readFileSync(join(QUERIES_DIR, file), 'utf8').split('\n')
     lines.forEach((line, i) => {
       if (CACHE_CALL.test(line)) return
-      const match = STATIC_KEY.exec(line)
+      const match = KEY_ARRAY.exec(line)
       if (!match) return
-      const key = match[1]!
-        .split(',')
-        .map((s) => s.trim().replace(/^'|'$/g, ''))
-        .filter(Boolean)
-        .join(' > ')
+      const segments = match[1]!.split(',').map((s) => s.trim()).filter(Boolean)
+      // A spread, helper call or variable segment means the key is scoped by
+      // that value and may legitimately repeat, so it is not a static key.
+      if (segments.length === 0) return
+      if (!segments.every((s) => STRING_SEGMENT.test(s))) return
+      const key = segments.map((s) => s.slice(1, -1)).join(' > ')
       const sites = found.get(key) ?? []
       sites.push(`${file}:${i + 1}`)
       found.set(key, sites)

--- a/apps/web/lib/queries/query-key-uniqueness.test.ts
+++ b/apps/web/lib/queries/query-key-uniqueness.test.ts
@@ -1,0 +1,67 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Source guard: two hooks must never declare the same static queryKey.
+ *
+ * TanStack Query caches by key, so two `useQuery` declarations sharing a key
+ * share one cache entry — the queryFn that resolves last wins and every
+ * consumer gets that shape. `useCurrentUser` (a `CurrentUser` object) and the
+ * old inline query inside `useCurrentMember` (an email string) both used
+ * `['current-user']`, which crashed the whole /settings route with
+ * "email.toLowerCase is not a function" whenever the object won the race.
+ *
+ * Only fully-static keys are checked: keys built from a helper or containing a
+ * variable segment are scoped by that variable and can legitimately repeat.
+ */
+
+const QUERIES_DIR = join(__dirname)
+
+/** Matches `queryKey: ['a', 'b']`, allowing a trailing `as const`. */
+const STATIC_KEY = /queryKey:\s*\[((?:\s*'[^']*'\s*,?)+)\]/
+
+/**
+ * Cache-management calls (`invalidateQueries`, `cancelQueries`,
+ * `setQueriesData`, ...) reference keys other hooks own. Repeating a key there
+ * is the point, so those lines are not declarations.
+ */
+const CACHE_CALL = /(invalidate|cancel|remove|refetch|reset|get|set)Quer(y|ies)/
+
+function collectStaticKeys(): Map<string, string[]> {
+  const found = new Map<string, string[]>()
+  for (const file of readdirSync(QUERIES_DIR)) {
+    if (!file.endsWith('.ts') || file.endsWith('.test.ts')) continue
+    const lines = readFileSync(join(QUERIES_DIR, file), 'utf8').split('\n')
+    lines.forEach((line, i) => {
+      if (CACHE_CALL.test(line)) return
+      const match = STATIC_KEY.exec(line)
+      if (!match) return
+      const key = match[1]!
+        .split(',')
+        .map((s) => s.trim().replace(/^'|'$/g, ''))
+        .filter(Boolean)
+        .join(' > ')
+      const sites = found.get(key) ?? []
+      sites.push(`${file}:${i + 1}`)
+      found.set(key, sites)
+    })
+  }
+  return found
+}
+
+describe('query key uniqueness', () => {
+  const keys = collectStaticKeys()
+
+  it('finds the static keys it is meant to guard', () => {
+    expect(keys.size).toBeGreaterThan(3)
+    expect(keys.has('current-user')).toBe(true)
+  })
+
+  it('declares every static query key exactly once', () => {
+    const duplicates = [...keys.entries()].filter(([, sites]) => sites.length > 1)
+    expect(
+      duplicates.map(([key, sites]) => `['${key}'] declared at ${sites.join(', ')}`),
+    ).toEqual([])
+  })
+})

--- a/apps/web/lib/queries/use-members.ts
+++ b/apps/web/lib/queries/use-members.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiDelete, apiGet, apiPatch, apiPost } from '@/lib/api'
 import { useOrganization } from './use-organization'
+import { useCurrentUser } from './use-current-user'
 import type { ApiEnvelope } from './types'
 
 export type OrgRole = 'admin' | 'editor' | 'viewer'
@@ -132,46 +133,19 @@ export function useCancelInvitation() {
 }
 
 /**
- * The current user's role in their organization. Null while loading or when
- * the user has no org. Used by UI permission gates — ALWAYS paired with
- * server-side `requireRole` since the client can be tampered with.
- */
-export function useCurrentRole(): OrgRole | null {
-  const members = useMembers()
-  const userQuery = useQuery<{ userId: string | null }>({
-    queryKey: ['current-user', 'id'],
-    queryFn: async () => {
-      const res = await apiGet<ApiEnvelope<{ id: string }>>('/api/v1/organizations/me')
-      // The endpoint returns the org, not the user — we need a user-id source.
-      // Fall back to parsing the auth cookie via a small dedicated endpoint in future.
-      return { userId: res.data?.id ? null : null }
-    },
-    enabled: false, // we use members list + current user id via Supabase session
-  })
-  void userQuery
-  // Simpler path: use Supabase's session for user id.
-  // members hook already has the roster; match by email in the consuming component.
-  if (!members.data) return null
-  // Caller should prefer `useCurrentMember()` instead.
-  return null
-}
-
-/**
  * Find the current user's member row by matching email against the Supabase
  * session email. Returns null while loading.
+ *
+ * Reuses `useCurrentUser()` rather than declaring its own query: both once used
+ * the `['current-user']` key with different result shapes, so whichever queryFn
+ * resolved last won the shared cache entry and this hook could receive a
+ * `CurrentUser` object where it expected a string.
  */
 export function useCurrentMember(): Member | null {
   const members = useMembers()
-  const userQuery = useQuery({
-    queryKey: ['current-user'],
-    queryFn: async () => {
-      const { createClient } = await import('@/lib/supabase/client')
-      const supabase = createClient()
-      const { data } = await supabase.auth.getSession()
-      return data.session?.user.email ?? null
-    },
-  })
-  const email = userQuery.data
+  const user = useCurrentUser()
+  const email = user.data?.email
   if (!email || !members.data) return null
-  return members.data.find((m) => m.email.toLowerCase() === email.toLowerCase()) ?? null
+  const needle = email.toLowerCase()
+  return members.data.find((m) => m.email?.toLowerCase() === needle) ?? null
 }


### PR DESCRIPTION
## Problem

`https://www.spanlens.io/settings` crashes for signed-in users with a route-level error boundary hit:

```
TypeError: a.toLowerCase is not a function
    at Array.find (<anonymous>)
[route-error:other] TypeError: a.toLowerCase is not a function
```

Deminifying the production chunk points at `useCurrentMember`:

```js
t.data.find(e => e.email.toLowerCase() === a.toLowerCase())
```

`a` is the session email, and it was not a string.

## Root cause

Two hooks declared the same TanStack Query key with different result shapes:

| Hook | queryKey | Result |
|---|---|---|
| `useCurrentUser` (`use-current-user.ts:17`) | `['current-user']` | `{ id, email, created_at }` |
| inline query in `useCurrentMember` (`use-members.ts:166`) | `['current-user']` | email `string \| null` |

One key means one cache entry, so whichever `queryFn` resolved last won it and both consumers got that value. `useCurrentUser` mounts on every dashboard page through `posthog-provider`, and `/settings` mounts `useCurrentMember` in four places, so the two raced on each load. When the object won, `useCurrentMember` called `.toLowerCase()` on a `CurrentUser` and took down the whole route. Intermittent by nature, which is why it presented as a page that sometimes worked.

## Fix

- `useCurrentMember` reuses `useCurrentUser()` instead of declaring a second query under the same key. No extra request: that query is already in flight on every dashboard page.
- Removes the dead `useCurrentRole` in `use-members.ts`. It always returned `null`, held a disabled query, and nothing imported it. The live implementation is in `use-current-role.ts`.
- Adds `lib/queries/query-key-uniqueness.test.ts`, a source guard that fails when two hooks in `lib/queries` declare the same static query key. Cache-management calls (`invalidateQueries` and friends) and keys with variable segments are excluded, since repeating a key there is intended.

## Test plan

- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint`
- [x] `pnpm --filter web test` (71 passed, including the new guard)
- [x] Verified the guard regexes match both old `['current-user']` declarations, so this regression would have failed CI
- [ ] Preview deploy: load `/settings` signed in, reload several times, confirm no error boundary and that role-gated controls still resolve (admin sees the org-name save button enabled)

The last item needs a signed-in session, so it is left for preview.
