### PR TITLE
fix(web): bring seven meta descriptions into the 110-160 range

### DIFF
--- a/apps/web/app/benchmarks/page.tsx
+++ b/apps/web/app/benchmarks/page.tsx
@@ -9,7 +9,7 @@ export const metadata = {
   openGraph: openGraphFor('/benchmarks'),
   title: 'Proxy Overhead Benchmark · Spanlens',
   description:
-    'How much latency does the Spanlens proxy add? A reproducible benchmark of synchronous per-request overhead, with the methodology and a command to run it yourself.',
+    'How much latency does the Spanlens proxy add? A reproducible benchmark of per-request overhead, with the method and a command to run it yourself.',
 }
 
 const MEASURED_DATE = '2026-07-14'

--- a/apps/web/app/docs/_lib/sections.ts
+++ b/apps/web/app/docs/_lib/sections.ts
@@ -118,7 +118,7 @@ export const DOCS_SECTIONS: DocsSection[] = [
             title: 'Prompts',
             href: '/docs/features/prompts',
             description:
-              'Version-controlled prompt templates with real-data A/B comparison, latency, cost, and error rate per version.',
+              'Version-controlled prompt templates with typed variables and real-data A/B comparison. See latency, cost, and error rate for every version you ship.',
           },
           {
             title: 'Prompts Playground',
@@ -206,7 +206,7 @@ export const DOCS_SECTIONS: DocsSection[] = [
             title: 'Billing & quotas',
             href: '/docs/features/billing',
             description:
-              'How Spanlens charges you: plan quotas, overage billing, the hard cap, and what your invoice looks like.',
+              'How Spanlens charges you. Plan quotas, overage rates per 100K requests, the hard cap that stops runaway spend, and what an invoice looks like.',
           },
         ],
       },

