### PR TITLE
chore: add local seed and integration smoke scripts

### DIFF
--- a/apps/server/scripts/test-vercel-ai-integration.ts
+++ b/apps/server/scripts/test-vercel-ai-integration.ts
@@ -1,0 +1,208 @@
+/**
+ * End-to-end smoke test for the @spanlens/sdk Vercel AI integration.
+ *
+ * Drives `createSpanlensTracker` through the same callback shape Vercel AI
+ * SDK's `generateText` / `streamText` emit, then verifies the trace + span
+ * actually landed in Supabase. Runs against the local server (localhost:3001)
+ * — no real OpenAI call needed (the tracker is duck-typed on the callback
+ * objects, not the AI SDK package).
+ *
+ * Run:
+ *   pnpm --filter server tsx scripts/test-vercel-ai-integration.ts
+ */
+import 'dotenv/config'
+import { createClient } from '@supabase/supabase-js'
+import { randomUUID } from 'node:crypto'
+// Local relative imports — apps/server doesn't declare @spanlens/sdk as a
+// workspace dep, so we point at the built dist directly. Run
+// `pnpm --filter sdk build` before this script if the dist is stale.
+import { SpanlensClient } from '../../../packages/sdk/dist/index.js'
+import { createSpanlensTracker } from '../../../packages/sdk/dist/integrations/vercel-ai.js'
+
+const SERVER_URL = 'http://localhost:3001'
+const SUPABASE_URL = process.env['SUPABASE_URL'] ?? 'http://127.0.0.1:54321'
+const SUPABASE_SERVICE_ROLE =
+  process.env['SUPABASE_SERVICE_ROLE_KEY'] ??
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU'
+const SUPABASE_ANON =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0'
+
+const TEST_EMAIL = 'testuser@spanlens.local'
+const TEST_PASSWORD = 'TestPass123!'
+
+function log(...args: unknown[]): void {
+  console.log(...args)
+}
+
+async function getJwt(): Promise<string> {
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: { apikey: SUPABASE_ANON, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: TEST_EMAIL, password: TEST_PASSWORD }),
+  })
+  if (!res.ok) throw new Error(`auth login: ${res.status} ${await res.text()}`)
+  const body = (await res.json()) as { access_token: string }
+  return body.access_token
+}
+
+async function findOrCreateProject(jwt: string): Promise<{ projectId: string }> {
+  // GET existing projects
+  const listRes = await fetch(`${SERVER_URL}/api/v1/projects`, {
+    headers: { Authorization: `Bearer ${jwt}` },
+  })
+  if (listRes.ok) {
+    const env = (await listRes.json()) as { data: Array<{ id: string; name: string }> }
+    const first = env.data?.[0]
+    if (first) return { projectId: first.id }
+  }
+  throw new Error('no project found for test account — seed first')
+}
+
+async function issueFullKey(jwt: string, projectId: string): Promise<string> {
+  const name = `vercel-ai-smoke-${randomUUID().slice(0, 8)}`
+  const res = await fetch(`${SERVER_URL}/api/v1/api-keys/issue`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${jwt}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, projectId, scope: 'full' }),
+  })
+  if (!res.ok) throw new Error(`issue key: ${res.status} ${await res.text()}`)
+  const body = (await res.json()) as { data: { key: string } }
+  return body.data.key
+}
+
+async function fetchTraceWithSpans(
+  supabase: ReturnType<typeof createClient>,
+  traceName: string,
+  startedAfterMs: number,
+): Promise<{ trace: any; spans: any[] } | null> {
+  // Poll a few times — ingest is fire-and-forget so the trace lands a beat
+  // after onFinish returns.
+  for (let i = 0; i < 6; i++) {
+    const { data: trace } = await supabase
+      .from('traces')
+      .select('*')
+      .eq('name', traceName)
+      .gte('created_at', new Date(startedAfterMs).toISOString())
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+    if (trace) {
+      const { data: spans } = await supabase
+        .from('spans')
+        .select('*')
+        .eq('trace_id', (trace as { id: string }).id)
+        .order('started_at', { ascending: true })
+      return { trace, spans: spans ?? [] }
+    }
+    await new Promise((r) => setTimeout(r, 500))
+  }
+  return null
+}
+
+async function main(): Promise<void> {
+  log('━'.repeat(64))
+  log('  Vercel AI SDK integration smoke test')
+  log('━'.repeat(64))
+
+  log('\n[1] Logging in as test account...')
+  const jwt = await getJwt()
+  log('    JWT acquired')
+
+  log('\n[2] Looking up a project to attach the key to...')
+  const { projectId } = await findOrCreateProject(jwt)
+  log(`    project: ${projectId}`)
+
+  log('\n[3] Issuing a full-access Spanlens key (ingest requires full)...')
+  const apiKey = await issueFullKey(jwt, projectId)
+  log(`    key: ${apiKey.slice(0, 18)}...${apiKey.slice(-6)}`)
+
+  log('\n[4] Setting up SpanlensClient + createSpanlensTracker...')
+  const client = new SpanlensClient({ apiKey, baseUrl: SERVER_URL })
+  const traceName = `ai.generate.smoke-${randomUUID().slice(0, 8)}`
+  const startedAtMs = Date.now()
+  const tracker = createSpanlensTracker({ client, traceName, modelName: 'gpt-4o-mini' })
+  log(`    trace started: ${traceName}`)
+
+  log('\n[5] Simulating a 2-step tool call run...')
+  // Mirror the shape Vercel AI SDK's onStepFinish emits between tool calls.
+  await tracker.onStepFinish({
+    usage: { promptTokens: 480, completionTokens: 30, totalTokens: 510 },
+    finishReason: 'tool-calls',
+    stepType: 'initial',
+    text: '',
+    response: { id: 'resp_step1', modelId: 'gpt-4o-mini-2024-07-18' },
+  })
+  await tracker.onStepFinish({
+    usage: { promptTokens: 950, completionTokens: 84, totalTokens: 1034 },
+    finishReason: 'stop',
+    stepType: 'continue',
+    text: 'Refund processed. The order will be re-shipped within 2 business days.',
+    response: { id: 'resp_step2', modelId: 'gpt-4o-mini-2024-07-18' },
+  })
+  log('    onStepFinish × 2 OK')
+
+  log('\n[6] Firing onFinish with cumulative usage...')
+  await tracker.onFinish({
+    usage: { promptTokens: 1430, completionTokens: 114, totalTokens: 1544 },
+    finishReason: 'stop',
+    text: 'Refund processed. The order will be re-shipped within 2 business days.',
+    response: { id: 'resp_final', modelId: 'gpt-4o-mini-2024-07-18' },
+  })
+  await client.flush()
+  log('    onFinish fired + client.flush() returned')
+
+  log('\n[7] Verifying trace + span landed in Supabase...')
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+  const found = await fetchTraceWithSpans(supabase, traceName, startedAtMs - 1000)
+  if (!found) {
+    throw new Error('trace not found after polling — ingest did not complete')
+  }
+
+  log('\n' + '━'.repeat(64))
+  log('  ✅ trace landed')
+  log('━'.repeat(64))
+  log(`  trace.id          : ${found.trace.id}`)
+  log(`  trace.name        : ${found.trace.name}`)
+  log(`  trace.status      : ${found.trace.status}`)
+  log(`  trace.duration_ms : ${found.trace.duration_ms}`)
+  log(`  trace.span_count  : ${found.trace.span_count}`)
+  log(`  trace.total_tokens: ${found.trace.total_tokens}`)
+  log(`  trace.cost_usd    : ${found.trace.total_cost_usd}`)
+  log(`\n  spans (${found.spans.length}):`)
+  for (const s of found.spans) {
+    log(`    - [${s.span_type}] ${s.name}`)
+    log(`         status=${s.status}  duration=${s.duration_ms}ms`)
+    log(`         tokens=${s.prompt_tokens}/${s.completion_tokens}/${s.total_tokens}`)
+    log(`         metadata=${JSON.stringify(s.metadata)}`)
+  }
+  log('━'.repeat(64))
+
+  // Assertions
+  const expectedSpan = found.spans.find((s) => s.span_type === 'llm')
+  if (!expectedSpan) {
+    throw new Error('FAIL: no llm span recorded')
+  }
+  if (expectedSpan.total_tokens !== 1544) {
+    throw new Error(
+      `FAIL: total_tokens mismatch — got ${expectedSpan.total_tokens}, expected 1544`,
+    )
+  }
+  if (expectedSpan.status !== 'completed') {
+    throw new Error(`FAIL: span status — got ${expectedSpan.status}, expected completed`)
+  }
+  const meta = expectedSpan.metadata as { model?: string; finishReason?: string; steps?: number }
+  if (meta?.model !== 'gpt-4o-mini-2024-07-18') {
+    throw new Error(`FAIL: model not resolved from response — got ${meta?.model}`)
+  }
+  if (meta?.steps !== 2) {
+    throw new Error(`FAIL: step count not tracked — got ${meta?.steps}, expected 2`)
+  }
+  log('\n  ✅ assertions: tokens / status / model / step count all match\n')
+}
+
+main().catch((err) => {
+  console.error('\n❌ smoke test failed:', err)
+  process.exit(1)
+})

