### PR TITLE
fix(web): stop child pages inheriting the homepage Open Graph card

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -47,9 +47,6 @@ export const metadata: Metadata = {
   openGraph: {
     type: 'website',
     siteName: 'Spanlens',
-    title: 'Spanlens · Open Source LLM Observability & Monitoring',
-    description: SITE_DESCRIPTION,
-    url: SITE_URL,
     locale: 'en_US',
     // No explicit `images`: the generated 1200×630 card from
     // app/opengraph-image.tsx (file convention) applies site-wide. The old
@@ -57,8 +54,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Spanlens · Open Source LLM Observability & Monitoring',
-    description: SITE_DESCRIPTION,
+    // No `title`/`description` here for the same reason as `openGraph` above.
     // images inherited from app/twitter-image.tsx (file convention).
   },
   // NOTE: no top-level `index`/`follow` here. Explicit `index, follow` is the

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,8 +3,19 @@ import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
 import { CopyInstallButton } from '@/components/landing/copy-install-button'
 
+// The root layout deliberately omits `openGraph.url` so child pages don't
+// inherit the homepage URL (see app/layout.tsx). The homepage is the one page
+// where that URL is correct, so it declares the block itself. Declaring
+// `openGraph` replaces the layout's copy wholesale rather than merging, so
+// `type`/`siteName`/`locale` are repeated here on purpose.
 export const metadata = {
   alternates: { canonical: '/' },
+  openGraph: {
+    type: 'website',
+    siteName: 'Spanlens',
+    locale: 'en_US',
+    url: '/',
+  },
 }
 
 const SITE_URL = 'https://www.spanlens.io'

--- a/apps/web/lib/root-metadata-inheritance.test.ts
+++ b/apps/web/lib/root-metadata-inheritance.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Source guard: the root layout must not declare page-specific metadata.
+ *
+ * Next.js merges metadata shallowly. A child page that declares no
+ * `openGraph` (or `twitter`, or `alternates`) inherits the root layout's copy
+ * verbatim, so any page-specific value at the root silently becomes the value
+ * on every page that doesn't override it.
+ *
+ * This has now bitten twice:
+ *
+ *  - 2026-06-11: a root `alternates.canonical` of '/' canonicalised the whole
+ *    site to the homepage. 61 pages (76%) fell out of the index.
+ *  - 2026-07-29: a root `openGraph.url` / `title` / `description` gave 77
+ *    pages the homepage's Open Graph card, complete with the homepage URL
+ *    (Ahrefs: "Open Graph URL not matching canonical", 77 pages).
+ *
+ * Omitting these fields at the root is what makes the fallback work: Next.js
+ * derives `og:title` / `og:description` (and the twitter equivalents) from the
+ * page's own `title` / `description` when the Open Graph block doesn't set
+ * them, so each page gets a correct card with no per-page boilerplate.
+ *
+ * `type`, `siteName`, and `locale` are safe to keep at the root: they are the
+ * same on every page.
+ */
+
+const LAYOUT = join(__dirname, '..', 'app', 'layout.tsx')
+
+/** Extract a top-level metadata block (e.g. `openGraph: { ... }`) by brace matching. */
+function metadataBlock(source: string, key: string): string {
+  const start = source.indexOf(`  ${key}: {`)
+  if (start === -1) return ''
+  let depth = 0
+  for (let i = source.indexOf('{', start); i < source.length; i++) {
+    if (source[i] === '{') depth++
+    if (source[i] === '}') {
+      depth--
+      if (depth === 0) return source.slice(start, i + 1)
+    }
+  }
+  return ''
+}
+
+describe('root layout metadata', () => {
+  const source = readFileSync(LAYOUT, 'utf-8')
+
+  it('declares no site-wide canonical', () => {
+    // A root canonical is inherited by every page that omits `alternates`.
+    expect(source).not.toMatch(/^\s{2}alternates:/m)
+  })
+
+  it.each(['openGraph', 'twitter'] as const)(
+    'declares no page-specific fields in %s',
+    (key) => {
+      const block = metadataBlock(source, key)
+      expect(block, `${key} block not found in app/layout.tsx`).not.toBe('')
+
+      for (const field of ['url', 'title', 'description']) {
+        expect(
+          new RegExp(`^\\s+${field}:`, 'm').test(block),
+          `app/layout.tsx sets \`${key}.${field}\`, which every page without its own ` +
+            `\`${key}\` block inherits. Remove it and let the page's own metadata supply it.`,
+        ).toBe(false)
+      }
+    },
+  )
+})


### PR DESCRIPTION
## The bug

Next.js merges metadata shallowly. A page that declares no `openGraph` block inherits the root layout's copy verbatim, and the root set `url`, `title`, and `description`. Every such page served the homepage's card:

```
GET https://www.spanlens.io/docs/cli
  og:title        Spanlens · Open Source LLM Observability & Monitoring
  og:description  Open source LLM observability and monitoring for OpenAI, ...
  og:url          https://www.spanlens.io
```

77 pages were affected: every docs page, every comparison page, and the legal pages. Share any of them in Slack, X, or LinkedIn and the unfurl reads "Spanlens · Open Source LLM Observability & Monitoring" with a link back to the homepage.

Ahrefs flags this as "Open Graph URL not matching canonical" on 77 pages. That is exactly the 78 pages which declare a canonical and no `openGraph`, minus the homepage, where the inherited URL happened to be correct.

## The fix

Removing `url` / `title` / `description` from the root `openGraph` block is sufficient. Next.js falls back to the page's own `title` and `description` when the Open Graph block omits them, so all 77 pages get a correct card without any per-page boilerplate. `type`, `siteName`, and `locale` stay at the root because they are identical on every page. Same treatment for `twitter`.

The homepage is the one page where the old URL was right, so `app/page.tsx` now declares the block itself.

## Why a source guard

This is the second inherited-root-metadata incident:

| Date | Field | Damage |
|---|---|---|
| 2026-06-11 | `alternates.canonical: '/'` | 61 pages (76%) canonicalised to the homepage and de-indexed |
| 2026-07-29 | `openGraph.url` + title/description | 77 pages served the homepage card |

`lib/root-metadata-inheritance.test.ts` now fails if `alternates` reappears at the root, or if `openGraph` / `twitter` regain a `url`, `title`, or `description`.

## Verified against the dev server

| URL | Before | After |
|---|---|---|
| `/docs/cli` | og:title = homepage, og:url = homepage | og:title `Spanlens CLI · Spanlens Docs`, no og:url |
| `/compare/langfuse` | og:title = homepage | og:title `Spanlens vs Langfuse · 2026 Comparison` |
| `/` | og:url = homepage | unchanged, og:url `https://www.spanlens.io` |
| `/llm-cost-tracking` | already page-specific | unchanged |

## Known follow-up

The 16 pages that declare their own `openGraph` replace the root block wholesale, so they lose `og:site_name` and `og:locale`. Pre-existing, cosmetic, and not touched here.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter web test` (74 passed, includes the new guard)
- [x] `pnpm --filter web build`
- [x] Dev-server meta tag inspection on the four URLs above
- [ ] After deploy: re-run Ahrefs Site Audit, expect "Open Graph URL not matching canonical" to drop from 77 to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)