### PR TITLE
fix(server): gate the last three ClickHouse crons on the activity watermark

### DIFF
--- a/apps/server/src/__tests__/anomaly-snapshot-gate.test.ts
+++ b/apps/server/src/__tests__/anomaly-snapshot-gate.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+/**
+ * snapshot-anomalies × activity watermark.
+ *
+ * This job opened its day with `SELECT DISTINCT organization_id FROM requests`
+ * — an unbounded scan, issued daily, against a service that is now allowed to
+ * be asleep. On 2026-08-19 it consumed the entire 60s request budget and still
+ * failed ("Failed to fetch active orgs: Timeout error."), having paid for the
+ * wake-up regardless.
+ *
+ * The watermark holds that exact answer in Postgres. What is pinned here:
+ *
+ *   - no active orgs → ClickHouse is never touched
+ *   - active orgs → they are still analysed
+ *   - unreadable watermark → the original scan still runs, because skipping a
+ *     day of anomaly detection is worse than one wake-up
+ */
+
+const chQueryMock = vi.fn()
+const getOrgActivitySinceMock = vi.fn()
+const detectAnomaliesMock = vi.fn()
+
+vi.mock('../lib/clickhouse.js', () => ({
+  unscopedClickhouse: () => ({ query: chQueryMock }),
+}))
+
+vi.mock('../lib/db.js', () => ({
+  supabaseAdmin: { from: () => ({ upsert: async () => ({ error: null }) }) },
+}))
+
+vi.mock('../lib/anomaly.js', () => ({
+  detectAnomalies: (orgId: string) => detectAnomaliesMock(orgId),
+  ANOMALY_DEFAULTS: {
+    OBSERVATION_HOURS: 1,
+    REFERENCE_HOURS: 24,
+    SIGMA_THRESHOLD: 3,
+    HIGH_SEVERITY_SIGMA: 5,
+  },
+}))
+
+vi.mock('../lib/notifiers.js', () => ({ deliverToChannel: vi.fn() }))
+
+vi.mock('../lib/org-activity.js', () => ({
+  getOrgActivitySince: (since: Date) => getOrgActivitySinceMock(since),
+}))
+
+const ORG = '00000000-0000-4000-8000-000000000001'
+
+let snapshotAnomaliesForAllOrgs:
+  typeof import('../lib/anomaly-snapshot.js').snapshotAnomaliesForAllOrgs
+
+beforeEach(async () => {
+  vi.resetModules()
+  chQueryMock.mockReset()
+  getOrgActivitySinceMock.mockReset()
+  detectAnomaliesMock.mockReset()
+  detectAnomaliesMock.mockResolvedValue([])
+  ;({ snapshotAnomaliesForAllOrgs } = await import('../lib/anomaly-snapshot.js'))
+})
+
+describe('snapshotAnomaliesForAllOrgs', () => {
+  test('never touches ClickHouse when no org has recent traffic', async () => {
+    getOrgActivitySinceMock.mockResolvedValue(new Map())
+
+    await expect(snapshotAnomaliesForAllOrgs()).resolves.toEqual([])
+
+    expect(chQueryMock).not.toHaveBeenCalled()
+    expect(detectAnomaliesMock).not.toHaveBeenCalled()
+  })
+
+  test('analyses the orgs the watermark reports as active', async () => {
+    getOrgActivitySinceMock.mockResolvedValue(new Map([[ORG, Date.now() - 60_000]]))
+
+    const results = await snapshotAnomaliesForAllOrgs()
+
+    // The org list came from Postgres, so the DISTINCT scan is gone entirely.
+    expect(chQueryMock).not.toHaveBeenCalled()
+    expect(detectAnomaliesMock).toHaveBeenCalledWith(ORG)
+    expect(results).toHaveLength(1)
+    expect(results[0]?.orgId).toBe(ORG)
+  })
+
+  test('falls back to the ClickHouse scan when the watermark is unreadable', async () => {
+    getOrgActivitySinceMock.mockResolvedValue(null)
+    chQueryMock.mockResolvedValue({ json: async () => [{ organization_id: ORG }] })
+
+    const results = await snapshotAnomaliesForAllOrgs()
+
+    expect(chQueryMock).toHaveBeenCalledTimes(1)
+    expect(detectAnomaliesMock).toHaveBeenCalledWith(ORG)
+    expect(results).toHaveLength(1)
+  })
+
+  test('asks the watermark for the same 24h window the scan used', async () => {
+    getOrgActivitySinceMock.mockResolvedValue(new Map())
+    const now = new Date('2026-08-19T12:00:00.000Z')
+
+    await snapshotAnomaliesForAllOrgs(now)
+
+    const since = getOrgActivitySinceMock.mock.calls[0]?.[0] as Date
+    expect(since.toISOString()).toBe('2026-08-18T12:00:00.000Z')
+  })
+})

