### PR TITLE
fix(db): correct Gemini flash and DeepSeek rates, seed five missing models

### DIFF
--- a/.claude/skills/model-price-refresh/SKILL.md
+++ b/.claude/skills/model-price-refresh/SKILL.md
@@ -190,11 +190,27 @@ Some price changes are scheduled rather than discovered. When you find one,
 write it into the migration header **and** tell the user to calendar it —
 a comment alone won't fire.
 
+A scheduled change is a *claim about the future*, so re-verify it on the page
+before acting on it. The 2026-09-01 Sonnet 5 increase sat here for a month and
+was then cancelled; applying it on the date, as written, would have
+over-reported every Sonnet 5 request by 50%.
+
 Currently pending:
 
-- **2026-09-01** — `claude-sonnet-5` introductory pricing ($2/$10, cache
-  0.20/2.50) expires. Standard is $3/$15, cache 0.30/3.75. Missing this
-  under-reports Sonnet 5 by 33%.
+- **2027-01-01** — `gemini-3.6-flash` and `gemini-3.7-flash` step off
+  introductory pricing (0.75 / 3.75 / cache 0.075) to 1.50 / 7.50 / 0.15.
+  Missing this under-reports both by 50%; applying it early over-reports by
+  2x. Both sides are pinned by a test in `model-prices-cache.test.ts`.
+- **Every run** — re-check the moving pointers, which go stale without any
+  announcement: `daybreak-blue-latest` / `daybreak-red-latest` (OpenAI
+  repoints these at each new flagship) and Mistral's `*-latest` family.
+
+Resolved, kept as a record of why:
+
+- ~~**2026-09-01** — `claude-sonnet-5` introductory pricing expires to $3/$15.~~
+  **Cancelled by Anthropic** (verified 2026-08-21, pricing-page note
+  `claude-sonnet-5-introductory-pricing`): $2/$10 with cache 0.20/2.50 is now
+  the standard price. Do not re-add.
 
 ## Reference
 

--- a/apps/server/src/lib/model-prices-cache.test.ts
+++ b/apps/server/src/lib/model-prices-cache.test.ts
@@ -172,6 +172,46 @@ describe('model-prices-cache', () => {
     expect(cyber?.longThreshold).toBeUndefined()
   })
 
