### PR TITLE
fix(web): send the sidebar Upgrade button to Plan & limits

### DIFF
--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -2,7 +2,7 @@
 import { useMemo, useState } from 'react'
 import Link from 'next/link'
 import dynamic from 'next/dynamic'
-import { useSearchParams } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { cn } from '@/lib/utils'
 import { Topbar } from '@/components/layout/topbar'
 import {
@@ -115,10 +115,30 @@ function TabContent({ tab }: { tab: TabId }) {
 
 export function SettingsClient() {
   const searchParams = useSearchParams()
-  const initialTab = (searchParams.get('tab') as TabId | null) ?? 'general'
-  const [tab, setTab] = useState<TabId>(
-    ALL_ITEMS.some((i) => i.id === initialTab) ? initialTab : 'general',
-  )
+  const router = useRouter()
+
+  /*
+   * `?tab=` is the single source of truth for which section is open.
+   *
+   * It used to seed a `useState` instead, which meant the param was read once
+   * at mount and never again. Anything that linked into a section from inside
+   * settings — the sidebar's Upgrade button pointing at Plan & limits, say —
+   * changed the URL without changing the panel, because a same-route push does
+   * not remount the component. Deriving the tab makes those links work, and
+   * makes the URL shareable and reload-stable.
+   */
+  const tab = useMemo<TabId>(() => {
+    const requested = searchParams.get('tab')
+    return ALL_ITEMS.some((i) => i.id === requested) ? (requested as TabId) : 'general'
+  }, [searchParams])
+
+  // `replace`, not `push`: stepping through five sections should not put five
+  // entries between the reader and the page they arrived from. `scroll: false`
+  // keeps the section swap feeling like a tab rather than a navigation.
+  const setTab = (next: TabId) => {
+    router.replace(next === 'general' ? '/settings' : `/settings?tab=${next}`, { scroll: false })
+  }
+
   const active = ALL_ITEMS.find((i) => i.id === tab) ?? ALL_ITEMS[0]!
 
   // Inner-nav search/filter. Empty input shows the full grouped nav.

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -612,7 +612,10 @@ export function Sidebar() {
         </div>
         {isAdmin && (
           <button
-            onClick={() => router.push('/settings')}
+            /* Straight to Plan & limits, not the Settings landing page: the
+               reader clicked this because of the usage bar above it, and
+               General has nothing to say about their quota. */
+            onClick={() => router.push('/settings?tab=plan')}
             className="mt-2.5 text-[12px] font-medium text-accent hover:text-accent-strong transition-colors"
           >
             {/* Upgrade only makes sense below Team. On Team/Enterprise the


### PR DESCRIPTION
The quota card's Upgrade link dropped the reader on the Settings landing page, which opens on General and says nothing about their plan. It now points at Plan & limits, the section the usage bar above it is actually about.

Making that link work meant making `?tab=` the source of truth for the open section. It used to seed a `useState`, so the parameter was read once at mount and never again: a link from inside settings changed the URL without changing the panel, because a same-route navigation does not remount the component. The tab is now derived from the URL, which also makes a settings section shareable and reload-stable.

Section switches use `replace` rather than `push`, so stepping through five sections does not put five entries between the reader and the page they came from; back still leaves settings in one press.

## Test plan

- [x] Upgrade from a non-settings page lands on `?tab=plan` with the Plan & limits panel and breadcrumb
- [x] Upgrade while already inside settings switches the panel (the case the old code got wrong)
- [x] `/settings?tab=plan` deep link opens the right section
- [x] Rail clicks keep the URL in step
- [x] Reload keeps the section
- [x] Back from settings returns to the page before it, in one press
- [x] Settings write flows still pass (21/21), dashboard sweep clean
- [x] `pnpm --filter web typecheck`, `lint`