### PR TITLE
fix(server): gate quota warnings on new traffic, not on the whole month

### DIFF
--- a/apps/server/src/__tests__/quota-warnings-gate.test.ts
+++ b/apps/server/src/__tests__/quota-warnings-gate.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+/**
+ * check-quota-warnings × activity watermark.
+ *
+ * The month-wide gate that shipped first was not enough: one tenant with
+ * traffic anywhere in the month keeps passing it, so the job still dragged
+ * ClickHouse awake every hour for the rest of the month. The gate here is the
+ * later of the month start and the last successful run, which is safe because
+ * this job's output moves only when new requests arrive.
+ *
+ * What these cases pin, in order of what would hurt most if it broke:
+ *
+ *   1. an org WITH new traffic is still counted and still warned
+ *   2. an unreadable watermark counts everyone, as before
+ *   3. an org with nothing new since the last run is skipped
+ *   4. the month start is the floor, so a run older than the month cannot
+ *      widen the window backwards past it
+ */
+
+const orgsResultMock = vi.fn()
+const countMonthlyRequestsMock = vi.fn()
+const getOrgActivitySinceMock = vi.fn()
+const lastSuccessfulRunAtMock = vi.fn()
+const sendQuotaWarningEmailMock = vi.fn()
+
+let capturedGateSince: Date | null = null
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: {
+    from: () => ({
+      select: () => ({
+        in: () => ({ returns: () => Promise.resolve(orgsResultMock()) }),
+      }),
+      update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+    }),
+    auth: {
+      admin: {
+        getUserById: async () => ({ data: { user: { email: 'owner@example.com' } }, error: null }),
+      },
+    },
+  },
+}))
+
+vi.mock('../lib/quota.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/quota.js')>('../lib/quota.js')
+  return { ...actual, countMonthlyRequests: countMonthlyRequestsMock }
+})
+
+vi.mock('../lib/notifiers.js', () => ({ sendQuotaWarningEmail: sendQuotaWarningEmailMock }))
+
+vi.mock('../lib/org-activity.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/org-activity.js')>(
+    '../lib/org-activity.js',
+  )
+  return {
+    ...actual,
+    getOrgActivitySince: (since: Date) => {
+      capturedGateSince = since
+      return getOrgActivitySinceMock(since)
+    },
+  }
+})
+
+vi.mock('../lib/cron-cadence.js', () => ({ lastSuccessfulRunAt: lastSuccessfulRunAtMock }))
+
+const ORG = '00000000-0000-4000-8000-000000000001'
+
+function freeOrg() {
+  return {
+    id: ORG,
+    name: 'Acme',
+    plan: 'free',
+    owner_id: 'user-1',
+    allow_overage: false,
+    overage_cap_multiplier: 1,
+    quota_warning_80_sent_at: null,
+    quota_warning_100_sent_at: null,
+  }
+}
+
+let runQuotaWarningsJob: typeof import('../lib/quota-warnings.js').runQuotaWarningsJob
+let monthlyLimit: number
+
+beforeEach(async () => {
+  vi.resetModules()
+  orgsResultMock.mockReset()
+  countMonthlyRequestsMock.mockReset()
+  getOrgActivitySinceMock.mockReset()
+  lastSuccessfulRunAtMock.mockReset()
+  sendQuotaWarningEmailMock.mockReset()
+  capturedGateSince = null
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  ;({ runQuotaWarningsJob } = await import('../lib/quota-warnings.js'))
+  const { MONTHLY_REQUEST_LIMITS } = await import('../lib/quota.js')
+  monthlyLimit = MONTHLY_REQUEST_LIMITS.free as number
+  orgsResultMock.mockReturnValue({ data: [freeOrg()], error: null })
+  sendQuotaWarningEmailMock.mockResolvedValue({ ok: true })
+})
+
+describe('runQuotaWarningsJob gating', () => {
+  test('counts and warns an org with new traffic since the last run', async () => {
+    lastSuccessfulRunAtMock.mockResolvedValue(new Date(Date.now() - 60 * 60 * 1000))
+    getOrgActivitySinceMock.mockResolvedValue(new Map([[ORG, Date.now() - 60_000]]))
+    countMonthlyRequestsMock.mockResolvedValue(Math.ceil(monthlyLimit * 0.9))
+
+    const result = await runQuotaWarningsJob()
+
+    expect(countMonthlyRequestsMock).toHaveBeenCalledTimes(1)
+    expect(result.sent80).toBe(1)
+    expect(result.skipped).toBe(0)
+  })
+
+  test('counts every org when the watermark cannot be read', async () => {
+    lastSuccessfulRunAtMock.mockResolvedValue(new Date(Date.now() - 60 * 60 * 1000))
+    getOrgActivitySinceMock.mockResolvedValue(null)
+    countMonthlyRequestsMock.mockResolvedValue(0)
+
+    await runQuotaWarningsJob()
+
+    expect(countMonthlyRequestsMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('counts every org when there is no successful run to gate on', async () => {
+    lastSuccessfulRunAtMock.mockResolvedValue(null)
+    getOrgActivitySinceMock.mockResolvedValue(new Map([[ORG, Date.now() - 60_000]]))
+    countMonthlyRequestsMock.mockResolvedValue(0)
+
+    await runQuotaWarningsJob()
+
+    expect(countMonthlyRequestsMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('skips ClickHouse for an org with nothing new since the last run', async () => {
+    const lastRun = new Date(Date.now() - 60 * 60 * 1000)
+    lastSuccessfulRunAtMock.mockResolvedValue(lastRun)
+    // Active this month, but two hours ago — before the last run.
+    getOrgActivitySinceMock.mockResolvedValue(new Map())
+
+    const result = await runQuotaWarningsJob()
+
+    expect(countMonthlyRequestsMock).not.toHaveBeenCalled()
+    expect(result.skipped).toBe(1)
+    expect(result.checked).toBe(1)
+    expect(result.sent80).toBe(0)
+  })
+
+  test('gates on the last run when it is inside the month', async () => {
+    const lastRun = new Date(Date.now() - 30 * 60 * 1000)
+    lastSuccessfulRunAtMock.mockResolvedValue(lastRun)
+    getOrgActivitySinceMock.mockResolvedValue(new Map())
+
+    await runQuotaWarningsJob()
+
+    expect(capturedGateSince?.getTime()).toBe(lastRun.getTime())
+  })
+
+  test('never widens the window past the month start', async () => {
+    const { currentMonthStartMs } = await import('../lib/quota-warnings-stats.js')
+    const monthStart = currentMonthStartMs(new Date())
+    // A run recorded before this month must not pull the gate back with it.
+    lastSuccessfulRunAtMock.mockResolvedValue(new Date(monthStart - 24 * 60 * 60 * 1000))
+    getOrgActivitySinceMock.mockResolvedValue(new Map())
+
+    await runQuotaWarningsJob()
+
+    expect(capturedGateSince?.getTime()).toBe(monthStart)
+  })
+
+  test('reports errors so the caller can withhold the success stamp', async () => {
+    lastSuccessfulRunAtMock.mockResolvedValue(new Date(Date.now() - 60 * 60 * 1000))
+    getOrgActivitySinceMock.mockResolvedValue(new Map([[ORG, Date.now() - 60_000]]))
+    countMonthlyRequestsMock.mockRejectedValue(new Error('ClickHouse timeout'))
+
+    const result = await runQuotaWarningsJob()
+
+    expect(result.errors).toBe(1)
+    expect(result.skipped).toBe(0)
+  })
+})

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -144,8 +144,20 @@ cronRouter.get('/check-quota-warnings', async (c) => {
   const start = Date.now()
   try {
     const result = await runQuotaWarningsJob()
-    await logCronRun('check-quota-warnings', 'ok', Date.now() - start)
-    return c.json({ success: true, ...result })
+    // A run that could not count every org is NOT a success. The job gates
+    // its ClickHouse reads on "anything new since the last successful run"
+    // (lib/quota-warnings.ts), so recording a partial run as ok would move
+    // that gate past orgs it never actually checked — one transient failure
+    // could then park an org just under its cap until its next request.
+    // Logging the error keeps the gate where it was and re-checks everyone.
+    const failed = result.errors > 0
+    await logCronRun(
+      'check-quota-warnings',
+      failed ? 'error' : 'ok',
+      Date.now() - start,
+      failed ? `${result.errors} org(s) failed to check` : undefined,
+    )
+    return c.json({ success: !failed, ...result })
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown'
     await logCronRun('check-quota-warnings', 'error', Date.now() - start, msg)

--- a/apps/server/src/lib/quota-warnings.ts
+++ b/apps/server/src/lib/quota-warnings.ts
@@ -3,6 +3,7 @@ import { MONTHLY_REQUEST_LIMITS, countMonthlyRequests, type Plan } from './quota
 import { sendQuotaWarningEmail } from './notifiers.js'
 import { decideQuotaWarning, currentMonthStartMs } from './quota-warnings-stats.js'
 import { getOrgActivitySince, orgActiveSince } from './org-activity.js'
+import { lastSuccessfulRunAt } from './cron-cadence.js'
 
 /**
  * Quota warning emails at 80% / 100% of the monthly request limit.
@@ -42,6 +43,8 @@ export interface QuotaWarningRunResult {
   sent80: number
   sent100: number
   errors: number
+  /** Orgs with no new requests since the last successful run — see the gate below. */
+  skipped: number
 }
 
 /**
@@ -67,18 +70,37 @@ export async function runQuotaWarningsJob(): Promise<QuotaWarningRunResult> {
 
   if (error || !orgs) {
     console.error('[quota-warnings] failed to list orgs:', error?.message)
-    return { checked: 0, sent80: 0, sent100: 0, errors: 1 }
+    return { checked: 0, sent80: 0, sent100: 0, errors: 1, skipped: 0 }
   }
 
-  const result: QuotaWarningRunResult = { checked: 0, sent80: 0, sent100: 0, errors: 0 }
+  const result: QuotaWarningRunResult = { checked: 0, sent80: 0, sent100: 0, errors: 0, skipped: 0 }
 
-  // Which of these orgs sent anything this month. Orgs that sent nothing are
-  // at 0% of their quota by definition, so counting them in ClickHouse can
-  // only ever return zero — and doing it anyway, once an hour, for every org
-  // on the platform, is a large part of what kept ClickHouse Cloud from ever
-  // suspending (lib/org-activity.ts). A null map means the watermark was
-  // unreadable, and every org falls back to the ClickHouse count.
-  const activity = await getOrgActivitySince(new Date(monthStartMs))
+  // Which orgs have anything new worth counting.
+  //
+  // The obvious window is "this month" — an org that sent nothing is at 0% of
+  // its quota and cannot need a warning. That alone was not enough: any org
+  // with traffic anywhere in the month keeps passing a month-wide gate, so a
+  // single active tenant still dragged ClickHouse awake once an hour, every
+  // hour, for the rest of the month.
+  //
+  // The tighter window is "since we last counted". This job's output is a
+  // function of the request count and the stored send timestamps, and neither
+  // moves without new requests: if the previous run decided not to send, and
+  // nothing has been logged since, this run reaches the same decision. So the
+  // gate is the later of the month start and the last successful run.
+  //
+  // What makes that safe is the error handling below — a run that failed to
+  // count any org is logged as an error, so `lastSuccessfulRunAt` does not
+  // advance past it and the next run re-checks everyone. Without that, one
+  // transient ClickHouse failure could park an org just under its cap until
+  // its next request.
+  //
+  // Both lookups fail open: a null watermark or missing run history falls
+  // back to counting every org in ClickHouse, exactly as before.
+  const lastRun = await lastSuccessfulRunAt('check-quota-warnings')
+  const gateSince =
+    lastRun && lastRun.getTime() > monthStartMs ? lastRun : new Date(monthStartMs)
+  const activity = await getOrgActivitySince(gateSince)
 
   // Same env-driven base the other lifecycle emails use (stale-key-digest,
   // data-silence) so the upgrade CTA lands on the right host in every env.
@@ -89,24 +111,27 @@ export async function runQuotaWarningsJob(): Promise<QuotaWarningRunResult> {
     const limit = MONTHLY_REQUEST_LIMITS[org.plan]
     if (limit === null) continue // defensive: enterprise slipped past the filter
 
+    // Nothing new since the gate, so the previous run's decision still holds
+    // and it was "don't send" — a run that sends stamps the timestamp, which
+    // makes a repeat impossible anyway. Skipping here is what keeps the job
+    // off ClickHouse on an idle platform.
+    if (!orgActiveSince(activity, org.id, gateSince)) {
+      result.skipped++
+      continue
+    }
+
     // Count this org's requests this month — same source of truth the
-    // proxy middleware uses for 429 enforcement. Skipped entirely when the
-    // watermark says the org has been silent all month: the count would be
-    // 0, and `decideQuotaWarning(0, …)` never sends.
+    // proxy middleware uses for 429 enforcement.
     let used: number
-    if (!orgActiveSince(activity, org.id, new Date(monthStartMs))) {
-      used = 0
-    } else {
-      try {
-        used = await countMonthlyRequests(org.id, new Date(monthStartMs))
-      } catch (err) {
-        console.error(
-          `[quota-warnings] count failed for org ${org.id}:`,
-          err instanceof Error ? err.message : err,
-        )
-        result.errors++
-        continue
-      }
+    try {
+      used = await countMonthlyRequests(org.id, new Date(monthStartMs))
+    } catch (err) {
+      console.error(
+        `[quota-warnings] count failed for org ${org.id}:`,
+        err instanceof Error ? err.message : err,
+      )
+      result.errors++
+      continue
     }
 
     const ratio = used / limit


### PR DESCRIPTION
Follow-up to #472, from watching it land.

## The gap

#472 gated `check-quota-warnings` on "did this org send anything this month". That window is too wide to help: an org counts as active from its first request of the month until the month rolls over, so one tenant with any traffic keeps the job counting in ClickHouse once an hour for the rest of the month — enough on its own to hold the service out of its 15-minute idle window.

Checked in production right after #472 deployed. `org_activity` backfilled two rows:

| org | last request | consequence under the month gate |
|---|---|---|
| `1f687418…` (owns all 3 active alerts) | Jul 27 | correctly skipped — this is the ~384 queries/day that stopped |
| `015a5187…` | Aug 17 | still counted hourly, ~24 ClickHouse wake-ups/day for the rest of August |

## The fix

Gate on the later of the month start and the last successful run.

Sound because the job's output is a function of the request count and the stored send timestamps, and neither moves without new requests: if the previous run decided not to send and nothing has been logged since, this run reaches the same decision. A run that did send stamps the timestamp, which makes a repeat impossible regardless. The month start stays as a floor so a stale run record cannot widen the window backwards past it.

## What makes it safe

The route now logs the run as `error` rather than `ok` when any org failed to count. `lastSuccessfulRunAt` therefore does not advance past a partial run and the next run re-checks everyone.

Without that, one transient ClickHouse failure could park an org just under its cap until its next request arrived — a worse outcome than the compute this saves, and the reason the gate could not simply be tightened on its own.

`skipped` is added to the result so the gate's effect shows up in the cron response instead of having to be inferred from an absence.

## Test plan

- [x] `pnpm --filter server typecheck`
- [x] `pnpm --filter server test` — 1679 passing, 143 files
- [x] `pnpm --filter server lint`
- [x] `pnpm --filter server build`
- [ ] After deploy: `check-quota-warnings` responses should report `skipped: 10` on a quiet hour, and `system.query_log` should stop showing hourly `count() AS n` queries

New tests in `quota-warnings-gate.test.ts` cover both directions: an org with new traffic is still counted and still warned, an unreadable watermark or missing run history counts everyone, an org with nothing new is skipped, and the month start holds as the floor.
