### PR TITLE
fix(web): add docs section hubs and clear the Search Console 404s

### DIFF
--- a/apps/server/public/index.html
+++ b/apps/server/public/index.html
@@ -1,1 +1,26 @@
-<h1>Spanlens API Server</h1>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- This host serves the API and the LLM proxy, not pages. It was a bare
+         one-line 200 until 2026-07-29, which Google Search Console classified
+         as a Soft 404. The X-Robots-Tag header in vercel.json is what actually
+         keeps the host out of the index; this tag is the belt-and-braces copy
+         for anything that reads the document instead of the headers. -->
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Spanlens API</title>
+  </head>
+  <body>
+    <h1>Spanlens API</h1>
+    <p>
+      This host serves the Spanlens REST API and the LLM proxy. There is nothing
+      to browse here.
+    </p>
+    <ul>
+      <li><a href="https://www.spanlens.io/docs/api">REST API reference</a></li>
+      <li><a href="https://www.spanlens.io/docs/proxy">Proxy quick start</a></li>
+      <li><a href="https://www.spanlens.io">spanlens.io</a></li>
+    </ul>
+  </body>
+</html>

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -10,6 +10,12 @@
     }
   },
   "rewrites": [{ "source": "/(.*)", "destination": "/api/index" }],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow" }]
