### PR TITLE
docs(web): changelog entry for the dashboard latency work

### DIFF
--- a/apps/web/lib/changelog/entries.ts
+++ b/apps/web/lib/changelog/entries.ts
@@ -40,6 +40,17 @@ export type ChangelogTag =
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
     date: '2026-08-11',
+    slug: 'dashboard-latency-and-idle-key-count-fix',
+    title: 'Much faster dashboard and API responses, plus an idle-key count fix',
+    tags: ['improvement', 'fix', 'infrastructure'],
+    body: [
+      'The API now runs in the same region as its databases. Our server functions were executing in Washington DC while both databases sit in Seoul, so every query that was not already cached crossed the Pacific and back before you saw anything. They now run in Seoul alongside the data. Measured against production: a request that does no database work at all went from about 240 ms to 65 ms, and a database round trip went from roughly 640 ms to between 55 and 114 ms. Every dashboard page, every API read, and every proxied request that has to look something up benefits from this.',
+      'The dashboard also asks for less. It used to fire seven separate requests as it loaded; the six that do not need live polling are now served by a single call, so it makes four. Settings and Evals were each shipping as one large bundle, and now load only the tab you actually open. Documentation pages with charts no longer download the charting library until you scroll near the figure, which takes roughly 116 KB of compressed JavaScript off the initial load of those pages. None of this changes what any page shows.',
+      'One number on screen was wrong. The "API keys idle" count on the dashboard and the matching badge in the sidebar were counting workspace-level public keys twice, so any workspace that had issued a public key saw an inflated figure. The count is correct now. If the number looked higher than the number of keys you recognised, that is why.',
+    ].join('\n\n'),
+  },
+  {
+    date: '2026-08-11',
     slug: 'faster-pages-and-lower-proxy-latency',
     title: 'Faster pages, lower proxy latency, and a robots.txt fix',
     tags: ['improvement', 'fix', 'infrastructure'],


### PR DESCRIPTION
Covers the user-facing half of #464 and #465, which the existing 2026-08-11 entry does not.

Three paragraphs:

1. **Compute region.** The API now runs in Seoul alongside both databases instead of Washington DC. Stated with the measured numbers: a request doing no database work went ~240 ms to 65 ms, a database round trip ~640 ms to 55-114 ms.
2. **Less work per page.** Dashboard down from seven client requests to four, Settings and Evals loading only the open tab, docs figures deferring the charting library until you scroll near them (~116 KB gzip off the initial load).
3. **The idle-key count fix.** The only item here a user could have noticed as *wrong* rather than *slow*: workspace-level public keys were counted twice in the dashboard card and the sidebar badge, so any workspace with a public key saw an inflated number. Worth calling out explicitly so anyone who noticed the discrepancy knows what it was.

#463 is deliberately left out. Removing the ClickHouse keep-warm was worth $232/mo, but it is pure infrastructure with no behaviour a customer can observe.

Checked against house rules: no em dashes (project bans them in customer-facing text), plain prose, no marketing language, three paragraphs.

## Test plan

- [x] `pnpm --filter web typecheck` green
- [x] `pnpm --filter web lint` green
- [x] `pnpm --filter web test` green (517)
- [x] Em dash / en dash count in the new entry: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)