--- a/apps/server/scripts/test-vercel-ai-integration.ts
+++ b/apps/server/scripts/test-vercel-ai-integration.ts
@@ -114,10 +114,11 @@ async function main(): Promise<void> {
 
   log('\n[3] Issuing a full-access Spanlens key (ingest requires full)...')
   const apiKey = await issueFullKey(jwt, projectId)
-  // Never print key material, not even a truncated prefix: `sl_live_` is a
-  // fixed 8 chars, so a 18-char prefix leaks 10 hex chars of the secret.
-  // The scope is the only part worth confirming here.
-  log(`    key issued (scope: full, ${apiKey.length} chars)`)
+  // Nothing derived from the key goes to stdout, not a truncated prefix and
+  // not its length: `sl_live_` is a fixed 8 chars, so an 18-char prefix leaked
+  // 10 hex chars of the secret, and CodeQL treats any read off `apiKey` as a
+  // clear-text-logging sink. The call below either works or throws.
+  log('    key issued (scope: full)')
 
   log('\n[4] Setting up SpanlensClient + createSpanlensTracker...')
   const client = new SpanlensClient({ apiKey, baseUrl: SERVER_URL })

--- a/apps/server/scripts/test-vercel-ai-integration.ts
+++ b/apps/server/scripts/test-vercel-ai-integration.ts
@@ -114,7 +114,10 @@ async function main(): Promise<void> {
 
   log('\n[3] Issuing a full-access Spanlens key (ingest requires full)...')
   const apiKey = await issueFullKey(jwt, projectId)
-  log(`    key: ${apiKey.slice(0, 18)}...${apiKey.slice(-6)}`)
+  // Never print key material, not even a truncated prefix: `sl_live_` is a
+  // fixed 8 chars, so a 18-char prefix leaks 10 hex chars of the secret.
+  // The scope is the only part worth confirming here.
+  log(`    key issued (scope: full, ${apiKey.length} chars)`)
 
   log('\n[4] Setting up SpanlensClient + createSpanlensTracker...')
   const client = new SpanlensClient({ apiKey, baseUrl: SERVER_URL })

--- a/scripts/seed-demo-data.ts
+++ b/scripts/seed-demo-data.ts
@@ -38,7 +38,11 @@ const ch = createClickHouseClient({
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 const uuid = () => crypto.randomUUID()
 const rand = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min
-const pick = <T>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)]
+// crypto.randomInt rather than Math.random: `pick` also chooses the seeded
+// user_id / session_id values, and CodeQL (js/insecure-randomness) treats any
+// Math.random feeding an identifier as a finding. Seed data doesn't need
+// unpredictability, but a CSPRNG costs nothing here and keeps the scan clean.
+const pick = <T>(arr: T[]): T => arr[crypto.randomInt(arr.length)]
 const toChTs = (d: Date) => d.toISOString().replace('T', ' ').replace('Z', '').slice(0, 23)
 const daysAgo = (n: number): Date => {
   const d = new Date()

--- a/scripts/seed-demo-data.ts
+++ b/scripts/seed-demo-data.ts
@@ -1,0 +1,598 @@
+/**
+ * Seed demo data for demo@spanlens.io
+ * Run: pnpm --filter server exec tsx ../../scripts/seed-demo-data.ts
+ */
+
+import { createClient } from '@supabase/supabase-js'
+import { createClient as createClickHouseClient } from '@clickhouse/client'
+import crypto from 'node:crypto'
+
+// ─── Config ─────────────────────────────────────────────────────────────────
+// Target workspace. Override per-environment via env vars so the script is not
+// pinned to one seeded org: SEED_ORG_ID / SEED_PROJECT_ID / SEED_API_KEY_ID /
+// SEED_USER_ID. Defaults point at the local demo@spanlens.io workspace.
+function required(name: string, fallback: string): string {
+  const value = process.env[name]?.trim()
+  return value && value.length > 0 ? value : fallback
+}
+
+const ORG_ID = required('SEED_ORG_ID', '5d98e450-b0a8-4361-bc8e-c30be1992983')
+const PROJECT_ID = required('SEED_PROJECT_ID', 'f00e80cf-6d94-4281-98ba-e731063463fb')
+const API_KEY_ID = required('SEED_API_KEY_ID', 'fed8bdde-b4b2-4646-a9a3-74d1ea44d3ac')
+const USER_ID = required('SEED_USER_ID', '0ee3a733-5d80-47df-b708-106416b00f82')
+
+const sb = createClient(
+  required('SUPABASE_URL', 'http://127.0.0.1:54321'),
+  required(
+    'SUPABASE_SERVICE_ROLE_KEY',
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU',
+  ),
+)
+const ch = createClickHouseClient({
+  url: required('CLICKHOUSE_URL', 'http://localhost:8123'),
+  username: required('CLICKHOUSE_USER', 'spanlens'),
+  password: required('CLICKHOUSE_PASSWORD', 'spanlens'),
+  database: required('CLICKHOUSE_DB', 'spanlens'),
+})
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+const uuid = () => crypto.randomUUID()
+const rand = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min
+const pick = <T>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)]
+const toChTs = (d: Date) => d.toISOString().replace('T', ' ').replace('Z', '').slice(0, 23)
+const daysAgo = (n: number): Date => {
+  const d = new Date()
+  d.setDate(d.getDate() - n)
+  d.setHours(rand(0, 23))
+  d.setMinutes(rand(0, 59))
+  d.setSeconds(rand(0, 59))
+  return d
+}
+
+async function insert<T extends Record<string, unknown>>(
+  table: string,
+  rows: T | T[],
+  opts: { onConflict?: string } = {},
+) {
+  const arr = Array.isArray(rows) ? rows : [rows]
+  const q = opts.onConflict
+    ? sb.from(table).upsert(arr as never, { onConflict: opts.onConflict, ignoreDuplicates: true })
+    : sb.from(table).insert(arr as never)
+  const { error } = await q
+  if (error) throw new Error(`Insert into ${table} failed: ${error.message}`)
+}
+
+// ─── Reference data ──────────────────────────────────────────────────────────
+const PROVIDERS = [
+  {
+    provider: 'openai',
+    models: ['gpt-4o', 'gpt-4o-mini', 'gpt-4o-mini-2024-07-18', 'o1-mini', 'gpt-3.5-turbo'],
+  },
+  {
+    provider: 'anthropic',
+    models: ['claude-opus-4-8', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'],
+  },
+  { provider: 'gemini', models: ['gemini-2.5-pro', 'gemini-2.0-flash'] },
+]
+const USERS = ['user_alice', 'user_bob', 'user_carol', 'user_dave', 'user_eve', 'user_frank']
+const SESSIONS = Array.from({ length: 15 }, (_, i) => `sess_${String(i + 1).padStart(3, '0')}`)
+const PRICE_MAP: Record<string, { inp: number; out: number }> = {
+  'gpt-4o': { inp: 0.0000025, out: 0.00001 },
+  'gpt-4o-mini': { inp: 0.00000015, out: 0.0000006 },
+  'gpt-4o-mini-2024-07-18': { inp: 0.00000015, out: 0.0000006 },
+  'o1-mini': { inp: 0.000003, out: 0.000012 },
+  'gpt-3.5-turbo': { inp: 0.0000005, out: 0.0000015 },
+  'claude-opus-4-8': { inp: 0.000015, out: 0.000075 },
+  'claude-sonnet-4-6': { inp: 0.000003, out: 0.000015 },
+  'claude-haiku-4-5-20251001': { inp: 0.00000025, out: 0.00000125 },
+  'gemini-2.5-pro': { inp: 0.00000125, out: 0.00001 },
+  'gemini-2.0-flash': { inp: 0.0000001, out: 0.0000004 },
+}
+
+// ─── 1. Prompt versions ───────────────────────────────────────────────────────
+async function seedPrompts(): Promise<string[]> {
+  console.log('Seeding prompt versions...')
+  const defs = [
+    {
+      name: 'customer-support',
+      versions: [
+        { v: 1, content: 'You are a helpful customer support agent. Answer concisely.' },
+        { v: 2, content: 'You are a friendly support specialist. Resolve issues empathetically.' },
+        { v: 3, content: 'You are an expert support agent. Always offer clear next steps.' },
+      ],
+    },
+    {
+      name: 'code-review',
+      versions: [
+        { v: 1, content: 'Review this code for bugs, style, and performance.' },
+        {
+          v: 2,
+          content:
+            'You are a senior engineer. Review for correctness, security, and maintainability.',
+        },
+      ],
+    },
+    {
+      name: 'rag-assistant',
+      versions: [
+        { v: 1, content: 'Answer using only the provided context. If unsure, say so.' },
+        {
+          v: 2,
+          content: 'Using the retrieved context, answer accurately. Cite sources when possible.',
+        },
+      ],
+    },
+  ]
+
+  const ids: string[] = []
+  for (const prompt of defs) {
+    for (const v of prompt.versions) {
+      const id = uuid()
+      ids.push(id)
+      await insert(
+        'prompt_versions',
+        {
+          id,
+          organization_id: ORG_ID,
+          project_id: PROJECT_ID,
+          name: prompt.name,
+          version: v.v,
+          content: v.content,
+          variables: {},
+          metadata: {},
+          created_by: USER_ID,
+          created_at: daysAgo(rand(5, 30)).toISOString(),
+          is_archived: false,
+        },
+        { onConflict: 'organization_id,name,version' },
+      )
+    }
+  }
+  console.log(`  Created ${ids.length} prompt versions`)
+  return ids
+}
+
+// ─── 2. ClickHouse requests ───────────────────────────────────────────────────
+async function seedRequests(promptVersionIds: string[]) {
+  console.log('Seeding ClickHouse requests...')
+
+  // SecurityFlag objects, not bare strings: the dashboard renders f.type and
+  // f.pattern per badge, so a plain string array renders empty badges.
+  const securityFlags = [
+    '[{"type":"injection","pattern":"ignore-previous","sample":"***ignore all previous instructions***"}]',
+    '[{"type":"pii","pattern":"email","sample":"te*****@e*****.com"}]',
+    '[{"type":"injection","pattern":"jailbreak","sample":"***pretend you have no rules***"}]',
+    '[{"type":"injection","pattern":"ignore-previous","sample":"***disregard the system prompt***"},{"type":"pii","pattern":"phone","sample":"+82-10-***-1234"}]',
+  ]
+
+  const rows: Record<string, unknown>[] = []
+
+  for (let day = 0; day < 30; day++) {
+    // Organic growth: fewer requests older days, more recent
+    const count = Math.max(10, Math.floor(12 + day * 1.8 + rand(-3, 5)))
+
+    for (let i = 0; i < count; i++) {
+      const pd = pick(PROVIDERS)
+      const model = pick(pd.models)
+      const provider = pd.provider
+      const promptTok = rand(80, 2000)
+      const completionTok = rand(40, 800)
+      const prices = PRICE_MAP[model] ?? { inp: 0.000002, out: 0.000008 }
+      const costUsd = promptTok * prices.inp + completionTok * prices.out
+      const isError = Math.random() < 0.05
+      const hasUser = Math.random() < 0.65
+      const hasPromptVer = promptVersionIds.length > 0 && Math.random() < 0.45
+      const hasFlags = Math.random() < 0.03
+
+      rows.push({
+        id: uuid(),
+        organization_id: ORG_ID,
+        project_id: PROJECT_ID,
+        api_key_id: API_KEY_ID,
+        provider,
+        model,
+        prompt_tokens: promptTok,
+        completion_tokens: completionTok,
+        total_tokens: promptTok + completionTok,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        cost_usd: costUsd,
+        latency_ms: rand(250, 4800),
+        proxy_overhead_ms: rand(5, 90),
+        status_code: isError ? pick([400, 429, 500, 503]) : 200,
+        request_body: JSON.stringify({
+          model,
+          messages: [
+            { role: 'system', content: 'You are a helpful assistant.' },
+            { role: 'user', content: `Query #${i} on day -${30 - day}` },
+          ],
+        }),
+        response_body: isError
+          ? JSON.stringify({ error: { message: 'Rate limit exceeded', type: 'rate_limit_error' } })
+          : JSON.stringify({
+              id: `chatcmpl-demo${i}`,
+              choices: [
+                {
+                  message: { role: 'assistant', content: 'Demo response.' },
+                  finish_reason: 'stop',
+                },
+              ],
+              usage: {
+                prompt_tokens: promptTok,
+                completion_tokens: completionTok,
+                total_tokens: promptTok + completionTok,
+              },
+            }),
+        error_message: isError ? 'Rate limit exceeded' : null,
+        trace_id: null,
+        span_id: null,
+        prompt_version_id: hasPromptVer ? pick(promptVersionIds) : null,
+        provider_key_id: null,
+        user_id: hasUser ? pick(USERS) : null,
+        session_id: hasUser ? pick(SESSIONS) : null,
+        // Both flag columns are JSON-encoded ARRAYS of SecurityFlag. Writing
+        // `{}` here makes the security page throw `resFlags.map is not a
+        // function` for any row with has_security_flags = 1.
+        flags: hasFlags ? pick(securityFlags) : '[]',
+        response_flags: '[]',
+        has_security_flags: hasFlags,
+        created_at: toChTs(daysAgo(30 - day)),
+        truncated: 0,
+        service_tier: '',
+      })
+    }
+  }
+
+  // Batch insert 100 at a time
+  for (let i = 0; i < rows.length; i += 100) {
+    await ch.insert({ table: 'requests', values: rows.slice(i, i + 100), format: 'JSONEachRow' })
+    process.stdout.write(`  ${Math.min(i + 100, rows.length)}/${rows.length} requests\r`)
+  }
+  console.log(`\n  Inserted ${rows.length} requests`)
+}
+
+// ─── 3. Traces + Spans ────────────────────────────────────────────────────────
+async function seedTraces() {
+  console.log('Seeding traces + spans...')
+
+  const scenarios = [
+    {
+      name: 'customer-support-agent',
+      spans: ['intent-parse', 'kb-retrieval', 'llm-respond', 'quality-check'],
+    },
+    { name: 'rag-pipeline', spans: ['embed-query', 'vector-search', 'rerank', 'llm-answer'] },
+    {
+      name: 'code-review-agent',
+      spans: ['parse-diff', 'security-scan', 'style-lint', 'summary-gen'],
+    },
+    { name: 'document-summarizer', spans: ['chunk-split', 'map-summarize', 'reduce-combine'] },
+    {
+      name: 'data-extraction',
+      spans: ['ocr-preprocess', 'llm-extract', 'schema-validate', 'post-process'],
+    },
+    {
+      name: 'multi-step-reasoning',
+      spans: ['decompose', 'search-step-1', 'search-step-2', 'synthesize'],
+    },
+    { name: 'content-moderation', spans: ['text-classify', 'policy-eval', 'action-dispatch'] },
+    {
+      name: 'email-drafter',
+      spans: ['context-fetch', 'tone-analysis', 'draft-gen', 'grammar-check'],
+    },
+    { name: 'api-orchestrator', spans: ['auth-check', 'upstream-call', 'transform-response'] },
+    {
+      name: 'onboarding-assistant',
+      spans: ['profile-load', 'recommendation-gen', 'personalize', 'send-msg'],
+    },
+  ]
+
+  let tc = 0,
+    sc = 0
+  for (const scenario of scenarios) {
+    for (let inst = 0; inst < 3; inst++) {
+      const traceId = uuid()
+      const traceStatus = Math.random() < 0.12 ? 'error' : 'completed'
+      const startTime = daysAgo(rand(0, 14))
+
+      let offset = 0
+      let totalDurationMs = 0
+      let totalTokens = 0
+      let totalCost = 0
+      const spanRows = []
+
+      let parentSpanId: string | null = null
+
+      for (let si = 0; si < scenario.spans.length; si++) {
+        const spanId = uuid()
+        const dur = rand(60, 1400)
+        const ptok = rand(50, 600)
+        const ctok = rand(20, 300)
+        const cost = ptok * 0.000002 + ctok * 0.000008
+        const isLastError = si === scenario.spans.length - 1 && traceStatus === 'error'
+
+        offset += si > 0 ? rand(10, 50) : 0
+        totalDurationMs += dur
+        totalTokens += ptok + ctok
+        totalCost += cost
+
+        spanRows.push({
+          id: spanId,
+          trace_id: traceId,
+          parent_span_id: si === 0 ? null : parentSpanId,
+          organization_id: ORG_ID,
+          name: scenario.spans[si],
+          span_type: pick(['llm', 'tool', 'retrieval', 'embedding', 'custom']),
+          status: isLastError ? 'error' : 'completed',
+          started_at: new Date(startTime.getTime() + offset).toISOString(),
+          ended_at: new Date(startTime.getTime() + offset + dur).toISOString(),
+          duration_ms: dur,
+          input: { step: si, query: `Input for ${scenario.spans[si]}` },
+          output: isLastError ? null : { result: 'ok', tokens: ptok + ctok },
+          metadata: { step_index: si },
+          error_message: isLastError ? 'Upstream timeout after 1400ms' : null,
+          request_id: null,
+          prompt_tokens: ptok,
+          completion_tokens: ctok,
+          total_tokens: ptok + ctok,
+          cost_usd: cost.toFixed(8),
+          created_at: startTime.toISOString(),
+        })
+
+        if (si === 0) parentSpanId = spanId
+        offset += dur
+      }
+
+      const { error: te } = await sb.from('traces').insert({
+        id: traceId,
+        organization_id: ORG_ID,
+        project_id: PROJECT_ID,
+        api_key_id: API_KEY_ID,
+        name: scenario.name,
+        status: traceStatus,
+        started_at: startTime.toISOString(),
+        ended_at: new Date(startTime.getTime() + totalDurationMs).toISOString(),
+        duration_ms: totalDurationMs,
+        metadata: { scenario: scenario.name, instance: inst },
+        error_message: traceStatus === 'error' ? 'Agent step failed' : null,
+        span_count: spanRows.length,
+        total_tokens: totalTokens,
+        total_cost_usd: totalCost.toFixed(8),
+        created_at: startTime.toISOString(),
+        updated_at: startTime.toISOString(),
+      })
+      if (te) {
+        console.warn(`  trace warn: ${te.message}`)
+        continue
+      }
+
+      const { error: se } = await sb.from('spans').insert(spanRows)
+      if (se) console.warn(`  span warn: ${se.message}`)
+
+      tc++
+      sc += spanRows.length
+    }
+  }
+  console.log(`  Created ${tc} traces, ${sc} spans`)
+}
+
+// ─── 4. Notification channels + alerts ───────────────────────────────────────
+async function seedAlerts(): Promise<string> {
+  console.log('Seeding notification channels + alerts...')
+
+  const emailChId = uuid()
+  await insert('notification_channels', {
+    id: emailChId,
+    organization_id: ORG_ID,
+    kind: 'email',
+    target: 'demo@spanlens.io',
+    label: 'Demo Email',
+    is_active: true,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  })
+
+  const slackChId = uuid()
+  await insert('notification_channels', {
+    id: slackChId,
+    organization_id: ORG_ID,
+    kind: 'slack',
+    target: 'https://hooks.slack.com/services/demo/placeholder',
+    label: '#llm-alerts',
+    is_active: false,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  })
+
+  const alertDefs = [
+    {
+      name: 'Monthly budget $50',
+      type: 'budget',
+      threshold: 50,
+      window_minutes: 43200,
+      cooldown_minutes: 1440,
+    },
+    {
+      name: 'Error rate > 5%',
+      type: 'error_rate',
+      threshold: 0.05,
+      window_minutes: 60,
+      cooldown_minutes: 60,
+    },
+    {
+      name: 'P95 latency > 3s',
+      type: 'latency_p95',
+      threshold: 3000,
+      window_minutes: 60,
+      cooldown_minutes: 120,
+    },
+    {
+      name: 'Weekly budget $10',
+      type: 'budget',
+      threshold: 10,
+      window_minutes: 10080,
+      cooldown_minutes: 720,
+    },
+  ]
+
+  for (const def of alertDefs) {
+    await insert('alerts', {
+      id: uuid(),
+      organization_id: ORG_ID,
+      project_id: PROJECT_ID,
+      name: def.name,
+      type: def.type,
+      threshold: def.threshold,
+      window_minutes: def.window_minutes,
+      is_active: true,
+      cooldown_minutes: def.cooldown_minutes,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+  }
+
+  console.log('  Created 2 channels, 4 alerts')
+  return emailChId
+}
+
+// ─── 5. Anomaly events ────────────────────────────────────────────────────────
+async function seedAnomalyEvents() {
+  console.log('Seeding anomaly events...')
+
+  const anomalies = [
+    {
+      provider: 'openai',
+      model: 'gpt-4o',
+      kind: 'latency',
+      current: 3850,
+      mean: 1200,
+      stddev: 280,
+    },
+    {
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      kind: 'cost',
+      current: 0.12,
+      mean: 0.04,
+      stddev: 0.01,
+    },
+    {
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      kind: 'error_rate',
+      current: 0.08,
+      mean: 0.02,
+      stddev: 0.008,
+    },
+    {
+      provider: 'gemini',
+      model: 'gemini-2.5-pro',
+      kind: 'latency',
+      current: 2800,
+      mean: 900,
+      stddev: 200,
+    },
+  ]
+
+  let count = 0
+  for (let day = 0; day < 14; day++) {
+    for (const a of anomalies) {
+      if (Math.random() < 0.4) continue
+      const detectedAt = daysAgo(day)
+      const deviations = (a.current - a.mean) / a.stddev
+      await insert(
+        'anomaly_events',
+        {
+          id: uuid(),
+          organization_id: ORG_ID,
+          detected_on: detectedAt.toISOString().slice(0, 10),
+          provider: a.provider,
+          model: a.model,
+          kind: a.kind,
+          current_value: a.current * (0.9 + Math.random() * 0.2),
+          baseline_mean: a.mean,
+          baseline_stddev: a.stddev,
+          deviations: parseFloat(deviations.toFixed(2)),
+          sample_count: rand(50, 300),
+          reference_count: rand(500, 3000),
+          detected_at: detectedAt.toISOString(),
+          confidence: deviations > 4 ? 'high' : deviations > 3 ? 'medium' : 'low',
+        },
+        { onConflict: 'organization_id,detected_on,provider,model,kind' },
+      )
+      count++
+    }
+  }
+  console.log(`  Created ${count} anomaly events`)
+}
+
+// ─── 6. Provider key ──────────────────────────────────────────────────────────
+async function seedProviderKey() {
+  console.log('Seeding provider key...')
+  const { data: existing } = await sb
+    .from('provider_keys')
+    .select('id')
+    .eq('api_key_id', API_KEY_ID)
+    .eq('provider', 'openai')
+    .eq('is_active', true)
+    .maybeSingle()
+  if (existing) {
+    console.log('  Provider key already exists, skipping')
+    return
+  }
+
+  await insert('provider_keys', {
+    id: uuid(),
+    organization_id: ORG_ID,
+    api_key_id: API_KEY_ID,
+    provider: 'openai',
+    name: 'Demo OpenAI Key',
+    encrypted_key: 'demo-encrypted-placeholder-not-usable',
+    is_active: true,
+    provider_metadata: {},
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  })
+  console.log('  Created 1 provider key')
+}
+
+// ─── 7. Webhook ───────────────────────────────────────────────────────────────
+async function seedWebhook() {
+  console.log('Seeding webhook...')
+  await insert('webhooks', {
+    id: uuid(),
+    organization_id: ORG_ID,
+    name: 'Demo Webhook',
+    url: 'https://example.com/webhook/demo',
+    secret: crypto.randomBytes(20).toString('hex'),
+    events: ['request.completed', 'anomaly.detected', 'alert.triggered'],
+    is_active: true,
+    created_at: new Date().toISOString(),
+  })
+  console.log('  Created 1 webhook')
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+async function main() {
+  console.log('=== Seeding demo@spanlens.io ===\n')
+  try {
+    const pvIds = await seedPrompts()
+    await seedRequests(pvIds)
+    await seedTraces()
+    await seedAlerts()
+    await seedAnomalyEvents()
+    await seedProviderKey()
+    await seedWebhook()
+
+    console.log('\n✓ Done!')
+    console.log('─────────────────────────────')
+    console.log('  Account:  demo@spanlens.io')
+    console.log('  Password: Demo1234!')
+    console.log('  URL:      http://localhost:3000')
+    console.log('─────────────────────────────')
+  } catch (err) {
+    console.error('\nFailed:', err)
+    process.exit(1)
+  }
+}
+
+main()

--- a/scripts/seed-recent-traffic.ts
+++ b/scripts/seed-recent-traffic.ts
@@ -1,0 +1,275 @@
+/**
+ * Seed the last 24 hours with dense traffic so the default dashboard window
+ * (24h) is populated. Complements seed-demo-data.ts, which spreads 30 days of
+ * history but leaves the most recent hours nearly empty.
+ *
+ * Run: pnpm --filter server exec tsx ../../scripts/seed-recent-traffic.ts
+ *
+ * Target workspace is overridable: SEED_ORG_ID / SEED_PROJECT_ID /
+ * SEED_API_KEY_ID. Defaults point at the local demo@spanlens.io workspace.
+ */
+
+import { createClient } from '@supabase/supabase-js'
+import { createClient as createClickHouseClient } from '@clickhouse/client'
+import crypto from 'node:crypto'
+
+function required(name: string, fallback: string): string {
+  const value = process.env[name]?.trim()
+  return value && value.length > 0 ? value : fallback
+}
+
+const ORG_ID = required('SEED_ORG_ID', '5d98e450-b0a8-4361-bc8e-c30be1992983')
+const PROJECT_ID = required('SEED_PROJECT_ID', 'f00e80cf-6d94-4281-98ba-e731063463fb')
+const API_KEY_ID = required('SEED_API_KEY_ID', 'fed8bdde-b4b2-4646-a9a3-74d1ea44d3ac')
+
+const sb = createClient(
+  required('SUPABASE_URL', 'http://127.0.0.1:54321'),
+  required(
+    'SUPABASE_SERVICE_ROLE_KEY',
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU',
+  ),
+)
+const ch = createClickHouseClient({
+  url: required('CLICKHOUSE_URL', 'http://localhost:8123'),
+  username: required('CLICKHOUSE_USER', 'spanlens'),
+  password: required('CLICKHOUSE_PASSWORD', 'spanlens'),
+  database: required('CLICKHOUSE_DB', 'spanlens'),
+})
+
+const uuid = () => crypto.randomUUID()
+const rand = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min
+const pick = <T>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)]!
+// ClickHouse DateTime64 rejects the ISO `T` separator and `Z` suffix.
+const toChTs = (d: Date) => d.toISOString().replace('T', ' ').replace('Z', '').slice(0, 23)
+
+const PROVIDERS = [
+  { provider: 'openai', models: ['gpt-4o', 'gpt-4o-mini-2024-07-18', 'o1-mini'] },
+  {
+    provider: 'anthropic',
+    models: ['claude-opus-4-8', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'],
+  },
+  { provider: 'gemini', models: ['gemini-2.5-pro', 'gemini-2.0-flash'] },
+]
+const USERS = ['user_alice', 'user_bob', 'user_carol', 'user_dave', 'user_eve', 'user_frank']
+const SESSIONS = Array.from({ length: 20 }, (_, i) => `sess_${String(i + 1).padStart(3, '0')}`)
+const PRICES: Record<string, { inp: number; out: number }> = {
+  'gpt-4o': { inp: 0.0000025, out: 0.00001 },
+  'gpt-4o-mini-2024-07-18': { inp: 0.00000015, out: 0.0000006 },
+  'o1-mini': { inp: 0.000003, out: 0.000012 },
+  'claude-opus-4-8': { inp: 0.000015, out: 0.000075 },
+  'claude-sonnet-4-6': { inp: 0.000003, out: 0.000015 },
+  'claude-haiku-4-5-20251001': { inp: 0.00000025, out: 0.00000125 },
+  'gemini-2.5-pro': { inp: 0.00000125, out: 0.00001 },
+  'gemini-2.0-flash': { inp: 0.0000001, out: 0.0000004 },
+}
+
+/**
+ * Requests per hour, indexed by hours-ago (0 = current hour).
+ * Shaped like real product traffic: a daytime plateau, a quiet night, and a
+ * busy current hour so the "last 1h" view is not empty either.
+ */
+function volumeForHoursAgo(hoursAgo: number): number {
+  const hourOfDay = (new Date(Date.now() - hoursAgo * 3_600_000).getHours() + 24) % 24
+  const daytime = hourOfDay >= 9 && hourOfDay <= 22
+  const base = daytime ? rand(22, 38) : rand(6, 14)
+  return hoursAgo === 0 ? Math.max(base, 18) : base
+}
+
+async function seedRequests(): Promise<number> {
+  console.log('Seeding last-24h requests...')
+  const rows: Record<string, unknown>[] = []
+
+  for (let hoursAgo = 0; hoursAgo < 24; hoursAgo++) {
+    const count = volumeForHoursAgo(hoursAgo)
+    for (let i = 0; i < count; i++) {
+      const pd = pick(PROVIDERS)
+      const model = pick(pd.models)
+      const promptTok = rand(120, 2400)
+      const completionTok = rand(60, 900)
+      const price = PRICES[model] ?? { inp: 0.000002, out: 0.000008 }
+      const isError = Math.random() < 0.045
+      const hasUser = Math.random() < 0.75
+      // Spread each hour's requests across its 60 minutes.
+      const ts = new Date(
+        Date.now() - hoursAgo * 3_600_000 - rand(0, 59) * 60_000 - rand(0, 59) * 1000,
+      )
+
+      rows.push({
+        id: uuid(),
+        organization_id: ORG_ID,
+        project_id: PROJECT_ID,
+        api_key_id: API_KEY_ID,
+        provider: pd.provider,
+        model,
+        prompt_tokens: promptTok,
+        completion_tokens: completionTok,
+        total_tokens: promptTok + completionTok,
+        cache_read_tokens: Math.random() < 0.25 ? rand(50, 800) : 0,
+        cache_write_tokens: 0,
+        cost_usd: promptTok * price.inp + completionTok * price.out,
+        latency_ms: rand(280, 5200),
+        proxy_overhead_ms: rand(4, 70),
+        status_code: isError ? pick([400, 429, 500, 503]) : 200,
+        request_body: JSON.stringify({
+          model,
+          messages: [
+            { role: 'system', content: 'You are a helpful assistant.' },
+            { role: 'user', content: `Request at T-${hoursAgo}h #${i}` },
+          ],
+        }),
+        response_body: isError
+          ? JSON.stringify({ error: { message: 'Rate limit exceeded', type: 'rate_limit_error' } })
+          : JSON.stringify({
+              id: `chatcmpl-recent${hoursAgo}-${i}`,
+              choices: [
+                { message: { role: 'assistant', content: 'Response.' }, finish_reason: 'stop' },
+              ],
+              usage: {
+                prompt_tokens: promptTok,
+                completion_tokens: completionTok,
+                total_tokens: promptTok + completionTok,
+              },
+            }),
+        error_message: isError ? 'Rate limit exceeded' : null,
+        trace_id: null,
+        span_id: null,
+        prompt_version_id: null,
+        provider_key_id: null,
+        user_id: hasUser ? pick(USERS) : null,
+        session_id: hasUser ? pick(SESSIONS) : null,
+        // Both flag columns are JSON-encoded ARRAYS of SecurityFlag. Writing
+        // `{}` here makes the security page throw `resFlags.map is not a
+        // function` as soon as a row is surfaced.
+        flags: '[]',
+        response_flags: '[]',
+        has_security_flags: false,
+        created_at: toChTs(ts),
+        truncated: 0,
+        service_tier: '',
+      })
+    }
+  }
+
+  for (let i = 0; i < rows.length; i += 200) {
+    await ch.insert({ table: 'requests', values: rows.slice(i, i + 200), format: 'JSONEachRow' })
+    process.stdout.write(`  ${Math.min(i + 200, rows.length)}/${rows.length}\r`)
+  }
+  console.log(`\n  Inserted ${rows.length} requests across the last 24h`)
+  return rows.length
+}
+
+async function seedTraces(): Promise<number> {
+  console.log('Seeding last-24h traces...')
+  const scenarios = [
+    {
+      name: 'customer-support-agent',
+      spans: ['intent-parse', 'kb-retrieval', 'llm-respond', 'quality-check'],
+    },
+    { name: 'rag-pipeline', spans: ['embed-query', 'vector-search', 'rerank', 'llm-answer'] },
+    {
+      name: 'multi-step-reasoning',
+      spans: ['decompose', 'search-step-1', 'search-step-2', 'synthesize'],
+    },
+    { name: 'document-summarizer', spans: ['chunk-split', 'map-summarize', 'reduce-combine'] },
+  ]
+
+  let traceCount = 0
+  for (const scenario of scenarios) {
+    for (let inst = 0; inst < 4; inst++) {
+      const traceId = uuid()
+      const isError = Math.random() < 0.2
+      const startTime = new Date(Date.now() - rand(5, 23 * 60) * 60_000)
+
+      let offset = 0
+      let totalMs = 0
+      let totalTokens = 0
+      let totalCost = 0
+      const spanRows: Record<string, unknown>[] = []
+      let parentSpanId: string | null = null
+
+      for (let si = 0; si < scenario.spans.length; si++) {
+        const spanId = uuid()
+        const dur = rand(80, 1600)
+        const ptok = rand(60, 700)
+        const ctok = rand(30, 350)
+        const cost = ptok * 0.000002 + ctok * 0.000008
+        const failsHere = isError && si === scenario.spans.length - 1
+
+        offset += si > 0 ? rand(10, 45) : 0
+        totalMs += dur
+        totalTokens += ptok + ctok
+        totalCost += cost
+
+        spanRows.push({
+          id: spanId,
+          trace_id: traceId,
+          parent_span_id: si === 0 ? null : parentSpanId,
+          organization_id: ORG_ID,
+          name: scenario.spans[si],
+          span_type: pick(['llm', 'tool', 'retrieval', 'embedding']),
+          status: failsHere ? 'error' : 'completed',
+          started_at: new Date(startTime.getTime() + offset).toISOString(),
+          ended_at: new Date(startTime.getTime() + offset + dur).toISOString(),
+          duration_ms: dur,
+          input: { step: si, query: `Input for ${scenario.spans[si]}` },
+          output: failsHere ? null : { result: 'ok', tokens: ptok + ctok },
+          metadata: { step_index: si },
+          error_message: failsHere ? 'Upstream timeout' : null,
+          request_id: null,
+          prompt_tokens: ptok,
+          completion_tokens: ctok,
+          total_tokens: ptok + ctok,
+          cost_usd: cost.toFixed(8),
+          created_at: startTime.toISOString(),
+        })
+
+        if (si === 0) parentSpanId = spanId
+        offset += dur
+      }
+
+      const { error: traceErr } = await sb.from('traces').insert({
+        id: traceId,
+        organization_id: ORG_ID,
+        project_id: PROJECT_ID,
+        api_key_id: API_KEY_ID,
+        name: scenario.name,
+        status: isError ? 'error' : 'completed',
+        started_at: startTime.toISOString(),
+        ended_at: new Date(startTime.getTime() + totalMs).toISOString(),
+        duration_ms: totalMs,
+        metadata: { scenario: scenario.name, instance: inst },
+        error_message: isError ? 'Agent step failed' : null,
+        span_count: spanRows.length,
+        total_tokens: totalTokens,
+        total_cost_usd: totalCost.toFixed(8),
+        created_at: startTime.toISOString(),
+        updated_at: startTime.toISOString(),
+      })
+      if (traceErr) {
+        console.warn(`  trace warn: ${traceErr.message}`)
+        continue
+      }
+
+      const { error: spanErr } = await sb.from('spans').insert(spanRows)
+      if (spanErr) console.warn(`  span warn: ${spanErr.message}`)
+      traceCount++
+    }
+  }
+  console.log(`  Created ${traceCount} traces in the last 24h`)
+  return traceCount
+}
+
+async function main() {
+  console.log('=== Seeding recent (last 24h) traffic ===\n')
+  try {
+    const requests = await seedRequests()
+    const traces = await seedTraces()
+    console.log('\nDone.')
+    console.log(`  ${requests} requests, ${traces} traces added to the last 24 hours`)
+  } catch (err) {
+    console.error('\nFailed:', err)
+    process.exit(1)
+  }
+}
+
+main()

--- a/scripts/seed-recent-traffic.ts
+++ b/scripts/seed-recent-traffic.ts
@@ -38,7 +38,9 @@ const ch = createClickHouseClient({
 
 const uuid = () => crypto.randomUUID()
 const rand = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min
-const pick = <T>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)]!
+// crypto.randomInt rather than Math.random: see the same helper in
+// seed-demo-data.ts (CodeQL js/insecure-randomness on seeded identifiers).
+const pick = <T>(arr: T[]): T => arr[crypto.randomInt(arr.length)]!
 // ClickHouse DateTime64 rejects the ISO `T` separator and `Z` suffix.
 const toChTs = (d: Date) => d.toISOString().replace('T', ' ').replace('Z', '').slice(0, 23)
 

--- a/supabase/seeds/dummy_traces.sql
+++ b/supabase/seeds/dummy_traces.sql
@@ -1,0 +1,332 @@
+-- Dummy traces + spans seed for local dev (Smoke Test Org)
+-- Run: docker exec -i supabase_db_Spanlens psql -U postgres -d postgres < supabase/seeds/dummy_traces.sql
+-- Cleanup: DELETE FROM traces WHERE organization_id = '5abce023-05c8-4e99-9b37-ea81b7e3e9ff';
+
+DO $$
+DECLARE
+  v_org_id   UUID := '5abce023-05c8-4e99-9b37-ea81b7e3e9ff';
+  v_proj_id  UUID := 'bb857d39-5ebc-4521-aab9-b0d81b46f742';
+  v_key_id   UUID := '8151e32c-2798-4761-bf7b-25fcfdf993f6';
+
+  v_trace UUID;
+  v_root  UUID;
+  v_a UUID; v_b UUID; v_c UUID; v_d UUID; v_e UUID; v_f UUID; v_g UUID;
+  v_start TIMESTAMPTZ;
+BEGIN
+
+  ------------------------------------------------------------------
+  -- TRACE 1: customer-support-agent (the hero trace for span tree)
+  -- 7 spans, parallel fan-out at step 3-4 (RAG + tool call)
+  ------------------------------------------------------------------
+  v_trace := gen_random_uuid();
+  v_start := now() - interval '12 minutes';
+
+  INSERT INTO traces (id, organization_id, project_id, api_key_id, name, status, started_at, ended_at, duration_ms, metadata)
+  VALUES (v_trace, v_org_id, v_proj_id, v_key_id,
+          'customer-support-agent', 'completed',
+          v_start, v_start + interval '3247 ms', 3247,
+          jsonb_build_object('user_id', 'u_42abc', 'session_id', 's_xyz', 'channel', 'in_app_chat'));
+
+  v_root := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     input, output, prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_root, v_trace, v_org_id, 'classify_intent', 'llm', 'completed',
+          v_start, v_start + interval '412 ms', 412,
+          '{"prompt":"Classify user intent","model":"gpt-4o-mini"}',
+          '{"intent":"refund_request","confidence":0.94}',
+          340, 22, 362, 0.000098);
+
+  v_a := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_a, v_trace, v_root, v_org_id, 'retrieve_order_history', 'retrieval', 'completed',
+          v_start + interval '420 ms', v_start + interval '688 ms', 268,
+          0, 0, 0, NULL);
+
+  v_b := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_b, v_trace, v_root, v_org_id, 'lookup_refund_policy', 'tool', 'completed',
+          v_start + interval '420 ms', v_start + interval '590 ms', 170,
+          0, 0, 0, NULL);
+
+  v_c := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     input, output, prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_c, v_trace, v_root, v_org_id, 'draft_response', 'llm', 'completed',
+          v_start + interval '700 ms', v_start + interval '2547 ms', 1847,
+          '{"prompt":"Draft a refund response using retrieved context","model":"gpt-4o"}',
+          '{"response":"Hi, I checked your order #4892..."}',
+          1820, 340, 2160, 0.0042);
+
+  v_d := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_d, v_trace, v_c, v_org_id, 'tone_check', 'llm', 'completed',
+          v_start + interval '2560 ms', v_start + interval '2890 ms', 330,
+          120, 18, 138, 0.000041);
+
+  v_e := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_e, v_trace, v_root, v_org_id, 'send_message', 'tool', 'completed',
+          v_start + interval '2900 ms', v_start + interval '3247 ms', 347,
+          0, 0, 0, NULL);
+
+  ------------------------------------------------------------------
+  -- TRACE 2: rag-document-qa (deep chain, 6 spans)
+  ------------------------------------------------------------------
+  v_trace := gen_random_uuid();
+  v_start := now() - interval '38 minutes';
+
+  INSERT INTO traces (id, organization_id, project_id, api_key_id, name, status, started_at, ended_at, duration_ms, metadata)
+  VALUES (v_trace, v_org_id, v_proj_id, v_key_id,
+          'rag-document-qa', 'completed',
+          v_start, v_start + interval '2104 ms', 2104,
+          jsonb_build_object('user_id', 'u_research_team', 'collection', 'product_docs_v3'));
+
+  v_root := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_root, v_trace, v_org_id, 'embed_query', 'embedding', 'completed',
+          v_start, v_start + interval '180 ms', 180,
+          24, 0, 24, 0.000003);
+
+  v_a := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms)
+  VALUES (v_a, v_trace, v_root, v_org_id, 'vector_search', 'retrieval', 'completed',
+          v_start + interval '185 ms', v_start + interval '405 ms', 220);
+
+  v_b := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_b, v_trace, v_a, v_org_id, 'rerank_results', 'llm', 'completed',
+          v_start + interval '410 ms', v_start + interval '720 ms', 310,
+          540, 12, 552, 0.000148);
+
+  v_c := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     input, output, prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_c, v_trace, v_b, v_org_id, 'synthesize_answer', 'llm', 'completed',
+          v_start + interval '730 ms', v_start + interval '2104 ms', 1374,
+          '{"model":"claude-sonnet-4-6","top_k":5}',
+          '{"answer":"Based on the docs, the rate limit is..."}',
+          2840, 410, 3250, 0.00891);
+
+  ------------------------------------------------------------------
+  -- TRACE 3: research-agent-deep (longer, with parallel branches)
+  ------------------------------------------------------------------
+  v_trace := gen_random_uuid();
+  v_start := now() - interval '2 hours';
+
+  INSERT INTO traces (id, organization_id, project_id, api_key_id, name, status, started_at, ended_at, duration_ms, metadata)
+  VALUES (v_trace, v_org_id, v_proj_id, v_key_id,
+          'research-agent-deep', 'completed',
+          v_start, v_start + interval '8420 ms', 8420,
+          jsonb_build_object('topic', 'competitor_analysis_q2'));
+
+  v_root := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_root, v_trace, v_org_id, 'plan_research', 'llm', 'completed',
+          v_start, v_start + interval '890 ms', 890,
+          480, 220, 700, 0.00136);
+
+  -- 3 parallel branches
+  v_a := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_a, v_trace, v_root, v_org_id, 'search_web', 'tool', 'completed',
+          v_start + interval '900 ms', v_start + interval '4200 ms', 3300,
+          0, 0, 0, NULL);
+
+  v_b := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_b, v_trace, v_root, v_org_id, 'search_internal_docs', 'retrieval', 'completed',
+          v_start + interval '900 ms', v_start + interval '2100 ms', 1200,
+          0, 0, 0, NULL);
+
+  v_c := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_c, v_trace, v_root, v_org_id, 'query_database', 'tool', 'completed',
+          v_start + interval '900 ms', v_start + interval '1640 ms', 740,
+          0, 0, 0, NULL);
+
+  v_d := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_d, v_trace, v_root, v_org_id, 'synthesize_report', 'llm', 'completed',
+          v_start + interval '4220 ms', v_start + interval '8420 ms', 4200,
+          5840, 980, 6820, 0.0224);
+
+  ------------------------------------------------------------------
+  -- TRACE 4: code-generation-pipeline (with one error span)
+  ------------------------------------------------------------------
+  v_trace := gen_random_uuid();
+  v_start := now() - interval '5 hours';
+
+  INSERT INTO traces (id, organization_id, project_id, api_key_id, name, status, started_at, ended_at, duration_ms, metadata, error_message)
+  VALUES (v_trace, v_org_id, v_proj_id, v_key_id,
+          'code-generation-pipeline', 'error',
+          v_start, v_start + interval '4100 ms', 4100,
+          jsonb_build_object('repo', 'spanlens/sdk', 'language', 'typescript'),
+          'Lint check failed after generation');
+
+  v_root := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_root, v_trace, v_org_id, 'parse_user_intent', 'llm', 'completed',
+          v_start, v_start + interval '320 ms', 320,
+          180, 40, 220, 0.000056);
+
+  v_a := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_a, v_trace, v_root, v_org_id, 'generate_code', 'llm', 'completed',
+          v_start + interval '330 ms', v_start + interval '3700 ms', 3370,
+          2410, 1280, 3690, 0.0184);
+
+  v_b := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     error_message)
+  VALUES (v_b, v_trace, v_a, v_org_id, 'lint_check', 'tool', 'error',
+          v_start + interval '3710 ms', v_start + interval '4100 ms', 390,
+          'ESLint found 3 errors: prefer-const, no-unused-vars, no-explicit-any');
+
+  ------------------------------------------------------------------
+  -- TRACE 5: voice-assistant-pipeline (short, fast)
+  ------------------------------------------------------------------
+  v_trace := gen_random_uuid();
+  v_start := now() - interval '8 hours';
+
+  INSERT INTO traces (id, organization_id, project_id, api_key_id, name, status, started_at, ended_at, duration_ms, metadata)
+  VALUES (v_trace, v_org_id, v_proj_id, v_key_id,
+          'voice-assistant-pipeline', 'completed',
+          v_start, v_start + interval '987 ms', 987,
+          jsonb_build_object('device', 'mobile_ios', 'locale', 'en-US'));
+
+  v_root := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_root, v_trace, v_org_id, 'speech_to_text', 'tool', 'completed',
+          v_start, v_start + interval '210 ms', 210,
+          0, 0, 0, NULL);
+
+  v_a := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_a, v_trace, v_root, v_org_id, 'reply_short', 'llm', 'completed',
+          v_start + interval '220 ms', v_start + interval '720 ms', 500,
+          240, 80, 320, 0.000088);
+
+  v_b := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_b, v_trace, v_a, v_org_id, 'text_to_speech', 'tool', 'completed',
+          v_start + interval '730 ms', v_start + interval '987 ms', 257,
+          0, 0, 0, NULL);
+
+  ------------------------------------------------------------------
+  -- TRACE 6: email-triage (yesterday)
+  ------------------------------------------------------------------
+  v_trace := gen_random_uuid();
+  v_start := now() - interval '1 day';
+
+  INSERT INTO traces (id, organization_id, project_id, api_key_id, name, status, started_at, ended_at, duration_ms, metadata)
+  VALUES (v_trace, v_org_id, v_proj_id, v_key_id,
+          'email-triage', 'completed',
+          v_start, v_start + interval '1840 ms', 1840,
+          jsonb_build_object('batch_size', 12, 'priority_levels', 4));
+
+  v_root := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_root, v_trace, v_org_id, 'classify_batch', 'llm', 'completed',
+          v_start, v_start + interval '980 ms', 980,
+          1840, 180, 2020, 0.00033);
+
+  v_a := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms)
+  VALUES (v_a, v_trace, v_root, v_org_id, 'apply_labels', 'tool', 'completed',
+          v_start + interval '990 ms', v_start + interval '1180 ms', 190);
+
+  v_b := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_b, v_trace, v_root, v_org_id, 'draft_responses', 'llm', 'completed',
+          v_start + interval '1190 ms', v_start + interval '1840 ms', 650,
+          840, 320, 1160, 0.000232);
+
+  ------------------------------------------------------------------
+  -- TRACE 7: sql-query-agent (in progress / running)
+  ------------------------------------------------------------------
+  v_trace := gen_random_uuid();
+  v_start := now() - interval '4 seconds';
+
+  INSERT INTO traces (id, organization_id, project_id, api_key_id, name, status, started_at, metadata)
+  VALUES (v_trace, v_org_id, v_proj_id, v_key_id,
+          'sql-query-agent', 'running',
+          v_start,
+          jsonb_build_object('database', 'analytics_replica'));
+
+  v_root := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_root, v_trace, v_org_id, 'understand_question', 'llm', 'completed',
+          v_start, v_start + interval '420 ms', 420,
+          280, 90, 370, 0.00007);
+
+  v_a := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at)
+  VALUES (v_a, v_trace, v_root, v_org_id, 'write_sql', 'llm', 'running',
+          v_start + interval '430 ms');
+
+  ------------------------------------------------------------------
+  -- TRACE 8: doc-summarization (2 days ago)
+  ------------------------------------------------------------------
+  v_trace := gen_random_uuid();
+  v_start := now() - interval '2 days';
+
+  INSERT INTO traces (id, organization_id, project_id, api_key_id, name, status, started_at, ended_at, duration_ms, metadata)
+  VALUES (v_trace, v_org_id, v_proj_id, v_key_id,
+          'doc-summarization', 'completed',
+          v_start, v_start + interval '5240 ms', 5240,
+          jsonb_build_object('document_id', 'doc_8472', 'pages', 18));
+
+  v_root := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_root, v_trace, v_org_id, 'extract_text', 'tool', 'completed',
+          v_start, v_start + interval '720 ms', 720,
+          0, 0, 0, NULL);
+
+  v_a := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_a, v_trace, v_root, v_org_id, 'chunk_document', 'custom', 'completed',
+          v_start + interval '730 ms', v_start + interval '890 ms', 160,
+          0, 0, 0, NULL);
+
+  v_b := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_b, v_trace, v_a, v_org_id, 'summarize_chunks_parallel', 'llm', 'completed',
+          v_start + interval '900 ms', v_start + interval '3800 ms', 2900,
+          7200, 1840, 9040, 0.0291);
+
+  v_c := gen_random_uuid();
+  INSERT INTO spans (id, trace_id, parent_span_id, organization_id, name, span_type, status, started_at, ended_at, duration_ms,
+                     prompt_tokens, completion_tokens, total_tokens, cost_usd)
+  VALUES (v_c, v_trace, v_b, v_org_id, 'combine_summaries', 'llm', 'completed',
+          v_start + interval '3810 ms', v_start + interval '5240 ms', 1430,
+          1840, 420, 2260, 0.00591);
+
+  RAISE NOTICE 'Inserted 8 traces and their spans for org %', v_org_id;
+END
+$$;
+
+-- Quick verification
+SELECT COUNT(*) AS trace_count FROM traces WHERE organization_id = '5abce023-05c8-4e99-9b37-ea81b7e3e9ff';
+SELECT COUNT(*) AS span_count FROM spans WHERE organization_id = '5abce023-05c8-4e99-9b37-ea81b7e3e9ff';


### PR DESCRIPTION
Local development helpers that had been sitting uncommitted. None of them run in CI or production.

| File | Purpose |
|---|---|
| `scripts/seed-demo-data.ts` | 30 days of requests, traces, and spans for the demo workspace |
| `scripts/seed-recent-traffic.ts` | Fills the last 24 hours so the default dashboard window is not empty after seeding history |
| `supabase/seeds/dummy_traces.sql` | Traces and spans for the local smoke-test org |
| `apps/server/scripts/test-vercel-ai-integration.ts` | Drives `createSpanlensTracker` through the callback shape the Vercel AI SDK emits, then asserts the trace and span reached Supabase |

Workspace ids in the seed scripts are local defaults, overridable via `SEED_ORG_ID` / `SEED_PROJECT_ID` / `SEED_API_KEY_ID` / `SEED_USER_ID`, so the scripts are not pinned to one seeded org.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)