### PR TITLE
fix(web): repair the /about Open Graph block and harden its guard

### DIFF
--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -14,13 +14,17 @@ export const metadata = {
   openGraph: {
     siteName: 'Spanlens',
     type: 'website',
-    title: 'About Spanlens — Open Source LLM Observability',
+    locale: 'en_US',
+    title: 'About Spanlens: Open Source LLM Observability',
     description: ABOUT_DESCRIPTION,
-    url: '/about',  },
+    url: '/about',
+    images: OG_IMAGE,
+  },
   twitter: {
     card: 'summary_large_image',
-    title: 'About Spanlens — Open Source LLM Observability',
-    description: ABOUT_DESCRIPTION,  },
+    title: 'About Spanlens: Open Source LLM Observability',
+    description: ABOUT_DESCRIPTION,
+  },
 }
 
 const aboutJsonLd = {

--- a/apps/web/lib/page-metadata.test.ts
+++ b/apps/web/lib/page-metadata.test.ts
@@ -26,7 +26,30 @@ const APP_DIR = join(__dirname, '..', 'app')
 
 const CANONICAL_RE = /alternates:\s*\{\s*canonical:\s*'([^']+)'\s*\}/
 const OG_HELPER_RE = /openGraph:\s*openGraphFor\(\s*'([^']+)'/
-const OG_LITERAL_RE = /openGraph:\s*\{([\s\S]*?)\n\s*\},/
+
+/**
+ * Body of the `openGraph: { … }` literal, by brace matching.
+ *
+ * Not a regex: the first version of this test ended the block at the first
+ * `\n  },`, and /about had lost the newline before its closing brace
+ * (`url: '/about',  },`). The match ran past the real end into the next
+ * property, picked up its keys, and the page passed while shipping without
+ * og:image or og:locale.
+ */
+function openGraphBody(source: string): string | null {
+  const start = source.indexOf('openGraph: {')
+  if (start === -1) return null
+  const open = source.indexOf('{', start)
+  let depth = 0
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++
+    else if (source[i] === '}') {
+      depth--
+      if (depth === 0) return source.slice(open + 1, i)
+    }
+  }
+  return null
+}
 
 function pageFiles(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -58,13 +81,13 @@ describe('page metadata', () => {
         return
       }
 
-      const literal = page.source.match(OG_LITERAL_RE)
+      const literal = openGraphBody(page.source)
       expect(
         literal,
         `${page.name} declares a canonical but no openGraph block. Add openGraph: openGraphFor('${page.canonical}').`,
       ).toBeTruthy()
 
-      const body = literal?.[1] ?? ''
+      const body = literal ?? ''
       expect(body.match(/url:\s*'([^']+)'/)?.[1]).toBe(page.canonical)
       // A hand-written block replaces the root's, so it has to repeat these.
       expect(body, `${page.name} openGraph is missing siteName`).toMatch(/siteName:/)


### PR DESCRIPTION
Scanning all 99 production pages after #452 found exactly one still short:

```
/about  missing: og:image, og:locale
```

## What broke

The `openGraph` block lost the newline before its closing brace during the #451 codemod:

```ts
openGraph: {
  siteName: 'Spanlens',
  type: 'website',
  title: 'About Spanlens — Open Source LLM Observability',
  description: ABOUT_DESCRIPTION,
  url: '/about',  },     ← here
```

`locale` never got added and `images` never landed.

## Why the guard missed it

`page-metadata.test.ts` located the end of the block with a regex anchored on `\n  },`. With that newline gone the match ran past the real closing brace into the next property, picked up keys from there, and the assertions passed against the wrong text.

Extraction brace-matches now. Confirmed the guard fails when `images` is removed from `/about`, which it did not before.

## Also

Em dash swapped in the `/about` og and twitter titles, the change #446 made everywhere else.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter web test` (246 passed)
- [x] Negative check: removing `images` from `/about` now fails the guard
- [ ] After deploy: re-scan all 99 pages for og:image / og:url / og:site_name / og:locale, expect 0 missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)