### PR TITLE
fix(server): give ClickHouse queries room to survive a cold start

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -73,6 +73,13 @@ CLICKHOUSE_URL=http://localhost:8123
 CLICKHOUSE_USER=spanlens
 CLICKHOUSE_PASSWORD=spanlens
 CLICKHOUSE_DB=spanlens
+# Optional. How long a ClickHouse request may take before the client gives up,
+# in milliseconds. Defaults to 60000. The library default is 30s, which is too
+# tight now that the service is allowed to idle-suspend: waking a suspended
+# ClickHouse Cloud service takes tens of seconds and a cron that hits one
+# mid-wake fails on the timeout rather than on anything real. Raise this if
+# cold starts get slower; the cron function's own limit is 300s.
+# CLICKHOUSE_REQUEST_TIMEOUT_MS=60000
 
 # 4B.2 — Spanlens dogfoods itself. When both vars are set the
 # eval-runner posts a `eval_run` trace to a dedicated "spanlens-team"

--- a/apps/server/src/__tests__/clickhouse-timeout.test.ts
+++ b/apps/server/src/__tests__/clickhouse-timeout.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+/**
+ * ClickHouse request timeouts.
+ *
+ * The library default is 30s. That was invisible for as long as the service
+ * was awake around the clock, and became a real failure the moment the cron
+ * fleet stopped waking it: a suspended ClickHouse Cloud service takes tens of
+ * seconds to come back, and the first cron to hit a sleeping one died at
+ * exactly 30014ms — the default timeout, not a fault.
+ *
+ * Two opposite deadlines matter here and it is easy to regress one while
+ * fixing the other, so both are pinned:
+ *
+ *   - queries get a WIDE timeout so a cold start finishes
+ *   - the health ping gets a SHORT one, because a probe that patiently hangs
+ *     for a minute is worse than one that answers "not ready" immediately.
+ *     Better Stack polls /health/deep every three minutes.
+ */
+
+const createClientMock = vi.fn()
+const pingMock = vi.fn()
+
+vi.mock('@clickhouse/client', () => ({
+  createClient: (config: unknown) => {
+    createClientMock(config)
+    return { ping: pingMock }
+  },
+}))
+
+const ENV_KEYS = [
+  'CLICKHOUSE_URL',
+  'CLICKHOUSE_USER',
+  'CLICKHOUSE_PASSWORD',
+  'CLICKHOUSE_REQUEST_TIMEOUT_MS',
+] as const
+const origEnv = new Map(ENV_KEYS.map((k) => [k, process.env[k]]))
+
+async function loadModule() {
+  const mod = await import('../lib/clickhouse.js')
+  mod.resetClickhouseClient()
+  return mod
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  createClientMock.mockReset()
+  pingMock.mockReset()
+  process.env['CLICKHOUSE_URL'] = 'http://localhost:8123'
+  process.env['CLICKHOUSE_USER'] = 'default'
+  process.env['CLICKHOUSE_PASSWORD'] = 'test'
+  delete process.env['CLICKHOUSE_REQUEST_TIMEOUT_MS']
+})
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const orig = origEnv.get(key)
+    if (orig === undefined) delete process.env[key]
+    else process.env[key] = orig
+  }
+})
+
+function configPassedToCreateClient(): { request_timeout?: number } {
+  return createClientMock.mock.calls[0]?.[0] as { request_timeout?: number }
+}
+
+describe('client request_timeout', () => {
+  test('defaults to 60s so a cold start has room to finish', async () => {
+    const mod = await loadModule()
+    mod.unscopedClickhouse()
+    expect(configPassedToCreateClient().request_timeout).toBe(60_000)
+  })
+
+  test('is overridable without a deploy', async () => {
+    process.env['CLICKHOUSE_REQUEST_TIMEOUT_MS'] = '90000'
+    const mod = await loadModule()
+    mod.unscopedClickhouse()
+    expect(configPassedToCreateClient().request_timeout).toBe(90_000)
+  })
+
+  test.each(['nonsense', '0', '-1', ''])(
+    'falls back to the default for the unusable value %o',
+    async (value) => {
+      process.env['CLICKHOUSE_REQUEST_TIMEOUT_MS'] = value
+      const mod = await loadModule()
+      mod.unscopedClickhouse()
+      expect(configPassedToCreateClient().request_timeout).toBe(60_000)
+    },
+  )
+})
+
+describe('pingClickhouse deadline', () => {
+  test('aborts on its own short deadline, not the client-wide one', async () => {
+    pingMock.mockResolvedValue({ success: true })
+    const mod = await loadModule()
+
+    await mod.pingClickhouse()
+
+    const params = pingMock.mock.calls[0]?.[0] as {
+      select: boolean
+      abort_signal: AbortSignal
+    }
+    // `select: false` keeps this on the HTTP /ping endpoint rather than a
+    // SELECT — a real query would reset the idle timer this whole effort
+    // exists to let expire.
+    expect(params.select).toBe(false)
+    expect(params.abort_signal).toBeInstanceOf(AbortSignal)
+    expect(params.abort_signal.aborted).toBe(false)
+  })
+
+  test('still reports false rather than throwing when the deadline fires', async () => {
+    pingMock.mockRejectedValue(new Error('The operation was aborted due to timeout'))
+    const mod = await loadModule()
+    await expect(mod.pingClickhouse()).resolves.toBe(false)
+  })
+})

