### PR TITLE
perf(web): gate docs figures on viewport so recharts is actually deferred

### DIFF
--- a/apps/web/app/docs/_components/lazy-chart-bodies.tsx
+++ b/apps/web/app/docs/_components/lazy-chart-bodies.tsx
@@ -37,8 +37,10 @@
  * pages already carry — is rendered by ./chart-shell on the server.
  */
 
+import type { ComponentType } from 'react'
 import dynamic from 'next/dynamic'
 import { ChartPlaceholder } from './chart-shell'
+import { useInViewport } from './use-in-viewport'
 
 // Each `loading` placeholder is rendered inside a shell box that is already the
 // chart's final height (280px, or 360px for the radar — see ./chart-shell), so
@@ -50,27 +52,68 @@ import { ChartPlaceholder } from './chart-shell'
 // options *literal* to decide how to treat the import, and passing the object
 // by reference is not a shape it is documented to handle. Every other
 // `dynamic()` in this repo inlines it too.
-export const LazyPromptAbChart = dynamic(
+const PromptAbChartBody = dynamic(
   () => import('./charts').then((m) => m.PromptAbChartBody),
   { ssr: false, loading: () => <ChartPlaceholder /> },
 )
 
-export const LazyAnomalyChart = dynamic(
+const AnomalyChartBody = dynamic(
   () => import('./charts').then((m) => m.AnomalyChartBody),
   { ssr: false, loading: () => <ChartPlaceholder /> },
 )
 
-export const LazyModelPriceChart = dynamic(
+const ModelPriceChartBody = dynamic(
   () => import('./charts').then((m) => m.ModelPriceChartBody),
   { ssr: false, loading: () => <ChartPlaceholder /> },
 )
 
-export const LazyPlanQuotaChart = dynamic(
+const PlanQuotaChartBody = dynamic(
   () => import('./charts').then((m) => m.PlanQuotaChartBody),
   { ssr: false, loading: () => <ChartPlaceholder /> },
 )
 
-export const LazyFeatureCoverageRadar = dynamic(
+const FeatureCoverageRadarBody = dynamic(
   () => import('./charts').then((m) => m.FeatureCoverageRadarBody),
   { ssr: false, loading: () => <ChartPlaceholder /> },
 )
+
+/**
+ * WHY THE VIEWPORT GATE (measured, not theoretical):
+ *
+ * `ssr: false` alone does not defer the network fetch. It moves recharts into
+ * its own chunk, but Next requests that chunk as soon as the wrapper *renders*,
+ * and these figures render on the initial pass even though they sit below the
+ * fold. Production /docs/why after the split: the 136 KB chart chunk still
+ * started at 54 ms against a 658 ms DOMContentLoaded, with the figure off
+ * screen. Build-level "recharts is no longer a first-load chunk" was true and
+ * the network timeline was unchanged.
+ *
+ * Wrapping the dynamic component in an intersection gate is what actually
+ * defers it: the `import()` lives inside the wrapper, so not rendering the
+ * wrapper means not fetching the chunk.
+ *
+ * `withViewportGate` keeps that logic in one place instead of five. Each
+ * returned component renders the placeholder — the same one `loading` uses —
+ * until the box nears the viewport, so the swap path is identical to before
+ * and the box height still comes from the server-rendered shell. No CLS.
+ */
+function withViewportGate(Body: ComponentType): ComponentType {
+  return function ViewportGatedChart() {
+    const { ref, inViewport } = useInViewport<HTMLDivElement>()
+    // The ref has to sit on a real element that occupies the shell box, so the
+    // observer has something with non-zero height to watch. ChartPlaceholder is
+    // exactly that, and rendering it here (rather than `null`) also keeps the
+    // pre-visible markup identical to the `loading` state.
+    return (
+      <div ref={ref} className="h-full w-full">
+        {inViewport ? <Body /> : <ChartPlaceholder />}
+      </div>
+    )
+  }
+}
+
+export const LazyPromptAbChart = withViewportGate(PromptAbChartBody)
+export const LazyAnomalyChart = withViewportGate(AnomalyChartBody)
+export const LazyModelPriceChart = withViewportGate(ModelPriceChartBody)
+export const LazyPlanQuotaChart = withViewportGate(PlanQuotaChartBody)
+export const LazyFeatureCoverageRadar = withViewportGate(FeatureCoverageRadarBody)

--- a/apps/web/app/docs/_components/use-in-viewport.ts
+++ b/apps/web/app/docs/_components/use-in-viewport.ts
@@ -1,0 +1,69 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Returns a ref to attach to an element and whether it has ever come near the
+ * viewport. Latches: once true it never goes back to false, because the point
+ * is to trigger a one-time lazy import, not to unmount the chart when the user
+ * scrolls past it.
+ *
+ * WHY THIS EXISTS:
+ *
+ * `next/dynamic(..., { ssr: false })` defers the module to a separate chunk,
+ * but the chunk is fetched as soon as the wrapper *renders*. On /docs pages the
+ * figures render on the initial pass even though they sit well below the fold,
+ * so the recharts chunk was still starting at ~54 ms — before DOMContentLoaded
+ * — despite being "lazy". Measured on production /docs/why: 136 KB starting at
+ * 54 ms against a 658 ms DCL, with the figure off-screen.
+ *
+ * Gating the render on intersection is what actually defers the network work:
+ * the `import()` inside the dynamic wrapper cannot fire until this hook flips,
+ * because the wrapper is never rendered before then.
+ *
+ * HYDRATION SAFETY: the initial value is `false` on both the server pass and
+ * the first client render, so the markup matches and the flip is an ordinary
+ * post-mount update. Do NOT seed this from a measurement taken during render
+ * (see CLAUDE.md gotcha #22 for the class of bug that creates).
+ *
+ * `rootMargin` starts the fetch a viewport-height early so the chart is usually
+ * already painted by the time it scrolls into view — the goal is to move the
+ * download off the critical path, not to make the user watch a placeholder.
+ *
+ * Falls open: if IntersectionObserver is unavailable (very old browsers, some
+ * test environments) the effect renders the chart immediately rather than
+ * leaving an empty box forever.
+ */
+export function useInViewport<T extends HTMLElement>(rootMargin = '200% 0px') {
+  const ref = useRef<T>(null)
+  const [inViewport, setInViewport] = useState(false)
+
+  useEffect(() => {
+    if (inViewport) return
+    const el = ref.current
+    if (!el) return
+
+    if (typeof IntersectionObserver === 'undefined') {
+      // Deliberately deferred to a frame rather than set inline: a synchronous
+      // setState in an effect body trips react-hooks/set-state-in-effect and
+      // causes a cascading render. The one-frame delay is irrelevant on the
+      // only path that reaches here (a browser with no IntersectionObserver).
+      const id = requestAnimationFrame(() => setInViewport(true))
+      return () => cancelAnimationFrame(id)
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          setInViewport(true)
+          observer.disconnect()
+        }
+      },
+      { rootMargin },
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [inViewport, rootMargin])
+
+  return { ref, inViewport }
+}

--- a/apps/web/lib/docs-chart-viewport-gate.test.tsx
+++ b/apps/web/lib/docs-chart-viewport-gate.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useInViewport } from '@/app/docs/_components/use-in-viewport'
+
+/**
+ * Behaviour lock for the /docs figure viewport gate.
+ *
+ * WHY THIS TEST EXISTS RATHER THAN A BROWSER CHECK:
+ *
+ * The gate's whole job is "do not fetch the recharts chunk until the figure
+ * nears the viewport". That is exactly the kind of claim a browser session
+ * cannot settle here: IntersectionObserver does not fire in a tab Chrome is not
+ * compositing, which is the state every automated tab is in. During the change
+ * that added this hook, a manually-armed observer on a 360x638 in-viewport
+ * element reported nothing — the environment, not the code. So the contract is
+ * pinned here instead, where it also survives into CI.
+ *
+ * The properties below are the ones the docs figures actually depend on. If any
+ * of them regress, either the charts never appear (gate stuck closed) or the
+ * deferral silently stops working (gate opens on mount, which is the bug this
+ * hook was written to fix — `ssr: false` alone left the 136 KB chart chunk
+ * starting at 54 ms against a 658 ms DOMContentLoaded).
+ *
+ * The hook is exercised through a probe component rather than `renderHook` so
+ * the ref actually lands on a DOM node, which is the part that matters: the
+ * observer needs a real element to watch.
+ */
+
+type IOCallback = (entries: Array<{ isIntersecting: boolean }>) => void
+
+interface FakeObserver {
+  callback: IOCallback
+  options: IntersectionObserverInit | undefined
+  observed: Element[]
+  disconnected: boolean
+}
+
+let observers: FakeObserver[] = []
+const OriginalIO = globalThis.IntersectionObserver
+
+function installFakeIO() {
+  class FakeIntersectionObserver {
+    constructor(cb: IOCallback, options?: IntersectionObserverInit) {
+      this.record = { callback: cb, options, observed: [], disconnected: false }
+      observers.push(this.record)
+    }
+    private record: FakeObserver
+    observe(el: Element) {
+      this.record.observed.push(el)
+    }
+    disconnect() {
+      this.record.disconnected = true
+    }
+    unobserve() {}
+    takeRecords() {
+      return []
+    }
+  }
+  // Cast through unknown: the fake implements only the surface the hook uses.
+  globalThis.IntersectionObserver =
+    FakeIntersectionObserver as unknown as typeof IntersectionObserver
+}
+
+/** Renders the two states the real gate renders, so assertions read like the UI. */
+function Probe() {
+  const { ref, inViewport } = useInViewport<HTMLDivElement>()
+  return (
+    <div ref={ref} data-testid="box">
+      {inViewport ? <span>chart</span> : <span>placeholder</span>}
+    </div>
+  )
+}
+
+beforeEach(() => {
+  observers = []
+  installFakeIO()
+})
+
+afterEach(() => {
+  globalThis.IntersectionObserver = OriginalIO
+  vi.restoreAllMocks()
+})
+
+describe('useInViewport', () => {
+  it('renders the placeholder on mount and does not open the gate', () => {
+    render(<Probe />)
+
+    expect(screen.getByText('placeholder')).toBeTruthy()
+    expect(screen.queryByText('chart')).toBeNull()
+  })
+
+  it('observes the ref element, not the document', () => {
+    render(<Probe />)
+
+    expect(observers).toHaveLength(1)
+    expect(observers[0]!.observed).toHaveLength(1)
+    expect(observers[0]!.observed[0]).toBe(screen.getByTestId('box'))
+  })
+
+  it('passes a rootMargin so the fetch starts before the figure is on screen', () => {
+    render(<Probe />)
+
+    // The exact value is a tuning knob, but it must be a positive vertical
+    // margin — a zero margin would mean the user watches the chunk download.
+    const margin = observers[0]!.options?.rootMargin
+    expect(margin).toBeTruthy()
+    expect(margin).toMatch(/^\d+%/)
+  })
+
+  it('opens the gate once an entry intersects', () => {
+    render(<Probe />)
+
+    act(() => {
+      observers[0]!.callback([{ isIntersecting: true }])
+    })
+
+    expect(screen.getByText('chart')).toBeTruthy()
+    expect(screen.queryByText('placeholder')).toBeNull()
+  })
+
+  it('ignores a non-intersecting entry', () => {
+    render(<Probe />)
+
+    act(() => {
+      observers[0]!.callback([{ isIntersecting: false }])
+    })
+
+    expect(screen.getByText('placeholder')).toBeTruthy()
+  })
+
+  it('disconnects after opening so it stops observing a chart that is already mounted', () => {
+    render(<Probe />)
+
+    act(() => {
+      observers[0]!.callback([{ isIntersecting: true }])
+    })
+
+    expect(observers[0]!.disconnected).toBe(true)
+  })
+
+  it('latches open — scrolling back past the figure does not unmount the chart', () => {
+    render(<Probe />)
+
+    act(() => {
+      observers[0]!.callback([{ isIntersecting: true }])
+    })
+    act(() => {
+      observers[0]!.callback([{ isIntersecting: false }])
+    })
+
+    expect(screen.getByText('chart')).toBeTruthy()
+  })
+
+  it('falls open when IntersectionObserver is unavailable', () => {
+    // Deleting the global is the "very old browser" path. The gate must open
+    // rather than leave an empty box forever — a missing API should degrade to
+    // the old eager behaviour, not to a broken page.
+    // @ts-expect-error - deliberately removing the global for this case
+    delete globalThis.IntersectionObserver
+
+    const raf = vi
+      .spyOn(globalThis, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(0)
+        return 1
+      })
+
+    render(<Probe />)
+
+    expect(raf).toHaveBeenCalled()
+    expect(screen.getByText('chart')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Follow-up to #464. Corrects a claim I made there and finishes the job it started.

## What #464 got wrong

#464 moved the five `/docs` recharts figures behind `next/dynamic(..., { ssr: false })` and verified from the build that recharts was no longer in those pages' first-load chunk lists. That was true. The network timeline was unchanged.

`ssr: false` splits the module into its own chunk, but the chunk is fetched as soon as the wrapper **renders**, and these figures render on the initial pass even though they sit below the fold. Measured on production `/docs/why` after #464 shipped:

| | before #464 | after #464 |
|---|---|---|
| JS transfer | 138 KB | **178 KB** |
| largest chunk | 116 KB | 136 KB |
| that chunk's start time | — | **54 ms** (DCL was 658 ms) |
| figure position | — | below the fold |

So the page got ~40 KB heavier, not lighter — the shared bodies chunk now carries all five figures — and the bytes still arrived on the critical path. #464's real win was the correctness fix (recharts stopped server-rendering at zero width, the React #418 shape in gotcha #22 D). The byte claim did not hold.

## What actually defers it

Gating the render on intersection. The `import()` lives inside the dynamic wrapper, so not rendering the wrapper means not fetching the chunk. `useInViewport` latches on first intersection with a 200% `rootMargin`, so the fetch starts a viewport-height early and the chart is normally painted before the reader scrolls to it — the goal is moving the download off the critical path, not making anyone watch a placeholder.

Verified against a local production server (`next start`), figure off screen:

```
rechartsChunksLoaded: []
```

No loaded script chunk contains recharts at all. Before this change one 430 KB decoded chunk was being fetched at 48 ms.

## Why this ships with a unit test instead of a browser check

IntersectionObserver does not fire in a tab Chrome is not compositing, which is the state of every automated tab. While working on this I armed an observer by hand on the real 360×638 element sitting in the viewport and it reported nothing — the environment, not the code. A browser session cannot settle this claim in either direction here, so the contract is pinned where it also survives into CI.

`lib/docs-chart-viewport-gate.test.tsx` (8 cases) covers: closed on mount, observes the ref element rather than the document, non-zero `rootMargin`, opens on intersection, ignores non-intersecting entries, disconnects after opening, **latches** so scrolling back past the figure does not unmount the chart, and falls open when `IntersectionObserver` is missing (an absent API should degrade to the old eager behaviour, not to a permanently empty box).

The test lives under `lib/` on purpose: `vitest.config.ts`'s `include` only covers `lib/**` and `components/**`, so a test placed next to the hook under `app/` would be silently skipped.

Confirmed the suite catches the regression it exists for: flipping the gate to open on mount turns **6 of 8** cases red.

## Implementation note

The `requestAnimationFrame` indirection on the no-IntersectionObserver path is deliberate, not incidental. A synchronous `setState` in an effect body trips `react-hooks/set-state-in-effect` and causes a cascading render; the one-frame delay is irrelevant on the only path that reaches it.

## Test plan

- [x] `pnpm --filter web typecheck` green
- [x] `pnpm --filter web lint` green
- [x] `pnpm --filter web test` green: **517** (509 + 8 new)
- [x] `pnpm build` exit 0
- [x] Local production server: no recharts chunk fetched with the figure off screen
- [x] Gate regression proven by deliberately breaking it and watching 6/8 cases fail
- [x] #464's build-level metrics still hold: SSR'd recharts containers 0, first-load recharts 0 KB, `figcaption` 1 on all five pages
- [x] Static/dynamic route split holds at 139/40
- [ ] After deploy: scroll `/docs/why` in a real browser and confirm the chart paints

🤖 Generated with [Claude Code](https://claude.com/claude-code)
