### PR TITLE
fix(db): refresh provider model prices for 2026-08

### DIFF
--- a/.claude/skills/model-price-refresh/SKILL.md
+++ b/.claude/skills/model-price-refresh/SKILL.md
@@ -115,6 +115,10 @@ header until there's a modality-aware column.
 Same for models with no published per-token price (Cohere's `command-a-plus`
 and the specialized `command-a-*` variants are sales-quoted).
 
+A model the provider lists as **free** is the opposite case: seed it at `0`,
+don't leave it out. Zero is the true cost, and a missing row renders as a gap
+in the dashboard rather than as $0.00.
+
 ### 6. Write the migration
 
 New file, `supabase/migrations/YYYYMMDDHHMMSS_seed_models_YYYY_MM.sql`. Never

--- a/.claude/skills/model-price-refresh/references/providers.md
+++ b/.claude/skills/model-price-refresh/references/providers.md
@@ -69,6 +69,13 @@ The flagship table shows only the newest family; the "All models" table has the
 long tail. The `.md` version contains both, which is why it's preferred.
 
 Traps:
+- **A family does not move together.** In 2026-08 OpenAI cut `gpt-5.6-terra`
+  and `gpt-5.6-luna` (luna by 5x) while leaving `gpt-5.6-sol` alone. Checking
+  the flagship and assuming its siblings followed would have missed both.
+  Diff every member, on both context tiers.
+- The flagship table is a tab group: **Standard / Batch / Flex / Fast mode**,
+  and "Fast mode" is what used to be called Priority (renamed 2026-07-30).
+  Only Standard belongs in the table.
 - Response bodies return **dated** ids (`gpt-4o-mini-2024-07-18`) and that's
   what lands in `requests.model`. Seed the base id and let the boundary-aware
   prefix match in `lookupPrice()` handle the variants.
@@ -147,10 +154,16 @@ Traps:
 
 ## Groq
 
-- <https://groq.com/pricing>
-- `WebFetch` works.
+- <https://console.groq.com/docs/models> — the live catalogue with prices
+- `WebFetch` on the console docs works; the page is plain enough to read
+  straight out of `document.body.innerText` in the browser too.
 
 Traps:
+- **`groq.com/pricing` is gone.** It 302s to the marketing homepage, and
+  because that returns 200 with plenty of prose, `WebFetch` reports success and
+  hands back a page with no prices in it rather than an error. If a Groq pass
+  comes back with "no pricing found", check the URL before concluding the
+  models were delisted (verified 2026-08-11).
 - Catalogue turns over fast; models disappear without deprecation notices.
 - Ids are namespaced (`openai/gpt-oss-120b`, `qwen/qwen3.6-27b`), which is
   exactly where collisions with OpenRouter come from. Run the collision query.

--- a/apps/server/src/lib/model-prices-cache.test.ts
+++ b/apps/server/src/lib/model-prices-cache.test.ts
@@ -143,6 +143,35 @@ describe('model-prices-cache', () => {
     }
   })
 
