### PR TITLE
fix(server): gate long-window budget alerts on new traffic too

### DIFF
--- a/apps/server/src/__tests__/evaluate-alerts-watermark.test.ts
+++ b/apps/server/src/__tests__/evaluate-alerts-watermark.test.ts
@@ -24,6 +24,7 @@ const alertsResultMock = vi.fn()
 const chQueryMock = vi.fn()
 const getOrgActivitySinceMock = vi.fn()
 const deliverToChannelMock = vi.fn()
+const lastSuccessfulRunAtMock = vi.fn()
 
 /**
  * PostgREST chains are fluent and end wherever the caller stops, so the mock
@@ -72,6 +73,8 @@ vi.mock('../lib/org-activity.js', async () => {
   return { ...actual, getOrgActivitySince: getOrgActivitySinceMock }
 })
 
+vi.mock('../lib/cron-cadence.js', () => ({ lastSuccessfulRunAt: lastSuccessfulRunAtMock }))
+
 const ORG = '00000000-0000-4000-8000-000000000001'
 
 function budgetAlert(overrides: Record<string, unknown> = {}) {
@@ -97,6 +100,8 @@ beforeEach(async () => {
   chQueryMock.mockReset()
   getOrgActivitySinceMock.mockReset()
   deliverToChannelMock.mockReset()
+  lastSuccessfulRunAtMock.mockReset()
+  lastSuccessfulRunAtMock.mockResolvedValue(null)
   ;({ runEvaluateAlertsJob } = await import('../lib/cron-jobs/evaluate-alerts.js'))
 })
 
@@ -161,6 +166,16 @@ describe('runEvaluateAlertsJob with the activity watermark', () => {
     expect(result.evaluated).toBe(0)
   })
 
+  test('reports a metric failure so the caller can withhold the success stamp', async () => {
+    alertsResultMock.mockReturnValue({ data: [budgetAlert()], error: null })
+    getOrgActivitySinceMock.mockResolvedValue(new Map([[ORG, Date.now() - 60_000]]))
+    chQueryMock.mockRejectedValue(new Error('ClickHouse timeout'))
+
+    const result = await runEvaluateAlertsJob()
+
+    expect(result.metric_errors).toBe(1)
+  })
+
   test('eval_score alerts are unaffected — they never read ClickHouse', async () => {
     alertsResultMock.mockReturnValue({
       data: [budgetAlert({ id: 'alert-2', type: 'eval_score', threshold: 0.8 })],
@@ -172,4 +187,86 @@ describe('runEvaluateAlertsJob with the activity watermark', () => {
 
     expect(chQueryMock).not.toHaveBeenCalled()
   })
+})
+
+/**
+ * Long-window budget alerts.
+ *
+ * A monthly spend cap runs a 30-day window, so any org that sent one request
+ * in the last month sits inside it and the window gate never bites. This was
+ * the last query still firing every 15 minutes in production after the
+ * watermark shipped, and one query every 15 minutes is all it takes to hold
+ * ClickHouse Cloud awake — the same bill as before.
+ *
+ * The extra gate only applies to budget, because `sum(cost_usd)` over a
+ * sliding window cannot rise without new rows. error_rate and p95 can, so
+ * they must keep evaluating; those cases are pinned here too.
+ */
+describe('budget alerts with a window longer than the cron interval', () => {
+  const THIRTY_DAYS_MIN = 43_200
+
+  test('skips ClickHouse when nothing arrived since the last successful run', async () => {
+    alertsResultMock.mockReturnValue({
+      data: [budgetAlert({ type: 'budget', window_minutes: THIRTY_DAYS_MIN })],
+      error: null,
+    })
+    lastSuccessfulRunAtMock.mockResolvedValue(new Date(Date.now() - 15 * 60 * 1000))
+    // Active three weeks ago: inside the 30-day window, before the last run.
+    getOrgActivitySinceMock.mockResolvedValue(
+      new Map([[ORG, Date.now() - 21 * 24 * 60 * 60 * 1000]]),
+    )
+
+    await runEvaluateAlertsJob()
+
+    expect(chQueryMock).not.toHaveBeenCalled()
+  })
+
+  test('still queries when traffic arrived after the last successful run', async () => {
+    alertsResultMock.mockReturnValue({
+      data: [budgetAlert({ type: 'budget', window_minutes: THIRTY_DAYS_MIN })],
+      error: null,
+    })
+    lastSuccessfulRunAtMock.mockResolvedValue(new Date(Date.now() - 15 * 60 * 1000))
+    getOrgActivitySinceMock.mockResolvedValue(new Map([[ORG, Date.now() - 60_000]]))
+    chQueryMock.mockResolvedValue({ json: async () => [{ total: '1' }] })
+
+    await runEvaluateAlertsJob()
+
+    expect(chQueryMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('falls back to the window when there is no successful run to gate on', async () => {
+    alertsResultMock.mockReturnValue({
+      data: [budgetAlert({ type: 'budget', window_minutes: THIRTY_DAYS_MIN })],
+      error: null,
+    })
+    lastSuccessfulRunAtMock.mockResolvedValue(null)
+    getOrgActivitySinceMock.mockResolvedValue(
+      new Map([[ORG, Date.now() - 21 * 24 * 60 * 60 * 1000]]),
+    )
+    chQueryMock.mockResolvedValue({ json: async () => [{ total: '1' }] })
+
+    await runEvaluateAlertsJob()
+
+    expect(chQueryMock).toHaveBeenCalledTimes(1)
+  })
+
+  test.each(['error_rate', 'latency_p95'])(
+    '%s keeps the window as its gate — it can rise without new traffic',
+    async (type) => {
+      alertsResultMock.mockReturnValue({
+        data: [budgetAlert({ type, window_minutes: THIRTY_DAYS_MIN })],
+        error: null,
+      })
+      lastSuccessfulRunAtMock.mockResolvedValue(new Date(Date.now() - 15 * 60 * 1000))
+      getOrgActivitySinceMock.mockResolvedValue(
+        new Map([[ORG, Date.now() - 21 * 24 * 60 * 60 * 1000]]),
+      )
+      chQueryMock.mockResolvedValue({ json: async () => [{ total: '1', errors: '0', p95: '1' }] })
+
+      await runEvaluateAlertsJob()
+
+      expect(chQueryMock).toHaveBeenCalledTimes(1)
+    },
+  )
 })

--- a/apps/server/src/api/cron.ts
+++ b/apps/server/src/api/cron.ts
@@ -113,8 +113,19 @@ cronRouter.get('/evaluate-alerts', async (c) => {
 
   const start = Date.now()
   const result = await runEvaluateAlertsJob()
-  await logCronRun('evaluate-alerts', 'ok', Date.now() - start)
-  return c.json(result)
+  // A run where a metric could not be computed is not a success. Budget
+  // alerts gate their ClickHouse read on "anything new since the last
+  // successful run" (lib/cron-jobs/evaluate-alerts.ts gateStartFor), so
+  // stamping a partial run as ok would move that gate past alerts this run
+  // never actually evaluated, silencing them until new traffic arrived.
+  const failed = result.metric_errors > 0
+  await logCronRun(
+    'evaluate-alerts',
+    failed ? 'error' : 'ok',
+    Date.now() - start,
+    failed ? `${result.metric_errors} metric(s) failed to compute` : undefined,
+  )
+  return c.json({ ...result, success: !failed })
 })
 
 // ── Paddle usage overage reporting (daily) ──────────────────────

--- a/apps/server/src/lib/cron-jobs/evaluate-alerts.ts
+++ b/apps/server/src/lib/cron-jobs/evaluate-alerts.ts
@@ -17,6 +17,7 @@
 
 import { getOrgClickhouse } from '../clickhouse.js'
 import { getOrgActivitySince, orgActiveSince, type OrgActivityMap } from '../org-activity.js'
+import { lastSuccessfulRunAt } from '../cron-cadence.js'
 import { supabaseAdmin } from '../db.js'
 import { deliverToChannel, type AlertNotification } from '../notifiers.js'
 import { emitWebhookEvent } from '../webhook-emit.js'
@@ -58,11 +59,52 @@ export interface EvaluateAlertsJobResult {
   success: boolean
   evaluated: number
   report: Array<{ alert_id: string; fired: boolean; reason?: string }>
+  /**
+   * Metrics that could not be computed (ClickHouse or Supabase error), as
+   * opposed to metrics that legitimately found no data. The caller logs the
+   * run as failed when this is non-zero so `lastSuccessfulRunAt` does not
+   * advance — budget alerts gate on it, and moving it past a run that never
+   * actually evaluated them would silence them until new traffic arrived.
+   */
+  metric_errors: number
+}
+
+/** Mutable per-run counters threaded through computeMetric. */
+interface RunStats {
+  metricErrors: number
+}
+
+/**
+ * Earliest moment new traffic could change this alert's verdict.
+ *
+ * For most metrics that is simply the start of the alert's window. `budget`
+ * is the exception, and it matters because budget alerts are the ones with
+ * long windows — a monthly spend cap runs a 30-day window, which any org
+ * that sent a single request in the last month falls inside. Gating on the
+ * window alone leaves those alerts querying ClickHouse every 15 minutes
+ * forever, which is the whole cost problem (lib/org-activity.ts).
+ *
+ * A budget metric is `sum(cost_usd)` over a sliding window, so with no new
+ * rows it can only fall as old rows age out. If the previous run did not
+ * breach, neither can this one. So for budget the gate moves forward to the
+ * last successful run.
+ *
+ * error_rate and latency_p95 deliberately keep the window as their gate:
+ * both are ratios or quantiles that CAN rise as old rows leave, so "no new
+ * traffic" does not imply "no new breach". Their natural windows are short
+ * anyway (an hour), which the watermark already handles well.
+ */
+function gateStartFor(alert: AlertRow, windowStart: Date, lastRun: Date | null): Date {
+  if (alert.type !== 'budget') return windowStart
+  if (!lastRun || lastRun.getTime() <= windowStart.getTime()) return windowStart
+  return lastRun
 }
 
 async function computeMetric(
   alert: AlertRow,
   activity: OrgActivityMap | null,
+  lastRun: Date | null,
+  stats: RunStats,
 ): Promise<number | null> {
   // eval_score reads from Supabase (eval_runs), not ClickHouse. It is the
   // mean of completed runs' avg_score over the window. Returns null when no
@@ -84,6 +126,7 @@ async function computeMetric(
         alertId: alert.id,
         kind: 'compute_metric_eval_score',
       }, error)
+      stats.metricErrors++
       return null
     }
     const scores = (data ?? [])
@@ -95,16 +138,21 @@ async function computeMetric(
 
   const windowStartDate = new Date(Date.now() - alert.window_minutes * 60 * 1000)
 
-  // Nothing was logged for this org inside the window, so ClickHouse would
-  // return an empty aggregate. Short-circuiting to the empty-result value
-  // is not just an optimisation: querying anyway resets ClickHouse Cloud's
-  // 15-minute idle timer and is what used to keep the service billed around
-  // the clock (lib/org-activity.ts). The three ClickHouse-backed metrics all
-  // collapse to 0 on no rows — budget sums nothing, error_rate divides by a
-  // zero total and returns 0, p95 of an empty set reads as 0 — so this is
-  // the same number the query would have produced, and the threshold
-  // comparison below stays untouched.
-  if (!orgActiveSince(activity, alert.organization_id, windowStartDate)) return 0
+  // No new traffic since the gate, so this alert cannot newly breach and the
+  // ClickHouse query is skipped. That is not just an optimisation: querying
+  // anyway resets ClickHouse Cloud's 15-minute idle timer, which is what kept
+  // the service billed around the clock (lib/org-activity.ts).
+  //
+  // 0 is the right stand-in for two different reasons depending on the gate.
+  // When the gate is the window start, it is literally what ClickHouse would
+  // have returned: budget sums nothing, error_rate divides by a zero total,
+  // p95 of an empty set reads as 0. When the gate is the last run (budget
+  // only — see gateStartFor), the true sum may still be non-zero, but it is
+  // no higher than it was on the run that already decided not to fire, so 0
+  // reaches the same verdict. The value is not surfaced on a non-firing
+  // alert, so nothing downstream reads it.
+  if (!orgActiveSince(activity, alert.organization_id, gateStartFor(alert, windowStartDate, lastRun)))
+    return 0
 
   const windowStart = windowStartDate
     .toISOString()
@@ -165,6 +213,7 @@ async function computeMetric(
       alertId: alert.id,
       kind: 'compute_metric',
     }, err)
+    stats.metricErrors++
     return null
   }
 }