--- a/apps/server/src/__tests__/anomaly-snapshot.test.ts
+++ b/apps/server/src/__tests__/anomaly-snapshot.test.ts
@@ -5,14 +5,23 @@ vi.mock('../lib/db.js', () => ({
   supabaseAdmin: { from: mockFrom },
 }))
 
-// snapshotAnomaliesForAllOrgs now queries ClickHouse for active orgs instead
-// of Supabase. Tests control which orgs come back via setActiveOrgsForCH.
+// The active-org list comes from the Postgres activity watermark
+// (lib/org-activity.ts). It used to be a `SELECT DISTINCT organization_id`
+// against ClickHouse, which stayed as the fallback for when the watermark
+// cannot be read — see anomaly-snapshot-gate.test.ts for both paths.
+// setActiveOrgs feeds whichever one the case under test exercises.
 const mockChQuery = vi.hoisted(() => vi.fn())
 vi.mock('../lib/clickhouse.js', () => ({
   unscopedClickhouse: () => ({ query: mockChQuery }),
 }))
 
-function setActiveOrgsForCH(orgIds: string[]): void {
+const mockGetOrgActivitySince = vi.hoisted(() => vi.fn())
+vi.mock('../lib/org-activity.js', () => ({
+  getOrgActivitySince: mockGetOrgActivitySince,
+}))
+
+function setActiveOrgs(orgIds: string[]): void {
+  mockGetOrgActivitySince.mockResolvedValue(new Map(orgIds.map((id) => [id, Date.now()])))
   mockChQuery.mockResolvedValue({
     json: () => Promise.resolve(orgIds.map((id) => ({ organization_id: id }))),
   })
@@ -73,8 +82,7 @@ function setupFrom({
   channels = [] as { kind: string; target: string }[],
   orgName = 'Test Org',
 } = {}) {
-  // Active-orgs discovery moved to ClickHouse — provide that response here too.
-  setActiveOrgsForCH(orgIds)
+  setActiveOrgs(orgIds)
   mockFrom.mockImplementation((table: string) => {
     if (table === 'anomaly_events') {
       return { upsert: () => Promise.resolve({ error: upsertError }) }
@@ -92,6 +100,7 @@ function setupFrom({
 beforeEach(() => {
   mockFrom.mockReset()
   mockChQuery.mockReset()
+  mockGetOrgActivitySince.mockReset()
   mockDetectAnomalies.mockReset()
   mockDeliverToChannel.mockReset()
 })

--- a/apps/server/src/__tests__/cron-cadence-wiring.test.ts
+++ b/apps/server/src/__tests__/cron-cadence-wiring.test.ts
@@ -42,6 +42,9 @@ const WATERMARK_GATED_JOB_SOURCES = [
   ['lib/cron-jobs/aggregate-usage.ts', 'anyActivitySince'],
   ['lib/cron-jobs/detect-missing-model-prices.ts', 'anyActivitySince'],
   ['lib/data-silence.ts', 'shouldScanClickhouse'],
+  ['lib/anomaly-snapshot.ts', 'getOrgActivitySince'],
+  ['lib/events-reconciliation.ts', 'anyActivitySince'],
+  ['lib/recommendation-notify.ts', 'getOrgActivitySince'],
 ] as const
 
 const cronSource = readFileSync(

--- a/apps/server/src/__tests__/events-reconciliation-gate.test.ts
+++ b/apps/server/src/__tests__/events-reconciliation-gate.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+/**
+ * events-reconciliation × activity watermark.
+ *
+ * The job compares row counts in `requests` and `events` over a 24h window.
+ * With no traffic in that window both counts are zero and the verdict is
+ * already known, so the two ClickHouse counts only serve to wake a suspended
+ * service. Measured 2026-08-19: this job spent 46s on a cold start to compare
+ * a handful of rows.
+ *
+ * The safety property is that a quiet window must still be reported as
+ * in-tolerance rather than as drift — a false "drift above threshold" would
+ * fail the cron and page for nothing.
+ */
+
+const chQueryMock = vi.fn()
+const anyActivitySinceMock = vi.fn()
+
+vi.mock('../lib/clickhouse.js', () => ({
+  unscopedClickhouse: () => ({ query: chQueryMock }),
+}))
+
+vi.mock('../lib/org-activity.js', () => ({
+  anyActivitySince: (since: Date) => anyActivitySinceMock(since),
+}))
+
+let mod: typeof import('../lib/events-reconciliation.js')
+
+beforeEach(async () => {
+  vi.resetModules()
+  chQueryMock.mockReset()
+  anyActivitySinceMock.mockReset()
+  mod = await import('../lib/events-reconciliation.js')
+})
+
+describe('computeReconciliation', () => {
+  test('skips both counts when nothing was logged in the window', async () => {
+    anyActivitySinceMock.mockResolvedValue(false)
+
+    const result = await mod.computeReconciliation()
+
+    expect(chQueryMock).not.toHaveBeenCalled()
+    expect(result.requestsCount).toBe(0)
+    expect(result.eventsCount).toBe(0)
+    expect(result.ratio).toBe(0)
+    // A quiet window is agreement, not drift.
+    expect(result.withinTolerance).toBe(true)
+  })
+
+  test('still compares when the window saw traffic', async () => {
+    anyActivitySinceMock.mockResolvedValue(true)
+    chQueryMock.mockResolvedValue({ json: async () => [{ c: '100' }] })
+
+    const result = await mod.computeReconciliation()
+
+    expect(chQueryMock).toHaveBeenCalledTimes(2)
+    expect(result.requestsCount).toBe(100)
+    expect(result.eventsCount).toBe(100)
+  })
+
+  test('compares anyway when the watermark is unreadable', async () => {
+    anyActivitySinceMock.mockResolvedValue(true) // fail-open contract
+    chQueryMock.mockResolvedValue({ json: async () => [{ c: '5' }] })
+
+    await mod.computeReconciliation()
+
+    expect(chQueryMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('gates on the start of the comparison window', async () => {
+    anyActivitySinceMock.mockResolvedValue(false)
+
+    const result = await mod.computeReconciliation()
+
+    const since = anyActivitySinceMock.mock.calls[0]?.[0] as Date
+    expect(since.toISOString()).toBe(result.windowFromUtc)
+  })
+
+  test('a quiet window does not fail the cron', async () => {
+    anyActivitySinceMock.mockResolvedValue(false)
+    await expect(mod.runReconciliationCron()).resolves.toMatchObject({
+      withinTolerance: true,
+    })
+  })
+})

--- a/apps/server/src/lib/anomaly-snapshot.ts
+++ b/apps/server/src/lib/anomaly-snapshot.ts
@@ -1,5 +1,6 @@
 import { supabaseAdmin } from './db.js'
 import { unscopedClickhouse } from './clickhouse.js'
+import { getOrgActivitySince } from './org-activity.js'
 import { detectAnomalies, ANOMALY_DEFAULTS, type AnomalyBucket } from './anomaly.js'
 import { deliverToChannel, type AlertNotification, type NotificationChannelRow } from './notifiers.js'
 
@@ -29,29 +30,46 @@ export async function snapshotAnomaliesForAllOrgs(
 
   // Pick orgs with at least one request in the past 24h — anomaly detection
   // needs traffic anyway, no point invoking it for inactive orgs.
-  // ClickHouse can DISTINCT cheaply, so we let the database deduplicate
-  // instead of pulling rows back to JS like the old Supabase pattern.
-  const sinceTs = new Date(now.getTime() - 86_400_000)
-    .toISOString()
-    .replace('T', ' ')
-    .replace('Z', '')
+  //
+  // This used to ask ClickHouse directly with a DISTINCT over `requests`.
+  // Once the cron fleet stopped holding ClickHouse awake (lib/org-activity.ts)
+  // that became the worst possible query to open the day with: an unbounded
+  // scan issued against a suspended service. On 2026-08-19 it took the whole
+  // 60s request budget and still failed, and the wake-up it paid for was
+  // billed either way.
+  //
+  // The Postgres activity watermark holds exactly this answer — which orgs
+  // logged a request, and when — and Postgres is awake regardless. When no
+  // org has traffic the job now returns without touching ClickHouse at all.
+  const since = new Date(now.getTime() - 86_400_000)
+  const activity = await getOrgActivitySince(since)
+
   let uniqueOrgIds: string[]
-  try {
-    const result = await unscopedClickhouse().query({
-      query:
-        'SELECT DISTINCT organization_id ' +
-        'FROM requests ' +
-        'WHERE created_at >= parseDateTime64BestEffort({since:String})',
-      query_params: { since: sinceTs },
-      format: 'JSONEachRow',
-    })
-    const rows = (await result.json()) as Array<{ organization_id: string }>
-    uniqueOrgIds = rows.map((r) => r.organization_id)
-  } catch (err) {
-    throw new Error(
-      `Failed to fetch active orgs: ${err instanceof Error ? err.message : String(err)}`,
-    )
+  if (activity !== null) {
+    uniqueOrgIds = [...activity.keys()]
+  } else {
+    // Watermark unreadable — fall back to the original ClickHouse scan rather
+    // than silently skipping a day of anomaly detection.
+    const sinceTs = since.toISOString().replace('T', ' ').replace('Z', '')
+    try {
+      const result = await unscopedClickhouse().query({
+        query:
+          'SELECT DISTINCT organization_id ' +
+          'FROM requests ' +
+          'WHERE created_at >= parseDateTime64BestEffort({since:String})',
+        query_params: { since: sinceTs },
+        format: 'JSONEachRow',
+      })
+      const rows = (await result.json()) as Array<{ organization_id: string }>
+      uniqueOrgIds = rows.map((r) => r.organization_id)
+    } catch (err) {
+      throw new Error(
+        `Failed to fetch active orgs: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
   }
+
+  if (uniqueOrgIds.length === 0) return []
 
   const results: SnapshotResult[] = []
 

--- a/apps/server/src/lib/events-reconciliation.ts
+++ b/apps/server/src/lib/events-reconciliation.ts
@@ -22,6 +22,7 @@
  */
 
 import { unscopedClickhouse } from './clickhouse.js'
+import { anyActivitySince } from './org-activity.js'
 
 const RECON_WINDOW_HOURS = 24
 const RECON_END_LAG_HOURS = 1
@@ -67,6 +68,25 @@ export async function computeReconciliation(): Promise<ReconciliationResult> {
   const params = {
     from_ts: fmt(windowFromUtc),
     to_ts: fmt(windowToUtc),
+  }
+
+  // Nothing was logged anywhere in the window, so both counts are zero and
+  // the comparison is already decided. Asking ClickHouse anyway wakes a
+  // suspended service for an answer we hold in Postgres — the activity
+  // watermark records every successful `requests` insert (lib/org-activity.ts),
+  // and a row is written to `events` on the same path, so "no activity" means
+  // neither table gained rows. `anyActivitySince` fails open, so an unreadable
+  // watermark still runs the real comparison.
+  if (!(await anyActivitySince(windowFromUtc))) {
+    return {
+      windowFromUtc: windowFromUtc.toISOString(),
+      windowToUtc: windowToUtc.toISOString(),
+      requestsCount: 0,
+      eventsCount: 0,
+      absDiff: 0,
+      ratio: 0,
+      withinTolerance: true,
+    }
   }
 
   const [requestsCount, eventsCount] = await Promise.all([

--- a/apps/server/src/lib/recommendation-notify.ts
+++ b/apps/server/src/lib/recommendation-notify.ts
@@ -1,5 +1,6 @@
 import { supabaseAdmin } from './db.js'
 import { recommendModelSwaps } from './model-recommend.js'
+import { getOrgActivitySince } from './org-activity.js'
 
 /**
  * High-confidence recommendation email alerts.
@@ -121,9 +122,25 @@ export async function sendHighConfidenceRecommendationAlerts(): Promise<Recommen
     return []
   }
 
+  // `recommendModelSwaps` runs a ClickHouse aggregation per org, so this loop
+  // used to wake a suspended service once for every organization on the
+  // platform — daily, whether or not any of them had sent a request. A
+  // recommendation needs HIGH_CONFIDENCE_MIN_SAMPLES calls inside the window
+  // to qualify, so an org with no traffic at all in that window cannot
+  // produce one. The watermark answers that from Postgres
+  // (lib/org-activity.ts); a null map means it was unreadable and every org
+  // is analysed exactly as before.
+  //
+  // Orgs skipped this way are omitted from the returned report rather than
+  // listed with zeroes: the report exists to show what the job did, and it
+  // did nothing for them.
+  const activity = await getOrgActivitySince(new Date(Date.now() - ANALYSIS_HOURS * 3_600_000))
+
   const results: RecommendNotifyResult[] = []
 
   for (const org of orgs) {
+    if (activity !== null && !activity.has(org.id)) continue
+
     const result: RecommendNotifyResult = { orgId: org.id, sent: 0, skipped: 0, errors: [] }
 
     try {


### PR DESCRIPTION
Measured on production the morning after the watermark shipped.

## What the measurement showed

Server queries against ClickHouse on Aug 19, whole day up to 04:45 UTC:

| bucket | queries | what |
|---|---|---|
| 00:00 – 02:00 | **0** | silent — the service was asleep |
| 02:00 | 20 | real customer traffic (INSERT) |
| 02:15 | 16 | real customer traffic (INSERT) |
| 02:45 | 2 | `events-reconciliation` |
| 03:00 | 3 | `check-quota-warnings` + `aggregate-usage` |
| 04:00 | 1 | `snapshot-anomalies` |

Two hours of total silence. The mechanism works. What remained were the daily jobs that still read ClickHouse unconditionally — each paying a cold start and holding the service open for the idle window afterwards.

## The three

**`snapshot-anomalies`** was the worst. It opened with

```sql
SELECT DISTINCT organization_id FROM requests WHERE created_at >= ...
```

An unbounded scan whose only purpose is "which orgs sent anything in the last 24h" — precisely what `org_activity` records. Against a suspended service it consumed the entire 60s request budget and **still failed** (`Failed to fetch active orgs: Timeout error.`), having paid for the wake-up either way. It now reads the watermark and returns without touching ClickHouse when nothing is active.

**`events-reconciliation`** compares row counts in `requests` and `events` over a 24h window. With no traffic in that window both counts are zero and the verdict is already known — 46s of cold start to compare a handful of rows. A quiet window now short-circuits to the in-tolerance result. That direction matters: reporting a quiet window as drift would fail the cron and page for nothing.

**`recommend-savings-alerts`** ran a ClickHouse aggregation per organization, daily, whether or not any had sent a request. A recommendation needs 100 samples inside the window to qualify, so an org with no traffic cannot produce one; those are skipped before the query.

## Fail-open, as everywhere else

A null watermark means every org is analysed exactly as before. `snapshot-anomalies` keeps the old `DISTINCT` scan as its fallback specifically because skipping a day of anomaly detection is worse than paying for one wake-up.

## Honest note on the numbers

Cost so far: Aug 16 $8.805, Aug 17 $8.805, Aug 18 $6.841, Aug 19 $1.159 through 04:45 UTC. The trend is real, but the billed figure does not reconcile cleanly with the query timeline — query_log accounts for roughly 1.5h of activity where billing shows 3.16h. Either a wake-up costs more than the 15-minute idle window suggests, or the in-period statement is approximate as the console warns. So this PR is not accompanied by a predicted daily figure; a few days of settled invoices will say.

## Test plan

- [x] `pnpm --filter server typecheck`
- [x] `pnpm --filter server test` — 1715 passing, 147 files
- [x] `pnpm --filter server lint`
- [x] `pnpm --filter server build`
- [ ] After deploy: the 04:00 `snapshot-anomalies` wake-up should disappear along with its timeout error, and `cron_job_runs` should stay all-ok

The existing `anomaly-snapshot` tests fed their org list through the ClickHouse mock, which is now the fallback rather than the primary path; they feed the watermark instead, and the ClickHouse path keeps its own coverage in the new gate test. `cron-cadence-wiring.test.ts` grows all three to its audited list.
