### PR TITLE
fix(web): give every page its own og:url and dedupe the product schema

### DIFF
--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -11,6 +11,7 @@ export const metadata = {
   title: 'About · Spanlens',
   description: ABOUT_DESCRIPTION,
   openGraph: {
+    siteName: 'Spanlens',
     type: 'website',
     title: 'About Spanlens — Open Source LLM Observability',
     description: ABOUT_DESCRIPTION,
@@ -35,6 +36,9 @@ const aboutJsonLd = {
   // now live on the canonical node in app/layout.tsx.
   mainEntity: {
     '@id': 'https://www.spanlens.io/#organization',
+
+    locale: 'en_US',
+
   },
 }
 

--- a/apps/web/app/accessibility/page.tsx
+++ b/apps/web/app/accessibility/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -5,6 +6,7 @@ import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/accessibility' },
+  openGraph: openGraphFor('/accessibility'),
   title: 'Accessibility Statement · Spanlens',
   description:
     'Spanlens accessibility statement: our WCAG 2.1 Level AA conformance target, the measures we take, known limitations, and how to report an accessibility barrier.',

--- a/apps/web/app/agent-tracing/page.tsx
+++ b/apps/web/app/agent-tracing/page.tsx
@@ -11,10 +11,12 @@ export const metadata = {
   title: 'AI Agent Tracing: Debug Multi-Agent LLM Workflows',
   description: DESCRIPTION,
   openGraph: {
+    siteName: 'Spanlens',
     type: 'article',
     title: 'AI Agent Tracing — Debug Multi-Agent LLM Workflows',
     description: DESCRIPTION,
     url: '/agent-tracing',
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/alternatives/page.tsx
+++ b/apps/web/app/alternatives/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -7,6 +8,7 @@ export const metadata = {
   description:
     'Open-source and SaaS alternatives to Langfuse, Helicone, LangSmith, Braintrust, and Arize Phoenix in 2026. Honest tradeoffs, MIT license, self-hostable.',
   alternates: { canonical: '/alternatives' },
+  openGraph: openGraphFor('/alternatives'),
 }
 
 const SITE_URL = 'https://www.spanlens.io'

--- a/apps/web/app/benchmarks/page.tsx
+++ b/apps/web/app/benchmarks/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -5,6 +6,7 @@ import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/benchmarks' },
+  openGraph: openGraphFor('/benchmarks'),
   title: 'Proxy Overhead Benchmark · Spanlens',
   description:
     'How much latency does the Spanlens proxy add? A reproducible benchmark of synchronous per-request overhead, with the methodology and a command to run it yourself.',

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Rss } from 'lucide-react'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -10,6 +11,7 @@ export const metadata = {
   description:
     'What is new in Spanlens. New features, improvements, infrastructure, and reliability work, in chronological order.',
   alternates: { canonical: '/changelog' },
+  openGraph: openGraphFor('/changelog'),
 }
 
 const TAG_LABEL: Record<ChangelogTag, string> = {

--- a/apps/web/app/compare/arize-phoenix/page.tsx
+++ b/apps/web/app/compare/arize-phoenix/page.tsx
@@ -1,7 +1,9 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CompareTemplate, type CompareGroup, type ComparePoint } from '@/components/marketing/compare-template'
 
 export const metadata = {
   alternates: { canonical: '/compare/arize-phoenix' },
+  openGraph: openGraphFor('/compare/arize-phoenix'),
   title: 'Arize Phoenix Is ELv2, Not OSI Open Source',
   description:
     'Phoenix ships under Elastic License 2.0, which restricts hosted resale. Spanlens is MIT with no EE folder and self-hosts with one Docker command.',

--- a/apps/web/app/compare/braintrust/page.tsx
+++ b/apps/web/app/compare/braintrust/page.tsx
@@ -1,7 +1,9 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CompareTemplate, type CompareGroup, type ComparePoint } from '@/components/marketing/compare-template'
 
 export const metadata = {
   alternates: { canonical: '/compare/braintrust' },
+  openGraph: openGraphFor('/compare/braintrust'),
   title: 'Spanlens vs Braintrust · 2026 Comparison',
   description:
     'Braintrust is eval-first, closed-source SaaS. Spanlens bundles eval into a full observability platform with proxy logging and agent tracing. Self-hostable.',

--- a/apps/web/app/compare/helicone/page.tsx
+++ b/apps/web/app/compare/helicone/page.tsx
@@ -1,7 +1,9 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CompareTemplate, type CompareGroup, type ComparePoint } from '@/components/marketing/compare-template'
 
 export const metadata = {
   alternates: { canonical: '/compare/helicone' },
+  openGraph: openGraphFor('/compare/helicone'),
   title: 'Helicone Alternative After the Mintlify Acquisition',
   description:
     'Helicone entered maintenance mode after Mintlify acquired it in March 2026. Spanlens is MIT, still shipping, and swaps in with the same one-line baseURL.',

--- a/apps/web/app/compare/langfuse/page.tsx
+++ b/apps/web/app/compare/langfuse/page.tsx
@@ -1,7 +1,9 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CompareTemplate, type CompareGroup, type ComparePoint } from '@/components/marketing/compare-template'
 
 export const metadata = {
   alternates: { canonical: '/compare/langfuse' },
+  openGraph: openGraphFor('/compare/langfuse'),
   title: 'Spanlens vs Langfuse · 2026 Comparison',
   description:
     'Spanlens is a drop-in proxy with evals, agent tracing, and Prompt A/B built in, fully MIT. Langfuse uses an SDK + OTel model with a commercial EE folder.',

--- a/apps/web/app/compare/langsmith/page.tsx
+++ b/apps/web/app/compare/langsmith/page.tsx
@@ -1,7 +1,9 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CompareTemplate, type CompareGroup, type ComparePoint } from '@/components/marketing/compare-template'
 
 export const metadata = {
   alternates: { canonical: '/compare/langsmith' },
+  openGraph: openGraphFor('/compare/langsmith'),
   title: 'Spanlens vs LangSmith · 2026 Comparison',
   description:
     'LangSmith is excellent inside the LangChain ecosystem. Spanlens is framework-agnostic: a 1-line baseURL swap works with any HTTP client. MIT licensed.',

--- a/apps/web/app/compare/page.tsx
+++ b/apps/web/app/compare/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -5,6 +6,7 @@ import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/compare' },
+  openGraph: openGraphFor('/compare'),
   title: 'Spanlens vs alternatives · Compare',
   description:
     'Honest comparisons of Spanlens against Langfuse, Helicone, LangSmith, Braintrust, and Arize Phoenix, feature by feature.',

--- a/apps/web/app/docs/api/errors/page.tsx
+++ b/apps/web/app/docs/api/errors/page.tsx
@@ -1,7 +1,9 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/api/errors' },
+  openGraph: openGraphFor('/docs/api/errors'),
   title: 'API error codes · Spanlens Docs',
   description:
     'Stable error.code values returned by the Spanlens server for every 4xx/5xx response. Branch on the code in your client; treat the message as user-facing copy.',

--- a/apps/web/app/docs/api/page.tsx
+++ b/apps/web/app/docs/api/page.tsx
@@ -1,7 +1,9 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/api' },
+  openGraph: openGraphFor('/docs/api'),
   title: 'REST API Reference · Spanlens Docs',
   description:
     'Interactive OpenAPI 3.0 reference for the Spanlens REST API. Authentication, requests, stats, traces, anomalies, members, and proxy endpoints.',

--- a/apps/web/app/docs/cli/page.tsx
+++ b/apps/web/app/docs/cli/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { CodeBlock } from '../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
@@ -7,6 +8,7 @@ export const metadata = {
   description:
     'One-command setup wizard for Spanlens in Node and Python. Auto-detects OpenAI, Anthropic, and Gemini SDK calls and routes them through the proxy.',
   alternates: { canonical: '/docs/cli' },
+  openGraph: openGraphFor('/docs/cli'),
 }
 
 const INSTALL_CMD = `npx @spanlens/cli init`

--- a/apps/web/app/docs/concepts/agent-tracing/page.tsx
+++ b/apps/web/app/docs/concepts/agent-tracing/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'How Spanlens models agent traces: trace root, agent steps, LLM calls, tool calls, parent/child links, and critical path computation.',
   alternates: { canonical: '/docs/concepts/agent-tracing' },
+  openGraph: openGraphFor('/docs/concepts/agent-tracing'),
 }
 
 export default function AgentTracingConcept() {

--- a/apps/web/app/docs/concepts/data-model/page.tsx
+++ b/apps/web/app/docs/concepts/data-model/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'Spanlens data model in one page: Request, Trace, Span, Prompt Version, Eval, Dataset, and how they relate for billing, debugging, and quality questions.',
   alternates: { canonical: '/docs/concepts/data-model' },
+  openGraph: openGraphFor('/docs/concepts/data-model'),
 }
 
 export default function DataModelDocs() {

--- a/apps/web/app/docs/concepts/evals/page.tsx
+++ b/apps/web/app/docs/concepts/evals/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'How Spanlens models evals: LLM-as-judge scoring, human annotation, judge-to-human correlation as a metric, and drift detection across prompt versions.',
   alternates: { canonical: '/docs/concepts/evals' },
+  openGraph: openGraphFor('/docs/concepts/evals'),
 }
 
 export default function EvalsConcept() {

--- a/apps/web/app/docs/concepts/llm-observability/page.tsx
+++ b/apps/web/app/docs/concepts/llm-observability/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'What LLM observability is, the five signal categories worth capturing, and how Spanlens maps each one to a concrete entity in the data model.',
   alternates: { canonical: '/docs/concepts/llm-observability' },
+  openGraph: openGraphFor('/docs/concepts/llm-observability'),
 }
 
 export default function LlmObservabilityConcept() {

--- a/apps/web/app/docs/concepts/page.tsx
+++ b/apps/web/app/docs/concepts/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 import { DocsSectionIndex } from '@/app/docs/_components/section-index'
 import { getDocsSection } from '@/app/docs/_lib/sections'
@@ -6,6 +7,7 @@ const SECTION = getDocsSection('concepts')
 
 export const metadata = {
   alternates: { canonical: '/docs/concepts' },
+  openGraph: openGraphFor('/docs/concepts'),
   title: 'Concepts · Spanlens Docs',
   description: SECTION.description,
 }

--- a/apps/web/app/docs/concepts/prompt-management/page.tsx
+++ b/apps/web/app/docs/concepts/prompt-management/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'How Spanlens versions prompts, runs Prompt A/B with Welch t-test on latency and cost, computes z-test on error rate, and rolls back without deploys.',
   alternates: { canonical: '/docs/concepts/prompt-management' },
+  openGraph: openGraphFor('/docs/concepts/prompt-management'),
 }
 
 export default function PromptManagementConcept() {

--- a/apps/web/app/docs/features/alerts/page.tsx
+++ b/apps/web/app/docs/features/alerts/page.tsx
@@ -1,9 +1,11 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { AlertLoopDiagram } from '../../_components/diagrams'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/alerts' },
+  openGraph: openGraphFor('/docs/features/alerts'),
   title: 'Alerts · Spanlens Docs',
   description:
     'Threshold-based alert rules for budget, error rate, and p95 latency. Delivered via email (Resend), Slack, or Discord webhooks.',

--- a/apps/web/app/docs/features/annotation/page.tsx
+++ b/apps/web/app/docs/features/annotation/page.tsx
@@ -1,8 +1,10 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/annotation' },
+  openGraph: openGraphFor('/docs/features/annotation'),
   title: 'Annotation · Spanlens Docs',
   description:
     'Human star-rating for production responses. Pearson r correlation with LLM judge scores makes judge reliability visible at a glance.',

--- a/apps/web/app/docs/features/anomalies/page.tsx
+++ b/apps/web/app/docs/features/anomalies/page.tsx
@@ -1,9 +1,11 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { AnomalyChart } from '../../_components/charts'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/anomalies' },
+  openGraph: openGraphFor('/docs/features/anomalies'),
   title: 'Anomalies · Spanlens Docs',
   description:
     '3-sigma statistical anomaly detection on latency, cost, and error rate per (provider, model) bucket. No ML, no configuration.',

--- a/apps/web/app/docs/features/audit-logs/page.tsx
+++ b/apps/web/app/docs/features/audit-logs/page.tsx
@@ -1,8 +1,10 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/audit-logs' },
+  openGraph: openGraphFor('/docs/features/audit-logs'),
   title: 'Audit Logs · Spanlens Docs',
   description:
     'Chronological record of every organization-level change: API keys, provider keys, member invitations, role changes, and billing plan switches.',

--- a/apps/web/app/docs/features/billing/page.tsx
+++ b/apps/web/app/docs/features/billing/page.tsx
@@ -1,9 +1,11 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { PlanQuotaChart } from '../../_components/charts'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/billing' },
+  openGraph: openGraphFor('/docs/features/billing'),
   title: 'Billing & quotas · Spanlens Docs',
   description:
     'How Spanlens charges you: plan quotas, overage billing, the hard cap, and what your invoice looks like.',

--- a/apps/web/app/docs/features/cost-tracking/page.tsx
+++ b/apps/web/app/docs/features/cost-tracking/page.tsx
@@ -1,9 +1,11 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { ModelPriceChart } from '../../_components/charts'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/cost-tracking' },
+  openGraph: openGraphFor('/docs/features/cost-tracking'),
   title: 'Cost tracking · Spanlens Docs',
   description:
     'Accurate per-request USD cost computed from provider token prices. Handles dated model variants via longest-prefix matching.',

--- a/apps/web/app/docs/features/datasets/page.tsx
+++ b/apps/web/app/docs/features/datasets/page.tsx
@@ -1,9 +1,11 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DatasetSchemaDiagram } from '../../_components/diagrams'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/datasets' },
+  openGraph: openGraphFor('/docs/features/datasets'),
   title: 'Datasets · Spanlens Docs',
   description:
     'Reusable (input, expected_output) test sets. Use in Evals and Experiments instead of pulling from live production traffic.',

--- a/apps/web/app/docs/features/evals/page.tsx
+++ b/apps/web/app/docs/features/evals/page.tsx
@@ -1,8 +1,10 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/evals' },
+  openGraph: openGraphFor('/docs/features/evals'),
   title: 'Evals · Spanlens Docs',
   description:
     'LLM-as-judge evaluation, automatically score production responses on a 0..1 scale and quantify quality per prompt version.',

--- a/apps/web/app/docs/features/experiments/page.tsx
+++ b/apps/web/app/docs/features/experiments/page.tsx
@@ -1,8 +1,10 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/experiments' },
+  openGraph: openGraphFor('/docs/features/experiments'),
   title: 'Experiments · Spanlens Docs',
   description:
     'Offline side-by-side comparison, run a dataset against two prompt versions and compare outputs, scores, and cost without touching production traffic.',

--- a/apps/web/app/docs/features/export/page.tsx
+++ b/apps/web/app/docs/features/export/page.tsx
@@ -1,8 +1,10 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/export' },
+  openGraph: openGraphFor('/docs/features/export'),
   title: 'Data Export · Spanlens Docs',
   description:
     'Download request logs, traces, anomalies, and security flags as CSV, JSONL, or JSON. Streamed exports handle millions of rows.',

--- a/apps/web/app/docs/features/members-invitations/page.tsx
+++ b/apps/web/app/docs/features/members-invitations/page.tsx
@@ -1,8 +1,10 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/members-invitations' },
+  openGraph: openGraphFor('/docs/features/members-invitations'),
   title: 'Members & invitations · Spanlens Docs',
   description:
     'Multi-user workspaces with admin, editor, and viewer roles, email invitations with auto-accept, and an audit log of every membership event.',

--- a/apps/web/app/docs/features/page.tsx
+++ b/apps/web/app/docs/features/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 import { DocsSectionIndex } from '@/app/docs/_components/section-index'
 import { getDocsSection } from '@/app/docs/_lib/sections'
@@ -6,6 +7,7 @@ const SECTION = getDocsSection('features')
 
 export const metadata = {
   alternates: { canonical: '/docs/features' },
+  openGraph: openGraphFor('/docs/features'),
   title: 'Features · Spanlens Docs',
   description: SECTION.description,
 }

--- a/apps/web/app/docs/features/projects/page.tsx
+++ b/apps/web/app/docs/features/projects/page.tsx
@@ -1,9 +1,11 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { ProjectsHierarchyDiagram } from '../../_components/diagrams'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/projects' },
+  openGraph: openGraphFor('/docs/features/projects'),
   title: 'Projects, Spanlens keys & provider keys · Spanlens Docs',
   description:
     'Scope your traffic into projects (dev / staging / prod, per-service). Each Spanlens key (sl_live_…) carries its own pool of encrypted provider keys.',

--- a/apps/web/app/docs/features/prompt-ab/page.tsx
+++ b/apps/web/app/docs/features/prompt-ab/page.tsx
@@ -1,9 +1,11 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { PromptAbChart } from '../../_components/charts'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/prompt-ab' },
+  openGraph: openGraphFor('/docs/features/prompt-ab'),
   title: 'Prompt A/B · Spanlens Docs',
   description:
     'Route live production traffic across two prompt versions and measure latency, cost, and error rate with statistical significance.',

--- a/apps/web/app/docs/features/prompts-playground/page.tsx
+++ b/apps/web/app/docs/features/prompts-playground/page.tsx
@@ -1,8 +1,10 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/prompts-playground' },
+  openGraph: openGraphFor('/docs/features/prompts-playground'),
   title: 'Prompts Playground · Spanlens Docs',
   description:
     'Interactive console inside the Prompts tab, select a version, set model, temperature, and variables, then run it immediately and see cost and token counts.',

--- a/apps/web/app/docs/features/prompts/page.tsx
+++ b/apps/web/app/docs/features/prompts/page.tsx
@@ -1,8 +1,10 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/prompts' },
+  openGraph: openGraphFor('/docs/features/prompts'),
   title: 'Prompts · Spanlens Docs',
   description:
     'Version-controlled prompt templates with real-data A/B comparison, latency, cost, and error rate per version.',

--- a/apps/web/app/docs/features/requests/page.tsx
+++ b/apps/web/app/docs/features/requests/page.tsx
@@ -1,8 +1,10 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/requests' },
+  openGraph: openGraphFor('/docs/features/requests'),
   title: 'Requests · Spanlens Docs',
   description:
     'Complete log of every LLM call routed through Spanlens, model, tokens, cost, latency, full request/response bodies.',

--- a/apps/web/app/docs/features/saved-filters/page.tsx
+++ b/apps/web/app/docs/features/saved-filters/page.tsx
@@ -1,8 +1,10 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/saved-filters' },
+  openGraph: openGraphFor('/docs/features/saved-filters'),
   title: 'Saved Filters · Spanlens Docs',
   description:
     'Save named filter combinations on the /requests page and restore them instantly from a dropdown on future visits.',

--- a/apps/web/app/docs/features/savings/page.tsx
+++ b/apps/web/app/docs/features/savings/page.tsx
@@ -1,8 +1,10 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/savings' },
+  openGraph: openGraphFor('/docs/features/savings'),
   title: 'Savings · Spanlens Docs',
   description:
     'Model recommendations based on your real token distribution. Cheaper substitutes with estimated monthly savings, confidence tiers, and email alerts.',

--- a/apps/web/app/docs/features/security/page.tsx
+++ b/apps/web/app/docs/features/security/page.tsx
@@ -1,8 +1,10 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/security' },
+  openGraph: openGraphFor('/docs/features/security'),
   title: 'Security (PII + prompt injection) · Spanlens Docs',
   description:
     'Automatic PII detection and prompt-injection scanning on every LLM request and response, with optional blocking mode and real-time alert emails.',

--- a/apps/web/app/docs/features/settings/page.tsx
+++ b/apps/web/app/docs/features/settings/page.tsx
@@ -1,9 +1,11 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { EncryptionFlowDiagram } from '../../_components/diagrams'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/settings' },
+  openGraph: openGraphFor('/docs/features/settings'),
   title: 'Keys & encryption · Spanlens Docs',
   description:
     'How Spanlens stores and protects your AI provider keys. AES-256-GCM encryption at rest, decrypted only in memory during proxy forwarding.',

--- a/apps/web/app/docs/features/shares/page.tsx
+++ b/apps/web/app/docs/features/shares/page.tsx
@@ -1,8 +1,10 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/shares' },
+  openGraph: openGraphFor('/docs/features/shares'),
   title: 'Shared links · Spanlens Docs',
   description:
     'Publish a public read-only render of any trace or request via a share link, with redaction presets, view counts, and one-click revoke.',

--- a/apps/web/app/docs/features/traces/page.tsx
+++ b/apps/web/app/docs/features/traces/page.tsx
@@ -1,9 +1,11 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { TraceWaterfallDiagram } from '../../_components/diagrams'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/traces' },
+  openGraph: openGraphFor('/docs/features/traces'),
   title: 'Traces · Spanlens Docs',
   description:
     'Agent tracing with nested span trees. See exactly where time goes when your LLM agent calls five tools in sequence.',

--- a/apps/web/app/docs/features/users/page.tsx
+++ b/apps/web/app/docs/features/users/page.tsx
@@ -1,8 +1,10 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/users' },
+  openGraph: openGraphFor('/docs/features/users'),
   title: 'Users · Spanlens Docs',
   description:
     'End-user attribution and per-user analytics for LLM usage. Tag requests with x-spanlens-user and see who is spending what.',

--- a/apps/web/app/docs/features/webhooks/page.tsx
+++ b/apps/web/app/docs/features/webhooks/page.tsx
@@ -1,8 +1,10 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/features/webhooks' },
+  openGraph: openGraphFor('/docs/features/webhooks'),
   title: 'Webhooks · Spanlens Docs',
   description:
     'Receive Spanlens events (request created, trace completed, alert triggered) as real-time HTTP POST payloads on your own server.',

--- a/apps/web/app/docs/integrations/bedrock/page.tsx
+++ b/apps/web/app/docs/integrations/bedrock/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'Capture AWS Bedrock model invocations (Claude, Llama, Mistral, Titan) with Spanlens. SigV4 auth handled by your SDK; Spanlens proxies the wire.',
   alternates: { canonical: '/docs/integrations/bedrock' },
+  openGraph: openGraphFor('/docs/integrations/bedrock'),
 }
 
 export default function BedrockIntegration() {

--- a/apps/web/app/docs/integrations/crewai/page.tsx
+++ b/apps/web/app/docs/integrations/crewai/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'Trace CrewAI crews, agents, and tasks with Spanlens. One install captures the full crew execution tree with per-agent cost and latency.',
   alternates: { canonical: '/docs/integrations/crewai' },
+  openGraph: openGraphFor('/docs/integrations/crewai'),
 }
 
 export default function CrewAIIntegration() {

--- a/apps/web/app/docs/integrations/flowise/page.tsx
+++ b/apps/web/app/docs/integrations/flowise/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'Connect Flowise visual flows to Spanlens. Flowise calls go through the Spanlens proxy and each node executions becomes a span.',
   alternates: { canonical: '/docs/integrations/flowise' },
+  openGraph: openGraphFor('/docs/integrations/flowise'),
 }
 
 export default function FlowiseIntegration() {

--- a/apps/web/app/docs/integrations/instructor/page.tsx
+++ b/apps/web/app/docs/integrations/instructor/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'Trace Instructor structured-output calls with Spanlens. Captures the Pydantic schema, retry count, and per-retry token cost.',
   alternates: { canonical: '/docs/integrations/instructor' },
+  openGraph: openGraphFor('/docs/integrations/instructor'),
 }
 
 export default function InstructorIntegration() {

--- a/apps/web/app/docs/integrations/langchain/page.tsx
+++ b/apps/web/app/docs/integrations/langchain/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'Trace LangChain (JS and Python) chains, agents, and tools with one callback handler. Every chain run, LLM call, and tool invocation becomes a Spanlens span.',
   alternates: { canonical: '/docs/integrations/langchain' },
+  openGraph: openGraphFor('/docs/integrations/langchain'),
 }
 
 export default function LangChainIntegration() {

--- a/apps/web/app/docs/integrations/langgraph/page.tsx
+++ b/apps/web/app/docs/integrations/langgraph/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'Trace LangGraph node and edge execution with Spanlens. One callback handler captures the full graph topology, parallel fan-out, and tool calls.',
   alternates: { canonical: '/docs/integrations/langgraph' },
+  openGraph: openGraphFor('/docs/integrations/langgraph'),
 }
 
 export default function LangGraphIntegration() {

--- a/apps/web/app/docs/integrations/llamaindex/page.tsx
+++ b/apps/web/app/docs/integrations/llamaindex/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'Trace LlamaIndex query engines and agents with Spanlens. One callback handler maps every CBEventType to a span so the trace mirrors your RAG pipeline.',
   alternates: { canonical: '/docs/integrations/llamaindex' },
+  openGraph: openGraphFor('/docs/integrations/llamaindex'),
 }
 
 export default function LlamaIndexIntegration() {

--- a/apps/web/app/docs/integrations/mcp/page.tsx
+++ b/apps/web/app/docs/integrations/mcp/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
@@ -7,6 +8,7 @@ export const metadata = {
   description:
     'Query Spanlens LLM cost, traces, and anomalies from Cursor, Claude Desktop, or Continue via MCP. Public-scope keys stay safe in plaintext IDE config.',
   alternates: { canonical: '/docs/integrations/mcp' },
+  openGraph: openGraphFor('/docs/integrations/mcp'),
 }
 
 export default function MCPIntegration() {

--- a/apps/web/app/docs/integrations/openai-assistants/page.tsx
+++ b/apps/web/app/docs/integrations/openai-assistants/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'Trace OpenAI Assistants API threads, runs, and steps with Spanlens. Tool calls and code-interpreter steps render as a span tree per run.',
   alternates: { canonical: '/docs/integrations/openai-assistants' },
+  openGraph: openGraphFor('/docs/integrations/openai-assistants'),
 }
 
 export default function OpenAIAssistantsIntegration() {

--- a/apps/web/app/docs/integrations/page.tsx
+++ b/apps/web/app/docs/integrations/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 import { DocsSectionIndex } from '@/app/docs/_components/section-index'
 import { getDocsSection } from '@/app/docs/_lib/sections'
@@ -6,6 +7,7 @@ const SECTION = getDocsSection('integrations')
 
 export const metadata = {
   alternates: { canonical: '/docs/integrations' },
+  openGraph: openGraphFor('/docs/integrations'),
   title: 'Integrations · Spanlens Docs',
   description: SECTION.description,
 }

--- a/apps/web/app/docs/integrations/vercel-ai/page.tsx
+++ b/apps/web/app/docs/integrations/vercel-ai/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'Trace generateText, streamText, generateObject, and streamObject with Spanlens. Two callbacks spread into the AI SDK options log every call automatically.',
   alternates: { canonical: '/docs/integrations/vercel-ai' },
+  openGraph: openGraphFor('/docs/integrations/vercel-ai'),
 }
 
 export default function VercelAiIntegration() {

--- a/apps/web/app/docs/migrate/from-helicone/page.tsx
+++ b/apps/web/app/docs/migrate/from-helicone/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { LangTabs } from '../../_components/lang-tabs'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
@@ -7,6 +8,7 @@ export const metadata = {
   description:
     'Move from Helicone to Spanlens in under 15 minutes. Base URL swap, properties to user / session mapping, and what to do about the AI Gateway features.',
   alternates: { canonical: '/docs/migrate/from-helicone' },
+  openGraph: openGraphFor('/docs/migrate/from-helicone'),
 }
 
 export default function MigrateFromHelicone() {

--- a/apps/web/app/docs/migrate/from-langfuse/page.tsx
+++ b/apps/web/app/docs/migrate/from-langfuse/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { LangTabs } from '../../_components/lang-tabs'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
@@ -7,6 +8,7 @@ export const metadata = {
   description:
     'Move from Langfuse to Spanlens in under 30 minutes. Code diffs, data model mapping, and dual-running steps so you can switch without losing history.',
   alternates: { canonical: '/docs/migrate/from-langfuse' },
+  openGraph: openGraphFor('/docs/migrate/from-langfuse'),
 }
 
 export default function MigrateFromLangfuse() {

--- a/apps/web/app/docs/migrate/from-langsmith/page.tsx
+++ b/apps/web/app/docs/migrate/from-langsmith/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { LangTabs } from '../../_components/lang-tabs'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
@@ -7,6 +8,7 @@ export const metadata = {
   description:
     'Move from LangSmith to Spanlens in under 45 minutes: traceable-to-observe() mapping, LangChain callback swap, and schema migration.',
   alternates: { canonical: '/docs/migrate/from-langsmith' },
+  openGraph: openGraphFor('/docs/migrate/from-langsmith'),
 }
 
 export default function MigrateFromLangsmith() {

--- a/apps/web/app/docs/migrate/page.tsx
+++ b/apps/web/app/docs/migrate/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 import { DocsSectionIndex } from '@/app/docs/_components/section-index'
 import { getDocsSection } from '@/app/docs/_lib/sections'
@@ -6,6 +7,7 @@ const SECTION = getDocsSection('migrate')
 
 export const metadata = {
   alternates: { canonical: '/docs/migrate' },
+  openGraph: openGraphFor('/docs/migrate'),
   title: 'Migrate to Spanlens · Spanlens Docs',
   description: SECTION.description,
 }

--- a/apps/web/app/docs/otel/page.tsx
+++ b/apps/web/app/docs/otel/page.tsx
@@ -1,9 +1,11 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../_components/code-block'
 import { OtelMappingDiagram } from '../_components/diagrams'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/otel' },
+  openGraph: openGraphFor('/docs/otel'),
   title: 'OpenTelemetry · Spanlens Docs',
   description:
     'Send traces to Spanlens via OTLP/HTTP using any OpenTelemetry SDK. Works with Python, Go, Java, and any gen_ai-instrumented framework.',

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { ArrowRight, Zap, Code, Globe, Server, Activity, Terminal } from 'lucide-react'
 import { QuickTabs } from './_components/quick-tabs'
@@ -7,6 +8,7 @@ export const metadata = {
   description:
     'Integrate drop-in LLM observability for OpenAI, Anthropic, and Gemini in 30 seconds. SDK reference, proxy API, OpenTelemetry, and self-hosting guides.',
   alternates: { canonical: '/docs' },
+  openGraph: openGraphFor('/docs'),
 }
 
 const TS_SNIPPET = `import { createOpenAI } from '@spanlens/sdk/openai'

--- a/apps/web/app/docs/production/disaster-recovery/page.tsx
+++ b/apps/web/app/docs/production/disaster-recovery/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'Operator runbook for Spanlens outages: what data is at risk per failure mode, how fallback queues protect it, and recovery steps for ClickHouse and Supabase.',
   alternates: { canonical: '/docs/production/disaster-recovery' },
+  openGraph: openGraphFor('/docs/production/disaster-recovery'),
 }
 
 export default function DisasterRecoveryDocs() {

--- a/apps/web/app/docs/production/page.tsx
+++ b/apps/web/app/docs/production/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 import { DocsSectionIndex } from '@/app/docs/_components/section-index'
 import { getDocsSection } from '@/app/docs/_lib/sections'
@@ -6,6 +7,7 @@ const SECTION = getDocsSection('production')
 
 export const metadata = {
   alternates: { canonical: '/docs/production' },
+  openGraph: openGraphFor('/docs/production'),
   title: 'Production · Spanlens Docs',
   description: SECTION.description,
 }

--- a/apps/web/app/docs/production/reliability/page.tsx
+++ b/apps/web/app/docs/production/reliability/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'How Spanlens degrades during a partial outage, what the fallback queue does, and how to monitor the proxy so it never silently drops logs.',
   alternates: { canonical: '/docs/production/reliability' },
+  openGraph: openGraphFor('/docs/production/reliability'),
 }
 
 export default function ReliabilityDocs() {

--- a/apps/web/app/docs/production/scaling/page.tsx
+++ b/apps/web/app/docs/production/scaling/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'Latency budget, log body trade-offs, sampling, and self-hosting tuning for high-throughput LLM workloads on Spanlens.',
   alternates: { canonical: '/docs/production/scaling' },
+  openGraph: openGraphFor('/docs/production/scaling'),
 }
 
 export default function ScalingDocs() {

--- a/apps/web/app/docs/proxy/page.tsx
+++ b/apps/web/app/docs/proxy/page.tsx
@@ -1,8 +1,10 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/proxy' },
+  openGraph: openGraphFor('/docs/proxy'),
   title: 'Direct proxy · Spanlens Docs',
   description: 'Use Spanlens from any language, Python, Ruby, Go, curl. Just swap the base URL.',
 }
@@ -314,7 +316,7 @@ res, _ := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
       </p>
       <p>
         Add <code>X-Trace-Id</code> and <code>X-Span-Id</code> headers (UUIDs) to link a proxy call
-        to an <a href="/docs/agents">agent trace</a> so it appears inside the span tree with its
+        to an <a href="/docs/concepts/agent-tracing">agent trace</a> so it appears inside the span tree with its
         cost and tokens. The SDK sets these for you via{' '}
         <code>trace.headers()</code> / <code>span.headers()</code>; raw HTTP callers can pass them
         directly. Non-UUID values are ignored rather than rejected:

--- a/apps/web/app/docs/quick-start/page.tsx
+++ b/apps/web/app/docs/quick-start/page.tsx
@@ -1,9 +1,11 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../_components/code-block'
 import { QuickStartFlowDiagram } from '../_components/diagrams'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/quick-start' },
+  openGraph: openGraphFor('/docs/quick-start'),
   title: 'Quick start · Spanlens Docs',
   description:
     'Get up and running with Spanlens in 30 seconds. Migrate existing OpenAI, Anthropic, or Gemini code with one command, or set up manually in four steps.',

--- a/apps/web/app/docs/sdk/page.tsx
+++ b/apps/web/app/docs/sdk/page.tsx
@@ -1,9 +1,11 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../_components/code-block'
 import { LangTabs } from '../_components/lang-tabs'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/sdk' },
+  openGraph: openGraphFor('/docs/sdk'),
   title: 'Spanlens SDK · Spanlens Docs',
   description:
     'Official SDK reference for TypeScript and Python, createOpenAI, createAnthropic, createGemini, observe(), and the trace / span API.',

--- a/apps/web/app/docs/self-host/backup/page.tsx
+++ b/apps/web/app/docs/self-host/backup/page.tsx
@@ -1,7 +1,9 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/self-host/backup' },
+  openGraph: openGraphFor('/docs/self-host/backup'),
   title: 'Backup & restore · Spanlens Docs',
   description:
     'Backup and restore runbook for self-hosted Spanlens: dump Supabase Postgres and ClickHouse log, snapshot Docker volumes, and back up ENCRYPTION_KEY separately.',

--- a/apps/web/app/docs/self-host/page.tsx
+++ b/apps/web/app/docs/self-host/page.tsx
@@ -1,9 +1,11 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../_components/code-block'
 import { SelfHostArchitectureDiagram } from '../_components/diagrams'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/self-host' },
+  openGraph: openGraphFor('/docs/self-host'),
   title: 'Self-hosting · Spanlens Docs',
   description:
     'Run the full Spanlens stack (dashboard + proxy) on your own infra with a Supabase project.',

--- a/apps/web/app/docs/troubleshooting/page.tsx
+++ b/apps/web/app/docs/troubleshooting/page.tsx
@@ -1,7 +1,9 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/troubleshooting' },
+  openGraph: openGraphFor('/docs/troubleshooting'),
   title: 'Troubleshooting · Spanlens Docs',
   description:
     'Symptom-first fixes for common Spanlens problems: 401/403 auth, 429 rate limits, 502/503/504 upstream errors, missing requests, and empty or truncated traces.',

--- a/apps/web/app/docs/tutorials/agent-tracing/page.tsx
+++ b/apps/web/app/docs/tutorials/agent-tracing/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'Tutorial: trace an agent that classifies intent, fans out to parallel tools, and composes an answer. Per-step cost and critical path in one waterfall.',
   alternates: { canonical: '/docs/tutorials/agent-tracing' },
+  openGraph: openGraphFor('/docs/tutorials/agent-tracing'),
 }
 
 export default function AgentTracingTutorial() {

--- a/apps/web/app/docs/tutorials/nightly-evals/page.tsx
+++ b/apps/web/app/docs/tutorials/nightly-evals/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'Tutorial: set up an LLM-as-judge evaluator on a nightly sample of production traffic and catch prompt quality regressions before users complain.',
   alternates: { canonical: '/docs/tutorials/nightly-evals' },
+  openGraph: openGraphFor('/docs/tutorials/nightly-evals'),
 }
 
 export default function NightlyEvalsTutorial() {

--- a/apps/web/app/docs/tutorials/page.tsx
+++ b/apps/web/app/docs/tutorials/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 import { DocsSectionIndex } from '@/app/docs/_components/section-index'
 import { getDocsSection } from '@/app/docs/_lib/sections'
@@ -6,6 +7,7 @@ const SECTION = getDocsSection('tutorials')
 
 export const metadata = {
   alternates: { canonical: '/docs/tutorials' },
+  openGraph: openGraphFor('/docs/tutorials'),
   title: 'Tutorials · Spanlens Docs',
   description: SECTION.description,
 }

--- a/apps/web/app/docs/tutorials/rag-chatbot/page.tsx
+++ b/apps/web/app/docs/tutorials/rag-chatbot/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import { CodeBlock } from '../../_components/code-block'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
@@ -6,6 +7,7 @@ export const metadata = {
   description:
     'End-to-end tutorial. Take a basic RAG chatbot, add Spanlens, and see retrieval + generation as one trace with token cost and per-step latency.',
   alternates: { canonical: '/docs/tutorials/rag-chatbot' },
+  openGraph: openGraphFor('/docs/tutorials/rag-chatbot'),
 }
 
 export default function RagChatbotTutorial() {

--- a/apps/web/app/docs/why/page.tsx
+++ b/apps/web/app/docs/why/page.tsx
@@ -1,9 +1,11 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { FeatureCoverageRadar } from '../_components/charts'
 import { DocsJsonLd } from '@/app/docs/_components/docs-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/docs/why' },
+  openGraph: openGraphFor('/docs/why'),
   title: 'Why Spanlens · Spanlens Docs',
   description:
     'Why pick Spanlens over Helicone, Langfuse, LangSmith, or Arize Phoenix. Honest comparison of the six things only Spanlens does end-to-end.',

--- a/apps/web/app/dpa/page.tsx
+++ b/apps/web/app/dpa/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -5,6 +6,7 @@ import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/dpa' },
+  openGraph: openGraphFor('/dpa'),
   title: 'Data Processing Addendum · Spanlens',
   description:
     'Spanlens Data Processing Addendum (DPA) for customers subject to GDPR or UK GDPR. Incorporates the EU Standard Contractual Clauses (Module 2).',

--- a/apps/web/app/faq/page.tsx
+++ b/apps/web/app/faq/page.tsx
@@ -11,10 +11,12 @@ export const metadata = {
   title: 'FAQ · Spanlens LLM Observability',
   description: FAQ_DESCRIPTION,
   openGraph: {
+    siteName: 'Spanlens',
     type: 'website',
     title: 'Spanlens FAQ — Open Source LLM Observability',
     description: FAQ_DESCRIPTION,
     url: '/faq',
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/feedback/page.tsx
+++ b/apps/web/app/feedback/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { MarketingNav } from '@/components/layout/marketing-nav'
 import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
@@ -28,6 +29,7 @@ export const metadata = {
   description:
     'Tell us what to build next. Vote on what others suggested. Track each item from new to shipped.',
   alternates: { canonical: '/feedback' },
+  openGraph: openGraphFor('/feedback'),
 }
 
 export default function FeedbackPage() {

--- a/apps/web/app/integrations/anthropic/page.tsx
+++ b/apps/web/app/integrations/anthropic/page.tsx
@@ -8,10 +8,12 @@ export const metadata = {
   title: 'Anthropic Observability — Spanlens Integration',
   description: DESCRIPTION,
   openGraph: {
+    siteName: 'Spanlens',
     type: 'website',
     title: 'Anthropic Claude Observability — Log every API call with Spanlens',
     description: DESCRIPTION,
     url: '/integrations/anthropic',
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/integrations/gemini/page.tsx
+++ b/apps/web/app/integrations/gemini/page.tsx
@@ -8,10 +8,12 @@ export const metadata = {
   title: 'Gemini Observability — Spanlens Integration',
   description: DESCRIPTION,
   openGraph: {
+    siteName: 'Spanlens',
     type: 'website',
     title: 'Google Gemini Observability — Log every API call with Spanlens',
     description: DESCRIPTION,
     url: '/integrations/gemini',
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/integrations/openai/page.tsx
+++ b/apps/web/app/integrations/openai/page.tsx
@@ -8,10 +8,12 @@ export const metadata = {
   title: 'OpenAI Observability — Spanlens Integration',
   description: DESCRIPTION,
   openGraph: {
+    siteName: 'Spanlens',
     type: 'website',
     title: 'OpenAI Observability — Log every API call with Spanlens',
     description: DESCRIPTION,
     url: '/integrations/openai',
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/llm-cost-tracking/page.tsx
+++ b/apps/web/app/llm-cost-tracking/page.tsx
@@ -11,10 +11,12 @@ export const metadata = {
   title: 'LLM Cost Tracking: Monitor and Reduce Your AI API Spend',
   description: DESCRIPTION,
   openGraph: {
+    siteName: 'Spanlens',
     type: 'article',
     title: 'LLM Cost Tracking: Monitor and Reduce Your AI API Spend',
     description: DESCRIPTION,
     url: '/llm-cost-tracking',
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/llm-observability/page.tsx
+++ b/apps/web/app/llm-observability/page.tsx
@@ -11,10 +11,12 @@ export const metadata = {
   title: 'LLM Observability: The 2026 Guide for Production AI Apps',
   description: DESCRIPTION,
   openGraph: {
+    siteName: 'Spanlens',
     type: 'article',
     title: 'LLM Observability — A 2026 Guide for Production AI Apps',
     description: DESCRIPTION,
     url: '/llm-observability',
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -116,9 +116,17 @@ const TRACE_SPANS = [
   { name: 'format_reply',           depth: 1, start: 90, width: 6,   critical: false, label: '480ms' },
 ]
 
+// Canonical product entity for the whole site. Comparison and integration
+// pages reference it by `@id` rather than declaring their own partial copy.
+//
+// No `aggregateRating` / `review`: Google wants one of them for the Software
+// App rich result, and Ahrefs reports the absence as an error, but there are
+// no genuine ratings to publish and inventing them would be worse than
+// forgoing the rich result. Add real ones here if that ever changes.
 const softwareApplicationJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'SoftwareApplication',
+  '@id': `${SITE_URL}/#software`,
   name: 'Spanlens',
   applicationCategory: 'DeveloperApplication',
   applicationSubCategory: 'LLM Observability',
@@ -126,11 +134,15 @@ const softwareApplicationJsonLd = {
   url: SITE_URL,
   description:
     'Drop-in LLM observability for OpenAI, Anthropic, and Gemini. Logging, cost tracking, agent tracing, evals, anomaly detection, and PII scanning. Open source.',
-  offers: PLANS.map((p) => ({
+  // Enterprise is excluded on purpose. `price` is required on an Offer, and
+  // "contact us" has no number to put there; emitting the Offer without one
+  // fails validation ("Missing required price property"), and inventing a
+  // figure would be worse. The three priced plans carry the pricing signal.
+  offers: PLANS.filter((p) => p.price !== 'Custom').map((p) => ({
     '@type': 'Offer',
     name: p.name,
-    price: p.price === 'Custom' ? undefined : p.price.replace('$', ''),
-    priceCurrency: p.price === 'Custom' ? undefined : 'USD',
+    price: p.price.replace('$', ''),
+    priceCurrency: 'USD',
     category: p.unit ? `subscription${p.unit}` : 'custom',
   })),
   featureList: FEATURES.map((f) => `${f.title}: ${f.body}`),

--- a/apps/web/app/pricing/claude-3-5-sonnet/page.tsx
+++ b/apps/web/app/pricing/claude-3-5-sonnet/page.tsx
@@ -8,14 +8,16 @@ export const metadata = {
   title: 'Claude 3.5 Sonnet Pricing 2026 · Spanlens',
   description: DESCRIPTION,
   openGraph: {
+    siteName: 'Spanlens',
     type: 'article',
-    title: 'Claude 3.5 Sonnet Pricing 2026 — Cost Per Token, Monthly Estimates',
+    title: 'Claude 3.5 Sonnet Pricing 2026: Cost Per Token, Monthly Estimates',
     description: DESCRIPTION,
     url: '/pricing/claude-3-5-sonnet',
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Claude 3.5 Sonnet Pricing 2026 — Cost Per Token, Monthly Estimates',
+    title: 'Claude 3.5 Sonnet Pricing 2026: Cost Per Token, Monthly Estimates',
     description: DESCRIPTION,
   },
 }

--- a/apps/web/app/pricing/gemini-2-0-flash/page.tsx
+++ b/apps/web/app/pricing/gemini-2-0-flash/page.tsx
@@ -8,14 +8,16 @@ export const metadata = {
   title: 'Gemini 2.0 Flash Pricing 2026 · Spanlens',
   description: DESCRIPTION,
   openGraph: {
+    siteName: 'Spanlens',
     type: 'article',
-    title: 'Gemini 2.0 Flash Pricing 2026 — Cost Per Token, Monthly Estimates',
+    title: 'Gemini 2.0 Flash Pricing 2026: Cost Per Token, Monthly Estimates',
     description: DESCRIPTION,
     url: '/pricing/gemini-2-0-flash',
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Gemini 2.0 Flash Pricing 2026 — Cost Per Token, Monthly Estimates',
+    title: 'Gemini 2.0 Flash Pricing 2026: Cost Per Token, Monthly Estimates',
     description: DESCRIPTION,
   },
 }

--- a/apps/web/app/pricing/gpt-4o-mini/page.tsx
+++ b/apps/web/app/pricing/gpt-4o-mini/page.tsx
@@ -8,14 +8,16 @@ export const metadata = {
   title: 'GPT-4o-mini Pricing 2026 · Spanlens',
   description: DESCRIPTION,
   openGraph: {
+    siteName: 'Spanlens',
     type: 'article',
-    title: 'GPT-4o-mini Pricing 2026 — Cost Per Token, Monthly Estimates',
+    title: 'GPT-4o-mini Pricing 2026: Cost Per Token, Monthly Estimates',
     description: DESCRIPTION,
     url: '/pricing/gpt-4o-mini',
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'GPT-4o-mini Pricing 2026 — Cost Per Token, Monthly Estimates',
+    title: 'GPT-4o-mini Pricing 2026: Cost Per Token, Monthly Estimates',
     description: DESCRIPTION,
   },
 }

--- a/apps/web/app/pricing/gpt-4o/page.tsx
+++ b/apps/web/app/pricing/gpt-4o/page.tsx
@@ -5,17 +5,19 @@ const DESCRIPTION =
 
 export const metadata = {
   alternates: { canonical: '/pricing/gpt-4o' },
-  title: 'GPT-4o Pricing 2026 — Cost Per Token, Monthly Estimates',
+  title: 'GPT-4o Pricing 2026: Cost Per Token, Monthly Estimates',
   description: DESCRIPTION,
   openGraph: {
+    siteName: 'Spanlens',
     type: 'article',
-    title: 'GPT-4o Pricing 2026 — Cost Per Token, Monthly Estimates',
+    title: 'GPT-4o Pricing 2026: Cost Per Token, Monthly Estimates',
     description: DESCRIPTION,
     url: '/pricing/gpt-4o',
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'GPT-4o Pricing 2026 — Cost Per Token, Monthly Estimates',
+    title: 'GPT-4o Pricing 2026: Cost Per Token, Monthly Estimates',
     description: DESCRIPTION,
   },
 }

--- a/apps/web/app/pricing/o3-mini/page.tsx
+++ b/apps/web/app/pricing/o3-mini/page.tsx
@@ -5,17 +5,19 @@ const DESCRIPTION =
 
 export const metadata = {
   alternates: { canonical: '/pricing/o3-mini' },
-  title: 'o3-mini Pricing 2026 — Cost Per Token, Monthly Estimates',
+  title: 'o3-mini Pricing 2026: Cost Per Token, Monthly Estimates',
   description: DESCRIPTION,
   openGraph: {
+    siteName: 'Spanlens',
     type: 'article',
-    title: 'o3-mini Pricing 2026 — Cost Per Token, Monthly Estimates',
+    title: 'o3-mini Pricing 2026: Cost Per Token, Monthly Estimates',
     description: DESCRIPTION,
     url: '/pricing/o3-mini',
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'o3-mini Pricing 2026 — Cost Per Token, Monthly Estimates',
+    title: 'o3-mini Pricing 2026: Cost Per Token, Monthly Estimates',
     description: DESCRIPTION,
   },
 }

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -14,10 +14,12 @@ export const metadata = {
   title: 'Pricing · Spanlens LLM Observability',
   description: PRICING_DESCRIPTION,
   openGraph: {
+    siteName: 'Spanlens',
     type: 'website',
     title: 'Spanlens Pricing — Free, Pro $29, Team $149',
     description: PRICING_DESCRIPTION,
     url: '/pricing',
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',
@@ -101,9 +103,12 @@ const PRICING_FAQS: { q: string; a: React.ReactNode }[] = [
   },
 ]
 
+// Same `@id` as the homepage node: one product entity, described twice.
+// See app/page.tsx for why there is no aggregateRating.
 const pricingJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'SoftwareApplication',
+  '@id': 'https://www.spanlens.io/#software',
   name: 'Spanlens',
   applicationCategory: 'DeveloperApplication',
   operatingSystem: 'Web, Linux, macOS, Windows (Docker)',
@@ -134,17 +139,11 @@ const pricingJsonLd = {
       description:
         '1M requests/month, 10 seats, 365-day log retention, Slack + webhooks, priority support. Overage $5 per 100K extra requests.',
     },
-    {
-      '@type': 'Offer',
-      name: 'Enterprise',
-      priceSpecification: {
-        '@type': 'PriceSpecification',
-        price: 'Custom',
-        priceCurrency: 'USD',
-      },
-      availability: 'https://schema.org/InStock',
-      description: 'Custom volume, SSO (SAML/Okta), dedicated SLA. Contact for pricing.',
-    },
+    // No Enterprise Offer. `price` is required and "contact for pricing" has
+    // no number; the earlier `price: '0'` read as free, and the
+    // priceSpecification that replaced it still failed validation ("Missing
+    // required price property for Software App"). The plan stays in the
+    // visible table, which is where a buyer looks for it anyway.
   ],
 }
 

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -5,6 +6,7 @@ import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/privacy' },
+  openGraph: openGraphFor('/privacy'),
   title: 'Privacy Policy · Spanlens',
   description:
     'How Spanlens collects, uses, and protects your data. Covers PIPA (Korea) and GDPR (EU) disclosures and your rights as a data subject.',

--- a/apps/web/app/refund/page.tsx
+++ b/apps/web/app/refund/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -5,6 +6,7 @@ import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/refund' },
+  openGraph: openGraphFor('/refund'),
   title: 'Refund Policy · Spanlens',
   description:
     'Spanlens refund policy, 14-day money-back guarantee, EU statutory withdrawal rights, and how to request a refund.',

--- a/apps/web/app/self-hosting/page.tsx
+++ b/apps/web/app/self-hosting/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -7,6 +8,7 @@ export const metadata = {
   description:
     'Self-host Spanlens, an open source LLM observability and monitoring platform, with one Docker command. Logging, cost tracking, and tracing on your infra.',
   alternates: { canonical: '/self-hosting' },
+  openGraph: openGraphFor('/self-hosting'),
 }
 
 const SITE_URL = 'https://www.spanlens.io'

--- a/apps/web/app/subprocessors/page.tsx
+++ b/apps/web/app/subprocessors/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -5,6 +6,7 @@ import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/subprocessors' },
+  openGraph: openGraphFor('/subprocessors'),
   title: 'Subprocessors · Spanlens',
   description:
     'The complete list of subprocessors Spanlens engages to operate the service, including data hosting locations and the purpose of each engagement.',

--- a/apps/web/app/terms/page.tsx
+++ b/apps/web/app/terms/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphFor } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -5,6 +6,7 @@ import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 export const metadata = {
   alternates: { canonical: '/terms' },
+  openGraph: openGraphFor('/terms'),
   title: 'Terms of Service · Spanlens',
   description:
     'The agreement governing your use of Spanlens. Covers accounts, billing, the 14-day refund policy, acceptable use, and liability.',

--- a/apps/web/app/tools/llm-cost-calculator/page.tsx
+++ b/apps/web/app/tools/llm-cost-calculator/page.tsx
@@ -10,10 +10,12 @@ export const metadata = {
   title: 'LLM Cost Calculator for OpenAI, Anthropic, and Gemini',
   description: DESCRIPTION,
   openGraph: {
+    siteName: 'Spanlens',
     type: 'website',
     title: 'LLM Cost Calculator — Free Tool by Spanlens',
     description: DESCRIPTION,
     url: '/tools/llm-cost-calculator',
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/components/marketing/compare-template.tsx
+++ b/apps/web/components/marketing/compare-template.tsx
@@ -127,19 +127,12 @@ function buildSoftwareCompareJsonLd(
       name: 'Spanlens',
       url: SITE_URL,
     },
-    about: {
-      '@type': 'SoftwareApplication',
-      name: 'Spanlens',
-      applicationCategory: 'DeveloperApplication',
-      operatingSystem: 'Web, Docker',
-      url: SITE_URL,
-      offers: {
-        '@type': 'Offer',
-        price: '0',
-        priceCurrency: 'USD',
-        description: 'Free plan with 50K requests/mo',
-      },
-    },
+    // Reference the product entity declared on the homepage rather than
+    // re-declaring a partial copy. Two divergent SoftwareApplication nodes for
+    // the same product break entity reconciliation, and the partial copy also
+    // failed Google's Software App rich-result check on every comparison page
+    // (Ahrefs 2026-07-29: "Missing required aggregateRating or review").
+    about: { '@id': `${SITE_URL}/#software` },
     mentions: {
       '@type': 'Thing',
       name: competitor,

--- a/apps/web/components/marketing/integration-template.tsx
+++ b/apps/web/components/marketing/integration-template.tsx
@@ -55,12 +55,9 @@ export function IntegrationTemplate({
     url: `${SITE_URL}/integrations/${slug}`,
     headline: `${provider} observability with Spanlens`,
     description,
-    about: {
-      '@type': 'SoftwareApplication',
-      name: 'Spanlens',
-      applicationCategory: 'DeveloperApplication',
-      url: SITE_URL,
-    },
+    // See compare-template.tsx: reference the homepage's product entity by
+    // @id instead of re-declaring a partial SoftwareApplication here.
+    about: { '@id': `${SITE_URL}/#software` },
     mentions: { '@type': 'Thing', name: provider },
     isPartOf: { '@type': 'WebSite', name: 'Spanlens', url: SITE_URL },
   }

--- a/apps/web/components/marketing/model-pricing-template.tsx
+++ b/apps/web/components/marketing/model-pricing-template.tsx
@@ -5,6 +5,19 @@ import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 const SITE_URL = 'https://www.spanlens.io'
 
+/**
+ * Provider display name to its /integrations page. This used to be
+ * `provider.toLowerCase()`, which works for OpenAI and Anthropic and produces
+ * /integrations/google for Gemini — a 404 linked from every Gemini pricing
+ * page. A provider with no integration page renders no link rather than a
+ * broken one.
+ */
+const INTEGRATION_SLUG: Record<string, string> = {
+  OpenAI: 'openai',
+  Anthropic: 'anthropic',
+  Google: 'gemini',
+}
+
 export interface UsageScenario {
   label: string
   inputTokens: number
@@ -301,12 +314,14 @@ export function ModelPricingTemplate({
             >
               Start free →
             </Link>
-            <Link
-              href={`/integrations/${provider.toLowerCase()}`}
-              className="h-10 px-5 rounded-[6px] border border-border text-text text-[14px] font-medium leading-10 hover:bg-bg-elev transition-colors text-center"
-            >
-              {provider} integration guide
-            </Link>
+            {INTEGRATION_SLUG[provider] ? (
+              <Link
+                href={`/integrations/${INTEGRATION_SLUG[provider]}`}
+                className="h-10 px-5 rounded-[6px] border border-border text-text text-[14px] font-medium leading-10 hover:bg-bg-elev transition-colors text-center"
+              >
+                {provider} integration guide
+              </Link>
+            ) : null}
             <a
               href={providerUrl}
               target="_blank"

--- a/apps/web/lib/page-metadata.test.ts
+++ b/apps/web/lib/page-metadata.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Every page that declares a canonical must also declare a matching Open
+ * Graph URL.
+ *
+ * The root layout deliberately sets no `openGraph.url`, because Next.js
+ * merges the block wholesale and every page without its own would inherit the
+ * homepage URL verbatim — which is exactly what happened to 77 pages until
+ * 2026-07-29. Removing it fixed the wrong URLs and left those pages with no
+ * `og:url` at all, which Ahrefs then reported as "Open Graph tags incomplete"
+ * on 96 pages.
+ *
+ * `openGraphFor()` in lib/page-metadata.ts is the fix for both: it builds the
+ * whole block from the canonical path, so `type` / `siteName` / `locale`
+ * survive the wholesale merge. This test pins the invariant that made the
+ * original bug possible: canonical and og:url must name the same URL.
+ *
+ * Pages with a `generateMetadata` function instead of a static object are out
+ * of scope — their canonical is computed per request.
+ */
+
+const APP_DIR = join(__dirname, '..', 'app')
+
+const CANONICAL_RE = /alternates:\s*\{\s*canonical:\s*'([^']+)'\s*\}/
+const OG_HELPER_RE = /openGraph:\s*openGraphFor\(\s*'([^']+)'/
+const OG_LITERAL_RE = /openGraph:\s*\{([\s\S]*?)\n\s*\},/
+
+function pageFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) pageFiles(full, out)
+    else if (entry.name === 'page.tsx') out.push(full)
+  }
+  return out
+}
+
+const pages = pageFiles(APP_DIR)
+  .map((file) => ({ file, source: readFileSync(file, 'utf-8') }))
+  .map((p) => ({ ...p, canonical: p.source.match(CANONICAL_RE)?.[1] }))
+  .filter((p): p is typeof p & { canonical: string } => Boolean(p.canonical))
+  .map((p) => ({ ...p, name: relative(APP_DIR, p.file).split(sep).join('/') }))
+
+describe('page metadata', () => {
+  it('finds the marketing and docs pages', () => {
+    // Guards against the glob silently matching nothing after a move.
+    expect(pages.length).toBeGreaterThan(80)
+  })
+
+  it.each(pages.map((p) => [p.name, p] as const))(
+    '%s declares an og:url matching its canonical',
+    (_name, page) => {
+      const viaHelper = page.source.match(OG_HELPER_RE)
+      if (viaHelper) {
+        expect(viaHelper[1]).toBe(page.canonical)
+        return
+      }
+
+      const literal = page.source.match(OG_LITERAL_RE)
+      expect(
+        literal,
+        `${page.name} declares a canonical but no openGraph block. Add openGraph: openGraphFor('${page.canonical}').`,
+      ).toBeTruthy()
+
+      const body = literal?.[1] ?? ''
+      expect(body.match(/url:\s*'([^']+)'/)?.[1]).toBe(page.canonical)
+      // A hand-written block replaces the root's, so it has to repeat these.
+      expect(body, `${page.name} openGraph is missing siteName`).toMatch(/siteName:/)
+      expect(body, `${page.name} openGraph is missing locale`).toMatch(/locale:/)
+    },
+  )
+})

--- a/apps/web/lib/page-metadata.ts
+++ b/apps/web/lib/page-metadata.ts
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next'
+
+const SITE_NAME = 'Spanlens'
+const LOCALE = 'en_US'
+
+/**
+ * Open Graph block for a page, keyed on the same path as its canonical.
+ *
+ * Two constraints make this a helper rather than a literal on each page:
+ *
+ *  - Next.js merges `openGraph` wholesale. A page that declares the block to
+ *    set `url` drops the `type` / `siteName` / `locale` it would otherwise
+ *    inherit from the root layout, which is how 19 pages ended up flagged as
+ *    "Open Graph tags incomplete" before this existed.
+ *  - The root layout deliberately sets no `url`, `title`, or `description`,
+ *    because every page without its own block inherits them verbatim. That
+ *    shipped twice: a root canonical de-indexed 61 pages (2026-06-11), and a
+ *    root `openGraph.url` gave 77 pages the homepage card (2026-07-29).
+ *
+ * `title` and `description` stay out on purpose. Next.js falls back to the
+ * page's own `title` / `description` when the Open Graph block omits them, so
+ * repeating them here would just be a second copy to keep in sync.
+ *
+ * `page-metadata.test.ts` checks every page's `openGraph.url` against its
+ * canonical.
+ */
+export function openGraphFor(
+  path: string,
+  options?: { type?: 'website' | 'article' },
+): Metadata['openGraph'] {
+  return {
+    type: options?.type ?? 'website',
+    siteName: SITE_NAME,
+    locale: LOCALE,
+    url: path,
+  }
+}


### PR DESCRIPTION
Works through A1–A5 from the Ahrefs re-crawl (Today vs 25 Jul).

## A1 — og:url on every page

#448 removed the root `openGraph.url` that was giving 77 pages the homepage URL. That fixed the wrong value and left those pages with no `og:url` at all, so **"Open Graph tags incomplete" went 19 → 96**.

`lib/page-metadata.ts` exports `openGraphFor(path)`. It builds the *whole* block rather than just the url, because Next.js merges `openGraph` wholesale: a page that declares the block to set `url` silently drops the `type` / `siteName` / `locale` it would inherit. That is exactly how the original 19 pages got on the list.

| | |
|---|---|
| Pages that gained a block | 83 |
| Pages that already had one, now with `siteName` + `locale` | 15 |
| Dashboard pages (no static canonical) | untouched |

`lib/page-metadata.test.ts` (100 assertions) checks every page's canonical against its `og:url`, and requires `siteName` / `locale` on any hand-written block.

## A3 — two broken internal links

Found by crawling the production sitemap and checking every internal link and image. Two real 404s, matching Ahrefs' "Page has links to broken page: 2":

| Link | From | Cause |
|---|---|---|
| `/integrations/google` | every Gemini pricing page | `provider.toLowerCase()` in the model-pricing template. Fine for OpenAI and Anthropic; Gemini's page is at `/integrations/gemini` |
| `/docs/agents` | `/docs/proxy` | page is `/docs/concepts/agent-tracing` |

The template now uses an explicit provider → slug map, and a provider with no integration page renders no link instead of a broken one.

## A4 — structured data, 10 rich-results errors

All ten traced to one type. `SoftwareApplication`:

- **8 pages** (5 comparison, 3 integration) re-declared a partial copy of the product entity inside `WebPage.about`. They now reference the homepage node by `@id`, the same treatment `Organization` got in #446. Better entity reconciliation, and the 8 errors go with it.
- **Enterprise offer** removed from the homepage and `/pricing` JSON-LD. `price` is required and "contact for pricing" has no number. Both previous attempts failed: `price: '0'` reads as free, and the `priceSpecification` that replaced it in #446 still failed validation with "Missing required price property". The plan stays in the visible table, which is where a buyer looks anyway.
- **The remaining 2** are the `aggregateRating` Google wants for the Software App rich result, on the two pages that declare the full entity. There are no genuine ratings to publish and inventing them would be worse than forgoing the rich result, so the markup stays and the reasoning sits next to the node.

## A2 — broken images: nothing to fix here

Ahrefs reports 5. Crawling all 99 sitemap pages turns up **2 unique `<img>` sources site-wide, both 200**, so 5 broken images cannot be on `www`. They are on `blog.spanlens.io` (WordPress) or `status.spanlens.io`, neither of which lives in this repo. The audit crawls in Subdomains mode, which is also where the 35 "canonical points to redirect" and most of the 3XX come from.

## A5 — slow pages: no longer flagged

"Slow page 4" appeared as *New* in the 25 Jul crawl and is absent from today's. Nothing to act on.

## Also

Em dash dropped from the five model-pricing titles, the follow-up left over from #446.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter web test` (246 passed, 100 of them the new og:url guard)
- [x] `pnpm --filter web build`
- [x] Dev server: `/docs/cli` emits `og:url` `https://www.spanlens.io/docs/cli`; `/compare/langfuse` `about` is `{"@id":"…/#software"}`; homepage JSON-LD carries 3 Offers, not 4
- [ ] After deploy: re-crawl, expect "Open Graph tags incomplete" 96 → ~0 and rich-results errors 10 → 2
- [ ] After deploy: `/integrations/gemini` reachable from every Gemini pricing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)