--- a/apps/web/app/docs/features/billing/page.tsx
+++ b/apps/web/app/docs/features/billing/page.tsx
@@ -8,7 +8,7 @@ export const metadata = {
   openGraph: openGraphFor('/docs/features/billing'),
   title: 'Billing & quotas · Spanlens Docs',
   description:
-    'How Spanlens charges you: plan quotas, overage billing, the hard cap, and what your invoice looks like.',
+    'How Spanlens charges you. Plan quotas, overage rates per 100K requests, the hard cap that stops runaway spend, and what an invoice looks like.',
 }
 
 export default function BillingDocs() {

--- a/apps/web/app/docs/features/prompts/page.tsx
+++ b/apps/web/app/docs/features/prompts/page.tsx
@@ -7,7 +7,7 @@ export const metadata = {
   openGraph: openGraphFor('/docs/features/prompts'),
   title: 'Prompts · Spanlens Docs',
   description:
-    'Version-controlled prompt templates with real-data A/B comparison, latency, cost, and error rate per version.',
+    'Version-controlled prompt templates with typed variables and real-data A/B comparison. See latency, cost, and error rate for every version you ship.',
 }
 
 export default function PromptsDocs() {

--- a/apps/web/app/docs/proxy/page.tsx
+++ b/apps/web/app/docs/proxy/page.tsx
@@ -6,7 +6,8 @@ export const metadata = {
   alternates: { canonical: '/docs/proxy' },
   openGraph: openGraphFor('/docs/proxy'),
   title: 'Direct proxy · Spanlens Docs',
-  description: 'Use Spanlens from any language, Python, Ruby, Go, curl. Just swap the base URL.',
+  description:
+    'Use Spanlens from any language. Point your OpenAI, Anthropic, or Gemini client at the proxy base URL and every call is logged. Python, Ruby, Go, and curl.',
 }
 
 export default function ProxyDocs() {

--- a/apps/web/app/docs/self-host/page.tsx
+++ b/apps/web/app/docs/self-host/page.tsx
@@ -8,7 +8,7 @@ export const metadata = {
   openGraph: openGraphFor('/docs/self-host'),
   title: 'Self-hosting · Spanlens Docs',
   description:
-    'Run the full Spanlens stack (dashboard + proxy) on your own infra with a Supabase project.',
+    'Run the full Spanlens stack, dashboard and proxy, on your own infrastructure with one Docker command and a Supabase project. Your request data stays put.',
 }
 
 export default function SelfHostDocs() {

--- a/apps/web/app/feedback/page.tsx
+++ b/apps/web/app/feedback/page.tsx
@@ -27,7 +27,7 @@ import { FeedbackRoadmapClient } from './feedback-roadmap-client'
 export const metadata = {
   title: 'Feedback & Feature Requests · Spanlens',
   description:
-    'Tell us what to build next. Vote on what others suggested. Track each item from new to shipped.',
+    'Tell us what to build next in Spanlens. Vote on what others suggested, and track every request from new through planned to shipped on the public board.',
   alternates: { canonical: '/feedback' },
   openGraph: openGraphFor('/feedback'),
 }

--- a/apps/web/app/llm-cost-tracking/page.tsx
+++ b/apps/web/app/llm-cost-tracking/page.tsx
@@ -5,7 +5,7 @@ import { MarketingNav } from '@/components/layout/marketing-nav'
 import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
 
 const DESCRIPTION =
-  'LLM cost tracking records per-request spend by model, prompt version, and customer. Monitor OpenAI, Anthropic, and Gemini bills, set budget alerts, and cut costs.'
+  'Record per-request LLM spend by model, prompt version, and customer. Monitor OpenAI, Anthropic, and Gemini bills, set budget alerts, and cut costs.'
 
 export const metadata = {
   alternates: { canonical: '/llm-cost-tracking' },

--- a/apps/web/lib/page-metadata.test.ts
+++ b/apps/web/lib/page-metadata.test.ts
@@ -60,6 +60,18 @@ function pageFiles(dir: string, out: string[] = []): string[] {
   return out
 }
 
+const DESCRIPTION_RE = /description:\s*\n?\s*'((?:[^'\\]|\\.)*)'/
+const DESCRIPTION_REF_RE = /description:\s*([A-Z_][A-Z0-9_]*),/
+
+/** The page's own meta description, following a `const` reference if used. */
+function description(source: string): string | null {
+  const literal = source.match(DESCRIPTION_RE)?.[1]
+  if (literal) return literal
+  const ref = source.match(DESCRIPTION_REF_RE)?.[1]
+  if (!ref) return null
+  return new RegExp(`const ${ref}\\s*=\\s*\\n?\\s*'((?:[^'\\\\]|\\\\.)*)'`).exec(source)?.[1] ?? null
+}
+
 const pages = pageFiles(APP_DIR)
   .map((file) => ({ file, source: readFileSync(file, 'utf-8') }))
   .map((p) => ({ ...p, canonical: p.source.match(CANONICAL_RE)?.[1] }))
@@ -97,4 +109,36 @@ describe('page metadata', () => {
       expect(body, `${page.name} openGraph is missing images`).toMatch(/images:/)
     },
   )
+})
+
+/**
+ * Meta description length.
+ *
+ * Google truncates a description somewhere past 160 characters and tends to
+ * substitute its own snippet when one is too thin to be useful. Ahrefs flags
+ * both ends, and seven pages were outside the range on 2026-07-30.
+ */
+describe('meta description length', () => {
+  const withText = pages
+    .map((p) => ({ ...p, text: description(p.source) }))
+    .filter((p): p is typeof p & { text: string } => p.text !== null)
+
+  it.each(withText.map((p) => [p.name, p] as const))('%s is 110-160 characters', (_name, page) => {
+    expect(page.text.length, `"${page.text}"`).toBeGreaterThanOrEqual(110)
+    expect(page.text.length, `"${page.text}"`).toBeLessThanOrEqual(160)
+  })
+
+  it('only the section hubs build their description from a variable', () => {
+    // Those six read `SECTION.description`, which sections.test.ts bounds.
+    // Anything else unresolvable here would be skipped silently above.
+    const unresolved = pages.filter((p) => description(p.source) === null).map((p) => p.name).sort()
+    expect(unresolved).toEqual([
+      'docs/concepts/page.tsx',
+      'docs/features/page.tsx',
+      'docs/integrations/page.tsx',
+      'docs/migrate/page.tsx',
+      'docs/production/page.tsx',
+      'docs/tutorials/page.tsx',
+    ])
+  })
 })


### PR DESCRIPTION
The last flagged content issue on `www`. Two descriptions ran past the point Google truncates, five were thin enough that Google is likely to substitute its own snippet.

| Page | Before | After |
|---|---|---|
| `/benchmarks` | 162 | 145 |
| `/llm-cost-tracking` | 162 | 147 |
| `/docs/proxy` | 79 | 154 |
| `/docs/self-host` | 90 | 153 |
| `/feedback` | 95 | 151 |
| `/docs/features/billing` | 103 | 142 |
| `/docs/features/prompts` | 109 | 148 |

The two under `/docs/features` are restated on the section hub, so `_lib/sections.ts` is updated in step. The existing drift test confirms the two copies match.

## Guard

`page-metadata.test.ts` now checks the range on every page. It follows a `description: CONST` reference to the underlying string, and asserts that the only pages it cannot resolve are the six section hubs, which read `SECTION.description` and are bounded by `sections.test.ts`. Without that second assertion an unreadable page would be skipped silently, which is how a page could drift back out of range unnoticed.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter web test` (346 passed)
- [x] `pnpm --filter web build`
- [x] Dev server: all seven render between 142 and 154 characters
- [ ] After deploy: re-crawl, expect "Meta description too long" and "too short" to reach 0 on the www segment

🤖 Generated with [Claude Code](https://claude.com/claude-code)