### PR TITLE
docs(web): changelog entry for docs section pages and link previews

### DIFF
--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -10,7 +10,9 @@ const ROUTE_LASTMOD: Record<string, string> = {
   '/pricing': '2026-06-16',
   '/self-hosting': '2026-05-20',
   '/alternatives': '2026-06-01',
-  '/changelog': '2026-06-15',
+  // Bump whenever an entry lands in lib/changelog/entries.ts. It had been
+  // stuck at 2026-06-15 through four rounds of entries.
+  '/changelog': '2026-07-30',
   '/feedback': '2026-04-10',
   '/faq': '2026-06-16',
   '/about': '2026-06-16',

--- a/apps/web/lib/changelog/entries.ts
+++ b/apps/web/lib/changelog/entries.ts
@@ -39,6 +39,17 @@ export type ChangelogTag =
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-07-30',
+    slug: 'docs-section-pages-and-link-previews',
+    title: 'Docs section pages and correct link previews',
+    tags: ['docs', 'fix'],
+    body: [
+      'The docs now have a page for each section. [Concepts](/docs/concepts), [Features](/docs/features), [Integrations](/docs/integrations), [Tutorials](/docs/tutorials), [Production](/docs/production), and [Migrate](/docs/migrate) each list what is inside with a short description per page, and a Sections group at the top of the sidebar reaches all six from anywhere in the docs. Those six paths used to return a 404.',
+      'Sharing a link now shows the right preview. Every page except the homepage was serving the homepage title, description, and URL in its Open Graph card, so a docs or comparison page pasted into Slack or X unfurled as the front page. Each page carries its own card now.',
+      'Two broken links are fixed. The Gemini pricing page pointed at an integration guide that does not exist, and the proxy docs linked to an agent-tracing page that had moved.',
+    ].join('\n\n'),
+  },
+  {
     date: '2026-07-07',
     slug: 'response-caching-weekly-digests-data-silence-alerts',
     title: 'Response caching, weekly digests, and data-silence alerts',


### PR DESCRIPTION
One entry covering the three user-visible parts of yesterday's work.

## What made it in

| Paragraph | From |
|---|---|
| Six docs section pages and the sidebar group that reaches them | #449, #454 |
| Open Graph cards that name the page being shared, not the homepage | #448, #451, #452, #453 |
| Two broken internal links | #451 |

## What stayed out

Canonical and schema plumbing, meta description lengths, the API host `noindex`, seed scripts, CodeQL fixes, sitemap wiring. None of it changes anything a user would notice, and the file's own guidance is "bug fix worth mentioning to users".

## Also

`/changelog` lastmod bumped. It had been stuck at 2026-06-15 through four rounds of entries, so the sitemap was under-reporting freshness on one of the pages that changes most often. Comment added so the next entry bumps it too.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter web test`
- [x] Dev server: entry renders at the top of `/changelog`, all six docs links resolve, RSS feed carries it as the newest item

🤖 Generated with [Claude Code](https://claude.com/claude-code)