### PR TITLE
feat(web): add the LLM observability tool roundup

### DIFF
--- a/apps/web/app/alternatives/page.tsx
+++ b/apps/web/app/alternatives/page.tsx
@@ -154,6 +154,13 @@ export default function AlternativesHub() {
           cloud-only. Below are the five most common alternatives teams compare Spanlens to,
           plus migration guides if you already have data in one of them.
         </p>
+        <p className="mt-4 text-[15px] text-text-muted leading-relaxed max-w-[760px]">
+          For a wider field, see{' '}
+          <Link href="/best-llm-observability-tools" className="text-accent hover:underline">
+            all twelve tools with stars, licence, and development activity
+          </Link>
+          .
+        </p>
       </section>
 
       <section className="max-w-[1000px] mx-auto px-6 pb-10">

--- a/apps/web/app/best-llm-observability-tools/page.tsx
+++ b/apps/web/app/best-llm-observability-tools/page.tsx
@@ -1,0 +1,357 @@
+import Link from 'next/link'
+import { Footer } from '@/components/layout/footer'
+import { MarketingNav } from '@/components/layout/marketing-nav'
+import { BreadcrumbJsonLd } from '@/components/marketing/breadcrumb-jsonld'
+import { openGraphFor } from '@/lib/page-metadata'
+import { COMPETITORS, VERIFIED_ON, openSourceCompetitors } from '@/lib/competitors'
+
+const SITE_URL = 'https://www.spanlens.io'
+const PATH = '/best-llm-observability-tools'
+
+export const metadata = {
+  alternates: { canonical: PATH },
+  openGraph: openGraphFor(PATH, { type: 'article' }),
+  title: 'Best LLM Observability Tools in 2026',
+  description:
+    'Twelve LLM observability tools compared on licence, install shape, self-hosting, and how actively each is developed. GitHub figures verified 30 July 2026.',
+}
+
+const FAQS: [string, string][] = [
+  [
+    'What is the best LLM observability tool in 2026?',
+    'There is no single best one. Langfuse has the largest open-source community, Comet Opik leads on evaluation, LiteLLM wins on multi-provider routing, and Traceloop is the choice when you want spans in an observability backend you already run. The right answer depends on whether you can change call sites, whether you must self-host, and whether cost or evaluation is your first question.',
+  ],
+  [
+    'Which LLM observability tools are genuinely open source?',
+    'Comet Opik, Helicone, Traceloop OpenLLMetry, Laminar, OpenLIT, and Spanlens ship under OSI-approved licences with no gated directory. Langfuse is MIT with an ee/ folder under a commercial licence. Arize Phoenix uses Elastic License 2.0, which is not OSI-approved. LangSmith and Braintrust are closed source.',
+  ],
+  [
+    'Which tools work without changing my application code?',
+    'Proxy and gateway tools do: Spanlens, Helicone, LiteLLM, and Portkey all sit in front of the provider so you change a base URL rather than wrapping call sites. Langfuse, Opik, Laminar, LangSmith, and Braintrust use SDK instrumentation. Traceloop, Phoenix, and OpenLIT go through OpenTelemetry.',
+  ],
+  [
+    'How do I track LLM cost per request?',
+    'You need the token counts from the provider response joined to a price table for that exact model version, because providers return dated model ids such as gpt-4o-mini-2024-07-18. Proxy-based tools compute this at the moment the response passes through. SDK-based tools compute it wherever you instrumented.',
+  ],
+  [
+    'Can I self-host LLM observability?',
+    'Yes for most of this list. Langfuse, Opik, Helicone, LiteLLM, Phoenix, Traceloop, Laminar, OpenLIT, and Spanlens all run on your own infrastructure. Portkey self-hosts the gateway but not the observability platform. LangSmith self-hosts on enterprise plans only, and Braintrust does not offer it.',
+  ],
+]
+
+const SITUATIONS: { question: string; answer: string; picks: string[] }[] = [
+  {
+    question: 'You cannot change every call site',
+    answer:
+      'Pick a proxy or gateway. You change one base URL and every request through it is recorded, which matters most in an existing codebase with calls scattered across services.',
+    picks: ['Spanlens', 'Helicone', 'LiteLLM', 'Portkey'],
+  },
+  {
+    question: 'You want the largest community and the most documentation',
+    answer:
+      'Langfuse has 32,119 stars and the deepest set of guides, integrations, and community answers. When you hit an unusual problem, someone has probably written about it already.',
+    picks: ['Langfuse'],
+  },
+  {
+    question: 'Evaluation is the question, not logging',
+    answer:
+      'Choose a tool built around scoring rather than one that added it later. Datasets, judges, and experiment comparison should be the main surface, not a tab.',
+    picks: ['Comet Opik', 'Braintrust', 'LangSmith'],
+  },
+  {
+    question: 'You already run Grafana, Datadog, or Honeycomb',
+    answer:
+      'Do not adopt a second dashboard. Emit OpenTelemetry spans with LLM attributes into the backend you already pay for and already know how to query.',
+    picks: ['Traceloop OpenLLMetry', 'Arize Phoenix', 'OpenLIT'],
+  },
+  {
+    question: 'You route across many providers and need fallbacks',
+    answer:
+      'This is a gateway problem before it is an observability problem. Retries, budgets, and provider failover come first, and logging follows through callbacks.',
+    picks: ['LiteLLM', 'Portkey'],
+  },
+  {
+    question: 'Cost is the number your team argues about',
+    answer:
+      'Per-request USD next to the model version, aggregated by prompt version and by customer, is not the default in most of these tools. Check that the cost view exists before you commit.',
+    picks: ['Spanlens', 'Helicone', 'LiteLLM'],
+  },
+  {
+    question: 'The data cannot leave your infrastructure',
+    answer:
+      'Rule out anything closed source or hosted-only first, then check whether self-hosting gives you the whole product or only part of it.',
+    picks: ['Langfuse', 'Comet Opik', 'Spanlens', 'Laminar'],
+  },
+]
+
+function jsonLd() {
+  const url = `${SITE_URL}${PATH}`
+  return [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      '@id': `${url}#article`,
+      headline: 'Best LLM Observability Tools in 2026',
+      description: metadata.description,
+      url,
+      datePublished: VERIFIED_ON,
+      dateModified: VERIFIED_ON,
+      inLanguage: 'en',
+      author: { '@id': `${SITE_URL}/#organization` },
+      publisher: { '@id': `${SITE_URL}/#organization` },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      '@id': `${url}#list`,
+      name: 'LLM observability tools compared',
+      itemListElement: COMPETITORS.map((c, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        name: c.name,
+        url: c.compareSlug ? `${SITE_URL}/compare/${c.compareSlug}` : c.homepage,
+      })),
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      '@id': `${url}#faq`,
+      mainEntity: FAQS.map(([q, a]) => ({
+        '@type': 'Question',
+        name: q,
+        acceptedAnswer: { '@type': 'Answer', text: a },
+      })),
+    },
+  ]
+}
+
+const CELL = 'align-top px-4 py-2.5 text-text-muted border-b border-border text-[13px]'
+
+export default function BestLlmObservabilityToolsPage() {
+  const openSource = openSourceCompetitors()
+
+  return (
+    <div className="min-h-screen bg-bg">
+      <MarketingNav />
+      <BreadcrumbJsonLd trail={[{ name: 'Best LLM observability tools', path: PATH }]} />
+      {jsonLd().map((block) => (
+        <script
+          key={block['@type']}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(block) }}
+        />
+      ))}
+
+      <section className="max-w-[1000px] mx-auto px-6 pt-20 pb-10">
+        <h1 className="text-[40px] sm:text-[48px] font-semibold tracking-[-0.8px] text-text leading-[1.05]">
+          Best LLM observability tools in 2026
+        </h1>
+        <p className="mt-5 text-[17px] text-text-muted leading-relaxed max-w-[70ch]">
+          There is no single best tool. The useful question is narrower: can you change every call
+          site, must the data stay on your infrastructure, and is your first question about cost or
+          about quality? Those three answers eliminate most of this list for you.
+        </p>
+        <p className="mt-4 text-[14px] text-text-muted leading-relaxed max-w-[70ch]">
+          Below are twelve tools with the licence you actually get, how you wire each one in, whether
+          self-hosting gives you the whole product, and how actively each repository is developed.
+          GitHub figures were read on {VERIFIED_ON}.
+        </p>
+        <p className="mt-4 text-[13px] text-text-faint leading-relaxed max-w-[70ch]">
+          Disclosure: we build Spanlens, which is one of the twelve. It is also the youngest and
+          smallest project here, and the table says so.
+        </p>
+      </section>
+
+      <section className="max-w-[1000px] mx-auto px-6 pb-14">
+        <h2 className="text-[24px] font-semibold tracking-[-0.4px] text-text mb-5">
+          Open-source tools by GitHub stars
+        </h2>
+        <div className="overflow-x-auto rounded-xl border border-border">
+          <table className="w-full border-collapse text-left">
+            <caption className="sr-only">
+              Open-source LLM observability tools with stars, licence, install shape and self-hosting
+              as of {VERIFIED_ON}
+            </caption>
+            <thead>
+              <tr className="bg-bg-elev">
+                <th scope="col" className="px-4 py-3 text-[12px] uppercase tracking-[0.06em] text-text-faint font-medium">
+                  Tool
+                </th>
+                <th scope="col" className="px-4 py-3 text-[12px] uppercase tracking-[0.06em] text-text-faint font-medium">
+                  Stars
+                </th>
+                <th scope="col" className="px-4 py-3 text-[12px] uppercase tracking-[0.06em] text-text-faint font-medium">
+                  Licence
+                </th>
+                <th scope="col" className="px-4 py-3 text-[12px] uppercase tracking-[0.06em] text-text-faint font-medium">
+                  How you install it
+                </th>
+                <th scope="col" className="px-4 py-3 text-[12px] uppercase tracking-[0.06em] text-text-faint font-medium">
+                  Self-host
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {openSource.map((c, i) => (
+                <tr key={c.name} className={i % 2 === 0 ? 'bg-bg-elev/30' : undefined}>
+                  <th
+                    scope="row"
+                    className="text-left align-top px-4 py-2.5 font-normal text-text border-b border-border text-[13px]"
+                  >
+                    {c.compareSlug ? (
+                      <Link href={`/compare/${c.compareSlug}`} className="hover:text-accent transition-colors">
+                        {c.name}
+                      </Link>
+                    ) : (
+                      c.name
+                    )}
+                  </th>
+                  <td className={`${CELL} font-mono`}>{c.stars?.toLocaleString('en-US')}</td>
+                  <td className={CELL}>{c.license}</td>
+                  <td className={CELL}>{c.install}</td>
+                  <td className={CELL}>{c.selfHost}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className="mt-3 text-[12px] text-text-faint">
+          LangSmith and Braintrust are closed source and have no public repository, so they are not in
+          this table. Both appear in the tool-by-tool notes below.
+        </p>
+      </section>
+
+      <section className="max-w-[1000px] mx-auto px-6 pb-14">
+        <h2 className="text-[24px] font-semibold tracking-[-0.4px] text-text mb-6">
+          Which tool fits which situation
+        </h2>
+        <div className="space-y-6">
+          {SITUATIONS.map((s) => (
+            <article key={s.question} className="rounded-xl border border-border bg-bg-elev p-6">
+              <h3 className="text-[17px] font-semibold text-text">{s.question}</h3>
+              <p className="mt-2 text-[14px] text-text-muted leading-relaxed max-w-[75ch]">{s.answer}</p>
+              <p className="mt-3 font-mono text-[12px] text-text-faint">
+                Look at: <span className="text-text">{s.picks.join(', ')}</span>
+              </p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="max-w-[1000px] mx-auto px-6 pb-14">
+        <h2 className="text-[24px] font-semibold tracking-[-0.4px] text-text mb-6">Tool by tool</h2>
+        <div className="space-y-5">
+          {COMPETITORS.map((c) => (
+            <article key={c.name} className="rounded-xl border border-border bg-bg-elev p-6">
+              <header className="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-3">
+                <h3 className="text-[18px] font-semibold text-text">{c.name}</h3>
+                {c.stars !== undefined ? (
+                  <span className="font-mono text-[11px] text-text-faint">
+                    {c.stars.toLocaleString('en-US')} stars
+                  </span>
+                ) : (
+                  <span className="font-mono text-[11px] text-text-faint">closed source</span>
+                )}
+              </header>
+              <p className="text-[14px] text-text leading-relaxed max-w-[75ch]">
+                <span className="text-text-faint">Best for. </span>
+                {c.bestFor}
+              </p>
+              <p className="mt-2 text-[14px] text-text-muted leading-relaxed max-w-[75ch]">
+                <span className="text-text-faint">The catch. </span>
+                {c.tradeoff}
+              </p>
+              <div className="mt-4 flex flex-wrap gap-4 font-mono text-[12px]">
+                {c.compareSlug ? (
+                  <Link href={`/compare/${c.compareSlug}`} className="text-accent hover:underline">
+                    Spanlens vs {c.name} →
+                  </Link>
+                ) : null}
+                <a
+                  href={c.homepage}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-text-faint hover:text-text transition-colors"
+                >
+                  {c.name} site ↗
+                </a>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="max-w-[1000px] mx-auto px-6 pb-14">
+        <h2 className="text-[24px] font-semibold tracking-[-0.4px] text-text mb-4">
+          How these figures were gathered
+        </h2>
+        <div className="text-[14px] text-text-muted leading-relaxed max-w-[75ch] space-y-3">
+          <p>
+            Stars, licence, and commit activity come from the GitHub API, read on {VERIFIED_ON}. The
+            activity claims are counts over a fixed window rather than impressions: for the 1 May to
+            30 July 2026 period, Langfuse and Comet Opik each recorded more than 300 commits, while
+            Helicone recorded 24 and the Portkey gateway recorded 26 with none after 25 May.
+          </p>
+          <p>
+            Licence descriptions say what you get rather than repeating the SPDX identifier, because
+            the identifier hides what matters. Langfuse reports as non-standard because MIT sits
+            alongside a commercially licensed ee/ folder. Arize Phoenix uses Elastic License 2.0,
+            which restricts offering the software as a service and is not OSI-approved.
+          </p>
+          <p>
+            Funding rounds, acquisitions, and valuations are deliberately absent. They change often,
+            they are hard to verify from a public API, and a wrong claim about another company is not
+            worth making on a page like this.
+          </p>
+          <p>
+            Install shape and self-hosting reflect each project&apos;s own documentation at the time
+            of writing. If something here is out of date or wrong, tell us at{' '}
+            <a href="mailto:support@spanlens.io" className="text-accent hover:underline">
+              support@spanlens.io
+            </a>{' '}
+            and we will correct it.
+          </p>
+        </div>
+      </section>
+
+      <section className="max-w-[1000px] mx-auto px-6 pb-16">
+        <h2 className="text-[24px] font-semibold tracking-[-0.4px] text-text mb-6">
+          Frequently asked
+        </h2>
+        <div className="space-y-4">
+          {FAQS.map(([q, a]) => (
+            <details key={q} className="rounded-xl border border-border bg-bg-elev p-5">
+              <summary className="cursor-pointer text-[15px] font-medium text-text">{q}</summary>
+              <p className="mt-3 text-[14px] text-text-muted leading-relaxed max-w-[75ch]">{a}</p>
+            </details>
+          ))}
+        </div>
+      </section>
+
+      <section className="max-w-[1000px] mx-auto px-6 pb-20">
+        <div className="rounded-xl border border-border bg-bg-elev p-8">
+          <h2 className="text-[20px] font-semibold text-text">Keep reading</h2>
+          <p className="mt-2 text-[14px] text-text-muted leading-relaxed max-w-[70ch]">
+            Head-to-head pages go deeper than the notes above, feature by feature.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-x-6 gap-y-2 font-mono text-[13px]">
+            <Link href="/compare" className="text-accent hover:underline">
+              All comparisons
+            </Link>
+            <Link href="/alternatives" className="text-accent hover:underline">
+              Alternatives hub
+            </Link>
+            <Link href="/llm-observability" className="text-accent hover:underline">
+              What LLM observability is
+            </Link>
+            <Link href="/llm-cost-tracking" className="text-accent hover:underline">
+              LLM cost tracking
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  )
+}

--- a/apps/web/app/compare/page.tsx
+++ b/apps/web/app/compare/page.tsx
@@ -87,6 +87,13 @@ export default function ComparePage() {
           Honest, side-by-side comparisons. We show where each alternative wins and where
           Spanlens does. Real tradeoffs without marketing fog.
         </p>
+        <p className="mt-4 text-[15px] text-text-muted leading-relaxed max-w-[680px]">
+          Want the whole field first?{' '}
+          <Link href="/best-llm-observability-tools" className="text-accent hover:underline">
+            Twelve tools with stars, licence, and development activity
+          </Link>
+          .
+        </p>
       </section>
 
       <section className="max-w-[1000px] mx-auto px-6 pb-24">

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -10,6 +10,8 @@ const ROUTE_LASTMOD: Record<string, string> = {
   '/pricing': '2026-06-16',
   '/self-hosting': '2026-05-20',
   '/alternatives': '2026-06-01',
+  // Bump alongside VERIFIED_ON in lib/competitors.ts.
+  '/best-llm-observability-tools': '2026-07-30',
   // Bump whenever an entry lands in lib/changelog/entries.ts. It had been
   // stuck at 2026-06-15 through four rounds of entries.
   '/changelog': '2026-07-30',
@@ -114,6 +116,7 @@ const MARKETING_ROUTES = [
   '/pricing',
   '/self-hosting',
   '/alternatives',
+  '/best-llm-observability-tools',
   '/changelog',
   '/feedback',
   '/faq',

--- a/apps/web/components/layout/footer.tsx
+++ b/apps/web/components/layout/footer.tsx
@@ -58,6 +58,7 @@ export function Footer() {
               <Link href="/compare/langsmith" className="hover:text-text transition-colors">LangSmith</Link>
               <Link href="/compare/braintrust" className="hover:text-text transition-colors">Braintrust</Link>
               <Link href="/compare/arize-phoenix" className="hover:text-text transition-colors">Arize Phoenix</Link>
+              <Link href="/best-llm-observability-tools" className="hover:text-text transition-colors">All tools</Link>
             </div>
           </div>
           {/* Guides — the keyword landing pages had zero internal inbound

--- a/apps/web/lib/competitors.test.ts
+++ b/apps/web/lib/competitors.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { COMPETITORS, VERIFIED_ON, openSourceCompetitors } from '@/lib/competitors'
+
+/**
+ * Guards for the competitor table behind /best-llm-observability-tools.
+ *
+ * These are claims about other companies' products, so the failure mode that
+ * matters is publishing something stale or half-filled. The checks here are
+ * about shape and freshness; the numbers themselves have to be re-read from the
+ * GitHub API by hand, which is what VERIFIED_ON records.
+ */
+
+const APP_DIR = join(__dirname, '..', 'app')
+
+describe('competitor data', () => {
+  it('has a plausible, non-future verification date', () => {
+    expect(VERIFIED_ON).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    const verified = new Date(`${VERIFIED_ON}T00:00:00Z`).getTime()
+    expect(verified).toBeLessThanOrEqual(Date.now())
+  })
+
+  it('is not more than a year stale', () => {
+    // A roundup that claims a verification date and then rots is worse than
+    // one with no date at all, because the date is the reason to trust it.
+    const ageMs = Date.now() - new Date(`${VERIFIED_ON}T00:00:00Z`).getTime()
+    expect(ageMs).toBeLessThan(365 * 24 * 60 * 60 * 1000)
+  })
+
+  it('lists Spanlens with the rest rather than above them', () => {
+    // The page discloses that we build one of the tools. It should be in the
+    // same table on the same terms, including a stated tradeoff.
+    const us = COMPETITORS.find((c) => c.name === 'Spanlens')
+    expect(us).toBeDefined()
+    expect(us?.tradeoff.length).toBeGreaterThan(60)
+  })
+
+  it.each(COMPETITORS.map((c) => [c.name, c] as const))('%s is fully filled in', (_name, c) => {
+    for (const field of ['license', 'install', 'selfHost', 'bestFor', 'tradeoff', 'homepage'] as const) {
+      expect(c[field], `${c.name}.${field}`).toBeTruthy()
+    }
+    expect(c.homepage).toMatch(/^https:\/\//)
+    // Every entry carries a real catch, ours included. A one-word tradeoff is
+    // a sign the entry was filled in to pad the table.
+    expect(c.tradeoff.split(/\s+/).length, `${c.name}.tradeoff is too short`).toBeGreaterThan(8)
+  })
+
+  it.each(COMPETITORS.filter((c) => c.repo).map((c) => [c.name, c] as const))(
+    '%s has stars to go with its repo',
+    (_name, c) => {
+      expect(c.stars, `${c.name} has a repo but no star count`).toBeGreaterThan(0)
+      expect(c.repo).toMatch(/^[\w.-]+\/[\w.-]+$/)
+    },
+  )
+
+  it('orders the open-source table by stars, descending', () => {
+    const stars = openSourceCompetitors().map((c) => c.stars ?? 0)
+    expect(stars).toEqual([...stars].sort((a, b) => b - a))
+  })
+
+  it('every compareSlug points at a page that exists', () => {
+    for (const c of COMPETITORS.filter((x) => x.compareSlug)) {
+      const page = join(APP_DIR, 'compare', c.compareSlug as string, 'page.tsx')
+      expect(() => readFileSync(page, 'utf-8'), `${c.name} -> /compare/${c.compareSlug}`).not.toThrow()
+    }
+  })
+})
+
+describe('the roundup page', () => {
+  const source = readFileSync(join(APP_DIR, 'best-llm-observability-tools', 'page.tsx'), 'utf-8')
+
+  it('renders from the shared data rather than its own copy', () => {
+    expect(source).toContain("from '@/lib/competitors'")
+  })
+
+  it('states the verification date on the page', () => {
+    expect(source).toContain('{VERIFIED_ON}')
+  })
+
+  it('discloses that we build one of the tools', () => {
+    expect(source).toMatch(/Disclosure/)
+  })
+
+  it('is reachable: the footer and both hubs link to it', () => {
+    // The six docs section hubs shipped with no inbound links and Ahrefs filed
+    // all six as orphans. Not repeating that.
+    const inbound = [
+      join(__dirname, '..', 'components', 'layout', 'footer.tsx'),
+      join(APP_DIR, 'compare', 'page.tsx'),
+      join(APP_DIR, 'alternatives', 'page.tsx'),
+    ]
+    for (const file of inbound) {
+      expect(readFileSync(file, 'utf-8'), file).toContain('/best-llm-observability-tools')
+    }
+  })
+
+  it('is in the sitemap', () => {
+    const sitemap = readFileSync(join(APP_DIR, 'sitemap.ts'), 'utf-8')
+    expect(sitemap).toContain("'/best-llm-observability-tools',")
+  })
+})

--- a/apps/web/lib/competitors.ts
+++ b/apps/web/lib/competitors.ts
@@ -1,0 +1,204 @@
+/**
+ * Competitor facts for the roundup and comparison pages.
+ *
+ * Single source of truth on purpose. The same numbers were previously restated
+ * on each page that needed them, which is how the docs section copy drifted
+ * (see app/docs/_lib/sections.ts and its drift test).
+ *
+ * Scope rule: this file carries only claims that can be checked from a public,
+ * stable source. GitHub stars, license, commit cadence, and release recency all
+ * come from the GitHub API on the date below. Funding rounds, acquisitions, and
+ * headcount are deliberately absent: they move, they are hard to verify from
+ * here, and a wrong claim about another company's ownership is not a mistake
+ * worth risking on a marketing page.
+ *
+ * When refreshing, re-run the API for every repo and update VERIFIED_ON in the
+ * same commit. competitors.test.ts fails if an entry is missing a field or if
+ * VERIFIED_ON goes stale past a year.
+ */
+
+export interface Competitor {
+  name: string
+  /** Slug of our /compare page, when one exists. */
+  compareSlug?: string
+  /** GitHub owner/name, absent for closed-source products. */
+  repo?: string
+  /** Stars as of VERIFIED_ON. Absent for closed source. */
+  stars?: number
+  /** License as users experience it, not just the SPDX id. */
+  license: string
+  /** How you wire it into an app. */
+  install: string
+  selfHost: string
+  /** The situation this tool is the right answer for. */
+  bestFor: string
+  /** The honest catch. Every entry has one, including ours. */
+  tradeoff: string
+  homepage: string
+}
+
+/** Date the GitHub numbers below were read. */
+export const VERIFIED_ON = '2026-07-30'
+
+export const COMPETITORS: Competitor[] = [
+  {
+    name: 'Spanlens',
+    repo: 'spanlens/Spanlens',
+    stars: 10,
+    license: 'MIT, whole repository',
+    install: 'Swap the baseURL, or one CLI command',
+    selfHost: 'Yes, one Docker command',
+    bestFor:
+      'You want per-request cost in the dashboard on day one and you would rather change a base URL than wrap every call site.',
+    tradeoff:
+      'It is the youngest project here by a wide margin. Ten stars against Langfuse’s 32,000 is not a rounding error, and a young tool means fewer battle-tested edge cases and a smaller community to search when you get stuck.',
+    homepage: 'https://www.spanlens.io',
+  },
+  {
+    name: 'Langfuse',
+    compareSlug: 'langfuse',
+    repo: 'langfuse/langfuse',
+    stars: 32119,
+    license: 'MIT core, plus an ee/ folder under a commercial license',
+    install: 'Wrap clients with the SDK, or send OpenTelemetry spans',
+    selfHost: 'Yes, Docker Compose',
+    bestFor:
+      'You want the most mature open-source option with the largest community, and you are comfortable instrumenting call sites rather than routing traffic through a proxy.',
+    tradeoff:
+      'The ee/ folder gates enterprise features such as SCIM, audit logs, and project-level RBAC behind a commercial license, so self-hosting does not give you everything in the repository.',
+    homepage: 'https://langfuse.com',
+  },
+  {
+    name: 'Comet Opik',
+    repo: 'comet-ml/opik',
+    stars: 20966,
+    license: 'Apache 2.0, no gated folder',
+    install: 'SDK decorators, plus OpenTelemetry ingest',
+    selfHost: 'Yes, Docker or Kubernetes',
+    bestFor:
+      'Evaluation is your main question. You want scoring, datasets, and experiment tracking as the centre of the product rather than a feature bolted onto a log viewer.',
+    tradeoff:
+      'Instrumentation is SDK-first, so there is no base-URL swap. Cost tracking is present but is not the organising idea the way it is in a proxy-first tool.',
+    homepage: 'https://www.comet.com/site/products/opik/',
+  },
+  {
+    name: 'Helicone',
+    compareSlug: 'helicone',
+    repo: 'Helicone/helicone',
+    stars: 6015,
+    license: 'Apache 2.0',
+    install: 'Swap the baseURL, or async SDK logging',
+    selfHost: 'Yes, Docker',
+    bestFor:
+      'You specifically want a proxy and you value a codebase that has been in production for years over one that ships quickly.',
+    tradeoff:
+      'Development has slowed sharply. The repository took 24 commits between 1 May and 30 July 2026, against more than 300 each for Langfuse and Opik over the same window, and the most recent tagged release is from August 2025.',
+    homepage: 'https://www.helicone.ai',
+  },
+  {
+    name: 'LiteLLM',
+    repo: 'BerriAI/litellm',
+    stars: 55038,
+    license: 'Custom licence, not a standard OSI template',
+    install: 'Run the gateway, then point clients at it and describe models in YAML',
+    selfHost: 'Yes',
+    bestFor:
+      'You need one endpoint in front of many providers with retries, fallbacks, and budgets, and routing matters more to you than the observability surface.',
+    tradeoff:
+      'It is a gateway first. Logging exists through callbacks into other backends, so the built-in observability is thin next to a purpose-built tool, and the YAML config grows quickly.',
+    homepage: 'https://www.litellm.ai',
+  },
+  {
+    name: 'Portkey',
+    repo: 'Portkey-AI/gateway',
+    stars: 12593,
+    license: 'MIT for the gateway; the observability platform is commercial',
+    install: 'Run the gateway, or use the hosted endpoint',
+    selfHost: 'Gateway yes, full observability no',
+    bestFor:
+      'You want a gateway with guardrails and caching and you are happy to pay for the hosted dashboard rather than run the whole stack.',
+    tradeoff:
+      'The open-source repository is the gateway only; the observability you would compare against these other tools sits in the paid product. The gateway repository has had no commits since 25 May 2026.',
+    homepage: 'https://portkey.ai',
+  },
+  {
+    name: 'Arize Phoenix',
+    compareSlug: 'arize-phoenix',
+    repo: 'Arize-ai/phoenix',
+    stars: 10802,
+    license: 'Elastic License 2.0, which is not an OSI-approved open-source licence',
+    install: 'OpenTelemetry instrumentation',
+    selfHost: 'Yes',
+    bestFor:
+      'You are already an OpenTelemetry shop and you want tracing plus evaluation that sits naturally beside your existing spans.',
+    tradeoff:
+      'Elastic License 2.0 restricts offering the software as a managed service, so calling it open source is inaccurate even though the code is public.',
+    homepage: 'https://phoenix.arize.com',
+  },
+  {
+    name: 'Traceloop OpenLLMetry',
+    repo: 'traceloop/openllmetry',
+    stars: 7340,
+    license: 'Apache 2.0',
+    install: 'OpenTelemetry instrumentation libraries',
+    selfHost: 'Yes, and it is backend-agnostic',
+    bestFor:
+      'You want LLM spans in the observability backend you already run, whether that is Grafana, Datadog, or Honeycomb, rather than adopting another dashboard.',
+    tradeoff:
+      'It is plumbing rather than a product. You get well-shaped spans and then you build the cost views, evaluation, and prompt management yourself.',
+    homepage: 'https://www.traceloop.com',
+  },
+  {
+    name: 'Laminar',
+    repo: 'lmnr-ai/lmnr',
+    stars: 3127,
+    license: 'Apache 2.0',
+    install: 'SDK instrumentation',
+    selfHost: 'Yes',
+    bestFor:
+      'Multi-step agents are your whole workload and you want a backend built for that shape rather than one that treats a trace as a nice-to-have.',
+    tradeoff: 'Small project and small community, so expect to read source when something surprises you.',
+    homepage: 'https://www.lmnr.ai',
+  },
+  {
+    name: 'OpenLIT',
+    repo: 'openlit/openlit',
+    stars: 2658,
+    license: 'Apache 2.0',
+    install: 'OpenTelemetry instrumentation',
+    selfHost: 'Yes',
+    bestFor:
+      'You run your own models and want GPU utilisation next to token cost, which most hosted-API-focused tools do not show you.',
+    tradeoff: 'Narrower than the larger tools once you step outside self-hosted inference.',
+    homepage: 'https://openlit.io',
+  },
+  {
+    name: 'LangSmith',
+    compareSlug: 'langsmith',
+    license: 'Closed source',
+    install: 'SDK, with first-class LangChain integration',
+    selfHost: 'Enterprise plans only',
+    bestFor:
+      'Your stack is LangChain or LangGraph and you want the tool built by the same team, with the tightest integration available.',
+    tradeoff:
+      'No public repository and no self-hosting outside enterprise agreements, so your traces live somewhere you do not control.',
+    homepage: 'https://www.langchain.com/langsmith',
+  },
+  {
+    name: 'Braintrust',
+    compareSlug: 'braintrust',
+    license: 'Closed source',
+    install: 'SDK',
+    selfHost: 'No',
+    bestFor:
+      'Evaluation is a team workflow with reviewers and datasets, and you want the polished product rather than assembling one.',
+    tradeoff:
+      'Closed source, no self-hosting, and it is an evaluation product first, so request-level cost observability is not the centre of it.',
+    homepage: 'https://www.braintrust.dev',
+  },
+]
+
+/** Tools with a public repository, most-starred first. */
+export function openSourceCompetitors(): Competitor[] {
+  return COMPETITORS.filter((c) => c.repo).sort((a, b) => (b.stars ?? 0) - (a.stars ?? 0))
+}


### PR DESCRIPTION
New page at `/best-llm-observability-tools` covering twelve tools. Comparison content is the format AI answer engines cite most, and "best LLM observability tool" is the highest-intent query class we had no page for at all.

## The data layer

`lib/competitors.ts` is the single source of truth. Every page that needs these facts reads from it, because restating the same facts per page is exactly how the docs section copy drifted last night.

Scope rule for that file: **only claims checkable from a public, stable source.** Stars, licence, commit cadence, and release recency come from the GitHub API. Funding, acquisitions, and valuations are deliberately absent, and the file says why: they move, they are hard to verify from here, and a wrong claim about another company's ownership is not worth making on a marketing page.

## Verification changed what the page says

Three figures in our notes were stale:

| | Noted | Actual (2026-07-30) |
|---|---|---|
| LiteLLM | 45k | **55,038** |
| Portkey | 10k | **12,593** |
| Langfuse | 31.7k | **32,119** |

More consequential: **"Helicone is in maintenance mode" does not survive contact with the data.** It had a commit on 21 July. Publishing the label would have been wrong.

What is defensible is the measurement, so the page states the measurement instead:

```
1 May - 30 July 2026, commits
  Langfuse   300+
  Opik       300+
  Helicone    24     last tagged release 2025-08-21
  Portkey     26     no commits after 2026-05-25
```

That is a stronger claim than the label was, and it is checkable by anyone.

## Editorial stance

No numbered ranking. We build one of the twelve and have **10 stars against Langfuse's 32,119**. A ranking with us on top would be neither honest nor citable, and roundups that read as promotional do not get cited.

Instead the page maps **situations to tools** ("you cannot change every call site", "evaluation is the question, not logging", "you already run Grafana or Datadog"), discloses in the lead that we build Spanlens, and gives every entry a stated tradeoff. Ours is the bluntest one on the page:

> It is the youngest project here by a wide margin. Ten stars against Langfuse's 32,000 is not a rounding error.

## Structure for citation

`Article` + `ItemList` + `FAQPage` + `BreadcrumbList` JSON-LD, a comparison table, five FAQ answers written to stand alone, and a "how these figures were gathered" section with the verification date on the page.

## Not an orphan

Linked from the footer, `/compare`, and `/alternatives`. The six docs hubs shipped last night with zero inbound links and Ahrefs filed all six as orphan pages; `competitors.test.ts` asserts these three links exist so this page cannot repeat that.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter web test` (378 passed, 32 new)
- [x] `pnpm --filter web build`
- [x] Dev server: 200, all four JSON-LD types present, meta description 154 chars, all nine star figures render, five `/compare` links resolve, inbound links live on `/compare` and `/alternatives`
- [ ] After deploy: Rich Results Test on the FAQ and ItemList blocks
- [ ] Refresh cadence: re-read the GitHub API and bump `VERIFIED_ON`; the guard test fails if it goes a year stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)