### PR TITLE
fix(web): link the docs section hubs and repair the /about JSON-LD

### DIFF
--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -39,15 +39,7 @@ const aboutJsonLd = {
   // duplicate nodes with divergent sameAs/foundingDate broke entity
   // reconciliation (2026-07-06 schema audit). foundingDate/founder/sameAs
   // now live on the canonical node in app/layout.tsx.
-  mainEntity: {
-    '@id': 'https://www.spanlens.io/#organization',
-
-    locale: 'en_US',
-
-
-    images: OG_IMAGE,
-
-  },
+  mainEntity: { '@id': 'https://www.spanlens.io/#organization' },
 }
 
 export default function AboutPage() {

--- a/apps/web/app/docs/_components/sidebar.tsx
+++ b/apps/web/app/docs/_components/sidebar.tsx
@@ -22,6 +22,23 @@ const NAV: NavGroup[] = [
       { title: 'Why Spanlens', href: '/docs/why' },
     ],
   },
+  // Section hubs. Added 2026-07-30: the six pages shipped in #449 were in the
+  // sitemap but nothing linked to them, so Ahrefs filed all six as orphans.
+  // Listing them here gives each one an inbound link from every docs page.
+  // Hardcoded rather than imported from _lib/sections.ts so the section
+  // descriptions stay out of the client bundle; sections.test.ts checks this
+  // list against the sections themselves.
+  {
+    title: 'Sections',
+    items: [
+      { title: 'Concepts', href: '/docs/concepts' },
+      { title: 'Features', href: '/docs/features' },
+      { title: 'Integrations', href: '/docs/integrations' },
+      { title: 'Tutorials', href: '/docs/tutorials' },
+      { title: 'Production', href: '/docs/production' },
+      { title: 'Migrate to Spanlens', href: '/docs/migrate' },
+    ],
+  },
   {
     title: 'Concepts',
     items: [

--- a/apps/web/lib/docs-sections-drift.test.ts
+++ b/apps/web/lib/docs-sections-drift.test.ts
@@ -83,3 +83,18 @@ describe('sitemap', () => {
     expect(source).toContain(`'/docs/${slug}',`)
   })
 })
+
+describe('docs sidebar', () => {
+  // The hubs shipped without a single inbound link and Ahrefs filed all six as
+  // orphan pages. The sidebar renders on every docs page, so a link here is
+  // what keeps them reachable.
+  const source = readFileSync(join(DOCS_DIR, '_components', 'sidebar.tsx'), 'utf-8')
+
+  it.each(DOCS_SECTIONS.map((s) => [s.slug, s.title] as const))(
+    'links to /docs/%s',
+    (slug, title) => {
+      expect(source).toContain(`href: '/docs/${slug}'`)
+      expect(source).toContain(`title: '${title}'`)
+    },
+  )
+})


### PR DESCRIPTION
Two findings from the re-crawl that confirmed the Open Graph work landed.

First, the headline numbers from that crawl, filtered to `www` only:

| Issue | Before | After |
|---|---|---|
| Open Graph tags incomplete | 102 | **0** |
| Structured data, Google rich results error | 10 | **0** |
| 404 page / 4XX page | 2 / 2 | **0 / 0** |
| Page has links to broken page | 2 | **0** |
| Canonical points to redirect | 35 | **0** (all `status.spanlens.io`) |
| Image broken | 6 | **0** (all subdomain) |
| Indexable page not in sitemap | 14 | **0** (all subdomain) |

Two real items remained, both introduced by this run of work.

## The six section hubs were orphans

Every hub from #449 sits in the sitemap with **zero incoming internal links**:

```
/docs/features       href inlinks: 0
/docs/integrations   href inlinks: 0
/docs/concepts       href inlinks: 0
/docs/production     href inlinks: 0
/docs/tutorials      href inlinks: 0
/docs/migrate        href inlinks: 0
```

They link out to their children. Nothing linked in — not the sidebar, not the docs index. A "Sections" group at the top of the docs sidebar fixes it: the sidebar renders on every docs page, so each hub picks up ~100 inbound links.

The list is hardcoded rather than imported from `_lib/sections.ts`, so the 45 section descriptions stay out of the client bundle. `docs-sections-drift.test.ts` checks it against `DOCS_SECTIONS`.

## /about had the site's only schema.org validation error

The og:image codemod injected `locale` and `images` into the AboutPage JSON-LD:

```json
"mainEntity": {
  "@id": "https://www.spanlens.io/#organization",
  "locale": "en_US",
  "images": [ … ]
}
```

`mainEntity` is meant to be a bare `@id` reference to the Organization node, and neither key is a schema.org property.

The codemod went wrong because that same file's `openGraph` block was missing the newline before its closing brace (the malformation #453 fixed), so brace matching landed on the wrong one. Checked for collateral elsewhere: every file referencing `OG_IMAGE` has exactly one import and one use, and every `locale: 'en_US'` in the app sits inside an `openGraph` block.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter web test` (252 passed, 6 new sidebar assertions)
- [x] `pnpm --filter web build`
- [x] Dev server: `/docs/quick-start` links to all six hubs; `/about` `mainEntity` is `{"@id":"…#organization"}`
- [ ] After deploy: re-crawl, expect orphan pages and the schema.org error to reach 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)