+  test('GPT-5.6 fallback rates match the published table on BOTH tiers', () => {
+    // OpenAI cut terra and luna on 2026-08 but left sol untouched, so a spot
+    // check of "the flagship" would have passed while every terra request was
+    // over-reported by 25% and every luna request by 5x. Pin the whole family,
+    // both tiers, so a partial move fails here instead of on a customer bill.
+    // Source: developers.openai.com/api/docs/pricing (verified 2026-08-11).
+    const expected = {
+      'gpt-5.6-sol':   { prompt: 5.0,  completion: 30,   cacheRead: 0.5,  cacheWrite: 6.25,
+                         longPrompt: 10,  longCompletion: 45,  longCacheRead: 1.0,  longCacheWrite: 12.5 },
+      'gpt-5.6-terra': { prompt: 2.0,  completion: 12,   cacheRead: 0.2,  cacheWrite: 2.5,
+                         longPrompt: 4,   longCompletion: 18,  longCacheRead: 0.4,  longCacheWrite: 5.0 },
+      'gpt-5.6-luna':  { prompt: 0.2,  completion: 1.2,  cacheRead: 0.02, cacheWrite: 0.25,
+                         longPrompt: 0.4, longCompletion: 1.8, longCacheRead: 0.04, longCacheWrite: 0.5 },
+    } as const
+
+    for (const [model, rates] of Object.entries(expected)) {
+      const actual = cache.FALLBACK_PRICES[model]
+      expect(actual, `missing fallback for ${model}`).toBeDefined()
+      expect({ ...actual, longThreshold: undefined }, model).toEqual({ ...rates, longThreshold: undefined })
+      expect(actual?.longThreshold, `${model} long-context threshold`).toBe(272000)
+    }
+
+    // Cyber publishes no long-context tier — pin that absence too, so adding
+    // one silently (or copying sol's by mistake) fails.
+    const cyber = cache.FALLBACK_PRICES['gpt-5.6-cyber']
+    expect(cyber).toEqual({ prompt: 12.5, completion: 75, cacheRead: 1.25, cacheWrite: 15.625 })
+    expect(cyber?.longThreshold).toBeUndefined()
+  })
+
   test('FALLBACK_PRICES stays provider-unambiguous', () => {
     // lookupPrice() consults FALLBACK_PRICES without a provider, which is only
     // safe while it holds direct-provider models exclusively. OpenRouter ids

--- a/apps/server/src/lib/model-prices-cache.ts
+++ b/apps/server/src/lib/model-prices-cache.ts
@@ -63,7 +63,7 @@ export interface ModelPrice {
   longCacheWrite?: number | undefined
 }
 
-// Prices in USD per 1M tokens (verified against provider pricing pages 2026-07-29).
+// Prices in USD per 1M tokens (verified against provider pricing pages 2026-08-11).
 // This map is the COLD-START FALLBACK — used when the DB cache is empty
 // (first request after deploy / DB unreachable). The DB is the source of truth
 // once loaded; this constant exists to guarantee `calculateCost()` always has
@@ -81,12 +81,14 @@ export const FALLBACK_PRICES: Record<string, ModelPrice> = {
   'gpt-5.6-sol':       { prompt: 5.0,  completion: 30,  cacheRead: 0.5,  cacheWrite: 6.25,
                          longThreshold: 272000, longPrompt: 10, longCompletion: 45,
                          longCacheRead: 1.0, longCacheWrite: 12.5 },
-  'gpt-5.6-terra':     { prompt: 2.5,  completion: 15,  cacheRead: 0.25, cacheWrite: 3.125,
-                         longThreshold: 272000, longPrompt: 5, longCompletion: 22.5,
-                         longCacheRead: 0.5, longCacheWrite: 6.25 },
-  'gpt-5.6-luna':      { prompt: 1.0,  completion: 6,   cacheRead: 0.1,  cacheWrite: 1.25,
-                         longThreshold: 272000, longPrompt: 2, longCompletion: 9,
-                         longCacheRead: 0.2, longCacheWrite: 2.5 },
+  'gpt-5.6-terra':     { prompt: 2.0,  completion: 12,  cacheRead: 0.2,  cacheWrite: 2.5,
+                         longThreshold: 272000, longPrompt: 4, longCompletion: 18,
+                         longCacheRead: 0.4, longCacheWrite: 5.0 },
+  'gpt-5.6-luna':      { prompt: 0.2,  completion: 1.2, cacheRead: 0.02, cacheWrite: 0.25,
+                         longThreshold: 272000, longPrompt: 0.4, longCompletion: 1.8,
+                         longCacheRead: 0.04, longCacheWrite: 0.5 },
+  // Cyber (Daybreak) family — no long-context tier published.
+  'gpt-5.6-cyber':     { prompt: 12.5, completion: 75,  cacheRead: 1.25, cacheWrite: 15.625 },
   // ── OpenAI: GPT-5.x flagship ─────────────────────────────────────────────
   // gpt-5.5 / 5.5-pro / 5.4 / 5.4-pro have a long-context tier at ≥272k tokens.
   'gpt-5.5':           { prompt: 5.0,  completion: 30,  cacheRead: 0.5,
@@ -256,6 +258,8 @@ export const FALLBACK_PRICES: Record<string, ModelPrice> = {
   'gemini-1.5-pro':        { prompt: 1.25,  completion: 5 },
   'gemini-1.5-flash':      { prompt: 0.075, completion: 0.3 },
   // ── Gemini: specialized (embeddings are input-only) ──────────────────────
+  'gemini-robotics-er-2-preview':           { prompt: 2.0, completion: 10, cacheRead: 0.2 },
+  'gemini-robotics-er-2-streaming-preview': { prompt: 2.0, completion: 10 },
   'gemini-robotics-er-1.6-preview': { prompt: 1.0,  completion: 5 },
   'gemini-embedding-2':             { prompt: 0.2,  completion: 0 },
   'gemini-embedding-001':           { prompt: 0.15, completion: 0 },

--- a/apps/web/lib/changelog/entries.ts
+++ b/apps/web/lib/changelog/entries.ts
@@ -39,6 +39,17 @@ export type ChangelogTag =
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-08-11',
+    slug: 'model-price-refresh-2026-08',
+    title: 'Corrected model prices and six newly priced models',
+    tags: ['fix'],
+    body: [
+      'Two OpenAI models were costed too high. OpenAI cut the price of `gpt-5.6-terra` and `gpt-5.6-luna` without changing `gpt-5.6-sol`, so requests to those two were reported above what you were actually billed: about 25 percent high for terra and 5 times high for luna. Both are corrected on the standard and long-context tiers. Mistral made `mistral-moderation-2603` free, and it now costs nothing instead of $0.10 per million input tokens.',
+      'Six models that had no price now have one. Requests to `gpt-5.6-cyber`, the two Gemini Robotics ER 2 previews, the two Groq Prompt Guard classifiers, and Leanstral used to log a blank cost, which showed up as a gap in your dashboard. They are priced from each provider\'s published rates as of August 11.',
+      'Costs are recomputed at request time, so this changes what new requests report. Requests already logged keep the cost that was recorded when they ran.',
+    ].join('\n\n'),
+  },
+  {
     date: '2026-07-30',
     slug: 'docs-section-pages-and-link-previews',
     title: 'Docs section pages and correct link previews',

--- a/supabase/migrations/20260811120000_seed_models_2026_08.sql
+++ b/supabase/migrations/20260811120000_seed_models_2026_08.sql
@@ -1,0 +1,113 @@
+-- Model price refresh — 2026-08-11.
+--
+-- Verified against the official pricing pages on 2026-08-11:
+--   OpenAI    developers.openai.com/api/docs/pricing
+--   Anthropic platform.claude.com  (Pricing + Models overview)
+--   Gemini    ai.google.dev/gemini-api/docs/pricing?hl=en
+--   xAI       docs.x.ai/docs/models
+--   Groq      console.groq.com/docs/models  (groq.com/pricing now redirects to the homepage)
+--   Mistral   mistral.ai/pricing/api
+--   DeepSeek  api-docs.deepseek.com/quick_start/pricing
+--   Cohere    cohere.com/pricing + docs.cohere.com/docs/models
+--
+-- Why this migration exists — customer impact, worst first:
+--
+--   1. gpt-5.6-terra and gpt-5.6-luna were CUT by OpenAI after the 2026-07-29
+--      seed. We were over-reporting cost on every request to them: terra by 25%
+--      and luna by 5x (input went $1.00 -> $0.20, output $6.00 -> $1.20). Both
+--      tiers moved, so the long-context rows are corrected too. gpt-5.6-sol is
+--      unchanged, which is why this went unnoticed — the family did not move
+--      together.
+--
+--   2. mistral-moderation-2603 is now free. We priced it at $0.10/1M input, so
+--      every moderation call was billed for something the customer isn't paying
+--      Mistral for. Zero is the honest number here, not NULL: NULL renders as
+--      missing data in the dashboard, and the real cost really is $0.
+--
+--   3. Five models were serving traffic with no row at all, so their requests
+--      logged cost_usd = NULL (gotcha #2): gpt-5.6-cyber (the new Daybreak
+--      flagship, and by far the most expensive OpenAI model we proxy at
+--      $12.50/$75), two Gemini Robotics ER 2 previews, and Groq's two Prompt
+--      Guard classifiers.
+--
+-- Deliberately NOT seeded:
+--   • gemini-omni-flash-preview — output is $9.00/1M for text but $17.50/1M for
+--     video off the same row. One completion_price_per_1m cannot express that,
+--     and picking either number mis-bills the other case. Same standing reason
+--     as the image/TTS/live-audio models (gemini-*-image, gemini-*-tts,
+--     gemini-3.5-live-translate-preview, gpt-image-2, sora-*, gpt-realtime-*).
+--   • minimaxai/minimax-m2.7 on Groq — "Contact Sales", no public per-token
+--     price. Same reasoning as Cohere command-a-plus-05-2026 and the
+--     command-a-{reasoning,vision,translate} variants, still unseeded.
+--   • groq/compound and groq/compound-mini — billed at the underlying model's
+--     rates, they have no rate of their own.
+--   • Mistral OCR 4 (per 1000 pages) and the Voxtral transcribe/TTS models
+--     (per minute / per 1k characters) — not per-token at all.
+--   • Mistral Classifier API fine-tunes — priced per fine-tune, no stable id.
+--
+-- Dropped off their provider's pricing page since the last refresh; rows are
+-- KEPT so historical requests still price, and noted here so the next refresh
+-- doesn't re-add them as "missing":
+--   • mistral: pixtral-large-latest, pixtral-12b (already flagged 2026-07-29)
+--   • groq:    meta-llama/llama-4-scout-17b-16e-instruct, qwen/qwen3-32b
+--   • gemini:  gemini-3.1-flash-lite-preview, gemini-1.5-pro, gemini-1.5-flash
+--
+-- STILL PENDING — 2026-09-01: claude-sonnet-5 introductory pricing ($2/$10,
+-- cache 0.20/2.50) expires on 2026-08-31. Standard is $3/$15, cache 0.30/3.75.
+-- Anthropic's pricing page lists both rows today. Not applied here because it
+-- would under-report every Sonnet 5 request for the next three weeks; it needs
+-- its own migration dated on or after 2026-09-01.
+--
+-- Idempotent: ON CONFLICT DO UPDATE on the (provider, model) unique index.
+
+INSERT INTO model_prices (
+  provider, model,
+  prompt_price_per_1m, completion_price_per_1m,
+  cache_read_price_per_1m, cache_write_price_per_1m
+) VALUES
+  -- ── OpenAI: price cuts on two thirds of the GPT-5.6 family ───────────────
+  ('openai', 'gpt-5.6-terra',                         2.00,  12.00,  0.20,   2.500),
+  ('openai', 'gpt-5.6-luna',                          0.20,   1.20,  0.02,   0.250),
+  -- New "Cyber models" (Daybreak) section. No long-context tier published.
+  ('openai', 'gpt-5.6-cyber',                        12.50,  75.00,  1.25,  15.625),
+  -- ── Gemini: Robotics ER 2 previews ───────────────────────────────────────
+  -- Successors to gemini-robotics-er-1.6-preview. The streaming variant
+  -- publishes no context-caching rate; the non-streaming one caches at 0.10x.
+  ('gemini', 'gemini-robotics-er-2-preview',           2.00,  10.00,  0.20,   NULL),
+  ('gemini', 'gemini-robotics-er-2-streaming-preview', 2.00,  10.00,  NULL,   NULL),
+  -- ── Groq: Prompt Guard classifiers ───────────────────────────────────────
+  -- Preview tier, but customers already route moderation traffic through them.
+  ('groq', 'meta-llama/llama-prompt-guard-2-22m',      0.03,   0.03,  NULL,   NULL),
+  ('groq', 'meta-llama/llama-prompt-guard-2-86m',      0.04,   0.04,  NULL,   NULL),
+  -- ── Mistral: free models seeded at 0, not left NULL ──────────────────────
+  -- Both are listed as "Free" on the pricing page. A 0 row prices them
+  -- correctly; a missing row would render as missing data in the dashboard.
+  ('mistral', 'mistral-moderation-2603',               0.00,   0.00,  NULL,   NULL),
+  ('mistral', 'labs-leanstral-2603',                   0.00,   0.00,  NULL,   NULL)
+ON CONFLICT (provider, model) DO UPDATE
+  SET prompt_price_per_1m      = EXCLUDED.prompt_price_per_1m,
+      completion_price_per_1m  = EXCLUDED.completion_price_per_1m,
+      cache_read_price_per_1m  = EXCLUDED.cache_read_price_per_1m,
+      cache_write_price_per_1m = EXCLUDED.cache_write_price_per_1m,
+      updated_at               = now();
+
+-- ── OpenAI GPT-5.6: long-context tier follows the same cut ──────────────────
+-- Threshold stays 272,000 tokens (see migration 20260522020000). Only terra and
+-- luna moved; gpt-5.6-sol keeps 10.00 / 45.00 / 1.00 / 12.50 from 20260729100000.
+UPDATE model_prices
+   SET long_context_threshold_tokens = 272000,
+       long_prompt_price_per_1m      =  4.00,
+       long_completion_price_per_1m  = 18.00,
+       long_cache_read_price_per_1m  =  0.40,
+       long_cache_write_price_per_1m =  5.00,
+       updated_at                    = now()
+ WHERE provider = 'openai' AND model = 'gpt-5.6-terra';
+
+UPDATE model_prices
+   SET long_context_threshold_tokens = 272000,
+       long_prompt_price_per_1m      =  0.40,
+       long_completion_price_per_1m  =  1.80,
+       long_cache_read_price_per_1m  =  0.04,
+       long_cache_write_price_per_1m =  0.50,
+       updated_at                    = now()
+ WHERE provider = 'openai' AND model = 'gpt-5.6-luna';

--- a/supabase/seeds/model_prices.sql
+++ b/supabase/seeds/model_prices.sql
@@ -1,4 +1,4 @@
--- Seed: Model pricing table (USD per 1M tokens, verified against provider pricing 2026-07-29)
+-- Seed: Model pricing table (USD per 1M tokens, verified against provider pricing 2026-08-11)
 --
 -- SCOPE: direct providers only. The 170 `openrouter` rows live exclusively in
 -- migration 20260613060000 — OpenRouter is a meta-provider whose catalogue
@@ -25,8 +25,9 @@ INSERT INTO model_prices (
 ) VALUES
   -- ── OpenAI: GPT-5.x flagship family ───────────────────────────────────────
   ('openai', 'gpt-5.6-sol',                      5.00,  30.00,   0.50,   6.250),
-  ('openai', 'gpt-5.6-terra',                    2.50,  15.00,   0.25,   3.125),
-  ('openai', 'gpt-5.6-luna',                     1.00,   6.00,   0.10,   1.250),
+  ('openai', 'gpt-5.6-terra',                    2.00,  12.00,   0.20,   2.500),
+  ('openai', 'gpt-5.6-luna',                     0.20,   1.20,   0.02,   0.250),
+  ('openai', 'gpt-5.6-cyber',                   12.50,  75.00,   1.25,  15.625), -- Cyber (Daybreak); no long-context tier
   ('openai', 'gpt-5.5',                          5.00,  30.00,   0.50,   NULL),
   ('openai', 'gpt-5.5-pro',                     30.00, 180.00,   NULL,   NULL),
   ('openai', 'gpt-5.4',                          2.50,  15.00,   0.25,   NULL),
@@ -104,7 +105,10 @@ INSERT INTO model_prices (
   ('mistral', 'pixtral-large-latest',            2.00,   6.00,   NULL,   NULL), -- off the current pricing page
   ('mistral', 'pixtral-12b',                     0.15,   0.15,   NULL,   NULL), -- off the current pricing page
   ('mistral', 'voxtral-small-latest',            0.10,   0.40,   NULL,   NULL),
-  ('mistral', 'mistral-moderation-2603',         0.10,   0.000,  NULL,   NULL),
+  -- Listed as "Free" on the pricing page — 0, not NULL, so cost renders as $0
+  -- rather than as missing data.
+  ('mistral', 'mistral-moderation-2603',         0.00,   0.000,  NULL,   NULL),
+  ('mistral', 'labs-leanstral-2603',             0.00,   0.000,  NULL,   NULL),
   ('mistral', 'mistral-embed',                   0.10,   0.000,  NULL,   NULL),
   ('mistral', 'codestral-embed',                 0.15,   0.000,  NULL,   NULL),
   -- ── Groq (OpenAI-compatible, api.groq.com/openai/v1) ─────────────────────
@@ -115,7 +119,9 @@ INSERT INTO model_prices (
   ('groq', 'openai/gpt-oss-safeguard-20b',               0.075, 0.30,    NULL,     NULL),
   ('groq', 'qwen/qwen3.6-27b',                           0.60,  3.00,    NULL,     NULL),
   ('groq', 'moonshotai/kimi-k2-instruct-0905',           1.00,  3.00,    0.50,     NULL),
-  -- Off the current Groq pricing page (2026-07-29) — kept so historical rows
+  ('groq', 'meta-llama/llama-prompt-guard-2-22m',        0.03,  0.03,    NULL,     NULL),
+  ('groq', 'meta-llama/llama-prompt-guard-2-86m',        0.04,  0.04,    NULL,     NULL),
+  -- Off the current Groq catalogue (2026-08-11) — kept so historical rows
   -- still price correctly, but Groq appears to have stopped serving them.
   ('groq', 'meta-llama/llama-4-scout-17b-16e-instruct',  0.11,  0.34,    NULL,     NULL),
   ('groq', 'qwen/qwen3-32b',                             0.29,  0.59,    NULL,     NULL),
@@ -192,6 +198,8 @@ INSERT INTO model_prices (
   ('gemini', 'gemini-1.5-pro',                         1.25,   5.00,   NULL,  NULL), -- retired, off the pricing page
   ('gemini', 'gemini-1.5-flash',                       0.075,  0.30,   NULL,  NULL), -- retired, off the pricing page
   -- ── Gemini: specialized ──────────────────────────────────────────────────
+  ('gemini', 'gemini-robotics-er-2-preview',           2.00,  10.00,   0.20,  NULL),
+  ('gemini', 'gemini-robotics-er-2-streaming-preview', 2.00,  10.00,   NULL,  NULL),
   ('gemini', 'gemini-robotics-er-1.6-preview',         1.00,   5.00,   NULL,  NULL),
   -- Embeddings are input-only (completion stays 0). gemini-embedding-2 is
   -- multimodal; the seeded rate is TEXT input — image (0.45) / audio (6.50) /
@@ -255,18 +263,18 @@ UPDATE model_prices
 
 UPDATE model_prices
    SET long_context_threshold_tokens = 272000,
-       long_prompt_price_per_1m      =  5.00,
-       long_completion_price_per_1m  = 22.50,
-       long_cache_read_price_per_1m  =  0.50,
-       long_cache_write_price_per_1m =  6.25
+       long_prompt_price_per_1m      =  4.00,
+       long_completion_price_per_1m  = 18.00,
+       long_cache_read_price_per_1m  =  0.40,
+       long_cache_write_price_per_1m =  5.00
  WHERE provider = 'openai' AND model = 'gpt-5.6-terra';
 
 UPDATE model_prices
    SET long_context_threshold_tokens = 272000,
-       long_prompt_price_per_1m      =  2.00,
-       long_completion_price_per_1m  =  9.00,
-       long_cache_read_price_per_1m  =  0.20,
-       long_cache_write_price_per_1m =  2.50
+       long_prompt_price_per_1m      =  0.40,
+       long_completion_price_per_1m  =  1.80,
+       long_cache_read_price_per_1m  =  0.04,
+       long_cache_write_price_per_1m =  0.50
  WHERE provider = 'openai' AND model = 'gpt-5.6-luna';
 
 UPDATE model_prices


### PR DESCRIPTION
## Customer impact

Two OpenAI models were being **over-reported** on every request, and six models were logging `cost_usd = NULL`.

| Model | Was | Is | Effect |
|---|---|---|---|
| `openai/gpt-5.6-terra` | 2.50 / 15.00 | **2.00 / 12.00** (cache 0.20/2.50, long 4/18) | ~25% over-reported |
| `openai/gpt-5.6-luna` | 1.00 / 6.00 | **0.20 / 1.20** (cache 0.02/0.25, long 0.4/1.8) | **5x** over-reported |
| `mistral/mistral-moderation-2603` | 0.10 input | **0** (now free) | billed for a free call |

OpenAI cut terra and luna but left `gpt-5.6-sol` untouched, so a spot-check of the flagship would have passed while both siblings drifted.

Newly priced (were logging NULL, which renders as a gap in the dashboard):

- `openai/gpt-5.6-cyber` 12.50 / 75.00, cache 1.25 / 15.625, no long-context tier. The most expensive OpenAI model we proxy.
- `gemini/gemini-robotics-er-2-preview` and `-streaming-preview` 2.00 / 10.00
- `groq/meta-llama/llama-prompt-guard-2-22m` and `-86m`
- `mistral/labs-leanstral-2603` (free, seeded at 0 rather than left out)

## Verified

All nine direct providers checked against their official pricing pages on 2026-08-11. Anthropic, xAI, DeepSeek, Cohere and the rest of Gemini/Mistral/Groq matched what we already had.

## Deliberately not seeded

`gemini-omni-flash-preview` (output is $9/1M text but $17.50/1M video off one row), `minimaxai/minimax-m2.7` and the Cohere `command-a-plus` / `command-a-{reasoning,vision,translate}` models (sales-quoted), and the per-page / per-minute / per-image models. Rows for models that dropped off a provider's page are kept so historical requests still price.

## Pending, needs its own migration

`claude-sonnet-5` leaves introductory pricing ($2/$10, cache 0.20/2.50) on 2026-08-31; standard is $3/$15, cache 0.30/3.75. Applying it now would under-report for three weeks, so it needs a migration dated on or after 2026-09-01. Missing it under-reports Sonnet 5 by 33%.

## Test plan

- [x] `pnpm --filter server typecheck && lint && test` (1602 passed)
- [x] `pnpm --filter web typecheck && lint && test` (384 passed)
- [x] `pnpm --filter web build`
- [x] Collision query run against production with the additions applied: no new `(model)` ambiguity, and no OpenRouter-style prefixed id added to `FALLBACK_PRICES`
- [x] New regression test pins the whole GPT-5.6 family on both context tiers, including the absence of a long tier on cyber
- [ ] After merge, confirm the rows landed in production rather than inferring it from a green workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)