@@ -192,6 +241,11 @@ export async function runEvaluateAlertsJob(): Promise<EvaluateAlertsJobResult> {
       ? await getOrgActivitySince(new Date(Date.now() - widestWindowMinutes * 60 * 1000))
       : null
 
+  // Budget alerts gate on the later of their window and this — see
+  // gateStartFor. Only fetched when there is something to evaluate.
+  const lastRun = alertRows.length > 0 ? await lastSuccessfulRunAt('evaluate-alerts') : null
+  const stats: RunStats = { metricErrors: 0 }
+
   // Phase 1: evaluate metrics
   for (const alert of alertRows) {
     if (alert.last_triggered_at) {
@@ -202,7 +256,7 @@ export async function runEvaluateAlertsJob(): Promise<EvaluateAlertsJobResult> {
       }
     }
 
-    const current = await computeMetric(alert, activity)
+    const current = await computeMetric(alert, activity, lastRun, stats)
     if (current == null) {
       // No data in the window (or a metric error) — can't assert a breach.
       report.push({ alert_id: alert.id, fired: false, reason: 'no_data' })
@@ -217,7 +271,7 @@ export async function runEvaluateAlertsJob(): Promise<EvaluateAlertsJobResult> {
   }
 
   if (firingAlerts.length === 0) {
-    return { success: true, evaluated: report.length, report }
+    return { success: true, evaluated: report.length, report, metric_errors: stats.metricErrors }
   }
 
   // Phase 2: batch-fetch channels + org names
@@ -298,5 +352,5 @@ export async function runEvaluateAlertsJob(): Promise<EvaluateAlertsJobResult> {
     report.push({ alert_id: alert.id, fired: true })
   }
 
-  return { success: true, evaluated: report.length, report }
+  return { success: true, evaluated: report.length, report, metric_errors: stats.metricErrors }
 }


### PR DESCRIPTION
The last one. Found by measuring production after #472 and #473 deployed.

## What the measurement showed

ClickHouse traffic from the server, per 15-minute bucket:

```
01:45  14      03:00  15
02:00   8      03:15  13      04:15   1   ← #472 live
02:15  13      03:30   6      04:30   1
02:30   3      03:45  13
02:45   5      04:00  22
```

Down from 13-22 to exactly one — and the one was always the same statement:

```sql
SELECT sum(cost_usd) AS total FROM requests WHERE organization_id = '1f6874…'
```

A budget alert with `window_minutes = 43200` (30 days). Any org that sent a single request in the last month sits inside that window, so the window gate never bites. One query every 15 minutes is all it takes to hold ClickHouse Cloud out of its idle window, so this alone would have kept the bill where it was.

The other two ClickHouse-backed alerts on that org were already being skipped correctly — that is what took the run from three queries to one. They use 60-minute windows and the org has been silent since July 27.

## The fix

Budget gets the same treatment quota warnings got in #473: gate on the later of the window start and the last successful run.

Sound for this metric specifically. `sum(cost_usd)` over a sliding window can only fall as old rows age out, so if the previous run did not breach, neither can this one without new rows.

`error_rate` and `latency_p95` deliberately keep the window as their gate. Both can rise as old rows leave — dropping aged-out successes lifts the error rate, dropping aged-out fast requests lifts p95 — so "no new traffic" does not imply "no new breach" for them. Their natural windows are short, which the watermark already handles. Tests pin that distinction in both directions.

## What makes it safe

Same pairing as #473: the route now logs the run as an error when a metric could not be computed. Without it, `lastSuccessfulRunAt` would advance past a run that never evaluated the budget alert, silencing it until new traffic arrived. `runEvaluateAlertsJob` gains `metric_errors` so a failed metric is distinguishable from one that legitimately found no data.

## Test plan

- [x] `pnpm --filter server typecheck`
- [x] `pnpm --filter server test` — 1685 passing, 143 files
- [x] `pnpm --filter server lint`
- [x] `pnpm --filter server build`
- [ ] After deploy: `system.query_log` for user `default` should show 15-minute buckets with zero rows, and gaps longer than 15 minutes should finally appear
- [ ] After 24h: console Usage breakdown daily compute against the $8.805 baseline
