### PR TITLE
fix(web): say what went wrong when checkout fails

### DIFF
--- a/apps/server/src/api/billing.ts
+++ b/apps/server/src/api/billing.ts
@@ -7,10 +7,56 @@ import {
   createPaddleCheckoutTransaction,
   findPaddleCustomerByEmail,
   cancelPaddleSubscription,
+  classifyPaddleFailure,
+  PaddleApiError,
 } from '../lib/paddle.js'
 import { checkMonthlyQuota } from '../lib/quota.js'
 import { recordAuditEvent } from '../lib/audit-log.js'
 import { ApiError } from '../lib/errors.js'
+import { logError } from '../lib/structured-logger.js'
+
+/**
+ * Turns a Paddle failure into the error the customer should see, and puts the
+ * part they should not see in the log.
+ *
+ * The old code concatenated Paddle's own words onto an `UPSTREAM_FAILED` and
+ * shipped the result to the browser, so an under-scoped API key surfaced as
+ * `502 … not authorized to create|read transaction`. That is our configuration
+ * described to a customer: it tells them nothing they can act on, and it is not
+ * theirs to read. Worse, every cause looked identical, so the only way to tell
+ * a missing permission from a Paddle outage was to open the runtime logs.
+ *
+ * Now the cause decides both halves. `stage` names the call so the log says
+ * which step failed without the reader having to infer it from a URL.
+ */
+function paddleFailure(err: unknown, stage: string, orgId: string): ApiError {
+  const kind = classifyPaddleFailure(err)
+
+  logError('PADDLE_API_FAILED', {
+    orgId,
+    stage,
+    kind,
+    // Paddle's status and its own error code are the two fields worth grepping
+    // when this shows up; `detail` carries the sentence that names the cause.
+    paddleStatus: err instanceof PaddleApiError ? err.status : null,
+    paddleCode: err instanceof PaddleApiError ? err.code : null,
+  }, err)
+
+  if (kind === 'unavailable') {
+    return new ApiError(
+      'UPSTREAM_FAILED',
+      'The payment provider is not responding. Please try again in a few minutes.',
+    )
+  }
+
+  // credentials and request are both ours to fix, and neither improves by being
+  // retried, so they read the same to the customer.
+  return new ApiError(
+    'BILLING_NOT_CONFIGURED',
+    'Checkout is unavailable because of a billing problem on our side. ' +
+      'We have been notified. Please contact support@spanlens.io if it persists.',
+  )
+}
 
 /**
  * Dashboard billing endpoints — JWT authenticated.
@@ -125,8 +171,7 @@ billingRouter.post('/checkout', requireRole('admin'), async (c) => {
         })
         paddleCustomerId = created.id
       } catch (err) {
-        const msg = err instanceof Error ? err.message : 'unknown error'
-        throw new ApiError('UPSTREAM_FAILED', `Paddle customer create failed: ${msg}`)
+        throw paddleFailure(err, 'customer.create', orgId)
       }
     }
     await supabaseAdmin
@@ -142,7 +187,21 @@ billingRouter.post('/checkout', requireRole('admin'), async (c) => {
       organizationId: orgId,
     })
     if (!tx.checkout?.url) {
-      throw new ApiError('UPSTREAM_FAILED', 'Paddle did not return a checkout URL')
+      // A 2xx transaction with no checkout URL means the Default Payment Link
+      // is unset for this Paddle environment — a dashboard setting, so it reads
+      // as a configuration problem rather than an outage.
+      logError('PADDLE_API_FAILED', {
+        orgId,
+        stage: 'transaction.create',
+        kind: 'request',
+        reason: 'no_checkout_url',
+        paddleTransactionId: tx.id,
+      })
+      throw new ApiError(
+        'BILLING_NOT_CONFIGURED',
+        'Checkout is unavailable because of a billing problem on our side. ' +
+          'We have been notified. Please contact support@spanlens.io if it persists.',
+      )
     }
     void recordAuditEvent(c, {
       action: 'billing.checkout_create',
@@ -154,8 +213,11 @@ billingRouter.post('/checkout', requireRole('admin'), async (c) => {
     })
     return c.json({ success: true, data: { url: tx.checkout.url, transactionId: tx.id } })
   } catch (err) {
-    const msg = err instanceof Error ? err.message : 'unknown error'
-    throw new ApiError('UPSTREAM_FAILED', `Paddle checkout create failed: ${msg}`)
+    // An ApiError from inside the try (the customer-create catch above, or the
+    // missing-checkout-URL guard) is already the message we want; re-wrapping it
+    // would relabel a decided failure as a Paddle one.
+    if (err instanceof ApiError) throw err
+    throw paddleFailure(err, 'transaction.create', orgId)
   }
 })
 
@@ -187,7 +249,7 @@ billingRouter.post('/cancel', requireRole('admin'), async (c) => {
     })
     return c.json({ success: true })
   } catch (err) {
-    const msg = err instanceof Error ? err.message : 'unknown error'
-    throw new ApiError('UPSTREAM_FAILED', `Paddle cancel failed: ${msg}`)
+    if (err instanceof ApiError) throw err
+    throw paddleFailure(err, 'subscription.cancel', orgId)
   }
 })

--- a/apps/server/src/lib/errors.contract.test.ts
+++ b/apps/server/src/lib/errors.contract.test.ts
@@ -58,6 +58,7 @@ describe('error contract: server ERROR_CODES ↔ @spanlens/api-types KnownApiErr
       'NO_PROVIDER_KEY',
       'UPSTREAM_TIMEOUT',
       'UPSTREAM_FAILED',
+      'BILLING_NOT_CONFIGURED',
     ]
     for (const code of knownAtCompileTime) {
       expect(ERROR_CODES).toHaveProperty(code)

--- a/apps/server/src/lib/errors.ts
+++ b/apps/server/src/lib/errors.ts
@@ -100,6 +100,18 @@ export const ERROR_CODES = {
   },
   UPSTREAM_TIMEOUT: { status: 504, message: 'Upstream request timed out' },
   UPSTREAM_FAILED: { status: 502, message: 'Upstream request failed' },
+
+  // Billing is wired wrong on our side: the payment provider rejected our
+  // credentials, or rejected the specific call because of stored state only we
+  // can correct. Distinct from UPSTREAM_FAILED (502) because retrying will not
+  // help, and distinct from a 5xx crash because nothing is broken — the request
+  // was understood and refused. The customer is told it is on us; the cause
+  // goes to the logs, never into the response, since it describes our keys and
+  // configuration.
+  BILLING_NOT_CONFIGURED: {
+    status: 503,
+    message: 'Checkout is unavailable because of a billing configuration problem on our side',
+  },
 } as const
 
 export type ErrorCode = keyof typeof ERROR_CODES

--- a/apps/server/src/lib/paddle.ts
+++ b/apps/server/src/lib/paddle.ts
@@ -28,6 +28,59 @@ interface PaddleError {
   error?: { type?: string; code?: string; detail?: string }
 }
 
+/**
+ * A non-2xx from the Paddle API, with the status kept separate from the prose.
+ *
+ * Callers need the status to tell "our key is wrong" from "Paddle is down",
+ * because those are a different message to the customer and a different job for
+ * us. Parsing that back out of a concatenated string is how error handling
+ * rots, so it travels as a field.
+ *
+ * `detail` is Paddle's own explanation. It is safe to log and must not be
+ * forwarded to a browser: it describes our credentials and configuration, not
+ * anything the customer did.
+ */
+export class PaddleApiError extends Error {
+  readonly name = 'PaddleApiError'
+
+  constructor(
+    readonly status: number,
+    readonly detail: string,
+    readonly method: string,
+    readonly path: string,
+    readonly code: string | null = null,
+  ) {
+    super(`Paddle ${method} ${path} failed (${status}): ${detail}`)
+  }
+}
+
+/**
+ * What kind of problem a Paddle failure is, from the point of view of whoever
+ * has to act on it.
+ *
+ *   credentials — the API key is missing, expired, or lacks a permission.
+ *                 Nobody but us can fix it, and retrying will not help.
+ *   unavailable — Paddle is erroring or unreachable. Retrying is reasonable.
+ *   request     — Paddle rejected the specific call: a stale customer id, an
+ *                 unknown price, a malformed body. Ours to fix, but scoped to
+ *                 this org rather than the whole integration.
+ *
+ * A key with too few permissions answers 403, which is why credentials covers
+ * both 401 and 403: an expired key and an under-scoped one are the same job.
+ */
+export type PaddleFailureKind = 'credentials' | 'unavailable' | 'request'
+
+export function classifyPaddleFailure(err: unknown): PaddleFailureKind {
+  if (!(err instanceof PaddleApiError)) {
+    // A thrown non-PaddleApiError here is a fetch rejection — DNS, TLS, socket,
+    // abort. Paddle is unreachable rather than unhappy.
+    return 'unavailable'
+  }
+  if (err.status === 401 || err.status === 403) return 'credentials'
+  if (err.status === 408 || err.status === 429 || err.status >= 500) return 'unavailable'
+  return 'request'
+}
+
 async function paddleFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
   const res = await fetch(`${getPaddleBase()}${path}`, {
     ...init,
@@ -41,11 +94,13 @@ async function paddleFetch<T>(path: string, init: RequestInit = {}): Promise<T> 
   const text = await res.text()
   if (!res.ok) {
     let detail = text.slice(0, 500)
+    let code: string | null = null
     try {
       const parsed = JSON.parse(text) as PaddleError
       if (parsed.error?.detail) detail = parsed.error.detail
+      if (parsed.error?.code) code = parsed.error.code
     } catch { /* ignore */ }
-    throw new Error(`Paddle ${init.method ?? 'GET'} ${path} failed (${res.status}): ${detail}`)
+    throw new PaddleApiError(res.status, detail, init.method ?? 'GET', path, code)
   }
 
   return (text ? JSON.parse(text) : null) as T

--- a/apps/web/app/(dashboard)/billing/billing-client.tsx
+++ b/apps/web/app/(dashboard)/billing/billing-client.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/lib/queries/use-billing'
 import { QuotaBanner } from '@/components/dashboard/quota-banner'
 import { PLANS } from '@/lib/billing-plans'
+import { describeBillingFailure, type BillingFailure } from '@/lib/billing-errors'
 import type { BillingPlan } from '@/lib/queries/types'
 
 /** Pill recipe shared by the chips in the current-plan card header. */
@@ -34,7 +35,7 @@ export function BillingClient() {
   // Local error state for runtime errors (checkout, cancel). The
   // "missing client token" case is derived directly from env below — no
   // effect needed for that branch.
-  const [runtimeError, setRuntimeError] = useState<string | null>(null)
+  const [runtimeError, setRuntimeError] = useState<BillingFailure | null>(null)
   const [paddle, setPaddle] = useState<Paddle | null>(null)
   // initializePaddle can reject (ad-block, network) with no way to recover in
   // this session. Without tracking that, `paddle` stays null forever and the
@@ -59,12 +60,26 @@ export function BillingClient() {
     | 'sandbox'
     | 'production'
 
-  const errorMessage = runtimeError
+  /*
+   * One banner, three sources: a failed call, a blocked Paddle.js, and a
+   * missing client token. `retryable` decides the tone — a problem the reader
+   * can outlast is warned, a problem that needs us is flagged — so the two are
+   * not dressed identically the way they were when everything was a 502.
+   */
+  const failure: BillingFailure | null = runtimeError
     ?? (clientToken
       ? paddleLoadFailed
-        ? 'Payment system failed to load. Please disable ad-blockers and retry.'
+        ? {
+            message: 'Payment system failed to load. Please disable ad-blockers and retry.',
+            retryable: true,
+          }
         : null
-      : 'Paddle client token not configured. Set NEXT_PUBLIC_PADDLE_CLIENT_TOKEN.')
+      : {
+          message:
+            'Checkout is unavailable because of a billing problem on our side. ' +
+            'We have been notified. Please contact support@spanlens.io if it persists.',
+          retryable: false,
+        })
 
   useEffect(() => {
     if (!clientToken) return
@@ -120,7 +135,10 @@ export function BillingClient() {
       setCheckoutCompleted(false)
       checkoutCompletedRef.current = false
       if (!paddle) {
-        setRuntimeError('Paddle.js is not ready yet. Please try again in a moment.')
+        setRuntimeError({
+          message: 'Paddle.js is not ready yet. Please try again in a moment.',
+          retryable: true,
+        })
         return
       }
       try {
@@ -132,9 +150,7 @@ export function BillingClient() {
         // second checkout start against the same upgrade.
         setUpgradeInProgress(true)
       } catch (err) {
-        setRuntimeError(
-          err instanceof Error ? err.message : 'Failed to start checkout',
-        )
+        setRuntimeError(describeBillingFailure(err, 'Failed to start checkout'))
       }
     },
     [paddle, createCheckout],
@@ -147,7 +163,7 @@ export function BillingClient() {
       setShowCancelConfirm(false)
       setCancelDone(true)
     } catch (err) {
-      setRuntimeError(err instanceof Error ? err.message : 'Failed to cancel subscription')
+      setRuntimeError(describeBillingFailure(err, 'Failed to cancel subscription'))
       setShowCancelConfirm(false)
     }
   }, [cancelSubscription])
@@ -194,9 +210,14 @@ export function BillingClient() {
           </div>
         )}
 
-        {errorMessage && (
-          <div className="rounded-lg bg-accent-bg px-4 py-3 text-[12.5px] text-accent">
-            {errorMessage}
+        {failure && (
+          <div
+            role="alert"
+            className={`rounded-lg px-4 py-3 text-[12.5px] ${
+              failure.retryable ? 'bg-warn-bg text-warn' : 'bg-bad-bg text-bad'
+            }`}
+          >
+            {failure.message}
           </div>
         )}
 

--- a/apps/web/app/(dashboard)/settings/_sections/plan-limits-tab.tsx
+++ b/apps/web/app/(dashboard)/settings/_sections/plan-limits-tab.tsx
@@ -21,6 +21,7 @@ import {
   PLAN_WORKSPACE_LIMITS,
 } from '@/lib/billing-plans'
 import type { BillingPlan } from '@/lib/queries/types'
+import { describeBillingFailure, type BillingFailure } from '@/lib/billing-errors'
 import { NativeInput, MonoPill, Hint, Toggle, TabHeader, PILL_SECONDARY } from '../_shared/ui'
 
 // ─── PLAN & LIMITS tab ────────────────────────────────────────────────────────
@@ -37,7 +38,7 @@ export function PlanLimitsTab() {
   const [multiplierDraft, setMultiplierDraft] = useState(String(org?.overage_cap_multiplier ?? 2))
   const [overageError, setOverageError] = useState<string | null>(null)
   const [paddle, setPaddle] = useState<Paddle | null>(null)
-  const [checkoutError, setCheckoutError] = useState<string | null>(null)
+  const [checkoutError, setCheckoutError] = useState<BillingFailure | null>(null)
   // initializePaddle can reject (ad-block, network). Without catching it,
   // `paddle` stays null forever and every Upgrade button is stuck on
   // "Loading…" with no explanation. Surface an actionable error instead.
@@ -70,14 +71,17 @@ export function PlanLimitsTab() {
   const handleUpgrade = useCallback(async (plan: 'starter' | 'team') => {
     setCheckoutError(null)
     if (!paddle) {
-      setCheckoutError('Paddle.js is not ready yet. Please try again in a moment.')
+      setCheckoutError({
+        message: 'Paddle.js is not ready yet. Please try again in a moment.',
+        retryable: true,
+      })
       return
     }
     try {
       const res = await createCheckout.mutateAsync({ plan })
       paddle.Checkout.open({ transactionId: res.transactionId })
     } catch (err) {
-      setCheckoutError(err instanceof Error ? err.message : 'Failed to start checkout')
+      setCheckoutError(describeBillingFailure(err, 'Failed to start checkout'))
     }
   }, [paddle, createCheckout])
 
@@ -120,12 +124,42 @@ export function PlanLimitsTab() {
     <div>
       <TabHeader title="Plan & limits" description="Compare plans. Hard limits apply per-workspace; can be lifted on Enterprise." />
 
-      {(checkoutError || paddleLoadFailed) && (
-        <div className="rounded-card border border-accent-border bg-accent-bg px-4 py-3 mb-4 text-[12.5px] text-accent">
-          {checkoutError
-            ?? 'Payment system failed to load. Please disable ad-blockers and retry.'}
-        </div>
-      )}
+      {/* Retryable problems are warned, problems that need us are flagged, so
+          "wait a minute" and "we broke it" no longer look the same.
+
+          The no-client-token case is listed here as well as on /billing. Without
+          it this tab said nothing at all: the effect that sets `paddleLoadFailed`
+          returns early when the token is missing, so the Upgrade buttons sat on
+          "Loading…" indefinitely with no explanation anywhere on the page. */}
+      {(() => {
+        const failure: BillingFailure | null = checkoutError
+          ?? (!clientToken
+            ? {
+                message:
+                  'Checkout is unavailable because of a billing problem on our side. ' +
+                  'We have been notified. Please contact support@spanlens.io if it persists.',
+                retryable: false,
+              }
+            : paddleLoadFailed
+              ? {
+                  message: 'Payment system failed to load. Please disable ad-blockers and retry.',
+                  retryable: true,
+                }
+              : null)
+        if (!failure) return null
+        return (
+          <div
+            role="alert"
+            className={`mb-4 rounded-card border px-4 py-3 text-[12.5px] ${
+              failure.retryable
+                ? 'border-warn/30 bg-warn-bg text-warn'
+                : 'border-bad/30 bg-bad-bg text-bad'
+            }`}
+          >
+            {failure.message}
+          </div>
+        )
+      })()}
 
       {/* Subscription load failure — don't fall through to the Free-plan
           default below. A paying user hitting a transient 500 would otherwise

--- a/apps/web/app/docs/api/errors/page.tsx
+++ b/apps/web/app/docs/api/errors/page.tsx
@@ -130,6 +130,12 @@ const ERROR_CATALOG_ROWS: CatalogRow[] = [
     description: 'Upstream provider returned an error or the network failed. The details object carries the provider name.',
   },
   {
+    code: 'BILLING_NOT_CONFIGURED',
+    status: 503,
+    description:
+      'A billing call was refused for a reason only Spanlens can fix: rejected credentials, or stored payment state that needs correcting. Retrying will not help, and the cause is deliberately kept out of the response. Contact support if it persists.',
+  },
+  {
     code: 'DECRYPT_FAILED',
     status: 503,
     description:

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -22,6 +22,12 @@ export class ApiError extends Error {
   constructor(
     message: string,
     public status: number,
+    /**
+     * The stable `error.code` from the server's catalog, when the response used
+     * the unified envelope. Branch on this rather than on the message: the
+     * prose is written for a human and will be reworded.
+     */
+    public code: string | null = null,
   ) {
     super(message)
   }
@@ -42,6 +48,16 @@ function extractErrorMessage(body: unknown, status: number): string {
     if (typeof message === 'string' && message.length > 0) return message
   }
   return `HTTP ${status}`
+}
+
+/** The envelope's `error.code`, or null for the legacy string shape. */
+function extractErrorCode(body: unknown): string | null {
+  const err = (body as { error?: unknown } | null | undefined)?.error
+  if (err && typeof err === 'object') {
+    const code = (err as { code?: unknown }).code
+    if (typeof code === 'string' && code.length > 0) return code
+  }
+  return null
 }
 
 const SESSION_TTL_MS = 10_000 // 10s, well under the default 1h access-token lifetime
@@ -107,7 +123,7 @@ export async function apiGet<T>(path: string): Promise<T> {
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new ApiError(extractErrorMessage(body, res.status), res.status)
+    throw new ApiError(extractErrorMessage(body, res.status), res.status, extractErrorCode(body))
   }
   return res.json() as Promise<T>
 }
@@ -120,7 +136,7 @@ export async function apiPost<T>(path: string, body?: unknown): Promise<T> {
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new ApiError(extractErrorMessage(body, res.status), res.status)
+    throw new ApiError(extractErrorMessage(body, res.status), res.status, extractErrorCode(body))
   }
   return res.json() as Promise<T>
 }
@@ -133,7 +149,7 @@ export async function apiPatch<T>(path: string, body?: unknown): Promise<T> {
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new ApiError(extractErrorMessage(body, res.status), res.status)
+    throw new ApiError(extractErrorMessage(body, res.status), res.status, extractErrorCode(body))
   }
   return res.json() as Promise<T>
 }
@@ -148,7 +164,7 @@ export async function apiDownload(path: string, filename: string): Promise<void>
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new ApiError(extractErrorMessage(body, res.status), res.status)
+    throw new ApiError(extractErrorMessage(body, res.status), res.status, extractErrorCode(body))
   }
   const blob = await res.blob()
   const url = URL.createObjectURL(blob)
@@ -168,7 +184,7 @@ export async function apiDelete<T>(path: string): Promise<T> {
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new ApiError(extractErrorMessage(body, res.status), res.status)
+    throw new ApiError(extractErrorMessage(body, res.status), res.status, extractErrorCode(body))
   }
   return res.json() as Promise<T>
 }

--- a/apps/web/lib/billing-errors.test.ts
+++ b/apps/web/lib/billing-errors.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { ApiError } from './api'
+import { describeBillingFailure } from './billing-errors'
+
+/**
+ * The billing banner used to show whatever string came back, which meant an
+ * under-scoped Paddle key reached customers as
+ * "502 … not authorized to create|read transaction". These cases pin the two
+ * things that has to keep being true: the reader is told whether trying again
+ * is worth it, and no failure surfaces a bare `HTTP <status>`.
+ */
+describe('describeBillingFailure', () => {
+  it('passes a configuration failure through and marks it not retryable', () => {
+    const message =
+      'Checkout is unavailable because of a billing problem on our side. ' +
+      'We have been notified. Please contact support@spanlens.io if it persists.'
+    const failure = describeBillingFailure(
+      new ApiError(message, 503, 'BILLING_NOT_CONFIGURED'),
+      'fallback',
+    )
+    expect(failure).toEqual({ message, retryable: false })
+  })
+
+  it('marks an upstream failure retryable', () => {
+    const message = 'The payment provider is not responding. Please try again in a few minutes.'
+    const failure = describeBillingFailure(
+      new ApiError(message, 502, 'UPSTREAM_FAILED'),
+      'fallback',
+    )
+    expect(failure).toEqual({ message, retryable: true })
+  })
+
+  it('replaces a bodiless 5xx rather than showing "HTTP 502"', () => {
+    // No envelope: an edge timeout or a crashed function never reaches the
+    // server's error handler, so `extractErrorMessage` yields the status line.
+    const failure = describeBillingFailure(new ApiError('HTTP 502', 502, null), 'fallback')
+    expect(failure.message).not.toMatch(/HTTP 502/)
+    expect(failure.message).toMatch(/not responding/i)
+    expect(failure.retryable).toBe(true)
+  })
+
+  it('treats a rejected fetch as a connection problem', () => {
+    const failure = describeBillingFailure(new TypeError('Failed to fetch'), 'fallback')
+    expect(failure.message).toMatch(/connection/i)
+    expect(failure.retryable).toBe(true)
+  })
+
+  it('keeps a plan-gate message and does not invite a retry', () => {
+    const failure = describeBillingFailure(
+      new ApiError('This action requires a higher plan', 402, 'PAYMENT_REQUIRED'),
+      'fallback',
+    )
+    expect(failure).toEqual({ message: 'This action requires a higher plan', retryable: false })
+  })
+
+  it('never surfaces the upstream provider detail, whatever the server sends', () => {
+    // Belt and braces: the server is responsible for not putting Paddle's words
+    // in the envelope, but if one ever leaks the banner should not read like a
+    // stack trace either. Any code we do not recognise still yields prose.
+    const failure = describeBillingFailure(new ApiError('HTTP 500', 500, null), 'fallback')
+    expect(failure.message).not.toMatch(/HTTP \d{3}/)
+  })
+})

--- a/apps/web/lib/billing-errors.ts
+++ b/apps/web/lib/billing-errors.ts
@@ -1,0 +1,61 @@
+import { ApiError } from '@/lib/api'
+
+/**
+ * Turns a failed billing call into something worth showing a customer.
+ *
+ * The billing endpoints answer with the unified error envelope, and the server
+ * already writes the prose for the cases it can name, so this mostly passes
+ * that through. What it adds is the two things the raw error cannot express:
+ *
+ *  - `retryable`, so the copy can tell "try again in a minute" apart from
+ *    "stop clicking, this one is ours". Those were indistinguishable when every
+ *    failure surfaced as the same 502.
+ *  - a sentence for the bodiless 5xx. A gateway timeout or a crashed function
+ *    never reaches our error handler, so the envelope is missing and the client
+ *    was left rendering the literal string "HTTP 502".
+ */
+export interface BillingFailure {
+  message: string
+  /** True when clicking the same button again is a reasonable next move. */
+  retryable: boolean
+}
+
+const UNREACHABLE =
+  'Could not reach Spanlens. Check your connection and try again.'
+const PROVIDER_DOWN =
+  'The payment provider is not responding. Please try again in a few minutes.'
+
+export function describeBillingFailure(err: unknown, fallback: string): BillingFailure {
+  if (!(err instanceof ApiError)) {
+    // fetch rejected: offline, DNS, TLS, aborted. Never reached the server.
+    return { message: UNREACHABLE, retryable: true }
+  }
+
+  switch (err.code) {
+    // Ours to fix and retrying will not help. The server's message already says
+    // so and names support, so it goes through untouched.
+    case 'BILLING_NOT_CONFIGURED':
+      return { message: err.message, retryable: false }
+
+    case 'UPSTREAM_FAILED':
+    case 'UPSTREAM_TIMEOUT':
+      return { message: err.message, retryable: true }
+
+    // Plan gate, permission, validation: the message is specific and the
+    // customer may be able to act on it, but repeating the call will not change
+    // the answer.
+    case 'PAYMENT_REQUIRED':
+    case 'FORBIDDEN':
+    case 'VALIDATION_FAILED':
+      return { message: err.message, retryable: false }
+  }
+
+  // No code means no envelope, which in practice means the request died before
+  // our error handler: an edge timeout, an OOM, a bad gateway. `err.message` is
+  // "HTTP 502" here, so replace it rather than show it.
+  if (err.code === null && err.status >= 500) {
+    return { message: PROVIDER_DOWN, retryable: true }
+  }
+
+  return { message: err.message || fallback, retryable: err.status >= 500 }
+}

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -101,6 +101,7 @@ export type KnownApiErrorCode =
   | 'NO_PROVIDER_KEY'
   | 'UPSTREAM_TIMEOUT'
   | 'UPSTREAM_FAILED'
+  | 'BILLING_NOT_CONFIGURED'
 
 /**
  * Branded string type: a code is known if it matches the literal union,


### PR DESCRIPTION
A failed checkout surfaced as a 502 carrying Paddle's own words, so the under-scoped API key we hit yesterday reached the customer as:

```
502 … not authorized to create|read transaction
```

That is our configuration described to someone who cannot act on it, and it is not theirs to read. Every cause also looked identical, so telling a missing permission from a Paddle outage meant opening the runtime logs.

## Server

`paddleFetch` throws a `PaddleApiError` that keeps the status separate from the prose, and `classifyPaddleFailure` sorts a failure into `credentials` / `unavailable` / `request`. Billing maps those onto two customer outcomes and logs the rest:

| Cause | Customer sees | Log |
|---|---|---|
| Paddle 5xx, 429, timeout, unreachable | 502, "not responding, try again in a few minutes" | `PADDLE_API_FAILED` + stage |
| 401/403, or a call Paddle refused | 503, "a billing problem on our side, we have been notified" | same, with Paddle status + error code + detail |

`BILLING_NOT_CONFIGURED` (503) is the new code for the second case: distinct from `UPSTREAM_FAILED` because retrying will not help, and distinct from a crash because nothing is broken. Registered in the shared `api-types` union and the public error table, as the two contract tests require. The upstream detail never enters the response.

## Web

`ApiError` now carries `error.code`, so callers branch on the code rather than on prose. `describeBillingFailure` decides both the sentence and whether a retry is worth offering; retryable problems are warned, ours are flagged. A bodiless 5xx — edge timeout, crashed function, anything that dies before the error handler — no longer renders as the literal string `HTTP 502`.

## Two smaller things found on the way

- The missing-client-token case told the customer to "Set `NEXT_PUBLIC_PADDLE_CLIENT_TOKEN`". Replaced with the same "on our side" message.
- Plan & limits had no banner for that case at all. The effect that sets `paddleLoadFailed` returns early when the token is missing, so the Upgrade buttons sat on "Loading…" indefinitely with nothing on the page explaining why.

## Test plan

- [x] 6 unit tests over `describeBillingFailure`: config, upstream, bodiless 5xx, rejected fetch, plan gate, and "never renders `HTTP <status>`"
- [x] Banner verified in the browser on `/billing` and `/settings?tab=plan`: `role="alert"`, no env var name in the copy, correct tone token
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` (1633 server + 523 web)
- [x] Upgrade routing 10/10, dashboard and docs sweeps unchanged