### PR TITLE
feat(web): compare pages for Portkey, LiteLLM, and Comet Opik

### DIFF
--- a/apps/web/app/compare/litellm/page.tsx
+++ b/apps/web/app/compare/litellm/page.tsx
@@ -1,0 +1,135 @@
+import { openGraphFor } from '@/lib/page-metadata'
+import { CompareTemplate, type CompareGroup, type ComparePoint } from '@/components/marketing/compare-template'
+
+export const metadata = {
+  alternates: { canonical: '/compare/litellm' },
+  openGraph: openGraphFor('/compare/litellm'),
+  title: 'Spanlens vs LiteLLM · 2026 Comparison',
+  description:
+    'LiteLLM is the dominant open-source LLM gateway with thin built-in logging. Spanlens is the observability half. Many teams end up running both.',
+}
+
+const whySpanlens: ComparePoint[] = [
+  {
+    title: 'Observability is the product, not a callback',
+    body:
+      'LiteLLM records what happened by handing it to something else: you register a callback and pick a backend. Spanlens is that backend, with the request log, cost views, traces, evaluation, and anomaly detection as the product itself rather than as configuration you assemble.',
+  },
+  {
+    title: 'Nothing to configure before the first request',
+    body:
+      'LiteLLM wants a config file describing your models, keys, and routing before it is useful, and that file keeps growing. Spanlens needs a base URL and a key, and the provider is inferred from the path, so there is no model registry to maintain.',
+  },
+  {
+    title: 'Cost matched to the exact model version',
+    body:
+      'Providers return dated ids such as gpt-4o-mini-2024-07-18, and a price table that only knows gpt-4o-mini will quietly produce the wrong number. Spanlens matches exact ids first and falls back to the longest boundary-aware prefix, then rolls the result up by prompt version and by end user.',
+  },
+  {
+    title: 'Agent traces with the critical path marked',
+    body:
+      'Spanlens shows a multi-step agent run as a span tree and marks the longest dependency chain, so you know which of five tool calls is actually costing you the wall-clock time. A gateway sees each call separately and cannot reconstruct the shape.',
+  },
+  {
+    title: 'Evaluation and Prompt A/B in the same place as the logs',
+    body:
+      'LLM-as-judge scoring, human annotation with judge-to-human correlation, and traffic-split prompt A/B with a Welch t-test all sit next to the requests they describe. With LiteLLM these are separate tools you wire together.',
+  },
+  {
+    title: 'Logs survive the analytics store going down',
+    body:
+      'Spanlens writes request logs to ClickHouse and, if that write fails, queues the row in Postgres and replays it when ClickHouse recovers. Silent log loss during an outage is the failure mode that makes observability untrustworthy.',
+  },
+]
+
+const whyCompetitor: ComparePoint[] = [
+  {
+    title: 'Far and away the larger project',
+    body:
+      'LiteLLM has 55,038 GitHub stars against Spanlens at 10, verified 30 July 2026, and it ships continuously. If community size and breadth of exercised integrations are your main criteria, this is not a close call.',
+  },
+  {
+    title: 'Provider coverage is much wider',
+    body:
+      'LiteLLM normalises well over a hundred providers behind one OpenAI-shaped interface. Spanlens proxies ten. If you are calling something unusual, check the Spanlens list before assuming it is covered.',
+  },
+  {
+    title: 'Routing, fallbacks, and budgets are its job',
+    body:
+      'Retries, provider failover, load balancing, rate limits, and per-key spend caps are core LiteLLM features with years behind them. Spanlens deliberately does not try to be your traffic manager.',
+  },
+  {
+    title: 'They compose well, so this may not be a choice',
+    body:
+      'A common shape is LiteLLM for routing with Spanlens as the observability backend behind it. If you already run LiteLLM, you probably want to add Spanlens rather than replace anything.',
+  },
+]
+
+const groups: CompareGroup[] = [
+  {
+    title: 'What each one is for',
+    rows: [
+      { feature: 'Primary job', spanlens: 'Observability', competitor: 'Routing' },
+      { feature: 'Licence', spanlens: 'MIT', competitor: 'Custom', note: 'LiteLLM does not use a standard OSI template; read it if licence terms matter to you.' },
+      { feature: 'Self-host', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'GitHub stars (2026-07-30)', spanlens: '10', competitor: '55,038' },
+      { feature: 'Providers normalised behind one interface', spanlens: '10', competitor: '100+' },
+    ],
+  },
+  {
+    title: 'Setup',
+    rows: [
+      { feature: 'Usable with no config file', spanlens: 'yes', competitor: 'no' },
+      { feature: 'One-line baseURL swap', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Model registry to maintain', spanlens: 'no', competitor: 'yes' },
+      { feature: 'OpenTelemetry (OTLP) ingest', spanlens: 'yes', competitor: 'partial' },
+    ],
+  },
+  {
+    title: 'Observability',
+    rows: [
+      { feature: 'Built-in request log UI', spanlens: 'yes', competitor: 'partial', note: 'LiteLLM ships a UI; the depth of the log view is not its focus.' },
+      { feature: 'Full request and response bodies stored', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Per-request USD cost', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Dated model variant pricing', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Cost by prompt version', spanlens: 'yes', competitor: 'no' },
+      { feature: 'Cost by end user and session', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Requires an external backend to retain logs', spanlens: 'no', competitor: 'yes' },
+    ],
+  },
+  {
+    title: 'Traces, quality, and safety',
+    rows: [
+      { feature: 'Agent trace waterfall', spanlens: 'yes', competitor: 'no' },
+      { feature: 'Critical path marked', spanlens: 'yes', competitor: 'no' },
+      { feature: 'LLM-as-judge evaluation', spanlens: 'yes', competitor: 'no' },
+      { feature: 'Prompt versioning and A/B with significance test', spanlens: 'yes', competitor: 'no' },
+      { feature: 'Statistical anomaly detection', spanlens: 'yes', competitor: 'no' },
+      { feature: 'PII and prompt-injection scanning', spanlens: 'yes', competitor: 'no' },
+    ],
+  },
+  {
+    title: 'Traffic management',
+    rows: [
+      { feature: 'Provider fallback and retries', spanlens: 'no', competitor: 'yes' },
+      { feature: 'Load balancing across deployments', spanlens: 'no', competitor: 'yes' },
+      { feature: 'Per-key spend caps', spanlens: 'partial', competitor: 'yes', note: 'Spanlens enforces monthly plan quotas, not arbitrary per-key budgets.' },
+      { feature: 'Response caching', spanlens: 'yes', competitor: 'yes' },
+    ],
+  },
+]
+
+export default function VsLiteLlmPage() {
+  return (
+    <CompareTemplate
+      competitor="LiteLLM"
+      tagline="Different jobs. One routes traffic, the other explains it."
+      tldr="LiteLLM is a gateway and Spanlens is an observability platform, so treating this as a head-to-head is slightly wrong from the start. LiteLLM normalises over a hundred providers, handles retries and fallbacks, and hands logging to a backend you choose. Spanlens is a backend of that kind, with cost attribution, agent traces, evaluation, and anomaly detection built in and no config file to maintain. Plenty of teams end up running both."
+      whySpanlens={whySpanlens}
+      whyCompetitor={whyCompetitor}
+      groups={groups}
+      lastUpdated="2026-07-30"
+      closing="If your problem is routing across many providers with fallbacks, use LiteLLM. If your problem is knowing what each request cost and why a trace was slow, add Spanlens. The two are not mutually exclusive."
+    />
+  )
+}

--- a/apps/web/app/compare/opik/page.tsx
+++ b/apps/web/app/compare/opik/page.tsx
@@ -1,0 +1,133 @@
+import { openGraphFor } from '@/lib/page-metadata'
+import { CompareTemplate, type CompareGroup, type ComparePoint } from '@/components/marketing/compare-template'
+
+export const metadata = {
+  alternates: { canonical: '/compare/opik' },
+  openGraph: openGraphFor('/compare/opik'),
+  title: 'Spanlens vs Comet Opik · 2026 Comparison',
+  description:
+    'Opik is evaluation-first under Apache 2.0. Spanlens is cost-first with a one-line baseURL swap. Which one fits depends on your first question.',
+}
+
+const whySpanlens: ComparePoint[] = [
+  {
+    title: 'No call sites to change',
+    body:
+      'Opik instruments your code: you add decorators or wrap clients, and every place that calls a model needs touching. Spanlens sits in front of the provider, so you change one base URL and existing calls are captured wherever they live. In a codebase with model calls spread across services, that difference decides how long adoption takes.',
+  },
+  {
+    title: 'Cost is the organising idea',
+    body:
+      'Spanlens computes per-request USD as the response passes through, matched to the exact dated model id, and rolls it up by model, prompt version, end user, and session. Opik tracks token usage and cost, but the product is built around scoring quality rather than around explaining a bill.',
+  },
+  {
+    title: 'A savings recommender that names a number',
+    body:
+      'Spanlens looks at your real token distribution per route and flags where a smaller model would plausibly hold quality, with an estimated monthly saving and a confidence tier. That is a different question from "did this response score well".',
+  },
+  {
+    title: 'Critical path on agent traces',
+    body:
+      'Both tools render multi-step runs as trees. Spanlens marks the longest dependency chain, so a five-tool agent tells you which span to fix instead of leaving you to compare timings by eye.',
+  },
+  {
+    title: 'Anomaly detection and log durability',
+    body:
+      'Spanlens flags 3-sigma deviations in latency, cost, and error rate against a rolling 7-day baseline per provider and model, and queues log writes to Postgres if ClickHouse is unavailable so rows are not silently dropped. These are operations concerns rather than evaluation concerns.',
+  },
+]
+
+const whyCompetitor: ComparePoint[] = [
+  {
+    title: 'Evaluation is deeper, and that is the point',
+    body:
+      'If your central question is whether output quality is improving, Opik is built for that question first. Datasets, judges, experiment comparison, and the workflow around them are more developed than what Spanlens ships, and Spanlens evaluation exists alongside cost rather than as the centre of the product.',
+  },
+  {
+    title: 'A much larger and faster-moving project',
+    body:
+      'Opik has 20,966 GitHub stars against Spanlens at 10, and recorded more than 300 commits between 1 May and 30 July 2026, verified on 30 July. It is one of the fastest-growing tools in this category.',
+  },
+  {
+    title: 'Apache 2.0 with nothing held back',
+    body:
+      'Opik has no gated enterprise directory, so self-hosting gives you the whole repository. Spanlens is MIT with the same property, so on licence terms this is a tie rather than an advantage for either side.',
+  },
+  {
+    title: 'Backed by an established company',
+    body:
+      'Opik comes from Comet, which has been selling experiment tracking to ML teams for years. If vendor longevity is part of your decision, that history counts for something Spanlens cannot match yet.',
+  },
+]
+
+const groups: CompareGroup[] = [
+  {
+    title: 'Licence and hosting',
+    rows: [
+      { feature: 'Licence', spanlens: 'MIT', competitor: 'Apache 2.0' },
+      { feature: 'Gated enterprise directory in the repo', spanlens: 'no', competitor: 'no' },
+      { feature: 'Self-host the whole product', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Single-command Docker install', spanlens: 'yes', competitor: 'partial', note: 'Opik documents Docker Compose and Kubernetes paths.' },
+      { feature: 'GitHub stars (2026-07-30)', spanlens: '10', competitor: '20,966' },
+    ],
+  },
+  {
+    title: 'Getting data in',
+    rows: [
+      { feature: 'One-line baseURL swap', spanlens: 'yes', competitor: 'no' },
+      { feature: 'Works without touching call sites', spanlens: 'yes', competitor: 'no' },
+      { feature: 'SDK decorators', spanlens: 'partial', competitor: 'yes' },
+      { feature: 'OpenTelemetry (OTLP) ingest', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Framework-agnostic', spanlens: 'yes', competitor: 'yes' },
+    ],
+  },
+  {
+    title: 'Cost',
+    rows: [
+      { feature: 'Per-request USD in the log', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Dated model variant pricing', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Cost by prompt version', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Cost by end user and session', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Cheaper-model recommendations with a dollar figure', spanlens: 'yes', competitor: 'no' },
+      { feature: 'Prompt-caching savings report', spanlens: 'yes', competitor: 'no' },
+    ],
+  },
+  {
+    title: 'Evaluation',
+    rows: [
+      { feature: 'LLM-as-judge scoring', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Datasets of test cases', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Offline experiments across versions', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Human annotation', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Judge-to-human correlation as a metric', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Live traffic A/B with significance test', spanlens: 'yes', competitor: 'no', note: 'Spanlens reports a Welch t-test on latency and cost plus a z-test on error rate.' },
+      { feature: 'Depth of the evaluation workflow overall', spanlens: 'partial', competitor: 'yes' },
+    ],
+  },
+  {
+    title: 'Traces and operations',
+    rows: [
+      { feature: 'Agent trace waterfall', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Critical path marked', spanlens: 'yes', competitor: 'no' },
+      { feature: 'Statistical anomaly detection', spanlens: 'yes', competitor: 'no' },
+      { feature: 'Log durability queue on analytics-store failure', spanlens: 'yes', competitor: 'no' },
+      { feature: 'PII and prompt-injection scanning', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Response caching at the proxy', spanlens: 'yes', competitor: 'no' },
+    ],
+  },
+]
+
+export default function VsOpikPage() {
+  return (
+    <CompareTemplate
+      competitor="Comet Opik"
+      tagline="Evaluation-first against cost-first. Both fully open."
+      tldr="Opik and Spanlens are both properly open source with nothing held back, so the licence argument that separates other tools does not apply here. They differ in what they are organised around. Opik starts from output quality: datasets, judges, and experiments are the main surface, and instrumentation is SDK-first. Spanlens starts from the bill and the trace: one base URL captures existing calls, cost is attributed per request, and evaluation sits beside it. Opik is much larger and its evaluation workflow is deeper."
+      whySpanlens={whySpanlens}
+      whyCompetitor={whyCompetitor}
+      groups={groups}
+      lastUpdated="2026-07-30"
+      closing="If your first question is whether quality is improving, Opik is built for it and is the safer pick on maturity. If your first question is what a request cost and where the latency went, and you would rather not instrument every call site, try Spanlens."
+    />
+  )
+}

--- a/apps/web/app/compare/page.tsx
+++ b/apps/web/app/compare/page.tsx
@@ -9,7 +9,7 @@ export const metadata = {
   openGraph: openGraphFor('/compare'),
   title: 'Spanlens vs alternatives · Compare',
   description:
-    'Honest comparisons of Spanlens against Langfuse, Helicone, LangSmith, Braintrust, and Arize Phoenix, feature by feature.',
+    'Honest comparisons of Spanlens against Langfuse, Helicone, Comet Opik, LiteLLM, Portkey, LangSmith, Braintrust, and Arize Phoenix, feature by feature.',
 }
 
 interface CompareEntry {
@@ -54,6 +54,27 @@ const ENTRIES: CompareEntry[] = [
     blurb:
       'Source-available (ELv2) observability from Arize. Python-first, ML-engineer-leaning. Spanlens is built for the application developer running LLM calls in production.',
     tag: 'Source-available · Python-first',
+  },
+  {
+    slug: 'opik',
+    competitor: 'Comet Opik',
+    blurb:
+      'Apache 2.0 with nothing held back, so the licence argument does not apply. Opik organises around evaluation and instruments through the SDK. Spanlens organises around cost and captures existing calls through the proxy.',
+    tag: 'OSS · eval-first',
+  },
+  {
+    slug: 'portkey',
+    competitor: 'Portkey',
+    blurb:
+      'The closest architecture after Helicone: both sit in front of the provider. Portkey open-sources the gateway and sells the observability, while Spanlens ships both halves under MIT.',
+    tag: 'Gateway · open-core',
+  },
+  {
+    slug: 'litellm',
+    competitor: 'LiteLLM',
+    blurb:
+      'Different jobs rather than rivals. LiteLLM routes across a hundred providers and hands logging to a backend; Spanlens is a backend of that kind. Many teams run both.',
+    tag: 'Gateway · routing-first',
   },
 ]
 

--- a/apps/web/app/compare/portkey/page.tsx
+++ b/apps/web/app/compare/portkey/page.tsx
@@ -1,0 +1,136 @@
+import { openGraphFor } from '@/lib/page-metadata'
+import { CompareTemplate, type CompareGroup, type ComparePoint } from '@/components/marketing/compare-template'
+
+export const metadata = {
+  alternates: { canonical: '/compare/portkey' },
+  openGraph: openGraphFor('/compare/portkey'),
+  title: 'Spanlens vs Portkey · 2026 Comparison',
+  description:
+    'Portkey open-sources the gateway and sells the observability. Spanlens is MIT end to end and self-hosts the whole product, including the dashboard.',
+}
+
+const whySpanlens: ComparePoint[] = [
+  {
+    title: 'The part you compare is the part Portkey keeps',
+    body:
+      'Portkey publishes its gateway under MIT, and that repository is the routing layer. The observability you would actually evaluate against a tool like this, the request log, the cost views, the traces, lives in the commercial platform. With Spanlens the dashboard and the proxy are the same MIT repository, so self-hosting gives you the product rather than the front door to it.',
+  },
+  {
+    title: 'Cost is the first column, not an add-on',
+    body:
+      'Spanlens computes per-request USD from the provider response at the moment it passes through, matched to the exact dated model id such as gpt-4o-mini-2024-07-18, and aggregates it by prompt version and by end user. Gateways tend to treat spend as a budget guard rather than as the number you open the dashboard to read.',
+  },
+  {
+    title: 'Agent traces with the critical path marked',
+    body:
+      'When an agent calls five tools in sequence, both tools can show you spans. Spanlens marks the longest dependency chain so you know which span to fix, rather than eyeballing a waterfall.',
+  },
+  {
+    title: 'Prompt A/B with a significance test attached',
+    body:
+      'Spanlens splits live traffic between two prompt versions and reports a Welch t-test on latency and cost plus a z-test on error rate. You get an answer about whether v8 beat v7 rather than two averages that look different.',
+  },
+  {
+    title: 'Public repository activity you can check',
+    body:
+      'The Portkey gateway repository had 26 commits between 1 May and 30 July 2026 and none after 25 May. Product work may well be happening in private repositories, but if you are choosing partly on the health of the open-source side, that is what the public record shows.',
+  },
+]
+
+const whyCompetitor: ComparePoint[] = [
+  {
+    title: 'Guardrails and routing are deeper',
+    body:
+      'Portkey ships request guardrails, conditional routing, load balancing across providers, and caching as first-class gateway features with a longer track record. Spanlens caches responses on request and proxies ten providers, but it is not trying to be your traffic manager.',
+  },
+  {
+    title: 'Much larger community',
+    body:
+      'The Portkey gateway has 12,593 GitHub stars against Spanlens at 10, verified 30 July 2026. That gap is real: more integrations have been exercised, more edge cases have been reported, and more answers already exist when you search for an error message.',
+  },
+  {
+    title: 'You may want the managed dashboard',
+    body:
+      'If you would rather not run an observability stack at all, paying for a hosted platform is a legitimate answer. Spanlens offers hosting too, but the reason to pick it is usually that you want the option to run everything yourself.',
+  },
+  {
+    title: 'Enterprise gateway features',
+    body:
+      'Virtual keys, per-team budgets, and provider-level access control are more developed on the Portkey side. Check both feature lists against your actual governance requirements before deciding.',
+  },
+]
+
+const groups: CompareGroup[] = [
+  {
+    title: 'Licence and hosting',
+    rows: [
+      { feature: 'Licence covering the observability product', spanlens: 'MIT', competitor: 'Commercial' },
+      { feature: 'Licence covering the gateway or proxy', spanlens: 'MIT', competitor: 'MIT' },
+      { feature: 'Self-host the whole product', spanlens: 'yes', competitor: 'no', note: 'Portkey self-hosts the gateway; the observability platform is hosted.' },
+      { feature: 'Single-command Docker install', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'GitHub stars (2026-07-30)', spanlens: '10', competitor: '12,593' },
+    ],
+  },
+  {
+    title: 'Getting data in',
+    rows: [
+      { feature: 'One-line baseURL swap', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Works without touching call sites', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'OpenTelemetry (OTLP) ingest', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Config file required to start', spanlens: 'no', competitor: 'partial' },
+    ],
+  },
+  {
+    title: 'Cost',
+    rows: [
+      { feature: 'Per-request USD in the log', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Dated model variant pricing', spanlens: 'yes', competitor: 'partial', note: 'Providers return ids like gpt-4o-mini-2024-07-18; matching them exactly is what makes the number right.' },
+      { feature: 'Cost by prompt version', spanlens: 'yes', competitor: 'no' },
+      { feature: 'Cost by end user and session', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Cheaper-model recommendations with a dollar figure', spanlens: 'yes', competitor: 'no' },
+    ],
+  },
+  {
+    title: 'Traces and quality',
+    rows: [
+      { feature: 'Agent trace waterfall', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Critical path marked', spanlens: 'yes', competitor: 'no' },
+      { feature: 'LLM-as-judge evaluation', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Prompt A/B with significance test', spanlens: 'yes', competitor: 'no' },
+      { feature: 'Human annotation with judge correlation', spanlens: 'yes', competitor: 'no' },
+    ],
+  },
+  {
+    title: 'Traffic management',
+    rows: [
+      { feature: 'Response caching', spanlens: 'yes', competitor: 'yes' },
+      { feature: 'Provider fallback and load balancing', spanlens: 'no', competitor: 'yes' },
+      { feature: 'Request guardrails', spanlens: 'partial', competitor: 'yes', note: 'Spanlens detects PII and prompt injection at log time, with optional blocking. Portkey guardrails are broader.' },
+      { feature: 'Virtual keys and per-team budgets', spanlens: 'partial', competitor: 'yes' },
+    ],
+  },
+  {
+    title: 'Operations',
+    rows: [
+      { feature: 'Log durability queue on analytics-store failure', spanlens: 'yes', competitor: 'no' },
+      { feature: 'Statistical anomaly detection', spanlens: 'yes', competitor: 'no' },
+      { feature: 'PII and prompt-injection scanning', spanlens: 'yes', competitor: 'partial' },
+      { feature: 'Data export (CSV, JSONL, JSON)', spanlens: 'yes', competitor: 'partial' },
+    ],
+  },
+]
+
+export default function VsPortkeyPage() {
+  return (
+    <CompareTemplate
+      competitor="Portkey"
+      tagline="Both sit in front of the provider. The difference is which half is open."
+      tldr="Portkey and Spanlens both let you change a base URL instead of wrapping call sites, so the architectures rhyme. They part company on what you get to run: Portkey's MIT repository is the gateway, and the observability platform it feeds is commercial, while Spanlens ships the proxy and the dashboard in one MIT repository you can host yourself. Portkey is further ahead on routing, guardrails, and community size. Spanlens is further ahead on cost attribution, agent traces, and evaluation."
+      whySpanlens={whySpanlens}
+      whyCompetitor={whyCompetitor}
+      groups={groups}
+      lastUpdated="2026-07-30"
+      closing="If you want a traffic manager with guardrails and are happy to pay for the dashboard, Portkey is a reasonable choice. If you want the observability itself to be the open part, and cost per request to be the first thing you see, try Spanlens."
+    />
+  )
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -37,6 +37,9 @@ const ROUTE_LASTMOD: Record<string, string> = {
   '/compare/langsmith': '2026-06-10',
   '/compare/braintrust': '2026-06-10',
   '/compare/arize-phoenix': '2026-06-10',
+  '/compare/opik': '2026-07-30',
+  '/compare/portkey': '2026-07-30',
+  '/compare/litellm': '2026-07-30',
   '/docs/migrate/from-langfuse': '2026-05-25',
   '/docs/migrate/from-helicone': '2026-05-25',
   '/docs/migrate/from-langsmith': '2026-05-25',
@@ -140,6 +143,9 @@ const MARKETING_ROUTES = [
   '/compare/langsmith',
   '/compare/braintrust',
   '/compare/arize-phoenix',
+  '/compare/opik',
+  '/compare/portkey',
+  '/compare/litellm',
 ] as const
 
 const MIGRATION_ROUTES = [

--- a/apps/web/components/layout/footer.tsx
+++ b/apps/web/components/layout/footer.tsx
@@ -58,6 +58,9 @@ export function Footer() {
               <Link href="/compare/langsmith" className="hover:text-text transition-colors">LangSmith</Link>
               <Link href="/compare/braintrust" className="hover:text-text transition-colors">Braintrust</Link>
               <Link href="/compare/arize-phoenix" className="hover:text-text transition-colors">Arize Phoenix</Link>
+              <Link href="/compare/opik" className="hover:text-text transition-colors">Comet Opik</Link>
+              <Link href="/compare/litellm" className="hover:text-text transition-colors">LiteLLM</Link>
+              <Link href="/compare/portkey" className="hover:text-text transition-colors">Portkey</Link>
               <Link href="/best-llm-observability-tools" className="hover:text-text transition-colors">All tools</Link>
             </div>
           </div>

--- a/apps/web/lib/competitors.ts
+++ b/apps/web/lib/competitors.ts
@@ -70,6 +70,7 @@ export const COMPETITORS: Competitor[] = [
   },
   {
     name: 'Comet Opik',
+    compareSlug: 'opik',
     repo: 'comet-ml/opik',
     stars: 20966,
     license: 'Apache 2.0, no gated folder',
@@ -97,6 +98,7 @@ export const COMPETITORS: Competitor[] = [
   },
   {
     name: 'LiteLLM',
+    compareSlug: 'litellm',
     repo: 'BerriAI/litellm',
     stars: 55038,
     license: 'Custom licence, not a standard OSI template',
@@ -110,6 +112,7 @@ export const COMPETITORS: Competitor[] = [
   },
   {
     name: 'Portkey',
+    compareSlug: 'portkey',
     repo: 'Portkey-AI/gateway',
     stars: 12593,
     license: 'MIT for the gateway; the observability platform is commercial',


### PR DESCRIPTION
The three highest-priority gaps from the competitive map, buildable now that `lib/competitors.ts` (#457) holds verified figures. Comparison content is the format AI answer engines cite most, and these three were the only close architectural peers with no page.

## The angle on each

| Page | What actually separates us |
|---|---|
| **Portkey** | Both sit in front of the provider, so the architectures rhyme. Their MIT repository is the *gateway*; the observability you would evaluate lives in the commercial platform. Ours ships both halves in one MIT repo. |
| **LiteLLM** | Different jobs, not rivals. It routes across 100+ providers and hands logging to a backend you choose. Spanlens is that kind of backend. The page says so and suggests running both. |
| **Comet Opik** | Both fully open with no gated directory, so the licence argument that separates other tools does not apply. Eval-first against cost-first. |

The LiteLLM page in particular does not pretend to be a head-to-head, because it isn't one. Claiming otherwise would be the kind of comparison nobody cites.

## Honesty is load-bearing here

Every page names where the competitor wins, with the numbers in plain text rather than buried:

```
GitHub stars, verified 2026-07-30
  LiteLLM   55,038
  Opik      20,966
  Portkey   12,593
  Spanlens      10
```

Opik's page states outright that its evaluation workflow is deeper than ours and that Comet's track record is something we cannot match yet. Portkey's says its routing and guardrails are ahead. LiteLLM's says provider coverage is not a close call.

Activity claims are counts over a fixed window, not labels, same rule as the roundup: the Portkey gateway repo recorded 26 commits between 1 May and 30 July 2026 with none after 25 May.

## Wiring

`/compare` index, footer, sitemap. The roundup picks all three up automatically now that each `COMPETITORS` entry carries a `compareSlug`, and `competitors.test.ts` already asserts every `compareSlug` resolves to a real page.

## The guard earned its keep

`page-metadata.test.ts` failed on two of these at 161 and 166 characters before they shipped. First time that check has caught something real.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter web test` (384 passed)
- [x] `pnpm --filter web build`, all three routes present
- [x] Dev server: all three return 200 with `WebPage` + `FAQPage` + `BreadcrumbList` schema; `/compare` now lists 8 comparisons
- [ ] After deploy: Rich Results Test on one of the FAQ blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)