### PR TITLE
fix(web): restore og:image on every page that declares its own card

### DIFF
--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -1,3 +1,4 @@
+import { OG_IMAGE } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -38,6 +39,9 @@ const aboutJsonLd = {
     '@id': 'https://www.spanlens.io/#organization',
 
     locale: 'en_US',
+
+
+    images: OG_IMAGE,
 
   },
 }

--- a/apps/web/app/agent-tracing/page.tsx
+++ b/apps/web/app/agent-tracing/page.tsx
@@ -1,3 +1,4 @@
+import { OG_IMAGE } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -17,6 +18,7 @@ export const metadata = {
     description: DESCRIPTION,
     url: '/agent-tracing',
     locale: 'en_US',
+    images: OG_IMAGE,
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/faq/page.tsx
+++ b/apps/web/app/faq/page.tsx
@@ -1,3 +1,4 @@
+import { OG_IMAGE } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -17,6 +18,7 @@ export const metadata = {
     description: FAQ_DESCRIPTION,
     url: '/faq',
     locale: 'en_US',
+    images: OG_IMAGE,
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/integrations/anthropic/page.tsx
+++ b/apps/web/app/integrations/anthropic/page.tsx
@@ -1,3 +1,4 @@
+import { OG_IMAGE } from '@/lib/page-metadata'
 import { IntegrationTemplate } from '@/components/marketing/integration-template'
 
 const DESCRIPTION =
@@ -14,6 +15,7 @@ export const metadata = {
     description: DESCRIPTION,
     url: '/integrations/anthropic',
     locale: 'en_US',
+    images: OG_IMAGE,
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/integrations/gemini/page.tsx
+++ b/apps/web/app/integrations/gemini/page.tsx
@@ -1,3 +1,4 @@
+import { OG_IMAGE } from '@/lib/page-metadata'
 import { IntegrationTemplate } from '@/components/marketing/integration-template'
 
 const DESCRIPTION =
@@ -14,6 +15,7 @@ export const metadata = {
     description: DESCRIPTION,
     url: '/integrations/gemini',
     locale: 'en_US',
+    images: OG_IMAGE,
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/integrations/openai/page.tsx
+++ b/apps/web/app/integrations/openai/page.tsx
@@ -1,3 +1,4 @@
+import { OG_IMAGE } from '@/lib/page-metadata'
 import { IntegrationTemplate } from '@/components/marketing/integration-template'
 
 const DESCRIPTION =
@@ -14,6 +15,7 @@ export const metadata = {
     description: DESCRIPTION,
     url: '/integrations/openai',
     locale: 'en_US',
+    images: OG_IMAGE,
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/llm-cost-tracking/page.tsx
+++ b/apps/web/app/llm-cost-tracking/page.tsx
@@ -1,3 +1,4 @@
+import { OG_IMAGE } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -17,6 +18,7 @@ export const metadata = {
     description: DESCRIPTION,
     url: '/llm-cost-tracking',
     locale: 'en_US',
+    images: OG_IMAGE,
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/llm-observability/page.tsx
+++ b/apps/web/app/llm-observability/page.tsx
@@ -1,3 +1,4 @@
+import { OG_IMAGE } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -17,6 +18,7 @@ export const metadata = {
     description: DESCRIPTION,
     url: '/llm-observability',
     locale: 'en_US',
+    images: OG_IMAGE,
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,3 +1,4 @@
+import { OG_IMAGE } from '@/lib/page-metadata'
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
@@ -15,6 +16,7 @@ export const metadata = {
     siteName: 'Spanlens',
     locale: 'en_US',
     url: '/',
+    images: OG_IMAGE,
   },
 }
 

--- a/apps/web/app/pricing/claude-3-5-sonnet/page.tsx
+++ b/apps/web/app/pricing/claude-3-5-sonnet/page.tsx
@@ -1,3 +1,4 @@
+import { OG_IMAGE } from '@/lib/page-metadata'
 import { ModelPricingTemplate } from '@/components/marketing/model-pricing-template'
 
 const DESCRIPTION =
@@ -14,6 +15,7 @@ export const metadata = {
     description: DESCRIPTION,
     url: '/pricing/claude-3-5-sonnet',
     locale: 'en_US',
+    images: OG_IMAGE,
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/pricing/gemini-2-0-flash/page.tsx
+++ b/apps/web/app/pricing/gemini-2-0-flash/page.tsx
@@ -1,3 +1,4 @@
+import { OG_IMAGE } from '@/lib/page-metadata'
 import { ModelPricingTemplate } from '@/components/marketing/model-pricing-template'
 
 const DESCRIPTION =
@@ -14,6 +15,7 @@ export const metadata = {
     description: DESCRIPTION,
     url: '/pricing/gemini-2-0-flash',
     locale: 'en_US',
+    images: OG_IMAGE,
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/pricing/gpt-4o-mini/page.tsx
+++ b/apps/web/app/pricing/gpt-4o-mini/page.tsx
@@ -1,3 +1,4 @@
+import { OG_IMAGE } from '@/lib/page-metadata'
 import { ModelPricingTemplate } from '@/components/marketing/model-pricing-template'
 
 const DESCRIPTION =
@@ -14,6 +15,7 @@ export const metadata = {
     description: DESCRIPTION,
     url: '/pricing/gpt-4o-mini',
     locale: 'en_US',
+    images: OG_IMAGE,
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/pricing/gpt-4o/page.tsx
+++ b/apps/web/app/pricing/gpt-4o/page.tsx
@@ -1,3 +1,4 @@
+import { OG_IMAGE } from '@/lib/page-metadata'
 import { ModelPricingTemplate } from '@/components/marketing/model-pricing-template'
 
 const DESCRIPTION =
@@ -14,6 +15,7 @@ export const metadata = {
     description: DESCRIPTION,
     url: '/pricing/gpt-4o',
     locale: 'en_US',
+    images: OG_IMAGE,
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/pricing/o3-mini/page.tsx
+++ b/apps/web/app/pricing/o3-mini/page.tsx
@@ -1,3 +1,4 @@
+import { OG_IMAGE } from '@/lib/page-metadata'
 import { ModelPricingTemplate } from '@/components/marketing/model-pricing-template'
 
 const DESCRIPTION =
@@ -14,6 +15,7 @@ export const metadata = {
     description: DESCRIPTION,
     url: '/pricing/o3-mini',
     locale: 'en_US',
+    images: OG_IMAGE,
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -1,3 +1,4 @@
+import { OG_IMAGE } from '@/lib/page-metadata'
 import type React from 'react'
 import Link from 'next/link'
 import { Check } from 'lucide-react'
@@ -20,6 +21,7 @@ export const metadata = {
     description: PRICING_DESCRIPTION,
     url: '/pricing',
     locale: 'en_US',
+    images: OG_IMAGE,
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/app/tools/llm-cost-calculator/page.tsx
+++ b/apps/web/app/tools/llm-cost-calculator/page.tsx
@@ -1,3 +1,4 @@
+import { OG_IMAGE } from '@/lib/page-metadata'
 import { Footer } from '@/components/layout/footer'
 import { MarketingNav } from '@/components/layout/marketing-nav'
 import { CostCalculator } from './_calculator'
@@ -16,6 +17,7 @@ export const metadata = {
     description: DESCRIPTION,
     url: '/tools/llm-cost-calculator',
     locale: 'en_US',
+    images: OG_IMAGE,
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/web/lib/page-metadata.test.ts
+++ b/apps/web/lib/page-metadata.test.ts
@@ -69,6 +69,9 @@ describe('page metadata', () => {
       // A hand-written block replaces the root's, so it has to repeat these.
       expect(body, `${page.name} openGraph is missing siteName`).toMatch(/siteName:/)
       expect(body, `${page.name} openGraph is missing locale`).toMatch(/locale:/)
+      // Including the card: app/opengraph-image.tsx only reaches pages that
+      // inherit the root block, so declaring one drops og:image with it.
+      expect(body, `${page.name} openGraph is missing images`).toMatch(/images:/)
     },
   )
 })

--- a/apps/web/lib/page-metadata.ts
+++ b/apps/web/lib/page-metadata.ts
@@ -4,6 +4,19 @@ const SITE_NAME = 'Spanlens'
 const LOCALE = 'en_US'
 
 /**
+ * The card from app/opengraph-image.tsx, referenced explicitly.
+ *
+ * That file convention only reaches pages that inherit the root layout's
+ * `openGraph` block. The moment a page declares its own, the generated image
+ * goes with the rest of the inherited block, and the page ships without an
+ * `og:image` — which is what Ahrefs reports as "Open Graph tags incomplete".
+ * `twitter:image` is unaffected because no page overrides `twitter`.
+ */
+export const OG_IMAGE = [
+  { url: '/opengraph-image', width: 1200, height: 630, alt: SITE_NAME },
+]
+
+/**
  * Open Graph block for a page, keyed on the same path as its canonical.
  *
  * Two constraints make this a helper rather than a literal on each page:
@@ -33,5 +46,6 @@ export function openGraphFor(
     siteName: SITE_NAME,
     locale: LOCALE,
     url: path,
+    images: OG_IMAGE,
   }
 }


### PR DESCRIPTION
Regression from #451, caught by re-crawling: "Open Graph tags incomplete" went 96 → 99 instead of dropping.

## What happened

#451 gave 98 pages their own `openGraph` block so they would carry `og:url`. Declaring that block replaces the *resolved* root block — and `app/opengraph-image.tsx` contributes to the resolved block, so the generated card went with it:

```
GET https://www.spanlens.io/docs/cli
  og:title, og:description, og:url, og:site_name, og:locale, og:type
  ← no og:image
```

`twitter:image` survived because no page overrides `twitter`. The homepage kept its card because the file convention lives in the same route segment.

## Fix

`lib/page-metadata.ts` exports `OG_IMAGE`, and `openGraphFor()` includes it. The 15 hand-written blocks reference it directly — those had been shipping without `og:image` since before #451, which is what the original 19 "incomplete" pages were.

`page-metadata.test.ts` now requires `images` next to `siteName` and `locale`, so the next block written by hand cannot omit it.

## Verified on the dev server

| URL | og:image | og:url |
|---|---|---|
| `/docs/cli` | ✓ | `https://www.spanlens.io/docs/cli` |
| `/pricing/gpt-4o` | ✓ | `https://www.spanlens.io/pricing/gpt-4o` |
| `/compare/langfuse` | ✓ | `https://www.spanlens.io/compare/langfuse` |
| `/` | ✓ | `https://www.spanlens.io` |

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter web test` (246 passed)
- [ ] After deploy: re-crawl, expect "Open Graph tags incomplete" to fall to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)