+  test('Gemini flash fallback holds the introductory rates, not the 2027 ones', () => {
+    // Google publishes two prices per axis for these models: 0.75/3.75/0.075
+    // through 2026-12-31, then 1.50/7.50/0.15 from 2027-01-01. The 2026-08-11
+    // seed took the 2027 column, so every 3.6-flash request was over-reported
+    // by exactly 2x on all three axes until 2026-08-21. Pin both sides of the
+    // boundary: flipping early over-reports by 2x, flipping late under-reports
+    // by 50%. Source: ai.google.dev/gemini-api/docs/pricing?hl=en (2026-08-21).
+    const introductory = { prompt: 0.75, completion: 3.75, cacheRead: 0.075 }
+
+    for (const model of ['gemini-3.6-flash', 'gemini-3.7-flash']) {
+      const actual = cache.FALLBACK_PRICES[model]
+      expect(actual, `missing fallback for ${model}`).toBeDefined()
+      expect(actual, model).toEqual(introductory)
+      // The >200k split is a Pro-family thing. Flash has none, and inheriting
+      // one from a neighbouring row would silently double long requests.
+      expect(actual?.longThreshold, `${model} must have no long-context tier`).toBeUndefined()
+    }
+  })
+
+  test('grok-4.6 doubles every axis at 200k and does not inherit 4.5 cache rate', () => {
+    // xAI re-rates the WHOLE request at 2x once the prompt reaches 200k, so the
+    // long tier is just the short tier doubled — including cache. grok-4.6 and
+    // grok-4.5 share input/output but NOT the cache rate (0.50 vs 0.30), so
+    // copying the 4.5 row would misprice every 4.6 cache hit by 67%.
+    // Source: docs.x.ai/docs/models (verified 2026-08-21).
+    const grok46 = cache.FALLBACK_PRICES['grok-4.6']
+    expect(grok46, 'missing fallback for grok-4.6').toBeDefined()
+    expect(grok46).toEqual({
+      prompt: 2.0, completion: 6.0, cacheRead: 0.5,
+      longThreshold: 200000, longPrompt: 4.0, longCompletion: 12.0, longCacheRead: 1.0,
+    })
+
+    for (const axis of ['prompt', 'completion', 'cacheRead'] as const) {
+      const long = ({ prompt: 'longPrompt', completion: 'longCompletion', cacheRead: 'longCacheRead' } as const)[axis]
+      expect(grok46?.[long], `grok-4.6 ${long} must be 2x ${axis}`).toBe((grok46?.[axis] ?? 0) * 2)
+    }
+
+    expect(cache.FALLBACK_PRICES['grok-4.5']?.cacheRead, 'grok-4.5 cache rate is distinct').toBe(0.3)
+  })
+
   test('FALLBACK_PRICES stays provider-unambiguous', () => {
     // lookupPrice() consults FALLBACK_PRICES without a provider, which is only
     // safe while it holds direct-provider models exclusively. OpenRouter ids

--- a/apps/server/src/lib/model-prices-cache.ts
+++ b/apps/server/src/lib/model-prices-cache.ts
@@ -87,8 +87,11 @@ export const FALLBACK_PRICES: Record<string, ModelPrice> = {
   'gpt-5.6-luna':      { prompt: 0.2,  completion: 1.2, cacheRead: 0.02, cacheWrite: 0.25,
                          longThreshold: 272000, longPrompt: 0.4, longCompletion: 1.8,
                          longCacheRead: 0.04, longCacheWrite: 0.5 },
-  // Cyber (Daybreak) family — no long-context tier published.
+  // Cyber (Daybreak) family — no long-context tier published. gpt-5.5-cyber
+  // publishes no cache-write rate; gpt-5.4-cyber publishes no rates at all and
+  // is deliberately absent.
   'gpt-5.6-cyber':     { prompt: 12.5, completion: 75,  cacheRead: 1.25, cacheWrite: 15.625 },
+  'gpt-5.5-cyber':     { prompt: 12.5, completion: 75,  cacheRead: 1.25 },
   // ── OpenAI: GPT-5.x flagship ─────────────────────────────────────────────
   // gpt-5.5 / 5.5-pro / 5.4 / 5.4-pro have a long-context tier at ≥272k tokens.
   'gpt-5.5':           { prompt: 5.0,  completion: 30,  cacheRead: 0.5,
@@ -110,6 +113,7 @@ export const FALLBACK_PRICES: Record<string, ModelPrice> = {
   'gpt-5-mini':    { prompt: 0.25, completion: 2.0,  cacheRead: 0.025 },
   'gpt-5-nano':    { prompt: 0.05, completion: 0.4,  cacheRead: 0.005 },
   'gpt-5-pro':     { prompt: 15,   completion: 120 },
+  'gpt-5-search-api': { prompt: 1.25, completion: 10, cacheRead: 0.125 },
   'chat-latest':   { prompt: 5,    completion: 30,   cacheRead: 0.5 },
   // ── OpenAI: Reasoning (o-series) ─────────────────────────────────────────
   'o4-mini':       { prompt: 1.10, completion: 4.4,  cacheRead: 0.275 },
@@ -156,6 +160,7 @@ export const FALLBACK_PRICES: Record<string, ModelPrice> = {
   // Same rows live in supabase/seeds/model_prices.sql + the 20260612150000
   // migration. cache pricing not published by Mistral.
   'mistral-large-latest':         { prompt: 0.50, completion: 1.50 },
+  'zai-glm-5-2':                  { prompt: 1.40, completion: 4.40 },
   'mistral-medium-latest':        { prompt: 1.50, completion: 7.50 },
   'mistral-small-latest':         { prompt: 0.15, completion: 0.60 },
   'magistral-medium-latest':      { prompt: 2.00, completion: 5.00 },
@@ -181,12 +186,19 @@ export const FALLBACK_PRICES: Record<string, ModelPrice> = {
   'llama-3.1-8b-instant':         { prompt: 0.05,  completion: 0.08 },
   'openai/gpt-oss-120b':          { prompt: 0.15,  completion: 0.60, cacheRead: 0.075 },
   'openai/gpt-oss-20b':           { prompt: 0.075, completion: 0.30, cacheRead: 0.0375 },
+  // DeepSeek bills by time of day: peak (01:00-04:00 and 06:00-10:00 UTC) is
+  // exactly 2x off-peak. These are the OFF-PEAK rates, correct 17 hours of 24.
+  'deepseek-v4-flash':            { prompt: 0.22,  completion: 0.66, cacheRead: 0.007 },
+  'deepseek-v4-pro':              { prompt: 0.66,  completion: 1.98, cacheRead: 0.022 },
+  // Compatibility aliases, dropped from DeepSeek's docs 2026-08-21. Kept at
+  // their last published rates; the docs no longer say which v4 they resolve to.
   'deepseek-chat':                { prompt: 0.14,  completion: 0.28, cacheRead: 0.0028 },
   'deepseek-reasoner':            { prompt: 0.14,  completion: 0.28, cacheRead: 0.0028 },
-  'deepseek-v4-flash':            { prompt: 0.14,  completion: 0.28, cacheRead: 0.0028 },
-  'deepseek-v4-pro':              { prompt: 0.435, completion: 0.87, cacheRead: 0.003625 },
   'qwen/qwen3.6-27b':             { prompt: 0.60,  completion: 3.00 },
   // Grok re-rates the WHOLE request at 2x once the prompt reaches 200k.
+  // 4.6 and 4.5 share input/output but NOT the cache rate (0.50 vs 0.30).
+  'grok-4.6':                     { prompt: 2.00,  completion: 6.00, cacheRead: 0.50,
+                                    longThreshold: 200000, longPrompt: 4, longCompletion: 12, longCacheRead: 1.0 },
   'grok-4.5':                     { prompt: 2.00,  completion: 6.00, cacheRead: 0.30,
                                     longThreshold: 200000, longPrompt: 4, longCompletion: 12, longCacheRead: 0.6 },
   'grok-4.3':                     { prompt: 1.25,  completion: 2.50, cacheRead: 0.20,
@@ -202,8 +214,10 @@ export const FALLBACK_PRICES: Record<string, ModelPrice> = {
   'claude-mythos-5':              { prompt: 10,   completion: 50, cacheRead: 1.0,  cacheWrite: 12.5 }, // invite-only
   'claude-mythos-preview':        { prompt: 10,   completion: 50, cacheRead: 1.0,  cacheWrite: 12.5 }, // invite-only
   'claude-opus-5':                { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 },
-  // ⚠ INTRODUCTORY pricing through 2026-08-31. From 2026-09-01 Sonnet 5 is
-  // 3 / 15 / 0.30 / 3.75 — update here AND in a follow-up migration.
+  // Launched as introductory pricing through 2026-08-31, but Anthropic
+  // CANCELLED the 2026-09-01 rise to 3 / 15 — $2/$10 is the standard price now
+  // (verified 2026-08-21, note claude-sonnet-5-introductory-pricing). Do not
+  // "restore" 3 / 15 / 0.30 / 3.75: that over-reports Sonnet 5 by 50%.
   'claude-sonnet-5':              { prompt: 2,    completion: 10, cacheRead: 0.2,  cacheWrite: 2.5 },
   // ── Anthropic: Claude 4.x (aliases + dated variants) ─────────────────────
   'claude-opus-4-8':              { prompt: 5,    completion: 25, cacheRead: 0.5,  cacheWrite: 6.25 },
@@ -231,7 +245,11 @@ export const FALLBACK_PRICES: Record<string, ModelPrice> = {
   'claude-3-opus-20240229':       { prompt: 15,   completion: 75, cacheRead: 1.5,  cacheWrite: 18.75 },
   'claude-3-haiku-20240307':      { prompt: 0.25, completion: 1.25 }, // retired 2026-04-19, no cache
   // ── Gemini 3.x (Pro family has >200k tier) ───────────────────────────────
-  'gemini-3.6-flash':                       { prompt: 1.5,  completion: 7.5, cacheRead: 0.15 },
+  // 3.7-flash and 3.6-flash are on INTRODUCTORY pricing through 2026-12-31.
+  // From 2027-01-01 both become 1.5 / 7.5 / 0.15. Flipping early doubles the
+  // reported cost; flipping late halves it. Pinned by a test.
+  'gemini-3.7-flash':                       { prompt: 0.75, completion: 3.75, cacheRead: 0.075 },
+  'gemini-3.6-flash':                       { prompt: 0.75, completion: 3.75, cacheRead: 0.075 },
   'gemini-3.5-flash':                       { prompt: 1.5,  completion: 9,   cacheRead: 0.15 },
   'gemini-3.5-flash-lite':                  { prompt: 0.3,  completion: 2.5, cacheRead: 0.03 },
   'gemini-3.1-pro-preview':                 { prompt: 2.0,  completion: 12,  cacheRead: 0.2,

--- a/supabase/migrations/20260821120000_seed_models_2026_08b.sql
+++ b/supabase/migrations/20260821120000_seed_models_2026_08b.sql
@@ -1,0 +1,143 @@
+-- Model price refresh — 2026-08-21.
+--
+-- Verified against the official pricing pages on 2026-08-21:
+--   OpenAI    developers.openai.com/api/docs/pricing
+--   Anthropic platform.claude.com  (Pricing + Models overview)
+--   Gemini    ai.google.dev/gemini-api/docs/pricing?hl=en
+--   xAI       docs.x.ai/docs/models
+--   Groq      console.groq.com/docs/models
+--   Mistral   mistral.ai/pricing/api
+--   DeepSeek  api-docs.deepseek.com/quick_start/pricing
+--   Cohere    cohere.com/pricing + docs.cohere.com/docs/models
+--
+-- Why this migration exists — customer impact, worst first:
+--
+--   1. gemini-3.6-flash was over-reporting by exactly 2x on all three axes.
+--      Google's flash pricing is $0.75 / $3.75 / cache $0.075 THROUGH
+--      2026-12-31; the $1.50 / $7.50 / $0.15 numbers the 2026-08-11 seed used
+--      are the rates that start 2027-01-01. Flash is a high-volume family, so
+--      this is the largest dollar error in the audit.
+--
+--   2. DeepSeek replaced flat pricing with a time-of-day schedule, and both
+--      tiers are more expensive than what we had. That means we were UNDER-
+--      reporting: the customer's DeepSeek invoice was larger than the number
+--      our dashboard showed them, which is the worse direction to be wrong in.
+--
+--        model              off-peak (17h)          peak (7h)
+--        deepseek-v4-flash  0.22 / 0.66 / 0.007     0.44 / 1.32 / 0.014
+--        deepseek-v4-pro    0.66 / 1.98 / 0.022     1.32 / 3.96 / 0.044
+--
+--      Peak is 01:00-04:00 and 06:00-10:00 UTC and is exactly 2x off-peak.
+--      model_prices has one price per axis and no time dimension, so one of
+--      the two has to be wrong for part of the day. Seeding OFF-PEAK is
+--      correct for 17 of 24 hours (~15% mean absolute error against uniform
+--      traffic); seeding peak would be correct for 7 (~71%). The residual is a
+--      50% under-report during peak hours. The real fix is a time-of-day
+--      dimension on this table; revisit if DeepSeek volume grows.
+--
+--   3. Five models had no row at all, so their requests logged cost_usd = NULL
+--      and rendered as a gap in the dashboard (gotcha #2):
+--        - gemini-3.7-flash   Google's new flash flagship, same introductory
+--                             pricing window as 3.6-flash.
+--        - grok-4.6           xAI's new flagship. Note the cache rate is
+--                             $0.50, NOT grok-4.5's $0.30; copying the 4.5
+--                             row would have mispriced every cache hit.
+--        - gpt-5.5-cyber      Cyber table. Input/cached/output are published;
+--                             cache WRITE is blank on the page, so NULL.
+--        - gpt-5-search-api   Specialized models table.
+--        - zai-glm-5-2        new in Mistral's Specialized section.
+--
+-- NOT a price change, but the reason this migration is urgent:
+--   Anthropic CANCELLED the 2026-09-01 Sonnet 5 increase. The pricing page now
+--   reads: "The $2/$10 ... announced at launch as introductory pricing through
+--   August 31, 2026, is now the standard price. The previously scheduled
+--   increase to $3/$15 ... on September 1, 2026 will not occur."
+--   (note id: claude-sonnet-5-introductory-pricing)
+--   The DB rows were already correct at 2.00/10.00/0.20/2.50 and are untouched
+--   here. What was wrong was every *instruction to change them*: the seed
+--   mirror, FALLBACK_PRICES and the refresh skill's pending-obligations list
+--   all told the next reader to raise Sonnet 5 on 2026-09-01. This refresh
+--   routine runs on the 1st and 15th, so it would have fired on exactly that
+--   date and over-reported every Sonnet 5 request by 50%. All three are
+--   corrected in the same PR.
+--
+-- Deliberately NOT seeded:
+--   - gpt-5.4-cyber: every price cell in the Cyber table is blank for this
+--     row. There is no honest number to put in, and a NULL cost is a visible
+--     gap rather than a silent wrong answer.
+--   - Gemini modality-split models: output billed per image, per second or per
+--     character cannot be expressed by a single completion_price_per_1m.
+--     gemini-*-image, gemini-*-tts, gemini-3.1-flash-live-preview,
+--     gemini-3.5-live-translate-preview, and gemini-omni-flash-preview
+--     ($9.00/1M text vs $17.50/1M video output). Standing reason, unchanged
+--     from 20260811120000.
+--   - gemini-embedding-2's non-text input rates (image $0.45, audio $6.50,
+--     video $12.00). The row carries the text rate ($0.20) only.
+--   - xAI Imagine (per image / per second) and Voice (per minute / per char).
+--   - groq/compound and groq/compound-mini: billed at the underlying model's
+--     rates, no rate of their own. minimaxai/minimax-m2.7: "Contact Sales".
+--     Groq's Whisper (per hour) and Orpheus (per 1M characters) are not
+--     per-token.
+--   - Cohere command-a-plus-05-2026 and command-a-{reasoning,vision,translate}:
+--     still no public per-token price.
+--
+-- Dropped off their provider's pricing page since 2026-08-11; rows are KEPT so
+-- historical requests still price, and listed here so the next refresh does not
+-- re-add them as "missing":
+--   - groq:     llama-3.3-70b-versatile, llama-3.1-8b-instant,
+--               moonshotai/kimi-k2-instruct-0905 (catalogue shrank to 11)
+--   - deepseek: deepseek-chat, deepseek-reasoner. Gone from the docs entirely.
+--               These were compatibility aliases onto the current v4 model. If
+--               they still resolve, they are now under-reported, but the page
+--               no longer says WHICH v4 they point at and flash vs pro is a 3x
+--               spread, so guessing risks making it worse. Rows left at their
+--               old values; verify with a live API key.
+--   - cohere:   command-a-03-2025 and command-r7b-12-2024 no longer show a
+--               per-token price. Rows kept at their last published rates.
+--
+-- NEW dated obligation, 2027-01-01: gemini-3.6-flash and gemini-3.7-flash both
+-- step up to 1.50 / 7.50 / 0.15. Missing it under-reports both by 50%. Pinned
+-- by a test in model-prices-cache.test.ts so CI catches drift in either
+-- direction.
+--
+-- Idempotent: ON CONFLICT DO UPDATE on the (provider, model) unique index.
+
+INSERT INTO model_prices (
+  provider, model,
+  prompt_price_per_1m, completion_price_per_1m,
+  cache_read_price_per_1m, cache_write_price_per_1m
+) VALUES
+  -- Gemini: introductory flash pricing through 2026-12-31.
+  -- 3.6-flash was seeded with the 2027 rates by mistake; 3.7-flash is new.
+  -- Neither publishes a long-context tier (that split is Pro-only).
+  ('gemini', 'gemini-3.6-flash',        0.75,   3.75,   0.075,  NULL),
+  ('gemini', 'gemini-3.7-flash',        0.75,   3.75,   0.075,  NULL),
+  -- DeepSeek: off-peak rates (see header for the peak/off-peak choice).
+  ('deepseek', 'deepseek-v4-flash',     0.22,   0.66,   0.007,  NULL),
+  ('deepseek', 'deepseek-v4-pro',       0.66,   1.98,   0.022,  NULL),
+  -- xAI: new flagship. Cache is 0.50, not grok-4.5's 0.30.
+  ('xai', 'grok-4.6',                   2.00,   6.00,   0.50,   NULL),
+  -- OpenAI: Cyber + Specialized rows that were logging NULL.
+  -- gpt-5.5-cyber publishes no cache-write rate (blank cell on the page).
+  ('openai', 'gpt-5.5-cyber',          12.50,  75.00,   1.25,   NULL),
+  ('openai', 'gpt-5-search-api',        1.25,  10.00,   0.125,  NULL),
+  -- Mistral: GLM 5.2, new in the Specialized section.
+  ('mistral', 'zai-glm-5-2',            1.40,   4.40,   NULL,   NULL)
+ON CONFLICT (provider, model) DO UPDATE
+  SET prompt_price_per_1m      = EXCLUDED.prompt_price_per_1m,
+      completion_price_per_1m  = EXCLUDED.completion_price_per_1m,
+      cache_read_price_per_1m  = EXCLUDED.cache_read_price_per_1m,
+      cache_write_price_per_1m = EXCLUDED.cache_write_price_per_1m,
+      updated_at               = now();
+
+-- xAI grok-4.6: crossing 200k re-rates the ENTIRE request at 2x, not just the
+-- overage, which is exactly how long_context_threshold_tokens is applied, so it
+-- maps cleanly. All three axes double: 2.00 -> 4.00, 6.00 -> 12.00,
+-- 0.50 -> 1.00.
+UPDATE model_prices
+   SET long_context_threshold_tokens = 200000,
+       long_prompt_price_per_1m      =  4.00,
+       long_completion_price_per_1m  = 12.00,
+       long_cache_read_price_per_1m  =  1.00,
+       updated_at                    = now()
+ WHERE provider = 'xai' AND model = 'grok-4.6';

--- a/supabase/seeds/model_prices.sql
+++ b/supabase/seeds/model_prices.sql
@@ -28,6 +28,9 @@ INSERT INTO model_prices (
   ('openai', 'gpt-5.6-terra',                    2.00,  12.00,   0.20,   2.500),
   ('openai', 'gpt-5.6-luna',                     0.20,   1.20,   0.02,   0.250),
   ('openai', 'gpt-5.6-cyber',                   12.50,  75.00,   1.25,  15.625), -- Cyber (Daybreak); no long-context tier
+  ('openai', 'gpt-5.5-cyber',                   12.50,  75.00,   1.25,   NULL), -- Cyber; cache-write cell is blank on the page
+  -- gpt-5.4-cyber is deliberately absent: every price cell in its Cyber row is
+  -- blank, so there is no honest number to seed.
   ('openai', 'gpt-5.5',                          5.00,  30.00,   0.50,   NULL),
   ('openai', 'gpt-5.5-pro',                     30.00, 180.00,   NULL,   NULL),
   ('openai', 'gpt-5.4',                          2.50,  15.00,   0.25,   NULL),
@@ -43,6 +46,7 @@ INSERT INTO model_prices (
   ('openai', 'gpt-5-mini',                       0.25,   2.00,   0.025,  NULL),
   ('openai', 'gpt-5-nano',                       0.05,   0.40,   0.005,  NULL),
   ('openai', 'gpt-5-pro',                       15.00, 120.00,   NULL,   NULL),
+  ('openai', 'gpt-5-search-api',                 1.25,  10.00,   0.125,  NULL), -- Specialized models table
   ('openai', 'chat-latest',                      5.00,  30.00,   0.50,   NULL), -- ChatGPT alias
   -- ── OpenAI: Reasoning (o-series) ─────────────────────────────────────────
   ('openai', 'o4-mini',                          1.10,   4.40,   0.275,  NULL),
@@ -105,6 +109,7 @@ INSERT INTO model_prices (
   ('mistral', 'pixtral-large-latest',            2.00,   6.00,   NULL,   NULL), -- off the current pricing page
   ('mistral', 'pixtral-12b',                     0.15,   0.15,   NULL,   NULL), -- off the current pricing page
   ('mistral', 'voxtral-small-latest',            0.10,   0.40,   NULL,   NULL),
+  ('mistral', 'zai-glm-5-2',                     1.40,   4.40,   NULL,   NULL), -- GLM 5.2, Specialized section
   -- Listed as "Free" on the pricing page — 0, not NULL, so cost renders as $0
   -- rather than as missing data.
   ('mistral', 'mistral-moderation-2603',         0.00,   0.000,  NULL,   NULL),
@@ -112,27 +117,38 @@ INSERT INTO model_prices (
   ('mistral', 'mistral-embed',                   0.10,   0.000,  NULL,   NULL),
   ('mistral', 'codestral-embed',                 0.15,   0.000,  NULL,   NULL),
   -- ── Groq (OpenAI-compatible, api.groq.com/openai/v1) ─────────────────────
-  ('groq', 'llama-3.3-70b-versatile',                    0.59,  0.79,    NULL,     NULL),
-  ('groq', 'llama-3.1-8b-instant',                       0.05,  0.08,    NULL,     NULL),
   ('groq', 'openai/gpt-oss-120b',                        0.15,  0.60,    0.075,    NULL),
   ('groq', 'openai/gpt-oss-20b',                         0.075, 0.30,    0.0375,   NULL),
   ('groq', 'openai/gpt-oss-safeguard-20b',               0.075, 0.30,    NULL,     NULL),
   ('groq', 'qwen/qwen3.6-27b',                           0.60,  3.00,    NULL,     NULL),
-  ('groq', 'moonshotai/kimi-k2-instruct-0905',           1.00,  3.00,    0.50,     NULL),
   ('groq', 'meta-llama/llama-prompt-guard-2-22m',        0.03,  0.03,    NULL,     NULL),
   ('groq', 'meta-llama/llama-prompt-guard-2-86m',        0.04,  0.04,    NULL,     NULL),
-  -- Off the current Groq catalogue (2026-08-11) — kept so historical rows
-  -- still price correctly, but Groq appears to have stopped serving them.
+  -- Off the current Groq catalogue — kept so historical rows still price
+  -- correctly, but Groq has stopped serving them. Do not re-add as "missing".
+  -- Dropped by 2026-08-11: llama-4-scout, qwen3-32b.
+  -- Dropped by 2026-08-21: llama-3.3-70b-versatile, llama-3.1-8b-instant,
+  -- kimi-k2-instruct-0905 (the catalogue shrank to 11 entries).
   ('groq', 'meta-llama/llama-4-scout-17b-16e-instruct',  0.11,  0.34,    NULL,     NULL),
   ('groq', 'qwen/qwen3-32b',                             0.29,  0.59,    NULL,     NULL),
+  ('groq', 'llama-3.3-70b-versatile',                    0.59,  0.79,    NULL,     NULL),
+  ('groq', 'llama-3.1-8b-instant',                       0.05,  0.08,    NULL,     NULL),
+  ('groq', 'moonshotai/kimi-k2-instruct-0905',           1.00,  3.00,    0.50,     NULL),
   -- ── DeepSeek (OpenAI-compatible, api.deepseek.com/v1) ────────────────────
+  -- DeepSeek bills by time of day: peak is 01:00-04:00 and 06:00-10:00 UTC and
+  -- costs exactly 2x off-peak. This table has no time dimension, so these are
+  -- the OFF-PEAK rates (correct 17 of 24 hours). Peak requests are under-
+  -- reported by 50% until the table grows a time-of-day column.
+  ('deepseek', 'deepseek-v4-flash',                      0.22,  0.66,    0.007,    NULL),
+  ('deepseek', 'deepseek-v4-pro',                        0.66,  1.98,    0.022,    NULL),
+  -- Compatibility aliases, gone from the docs as of 2026-08-21. Kept at their
+  -- last published rates so historical requests still price; the page no longer
+  -- says which v4 model they resolve to, so they are NOT updated on a guess.
   ('deepseek', 'deepseek-chat',                          0.14,  0.28,    0.0028,   NULL),
   ('deepseek', 'deepseek-reasoner',                      0.14,  0.28,    0.0028,   NULL),
-  ('deepseek', 'deepseek-v4-flash',                      0.14,  0.28,    0.0028,   NULL),
-  ('deepseek', 'deepseek-v4-pro',                        0.435, 0.87,    0.003625, NULL),
   -- ── xAI / Grok (OpenAI-compatible, api.x.ai/v1) ──────────────────────────
   -- Every Grok model doubles ALL token rates once the prompt reaches 200k —
   -- modelled with the long_* columns at the bottom of this file.
+  ('xai', 'grok-4.6',                                    2.00,  6.00,    0.50,     NULL), -- cache is 0.50 here, not 4.5's 0.30
   ('xai', 'grok-4.5',                                    2.00,  6.00,    0.30,     NULL),
   ('xai', 'grok-4.3',                                    1.25,  2.50,    0.20,     NULL),
   ('xai', 'grok-4.20-0309-reasoning',                    1.25,  2.50,    0.20,     NULL),
@@ -140,6 +156,10 @@ INSERT INTO model_prices (
   ('xai', 'grok-4.20-multi-agent-0309',                  1.25,  2.50,    0.20,     NULL),
   ('xai', 'grok-build-0.1',                              1.00,  2.00,    0.20,     NULL),
   -- ── Cohere (OpenAI-compatible, api.cohere.ai/compatibility/v1) ───────────
+  -- As of 2026-08-21 cohere.com/pricing only lists legacy models; command-a and
+  -- command-r7b no longer show a per-token price. Rows kept at their last
+  -- published rates. command-a-plus-05-2026 and the command-a-{reasoning,
+  -- vision,translate} variants are still deliberately unseeded (no public rate).
   ('cohere', 'command-a-03-2025',                        2.50,  10.00,   NULL,     NULL),
   ('cohere', 'command-r-plus-08-2024',                   2.50,  10.00,   NULL,     NULL),
   ('cohere', 'command-r-08-2024',                        0.15,  0.60,    NULL,     NULL),
@@ -150,8 +170,10 @@ INSERT INTO model_prices (
   ('anthropic', 'claude-mythos-5',              10.00,  50.00,   1.00,  12.50),
   ('anthropic', 'claude-mythos-preview',        10.00,  50.00,   1.00,  12.50),
   ('anthropic', 'claude-opus-5',                 5.00,  25.00,   0.50,   6.25),
-  -- ⚠ INTRODUCTORY pricing through 2026-08-31. From 2026-09-01 this becomes
-  -- 3.00 / 15.00 / 0.30 / 3.75 — flip it or we under-report Sonnet 5 by 33%.
+  -- Launched as introductory pricing through 2026-08-31. Anthropic CANCELLED
+  -- the scheduled 2026-09-01 rise to 3.00 / 15.00 — $2/$10 is now the standard
+  -- price (verified 2026-08-21, note claude-sonnet-5-introductory-pricing).
+  -- Do NOT "restore" 3.00 / 15.00: that over-reports Sonnet 5 by 50%.
   ('anthropic', 'claude-sonnet-5',               2.00,  10.00,   0.20,   2.50),
   -- ── Anthropic: Claude 4.x (aliases + dated variants) ────────────────────
   ('anthropic', 'claude-opus-4-8',               5.00,  25.00,   0.50,   6.25),
@@ -178,7 +200,11 @@ INSERT INTO model_prices (
   ('anthropic', 'claude-3-opus-20240229',       15.00,  75.00,   1.50,  18.75),
   ('anthropic', 'claude-3-haiku-20240307',       0.25,   1.25,   NULL,   NULL), -- retired 2026-04-19
   -- ── Gemini 3.x ───────────────────────────────────────────────────────────
-  ('gemini', 'gemini-3.6-flash',                       1.50,   7.50,   0.15,  NULL),
+  -- 3.7-flash and 3.6-flash are on INTRODUCTORY pricing through 2026-12-31.
+  -- From 2027-01-01 both become 1.50 / 7.50 / 0.15. Flipping early doubles the
+  -- reported cost; flipping late halves it. Pinned by model-prices-cache.test.ts.
+  ('gemini', 'gemini-3.7-flash',                       0.75,   3.75,   0.075, NULL),
+  ('gemini', 'gemini-3.6-flash',                       0.75,   3.75,   0.075, NULL),
   ('gemini', 'gemini-3.5-flash',                       1.50,   9.00,   0.15,  NULL),
   ('gemini', 'gemini-3.5-flash-lite',                  0.30,   2.50,   0.03,  NULL),
   ('gemini', 'gemini-3.1-pro-preview',                 2.00,  12.00,   0.20,  NULL), -- ≤200k tier; >200k is 4.00/18.00/0.40
@@ -343,6 +369,15 @@ UPDATE model_prices
        long_completion_price_per_1m  = 12.00,
        long_cache_read_price_per_1m  =  0.60
  WHERE provider = 'xai' AND model = 'grok-4.5';
+
+-- grok-4.6 shares 4.5's short-tier input/output but caches at 0.50, so its
+-- doubled long-tier cache rate is 1.00 rather than 0.60.
+UPDATE model_prices
+   SET long_context_threshold_tokens = 200000,
+       long_prompt_price_per_1m      =  4.00,
+       long_completion_price_per_1m  = 12.00,
+       long_cache_read_price_per_1m  =  1.00
+ WHERE provider = 'xai' AND model = 'grok-4.6';
 
 UPDATE model_prices
    SET long_context_threshold_tokens = 200000,


### PR DESCRIPTION
Price audit against every provider's official pricing page, verified 2026-08-21.

## Customer impact

**`gemini-3.6-flash` was over-reporting by exactly 2x on all three axes.**
Google's flash rate is `0.75 / 3.75 / cache 0.075` **through 2026-12-31**; the
`1.50 / 7.50 / 0.15` values the 2026-08-11 seed used are the rates that start
2027-01-01. Flash is a high-volume family, so this is the largest dollar error
in the audit.

**DeepSeek moved to time-of-day pricing and both tiers cost more than what we
had**, so we were *under*-reporting: the customer's DeepSeek invoice was larger
than the number our dashboard showed them.

| model | off-peak (17h) | peak (7h) | what we had |
|---|---|---|---|
| `deepseek-v4-flash` | 0.22 / 0.66 / 0.007 | 0.44 / 1.32 / 0.014 | 0.14 / 0.28 / 0.0028 |
| `deepseek-v4-pro` | 0.66 / 1.98 / 0.022 | 1.32 / 3.96 / 0.044 | 0.435 / 0.87 / 0.003625 |

Peak is 01:00-04:00 and 06:00-10:00 UTC and is exactly 2x off-peak. `model_prices`
has one price per axis and no time dimension, so one of the two is wrong for part
of the day. **Seeded off-peak** (correct 17 of 24 hours, ~15% mean absolute error
against uniform traffic) rather than peak (correct 7, ~71%). Residual: peak-hour
requests stay 50% under-reported. **This is the main review question** — the
reasoning is in the migration header and the call is easy to flip.

**Five models had no row at all**, so their requests logged `cost_usd = NULL` and
rendered as a gap in the dashboard: `gemini-3.7-flash`, `grok-4.6`,
`gpt-5.5-cyber`, `gpt-5-search-api`, `zai-glm-5-2`.

## The scheduled landmine this removes

Anthropic **cancelled** the 2026-09-01 Sonnet 5 increase — `$2/$10` is now the
standard price (pricing-page note `claude-sonnet-5-introductory-pricing`).

The DB rows were already correct and are untouched. What was wrong was every
*instruction to change them*: the seed mirror, `FALLBACK_PRICES`, and the refresh
skill's pending-obligations list all told the next reader to raise Sonnet 5 on
2026-09-01. This routine runs on the 1st and 15th, so it would have fired on
exactly that date and over-reported every Sonnet 5 request by 50%. All three are
corrected here, and the skill now says to re-verify a scheduled change on the page
before acting on it.

## Deliberately not seeded

- `gpt-5.4-cyber` — every price cell in its row is blank. A visible NULL beats a
  silently invented number.
- Gemini modality-split models (`*-image`, `*-tts`, `*-live-*`, `omni-flash`) —
  output billed per image/second/character can't be one `completion_price_per_1m`.
- `gemini-embedding-2`'s non-text input rates (image 0.45, audio 6.50, video 12.00).
- Groq `compound`/`compound-mini` (no rate of their own), `minimax-m2.7` (Contact
  Sales), Whisper (per hour), Orpheus (per character).
- Cohere `command-a-plus` and the `command-a-{reasoning,vision,translate}` variants
  — still no public per-token price.

Rows kept for models that vanished from their provider's page (so history still
prices): three Groq models, two Cohere, and DeepSeek's `deepseek-chat` /
`deepseek-reasoner` aliases.

## Regression tests

Two added, pinning the boundaries this audit tripped over:

- **Gemini flash introductory window** — pins both sides of 2027-01-01, so
  forgetting the flip (50% under) *and* applying it early (2x over) both fail CI.
  Also pins that flash has no long-context tier.
- **`grok-4.6` 200k tier** — all three axes double. `grok-4.6` caches at 0.50 and
  `grok-4.5` at 0.30, so copying the 4.5 row would misprice every 4.6 cache hit by
  67%; the test pins that they stay distinct.

## Verification

- `pnpm --filter server typecheck` — clean
- `pnpm --filter server lint` — clean
- `pnpm --filter server test` — 134 files / 1655 tests passing (1653 before)
- Migration SQL executed against production inside a `BEGIN … ROLLBACK`
  transaction: it parses and produces exactly the intended rows. Confirmed
  afterwards that production is unchanged.
- Seed mirror and `FALLBACK_PRICES` diffed against each other for every touched
  model: no divergence.

## Follow-ups

- [ ] **`deepseek-chat` / `deepseek-reasoner`** — gone from DeepSeek's docs. If
  they still resolve, they're now under-reported, but the page no longer says
  *which* v4 they alias and flash vs pro is a 3x spread, so this PR does not
  guess. Needs a live API key to settle.
- [ ] **Peak/off-peak** — revisit if DeepSeek volume grows; the real fix is a
  time-of-day dimension on `model_prices`.
- [ ] **2027-01-01** — Gemini flash steps up to 1.50 / 7.50 / 0.15. Recorded in
  the skill's pending obligations and pinned by test, but a comment doesn't fire:
  worth a calendar entry.

## Deploy note

`deploy-server.yml` runs `supabase db push` on merge. Worth confirming the rows
actually landed in production afterwards rather than inferring it from a green
workflow — the `gemini-3.6-flash` 2x error is live until then.
