### PR TITLE
docs(web): changelog entry for the design rework

### DIFF
--- a/apps/web/lib/changelog/entries.ts
+++ b/apps/web/lib/changelog/entries.ts
@@ -39,6 +39,17 @@ export type ChangelogTag =
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: '2026-08-17',
+    slug: 'new-design-across-the-app',
+    title: 'A new look across the whole app',
+    tags: ['improvement', 'fix'],
+    body: [
+      'Every screen has been rebuilt on a new design: the dashboard, the landing page, the documentation, the sign-in screens, the shared trace pages, and the notification emails. The layout and the information on each page are the same; the typography, spacing, colour and controls are not. Charts keep their existing palette rules, so a red bar still means what it meant last week.',
+      'The landing page now moves. Provider tiles drift, each integration lights up in turn along its wire into the mark, sections arrive as you scroll, and the integrations arc rotates on its own. All of it honours your reduced-motion setting: if your system asks for less movement, everything renders still.',
+      'Two long-standing layout bugs went with it. Tables and long inline code in the documentation used to push whole pages sideways on a phone, so you could scroll horizontally away from the text; tables now scroll inside their own box. And a hidden column label in the dashboard tables was escaping its container, which made several boards scroll sideways on narrow screens.',
+    ].join('\n\n'),
+  },
+  {
     date: '2026-08-11',
     slug: 'dashboard-latency-and-idle-key-count-fix',
     title: 'Much faster dashboard and API responses, plus an idle-key count fix',


### PR DESCRIPTION
One entry for the design rework, covering the three things a reader would actually notice: every surface rebuilt on the new design, the landing page motion with its reduced-motion fallback, and the two layout bugs that were letting documentation and dashboard pages scroll sideways on a phone.

Tagged `improvement` + `fix` rather than `feature`. Nothing new can be done; the existing screens look different. `feature` is the only tag that gets the accent chip, and reserving it for real capability launches is the convention the tag styles were built around.

Code spans are written as prose ("your reduced-motion setting", not the CSS media query) because the body renderer only parses `[label](href)` — anything else would render literally.

The other candidates from the same day were deliberately left out: settings deep links and the clearer checkout errors are queued for a separate entry, and the Paddle key rotation is our own configuration rather than a product change.

## Test plan

- [x] Entry renders first, all three paragraphs, correct date and tag chips
- [x] Anchor `#new-design-across-the-app` resolves
- [x] JSON-LD `ItemList` includes the new entry
- [x] `/changelog/feed.xml` serves 200 and includes it, no unescaped markup
- [x] No raw markdown or backticks leaked into the rendered copy
- [x] `pnpm --filter web typecheck`, `lint`, `test` (523)