+    }
+  ],
   "crons": [
     { "path": "/cron/evaluate-alerts",      "schedule": "*/15 * * * *" },
     { "path": "/cron/snapshot-anomalies",   "schedule": "0 1 * * *" },

--- a/apps/web/app/docs/_components/docs-jsonld.tsx
+++ b/apps/web/app/docs/_components/docs-jsonld.tsx
@@ -1,3 +1,5 @@
+import { findDocsSection } from '@/app/docs/_lib/sections'
+
 const SITE_URL = 'https://www.spanlens.io'
 
 /**
@@ -18,9 +20,10 @@ interface DocsPageMeta {
  *
  *   <DocsJsonLd meta={metadata} />
  *
- * The breadcrumb is intentionally a uniform Home → Docs → page trail: most
- * docs sections (/docs/concepts, /docs/features, …) have no index page, so
- * deeper trails would point crawlers at 404s.
+ * The breadcrumb inserts a section crumb (Home → Docs → Features → page) when
+ * the page sits under one of the six sections that now have a hub page. It
+ * used to be a flat Home → Docs → page trail because those section paths
+ * returned 404 and a deeper trail would have pointed crawlers at them.
  *
  * Renders nothing if the page metadata is missing a canonical or title —
  * docs routes are server-rendered on demand, so throwing here would turn a
@@ -34,14 +37,28 @@ export function DocsJsonLd({ meta }: { meta: DocsPageMeta }) {
   // "Quick start · Spanlens Docs" → "Quick start" for the breadcrumb label.
   const shortTitle = meta.title.split('·')[0]?.trim() ?? meta.title
 
+  // '/docs/features/evals' → 'features'. Undefined for '/docs' itself and for
+  // pages that sit directly under /docs (e.g. '/docs/quick-start'), which have
+  // no section to insert.
+  const sectionSlug = canonical.split('/')[2]
+  const section = canonical.split('/').length > 3 && sectionSlug ? findDocsSection(sectionSlug) : undefined
+
+  const trail = [
+    { name: 'Home', item: SITE_URL },
+    { name: 'Docs', item: `${SITE_URL}/docs` },
+    ...(section ? [{ name: section.title, item: `${SITE_URL}/docs/${section.slug}` }] : []),
+    { name: shortTitle, item: url },
+  ]
+
   const breadcrumbJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
-    itemListElement: [
-      { '@type': 'ListItem', position: 1, name: 'Home', item: SITE_URL },
-      { '@type': 'ListItem', position: 2, name: 'Docs', item: `${SITE_URL}/docs` },
-      { '@type': 'ListItem', position: 3, name: shortTitle, item: url },
-    ],
+    itemListElement: trail.map((crumb, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: crumb.name,
+      item: crumb.item,
+    })),
   }
 
   const articleJsonLd = {

--- a/apps/web/app/docs/_components/section-index.tsx
+++ b/apps/web/app/docs/_components/section-index.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link'
+import { ArrowRight } from 'lucide-react'
+import type { DocsSection } from '@/app/docs/_lib/sections'
+
+/**
+ * Hub page for a /docs/<section> path. Lists every child page with its own
+ * description so the page carries real content rather than a bare link list,
+ * and so each child gains a second internal link besides the sidebar.
+ */
+export function DocsSectionIndex({ section }: { section: DocsSection }) {
+  return (
+    <div className="not-prose">
+      <h1 className="text-4xl font-bold tracking-tight mb-3">{section.title}</h1>
+      <p className="text-lg text-muted-foreground mb-10">{section.description}</p>
+
+      {section.groups.map((group, i) => (
+        <section key={group.title || i} className="mb-10">
+          {group.title ? (
+            <h2 className="text-xl font-semibold mb-4">{group.title}</h2>
+          ) : null}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {group.pages.map((page) => (
+              <Link
+                key={page.href}
+                href={page.href}
+                className="group rounded-xl border border-border bg-bg-elev p-5 hover:border-border-strong hover:shadow-sm transition-all"
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  <h3 className="font-semibold group-hover:text-accent">{page.title}</h3>
+                  <ArrowRight className="h-4 w-4 text-border group-hover:text-accent group-hover:translate-x-0.5 transition-all ml-auto shrink-0" />
+                </div>
+                <p className="text-sm text-muted-foreground">{page.description}</p>
+              </Link>
+            ))}
+          </div>
+        </section>
+      ))}
+
+      <p className="text-sm text-muted-foreground">
+        Back to the{' '}
+        <Link href="/docs" className="text-accent hover:underline">
+          docs overview
+        </Link>
+        .
+      </p>
+    </div>
+  )
+}

--- a/apps/web/app/docs/_lib/sections.ts
+++ b/apps/web/app/docs/_lib/sections.ts
@@ -1,0 +1,440 @@
+/**
+ * Section index data for the six /docs/<section> hub pages.
+ *
+ * Those six paths returned 404 until 2026-07-29 (Google Search Console logged
+ * /docs/features as "Not found"), because every docs page lives one level
+ * deeper and no section had an index. The hub pages also give each section's
+ * children a second internal link: previously they were reachable only from
+ * the sidebar.
+ *
+ * `title` and `description` are copied from each child page's own metadata.
+ * `sections.test.ts` fails if they drift apart, or if a page is added under a
+ * section directory without being listed here.
+ */
+
+export interface DocsSectionPage {
+  title: string
+  href: string
+  description: string
+}
+
+export interface DocsSectionGroup {
+  /** Empty for sections small enough to render as one flat list. */
+  title: string
+  pages: DocsSectionPage[]
+}
+
+export interface DocsSection {
+  /** Path segment under /docs. */
+  slug: string
+  title: string
+  description: string
+  groups: DocsSectionGroup[]
+}
+
+export const DOCS_SECTIONS: DocsSection[] = [
+  {
+    slug: 'concepts',
+    title: 'Concepts',
+    description:
+      'How Spanlens models LLM observability: the signals worth capturing, the entities they map to, and how traces, evals, and prompt versions relate.',
+    groups: [
+      {
+        title: '',
+        pages: [
+          {
+            title: 'LLM observability',
+            href: '/docs/concepts/llm-observability',
+            description:
+              'What LLM observability is, the five signal categories worth capturing, and how Spanlens maps each one to a concrete entity in the data model.',
+          },
+          {
+            title: 'Agent tracing',
+            href: '/docs/concepts/agent-tracing',
+            description:
+              'How Spanlens models agent traces: trace root, agent steps, LLM calls, tool calls, parent/child links, and critical path computation.',
+          },
+          {
+            title: 'Evals',
+            href: '/docs/concepts/evals',
+            description:
+              'How Spanlens models evals: LLM-as-judge scoring, human annotation, judge-to-human correlation as a metric, and drift detection across prompt versions.',
+          },
+          {
+            title: 'Prompt management',
+            href: '/docs/concepts/prompt-management',
+            description:
+              'How Spanlens versions prompts, runs Prompt A/B with Welch t-test on latency and cost, computes z-test on error rate, and rolls back without deploys.',
+          },
+          {
+            title: 'Data model',
+            href: '/docs/concepts/data-model',
+            description:
+              'Spanlens data model in one page: Request, Trace, Span, Prompt Version, Eval, Dataset, and how they relate for billing, debugging, and quality questions.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    slug: 'features',
+    title: 'Features',
+    description:
+      'Request logs, agent traces, prompt versioning and A/B, evals, anomaly detection, PII scanning, cost tracking, and workspace administration.',
+    groups: [
+      {
+        title: 'Core',
+        pages: [
+          {
+            title: 'Requests',
+            href: '/docs/features/requests',
+            description:
+              'Complete log of every LLM call routed through Spanlens, model, tokens, cost, latency, full request/response bodies.',
+          },
+          {
+            title: 'Saved Filters',
+            href: '/docs/features/saved-filters',
+            description:
+              'Save named filter combinations on the /requests page and restore them instantly from a dropdown on future visits.',
+          },
+          {
+            title: 'Users',
+            href: '/docs/features/users',
+            description:
+              'End-user attribution and per-user analytics for LLM usage. Tag requests with x-spanlens-user and see who is spending what.',
+          },
+          {
+            title: 'Traces',
+            href: '/docs/features/traces',
+            description:
+              'Agent tracing with nested span trees. See exactly where time goes when your LLM agent calls five tools in sequence.',
+          },
+        ],
+      },
+      {
+        title: 'Prompts and evaluation',
+        pages: [
+          {
+            title: 'Prompts',
+            href: '/docs/features/prompts',
+            description:
+              'Version-controlled prompt templates with real-data A/B comparison, latency, cost, and error rate per version.',
+          },
+          {
+            title: 'Prompts Playground',
+            href: '/docs/features/prompts-playground',
+            description:
+              'Interactive console inside the Prompts tab, select a version, set model, temperature, and variables, then run it immediately and see cost and token counts.',
+          },
+          {
+            title: 'Prompt A/B',
+            href: '/docs/features/prompt-ab',
+            description:
+              'Route live production traffic across two prompt versions and measure latency, cost, and error rate with statistical significance.',
+          },
+          {
+            title: 'Evals',
+            href: '/docs/features/evals',
+            description:
+              'LLM-as-judge evaluation, automatically score production responses on a 0..1 scale and quantify quality per prompt version.',
+          },
+          {
+            title: 'Datasets',
+            href: '/docs/features/datasets',
+            description:
+              'Reusable (input, expected_output) test sets. Use in Evals and Experiments instead of pulling from live production traffic.',
+          },
+          {
+            title: 'Experiments',
+            href: '/docs/features/experiments',
+            description:
+              'Offline side-by-side comparison, run a dataset against two prompt versions and compare outputs, scores, and cost without touching production traffic.',
+          },
+          {
+            title: 'Annotation',
+            href: '/docs/features/annotation',
+            description:
+              'Human star-rating for production responses. Pearson r correlation with LLM judge scores makes judge reliability visible at a glance.',
+          },
+        ],
+      },
+      {
+        title: 'Reliability',
+        pages: [
+          {
+            title: 'Security (PII + prompt injection)',
+            href: '/docs/features/security',
+            description:
+              'Automatic PII detection and prompt-injection scanning on every LLM request and response, with optional blocking mode and real-time alert emails.',
+          },
+          {
+            title: 'Anomalies',
+            href: '/docs/features/anomalies',
+            description:
+              '3-sigma statistical anomaly detection on latency, cost, and error rate per (provider, model) bucket. No ML, no configuration.',
+          },
+          {
+            title: 'Alerts',
+            href: '/docs/features/alerts',
+            description:
+              'Threshold-based alert rules for budget, error rate, and p95 latency. Delivered via email (Resend), Slack, or Discord webhooks.',
+          },
+          {
+            title: 'Webhooks',
+            href: '/docs/features/webhooks',
+            description:
+              'Receive Spanlens events (request created, trace completed, alert triggered) as real-time HTTP POST payloads on your own server.',
+          },
+        ],
+      },
+      {
+        title: 'Cost',
+        pages: [
+          {
+            title: 'Cost tracking',
+            href: '/docs/features/cost-tracking',
+            description:
+              'Accurate per-request USD cost computed from provider token prices. Handles dated model variants via longest-prefix matching.',
+          },
+          {
+            title: 'Savings',
+            href: '/docs/features/savings',
+            description:
+              'Model recommendations based on your real token distribution. Cheaper substitutes with estimated monthly savings, confidence tiers, and email alerts.',
+          },
+          {
+            title: 'Billing & quotas',
+            href: '/docs/features/billing',
+            description:
+              'How Spanlens charges you: plan quotas, overage billing, the hard cap, and what your invoice looks like.',
+          },
+        ],
+      },
+      {
+        title: 'Workspace',
+        pages: [
+          {
+            title: 'Projects, Spanlens keys & provider keys',
+            href: '/docs/features/projects',
+            description:
+              'Scope your traffic into projects (dev / staging / prod, per-service). Each Spanlens key (sl_live_…) carries its own pool of encrypted provider keys.',
+          },
+          {
+            title: 'Shared links',
+            href: '/docs/features/shares',
+            description:
+              'Publish a public read-only render of any trace or request via a share link, with redaction presets, view counts, and one-click revoke.',
+          },
+          {
+            title: 'Keys & encryption',
+            href: '/docs/features/settings',
+            description:
+              'How Spanlens stores and protects your AI provider keys. AES-256-GCM encryption at rest, decrypted only in memory during proxy forwarding.',
+          },
+          {
+            title: 'Members & invitations',
+            href: '/docs/features/members-invitations',
+            description:
+              'Multi-user workspaces with admin, editor, and viewer roles, email invitations with auto-accept, and an audit log of every membership event.',
+          },
+          {
+            title: 'Audit Logs',
+            href: '/docs/features/audit-logs',
+            description:
+              'Chronological record of every organization-level change: API keys, provider keys, member invitations, role changes, and billing plan switches.',
+          },
+          {
+            title: 'Data Export',
+            href: '/docs/features/export',
+            description:
+              'Download request logs, traces, anomalies, and security flags as CSV, JSONL, or JSON. Streamed exports handle millions of rows.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    slug: 'integrations',
+    title: 'Integrations',
+    description:
+      'Spanlens integrations for LangChain, LangGraph, CrewAI, LlamaIndex, Vercel AI SDK, Instructor, Flowise, OpenAI Assistants, AWS Bedrock, and MCP.',
+    groups: [
+      {
+        title: '',
+        pages: [
+          {
+            title: 'LangChain integration',
+            href: '/docs/integrations/langchain',
+            description:
+              'Trace LangChain (JS and Python) chains, agents, and tools with one callback handler. Every chain run, LLM call, and tool invocation becomes a Spanlens span.',
+          },
+          {
+            title: 'LangGraph integration',
+            href: '/docs/integrations/langgraph',
+            description:
+              'Trace LangGraph node and edge execution with Spanlens. One callback handler captures the full graph topology, parallel fan-out, and tool calls.',
+          },
+          {
+            title: 'CrewAI integration',
+            href: '/docs/integrations/crewai',
+            description:
+              'Trace CrewAI crews, agents, and tasks with Spanlens. One install captures the full crew execution tree with per-agent cost and latency.',
+          },
+          {
+            title: 'LlamaIndex integration',
+            href: '/docs/integrations/llamaindex',
+            description:
+              'Trace LlamaIndex query engines and agents with Spanlens. One callback handler maps every CBEventType to a span so the trace mirrors your RAG pipeline.',
+          },
+          {
+            title: 'Vercel AI SDK integration',
+            href: '/docs/integrations/vercel-ai',
+            description:
+              'Trace generateText, streamText, generateObject, and streamObject with Spanlens. Two callbacks spread into the AI SDK options log every call automatically.',
+          },
+          {
+            title: 'OpenAI Assistants API integration',
+            href: '/docs/integrations/openai-assistants',
+            description:
+              'Trace OpenAI Assistants API threads, runs, and steps with Spanlens. Tool calls and code-interpreter steps render as a span tree per run.',
+          },
+          {
+            title: 'Instructor integration',
+            href: '/docs/integrations/instructor',
+            description:
+              'Trace Instructor structured-output calls with Spanlens. Captures the Pydantic schema, retry count, and per-retry token cost.',
+          },
+          {
+            title: 'Flowise integration',
+            href: '/docs/integrations/flowise',
+            description:
+              'Connect Flowise visual flows to Spanlens. Flowise calls go through the Spanlens proxy and each node executions becomes a span.',
+          },
+          {
+            title: 'AWS Bedrock integration',
+            href: '/docs/integrations/bedrock',
+            description:
+              'Capture AWS Bedrock model invocations (Claude, Llama, Mistral, Titan) with Spanlens. SigV4 auth handled by your SDK; Spanlens proxies the wire.',
+          },
+          {
+            title: 'MCP integration',
+            href: '/docs/integrations/mcp',
+            description:
+              'Query Spanlens LLM cost, traces, and anomalies from Cursor, Claude Desktop, or Continue via MCP. Public-scope keys stay safe in plaintext IDE config.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    slug: 'production',
+    title: 'Production',
+    description:
+      'Running Spanlens under real traffic: outage behaviour, the fallback queue, recovery runbooks, and tuning for high-throughput workloads.',
+    groups: [
+      {
+        title: '',
+        pages: [
+          {
+            title: 'Reliability',
+            href: '/docs/production/reliability',
+            description:
+              'How Spanlens degrades during a partial outage, what the fallback queue does, and how to monitor the proxy so it never silently drops logs.',
+          },
+          {
+            title: 'Disaster recovery',
+            href: '/docs/production/disaster-recovery',
+            description:
+              'Operator runbook for Spanlens outages: what data is at risk per failure mode, how fallback queues protect it, and recovery steps for ClickHouse and Supabase.',
+          },
+          {
+            title: 'Scaling',
+            href: '/docs/production/scaling',
+            description:
+              'Latency budget, log body trade-offs, sampling, and self-hosting tuning for high-throughput LLM workloads on Spanlens.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    slug: 'tutorials',
+    title: 'Tutorials',
+    description:
+      'Walkthroughs: instrument a RAG chatbot, trace a multi-step agent with parallel tool calls, and run nightly LLM-as-judge evals on production traffic.',
+    groups: [
+      {
+        title: '',
+        pages: [
+          {
+            title: 'Add observability to a RAG chatbot',
+            href: '/docs/tutorials/rag-chatbot',
+            description:
+              'End-to-end tutorial. Take a basic RAG chatbot, add Spanlens, and see retrieval + generation as one trace with token cost and per-step latency.',
+          },
+          {
+            title: 'Multi-step agent tracing',
+            href: '/docs/tutorials/agent-tracing',
+            description:
+              'Tutorial: trace an agent that classifies intent, fans out to parallel tools, and composes an answer. Per-step cost and critical path in one waterfall.',
+          },
+          {
+            title: 'Nightly evals on production traffic',
+            href: '/docs/tutorials/nightly-evals',
+            description:
+              'Tutorial: set up an LLM-as-judge evaluator on a nightly sample of production traffic and catch prompt quality regressions before users complain.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    slug: 'migrate',
+    title: 'Migrate to Spanlens',
+    description:
+      'Migration guides from Langfuse, Helicone, and LangSmith: code diffs, data model mapping, and dual-running so you switch without losing history.',
+    groups: [
+      {
+        title: '',
+        pages: [
+          {
+            title: 'Migrate from Langfuse to Spanlens',
+            href: '/docs/migrate/from-langfuse',
+            description:
+              'Move from Langfuse to Spanlens in under 30 minutes. Code diffs, data model mapping, and dual-running steps so you can switch without losing history.',
+          },
+          {
+            title: 'Migrate from Helicone to Spanlens',
+            href: '/docs/migrate/from-helicone',
+            description:
+              'Move from Helicone to Spanlens in under 15 minutes. Base URL swap, properties to user / session mapping, and what to do about the AI Gateway features.',
+          },
+          {
+            title: 'Migrate from LangSmith to Spanlens',
+            href: '/docs/migrate/from-langsmith',
+            description:
+              'Move from LangSmith to Spanlens in under 45 minutes: traceable-to-observe() mapping, LangChain callback swap, and schema migration.',
+          },
+        ],
+      },
+    ],
+  },
+]
+
+/** Section slugs that have a hub page, for breadcrumb and sitemap lookups. */
+export const DOCS_SECTION_SLUGS = DOCS_SECTIONS.map((s) => s.slug)
+
+export function findDocsSection(slug: string): DocsSection | undefined {
+  return DOCS_SECTIONS.find((s) => s.slug === slug)
+}
+
+/**
+ * Same lookup, but throws rather than returning undefined. The six hub pages
+ * call this at module scope with a literal slug, so a typo should fail the
+ * build instead of rendering an empty page.
+ */
+export function getDocsSection(slug: string): DocsSection {
+  const section = findDocsSection(slug)
+  if (!section) throw new Error(`Unknown docs section: ${slug}`)
+  return section
+}

--- a/apps/web/app/docs/concepts/page.tsx
+++ b/apps/web/app/docs/concepts/page.tsx
@@ -1,0 +1,20 @@
+import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
+import { DocsSectionIndex } from '@/app/docs/_components/section-index'
+import { getDocsSection } from '@/app/docs/_lib/sections'
+
+const SECTION = getDocsSection('concepts')
+
+export const metadata = {
+  alternates: { canonical: '/docs/concepts' },
+  title: 'Concepts · Spanlens Docs',
+  description: SECTION.description,
+}
+
+export default function ConceptsIndex() {
+  return (
+    <div>
+      <DocsJsonLd meta={metadata} />
+      <DocsSectionIndex section={SECTION} />
+    </div>
+  )
+}

--- a/apps/web/app/docs/features/page.tsx
+++ b/apps/web/app/docs/features/page.tsx
@@ -1,0 +1,20 @@
+import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
+import { DocsSectionIndex } from '@/app/docs/_components/section-index'
+import { getDocsSection } from '@/app/docs/_lib/sections'
+
+const SECTION = getDocsSection('features')
+
+export const metadata = {
+  alternates: { canonical: '/docs/features' },
+  title: 'Features · Spanlens Docs',
+  description: SECTION.description,
+}
+
+export default function FeaturesIndex() {
+  return (
+    <div>
+      <DocsJsonLd meta={metadata} />
+      <DocsSectionIndex section={SECTION} />
+    </div>
+  )
+}

--- a/apps/web/app/docs/integrations/page.tsx
+++ b/apps/web/app/docs/integrations/page.tsx
@@ -1,0 +1,20 @@
+import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
+import { DocsSectionIndex } from '@/app/docs/_components/section-index'
+import { getDocsSection } from '@/app/docs/_lib/sections'
+
+const SECTION = getDocsSection('integrations')
+
+export const metadata = {
+  alternates: { canonical: '/docs/integrations' },
+  title: 'Integrations · Spanlens Docs',
+  description: SECTION.description,
+}
+
+export default function IntegrationsIndex() {
+  return (
+    <div>
+      <DocsJsonLd meta={metadata} />
+      <DocsSectionIndex section={SECTION} />
+    </div>
+  )
+}

--- a/apps/web/app/docs/migrate/page.tsx
+++ b/apps/web/app/docs/migrate/page.tsx
@@ -1,0 +1,20 @@
+import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
+import { DocsSectionIndex } from '@/app/docs/_components/section-index'
+import { getDocsSection } from '@/app/docs/_lib/sections'
+
+const SECTION = getDocsSection('migrate')
+
+export const metadata = {
+  alternates: { canonical: '/docs/migrate' },
+  title: 'Migrate to Spanlens · Spanlens Docs',
+  description: SECTION.description,
+}
+
+export default function MigrateIndex() {
+  return (
+    <div>
+      <DocsJsonLd meta={metadata} />
+      <DocsSectionIndex section={SECTION} />
+    </div>
+  )
+}

--- a/apps/web/app/docs/production/page.tsx
+++ b/apps/web/app/docs/production/page.tsx
@@ -1,0 +1,20 @@
+import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
+import { DocsSectionIndex } from '@/app/docs/_components/section-index'
+import { getDocsSection } from '@/app/docs/_lib/sections'
+
+const SECTION = getDocsSection('production')
+
+export const metadata = {
+  alternates: { canonical: '/docs/production' },
+  title: 'Production · Spanlens Docs',
+  description: SECTION.description,
+}
+
+export default function ProductionIndex() {
+  return (
+    <div>
+      <DocsJsonLd meta={metadata} />
+      <DocsSectionIndex section={SECTION} />
+    </div>
+  )
+}

--- a/apps/web/app/docs/tutorials/page.tsx
+++ b/apps/web/app/docs/tutorials/page.tsx
@@ -1,0 +1,20 @@
+import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
+import { DocsSectionIndex } from '@/app/docs/_components/section-index'
+import { getDocsSection } from '@/app/docs/_lib/sections'
+
+const SECTION = getDocsSection('tutorials')
+
+export const metadata = {
+  alternates: { canonical: '/docs/tutorials' },
+  title: 'Tutorials · Spanlens Docs',
+  description: SECTION.description,
+}
+
+export default function TutorialsIndex() {
+  return (
+    <div>
+      <DocsJsonLd meta={metadata} />
+      <DocsSectionIndex section={SECTION} />
+    </div>
+  )
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -93,13 +93,18 @@ const FAQS: [string, string][] = [
   ['Does Spanlens work for a whole team?', 'Projects isolate workloads, roles and invitations manage access, and audit logs record every change. Team and Enterprise add Slack, webhooks, unlimited alerts, and SSO.'],
 ]
 
+// Sample rows for the dashboard preview. The endpoint column is `/api/…`
+// rather than a bare `/chat`: Google read the old bare paths as URLs on this
+// origin and crawled them, so `/extract` showed up in Search Console as a 404.
+// Anything under `/api/` is disallowed in robots.txt, so these can't be
+// mistaken for real pages again.
 const PREVIEW_ROWS = [
-  { m: 'claude-sonnet-4.5', ep: '/chat',      lat: 1240, tok: '2,104', cost: '$0.0312', st: 200, age: '2s',  anom: false },
-  { m: 'gpt-4o-mini',       ep: '/extract',   lat: 410,  tok: '612',   cost: '$0.0009', st: 200, age: '5s',  anom: false },
-  { m: 'gpt-4o',            ep: '/summarize', lat: 3440, tok: '3,218', cost: '$0.0482', st: 200, age: '7s',  anom: true  },
-  { m: 'gemini-2.0-flash',  ep: '/rerank',    lat: 180,  tok: '240',   cost: '$0.0001', st: 200, age: '9s',  anom: false },
-  { m: 'claude-haiku-4.5',  ep: '/chat',      lat: 680,  tok: '984',   cost: '$0.0018', st: 200, age: '11s', anom: false },
-  { m: 'gpt-4o',            ep: '/classify',  lat: 2120, tok: '1,840', cost: '$0.0276', st: 429, age: '14s', anom: false },
+  { m: 'claude-sonnet-4.5', ep: '/api/chat',      lat: 1240, tok: '2,104', cost: '$0.0312', st: 200, age: '2s',  anom: false },
+  { m: 'gpt-4o-mini',       ep: '/api/extract',   lat: 410,  tok: '612',   cost: '$0.0009', st: 200, age: '5s',  anom: false },
+  { m: 'gpt-4o',            ep: '/api/summarize', lat: 3440, tok: '3,218', cost: '$0.0482', st: 200, age: '7s',  anom: true  },
+  { m: 'gemini-2.0-flash',  ep: '/api/rerank',    lat: 180,  tok: '240',   cost: '$0.0001', st: 200, age: '9s',  anom: false },
+  { m: 'claude-haiku-4.5',  ep: '/api/chat',      lat: 680,  tok: '984',   cost: '$0.0018', st: 200, age: '11s', anom: false },
+  { m: 'gpt-4o',            ep: '/api/classify',  lat: 2120, tok: '1,840', cost: '$0.0276', st: 429, age: '14s', anom: false },
 ]
 
 const TRACE_SPANS = [

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -37,6 +37,12 @@ const ROUTE_LASTMOD: Record<string, string> = {
   '/docs/migrate/from-helicone': '2026-05-25',
   '/docs/migrate/from-langsmith': '2026-05-25',
   '/docs': '2026-06-12',
+  '/docs/concepts': '2026-07-29',
+  '/docs/features': '2026-07-29',
+  '/docs/integrations': '2026-07-29',
+  '/docs/production': '2026-07-29',
+  '/docs/tutorials': '2026-07-29',
+  '/docs/migrate': '2026-07-29',
   '/docs/quick-start': '2026-06-12',
   '/docs/cli': '2026-06-12',
   '/docs/sdk': '2026-06-12',
@@ -139,6 +145,15 @@ const MIGRATION_ROUTES = [
 
 const DOCS_ROUTES = [
   '/docs',
+  // Section hub pages. These six paths used to 404 (Search Console logged
+  // /docs/features as "Not found" on 2026-06-23) because every docs page sits
+  // one level deeper and no section had an index.
+  '/docs/concepts',
+  '/docs/features',
+  '/docs/integrations',
+  '/docs/production',
+  '/docs/tutorials',
+  '/docs/migrate',
   '/docs/quick-start',
   '/docs/cli',
   '/docs/sdk',
@@ -171,7 +186,6 @@ const DOCS_ROUTES = [
   '/docs/tutorials/agent-tracing',
   '/docs/tutorials/nightly-evals',
   '/docs/tutorials/rag-chatbot',
-  // NOTE: no bare '/docs/features' entry — that route does not exist (404).
   '/docs/features/requests',
   '/docs/features/traces',
   '/docs/features/prompts',

--- a/apps/web/lib/docs-sections-drift.test.ts
+++ b/apps/web/lib/docs-sections-drift.test.ts
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { DOCS_SECTIONS } from '@/app/docs/_lib/sections'
+
+/**
+ * Drift guard for the six /docs/<section> hub pages.
+ *
+ * The hub pages restate every child page's title and description so the
+ * section reads as real content rather than a bare link list. That copy is a
+ * second home for strings whose source of truth is each page's own
+ * `export const metadata`, so it can silently rot: a page gets reworded, or a
+ * new page is added under a section directory and never appears on the hub.
+ *
+ * The section paths themselves are the reason this exists. All six returned
+ * 404 until 2026-07-29 (Search Console logged /docs/features as "Not found"),
+ * because every docs page lives one level deeper and no section had an index.
+ *
+ * If this test fails: re-copy the child page's `title` / `description` into
+ * app/docs/_lib/sections.ts, or add the missing page to the right group.
+ */
+
+const APP_DIR = join(__dirname, '..', 'app')
+const DOCS_DIR = join(APP_DIR, 'docs')
+
+const TITLE_RE = /title:\s*'((?:[^'\\]|\\.)*)'/
+const DESCRIPTION_RE = /description:\s*\n?\s*'((?:[^'\\]|\\.)*)'/
+
+function pageSource(href: string): string {
+  const file = join(APP_DIR, ...href.split('/').filter(Boolean), 'page.tsx')
+  expect(existsSync(file), `${href} has no page.tsx`).toBe(true)
+  return readFileSync(file, 'utf-8')
+}
+
+/** Child directories under a section that actually hold a page. */
+function childSlugs(slug: string): string[] {
+  const dir = join(DOCS_DIR, slug)
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && existsSync(join(dir, e.name, 'page.tsx')))
+    .map((e) => e.name)
+}
+
+describe.each(DOCS_SECTIONS.map((s) => [s.slug, s] as const))('/docs/%s', (slug, section) => {
+  const listed = section.groups.flatMap((g) => g.pages)
+
+  it('has a hub page of its own', () => {
+    const source = pageSource(`/docs/${slug}`)
+    expect(source).toContain(`canonical: '/docs/${slug}'`)
+  })
+
+  it('keeps the meta description under 160 characters', () => {
+    // Google truncates around here, and Ahrefs Site Audit flags anything
+    // longer as "Meta description too long".
+    expect(section.description.length).toBeLessThanOrEqual(160)
+  })
+
+  it('lists every child page exactly once', () => {
+    const hrefs = listed.map((p) => p.href).sort()
+    const expected = childSlugs(slug)
+      .map((child) => `/docs/${slug}/${child}`)
+      .sort()
+    expect(hrefs).toEqual(expected)
+  })
+
+  it.each(listed.map((p) => [p.href, p] as const))('%s matches the page metadata', (href, page) => {
+    const source = pageSource(href)
+    const title = source.match(TITLE_RE)?.[1]
+    const description = source.match(DESCRIPTION_RE)?.[1]
+
+    expect(title, `no title in ${href}`).toBeTruthy()
+    expect(description, `no description in ${href}`).toBeTruthy()
+
+    // Page titles carry a "· Spanlens Docs" suffix the hub card drops.
+    expect(page.title).toBe(title?.split('·')[0]?.trim())
+    expect(page.description).toBe(description)
+  })
+})
+
+describe('sitemap', () => {
+  const source = readFileSync(join(APP_DIR, 'sitemap.ts'), 'utf-8')
+
+  it.each(DOCS_SECTIONS.map((s) => s.slug))('includes /docs/%s', (slug) => {
+    expect(source).toContain(`'/docs/${slug}',`)
+  })
+})


### PR DESCRIPTION
Google Search Console (data through 2026-07-24) reports 112 indexed URLs and 49 it declined to index. Going through the 49 one by one, most are intentional: 15 blocked by robots.txt, 5 noindex, 5 apex/http redirects, 2 UTM variants folded into their canonical, 403/401 on dashboard routes. Three were real, and this PR fixes all three.

## 1. Six `/docs/<section>` paths returned 404

Every docs page lives one level deeper (`/docs/features/evals`) and no section had an index page, so all six section paths 404'd:

| Path | Before | After |
|---|---|---|
| `/docs/features` | 404 | hub, 24 children |
| `/docs/integrations` | 404 | hub, 10 children |
| `/docs/concepts` | 404 | hub, 5 children |
| `/docs/production` | 404 | hub, 3 children |
| `/docs/tutorials` | 404 | hub, 3 children |
| `/docs/migrate` | 404 | hub, 3 children |

Google found and crawled `/docs/features` on 2026-06-23 and has been reporting it as "Not found" since. `sitemap.ts` carried `// NOTE: no bare '/docs/features' entry — that route does not exist (404).`, which routed around the hole instead of filling it.

Each hub lists its children with their own descriptions, so the page is real content rather than a bare link list, and every child page gains a second internal link besides the sidebar. That matters more than the 404: docs pages were reachable from exactly one place.

The docs breadcrumb now inserts the section crumb, which it could not do while those paths 404'd:

```
before  Home > Docs > Evals
after   Home > Docs > Features > Evals
```

Section copy in `app/docs/_lib/sections.ts` is copied from each child page's own `metadata`. `lib/docs-sections-drift.test.ts` (72 assertions) fails if the two drift apart, if a page is added under a section directory without being listed, or if a section's meta description passes 160 characters.

## 2. `/extract` 404

The dashboard preview table on the homepage used bare sample endpoints as sample data:

```js
{ m: 'gpt-4o-mini', ep: '/extract', ... }
```

Google read those as URLs on this origin and crawled them. They are `/api/...` now, which `robots.txt` already disallows, so they cannot be mistaken for pages again.

## 3. `api.spanlens.io` filed as a Soft 404

The API host answered `/` with a 29-byte document:

```html
<h1>Spanlens API Server</h1>
```

A 200 with nothing in it is what Google calls a Soft 404. The root now returns a real document pointing at the API docs, and `vercel.json` sets `X-Robots-Tag: noindex, nofollow` across the host. The header is what actually does the work: a `robots.txt` disallow would block the crawl and leave the URL indexable by reference, whereas an explicit noindex is authoritative for an origin that serves no pages.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter web test` (146 passed, 72 of them the new drift guard)
- [x] `pnpm --filter web build`, all six routes present in the route table
- [x] Dev server: six section paths return 200, `/docs/features` renders 24 cards across 5 groups, `/docs/integrations` renders 10
- [x] Dev server: `/docs/features/evals` emits the 4-step breadcrumb, `/docs/quick-start` still emits 3
- [ ] After deploy: confirm `X-Robots-Tag` on `https://api.spanlens.io/`
- [ ] After deploy: Search Console, validate the "Not found (404)" and "Soft 404" items

🤖 Generated with [Claude Code](https://claude.com/claude-code)