--- a/apps/server/src/lib/clickhouse.ts
+++ b/apps/server/src/lib/clickhouse.ts
@@ -16,6 +16,37 @@ import { createClient, type ClickHouseClient } from '@clickhouse/client'
 
 let _client: ClickHouseClient | null = null
 
+/**
+ * How long a ClickHouse request may take before the client gives up.
+ *
+ * The library default is 30s, which was invisible while the service was
+ * awake around the clock. Once the cron fleet stopped waking it
+ * (lib/org-activity.ts), ClickHouse Cloud started actually suspending, and
+ * a suspended service takes tens of seconds to come back. The first cron to
+ * hit a sleeping service after that change died at exactly 30014ms —
+ * the default timeout, not a real fault.
+ *
+ * 60s clears a normal cold start with room to spare and still sits well
+ * under the 300s maxDuration on the cron function, so a genuinely stuck
+ * query still fails inside the request rather than hanging the platform.
+ * Overridable for ops without a deploy.
+ */
+const DEFAULT_REQUEST_TIMEOUT_MS = 60_000
+
+/**
+ * Deadline for the health-check ping specifically — see `pingClickhouse`.
+ * A probe wants a fast honest answer, not a patient one.
+ */
+const PING_TIMEOUT_MS = 5_000
+
+function readRequestTimeoutMs(): number {
+  const raw = process.env['CLICKHOUSE_REQUEST_TIMEOUT_MS']
+  if (!raw) return DEFAULT_REQUEST_TIMEOUT_MS
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_REQUEST_TIMEOUT_MS
+}
+
+
 interface ClickhouseEnv {
   url: string
   username: string
@@ -75,6 +106,7 @@ export function unscopedClickhouse(): ClickHouseClient {
     password: env.password,
     database: env.database,
     compression: { request: true, response: true },
+    request_timeout: readRequestTimeoutMs(),
     clickhouse_settings: {
       // async_insert lets the server batch INSERTs server-side, which is the
       // recommended pattern for high-volume log ingestion. wait_for_async_insert=0
@@ -136,7 +168,16 @@ export function resetClickhouseClient(): void {
  */
 export async function pingClickhouse(): Promise<boolean> {
   try {
-    const result = await unscopedClickhouse().ping()
+    // Short, explicit deadline instead of the client-wide request_timeout.
+    // The wide one exists so cron queries survive a cold start; a health
+    // probe wants the opposite. Better Stack polls /health/deep every three
+    // minutes, so inheriting a 60s timeout would turn one sleeping service
+    // into a minute-long hanging health check and a worse status page than
+    // the honest fast "not ready".
+    const result = await unscopedClickhouse().ping({
+      select: false,
+      abort_signal: AbortSignal.timeout(PING_TIMEOUT_MS),
+    })
     return result.success
   } catch {
     return false


### PR DESCRIPTION
Fallout from #471-#475 working. Letting ClickHouse Cloud idle again brought back a failure the always-on period had hidden.

## What broke

A suspended ClickHouse Cloud service takes tens of seconds to come back. The client's default request timeout is 30s, so the first cron to hit a sleeping service loses the race.

Production, two hours after the gating landed:

```
detect-data-silence   error   30014ms   "Timeout error."
```

30014ms is the default timeout to the millisecond. Nothing was wrong except the deadline.

## The two deadlines

**Queries get 60s** (`CLICKHOUSE_REQUEST_TIMEOUT_MS` to override without a deploy). Clears a normal cold start with room to spare, and still sits well under the 300s `maxDuration` on the cron function, so a genuinely stuck query fails inside its own request rather than hanging the platform.

**The health ping deliberately does not inherit that.** A probe wants a fast honest answer, not a patient one — Better Stack polls `/health/deep` every three minutes, and a 60s hang would turn one sleeping service into a minute-long health check and a worse status page than an immediate "not ready". `pingClickhouse` passes its own 5s `AbortSignal`.

It also keeps `select: false` so it stays on the HTTP `/ping` endpoint. A SELECT would reset the very idle timer this whole effort exists to let expire — the exact regression that cost $232/month in July (see the `pingClickhouse` docstring). Both properties are pinned by tests, because fixing one of these deadlines while regressing the other is the easy mistake here.

## Scope

This does not remove the exposure, it makes it survivable. The crons that still read ClickHouse without an activity gate — `recommend-savings-alerts`, `snapshot-anomalies`, `events-reconciliation`, `check-past-due-downgrades`, and the weekly pair — will each pay a cold start now. They will pay it successfully instead of erroring. Gating them is separate work, tracked in the #475 description.

Worth stating plainly: dashboard reads after an idle period are now slow too, for the same reason. That is inherent to letting the service sleep, not something this PR can fix.

## Test plan

- [x] `pnpm --filter server typecheck`
- [x] `pnpm --filter server test` — 1703 passing, 145 files
- [x] `pnpm --filter server lint`
- [x] `pnpm --filter server build`
- [ ] After deploy: next `detect-data-silence` / `snapshot-anomalies` run against a sleeping service should complete instead of logging `Timeout error.`

New `clickhouse-timeout.test.ts` covers the default, the env override, unusable override values, and both ping properties.
